### PR TITLE
remove pre spacing for tab bars

### DIFF
--- a/_src/docs.css
+++ b/_src/docs.css
@@ -33,6 +33,7 @@ code-tabs {
   overflow-x: scroll;
 }
 .tab-bar {
+  margin-bottom: -18px;
   margin-top: 32px;
   white-space: nowrap;
 }
@@ -72,7 +73,7 @@ rdme-callout > *:first-child {
 .cl-box-blue h2,
 .cl-box-blue h3 {
   color: #fff;
-  margin-top:0;
+  margin-top: 0;
 }
 
 /** Top Navigation */
@@ -368,8 +369,6 @@ hr {
   background-color: #375bd2;
 }
 
-
-
 .cl-box {
   width: 100%;
   height: auto;
@@ -434,7 +433,7 @@ hr {
   background-color: #375bd2;
   border-radius: 16px;
   color: #fff;
-  padding:32px;
+  padding: 32px;
 }
 
 .cl-box-blue a {
@@ -681,11 +680,11 @@ input[type='reset'] {
 .footer {
   padding: 120px 0 0;
   background-color: #252e42;
-  font-size:16px;
+  font-size: 16px;
 }
 .footer h3 {
-  font-size:16px;
-  font-weight:700;
+  font-size: 16px;
+  font-weight: 700;
 }
 
 .footer-grid {


### PR DESCRIPTION
In a previous commit we added 24 pixels of space above and below every code
example. This unintentionally added space between the tab bar and the code
sample. This negative margin removes the extra space.