### PR TITLE
Add data categories for data provider nodes list

### DIFF
--- a/docs/Data Provider Nodes/data-provider-nodes-list.md
+++ b/docs/Data Provider Nodes/data-provider-nodes-list.md
@@ -6,19 +6,19 @@ title: "Data Provider Nodes List"
 permalink: "docs/data-provider-nodes-list/"
 ---
 
-| Name                                                                      | Supported Blockchains                        |
-|:------------------------------------------------------------------------- |:-------------------------------------------- |
-| [Chainlink Alarm Clock (Testnet)](../chainlink-alarm-clock)               | Ethereum                                     |
-| [LCX (Testnet)](../lcx-testnet)                                           | Ethereum                                     |
-| [Kraken Rates Oracle Node](../kraken-rates-oracle-node)                   | Ethereum                                     |
-| [Tiingo EOD Stock Price Oracle](../tiingo-eod-stock-price-oracle)         | Ethereum, Binance Smart Chain                |
-| [GeoDB Oracle Node](../geodb-oracle-node)                                 | Ethereum, Binance Smart Chain                |
-| [TheRunDown Oracle Node](../therundown-oracle-node)                       | Ethereum, Polygon                            |
-| [DNS Ownership Oracle](../dns-ownership-oracle)                           | Ethereum, Binance Smart Chain, Polygon       |
-| [WatchSignals Luxury Watch Price Oracle](../watchsignals)                 | Ethereum, Binance Smart Chain                |
-| [Genesis Volatility Cryptocurrency Options Oracle](../genesis-volatility) | Ethereum, Binance Smart Chain, Polygon, xDAI |
-| [dxFeed Price Oracle](../dxfeed-oracle)                                   | Ethereum, Binance Smart Chain                |
-| [CipherTrace DeFi Compli Oracle](../ciphertrace-defi-compli-oracle)       | Ethereum, Binance Smart Chain, Polygon       |
-| [Bookmaker Ratings Oracle](../bookmaker-ratings-oracle)                   | Ethereum, Binance Smart Chain                |
-| [Finage Global Market Data Oracle](../finage-global-market-data-oracle)   | Ethereum, Binance Smart Chain                |
-| [SportMonks Sports Data Oracle](../sport-monks-oracle)                    | Ethereum, Binance Smart Chain                |
+| Data Category | Name                                                                      | Supported Blockchains                        |
+|:------------- |:------------------------------------------------------------------------- |:-------------------------------------------- |
+| Collectibles  | [WatchSignals Luxury Watch Price Oracle](../watchsignals)                 | Ethereum, Binance Smart Chain                |
+| Crypto        | [Genesis Volatility Cryptocurrency Options Oracle](../genesis-volatility) | Ethereum, Binance Smart Chain, Polygon, xDAI |
+| Crypto        | [Kraken Rates Oracle Node](../kraken-rates-oracle-node)                   | Ethereum                                     |
+| Crypto        | [LCX (Testnet)](../lcx-testnet)                                           | Ethereum                                     |
+| DNS Lookup    | [DNS Ownership Oracle](../dns-ownership-oracle)                           | Ethereum, Binance Smart Chain, Polygon       |
+| Equities      | [dxFeed Price Oracle](../dxfeed-oracle)                                   | Ethereum, Binance Smart Chain                |
+| Equities      | [Finage Global Market Data Oracle](../finage-global-market-data-oracle)   | Ethereum, Binance Smart Chain                |
+| Equities      | [Tiingo EOD Stock Price Oracle](../tiingo-eod-stock-price-oracle)         | Ethereum, Binance Smart Chain                |
+| Identity      | [CipherTrace DeFi Compli Oracle](../ciphertrace-defi-compli-oracle)       | Ethereum, Binance Smart Chain, Polygon       |
+| Location      | [GeoDB Oracle Node](../geodb-oracle-node)                                 | Ethereum, Binance Smart Chain                |
+| Sports        | [Bookmaker Ratings Oracle](../bookmaker-ratings-oracle)                   | Ethereum, Binance Smart Chain                |
+| Sports        | [SportMonks Sports Data Oracle](../sport-monks-oracle)                    | Ethereum, Binance Smart Chain                |
+| Sports        | [TheRunDown Oracle Node](../therundown-oracle-node)                       | Ethereum, Polygon                            |
+| Time          | [Chainlink Alarm Clock (Testnet)](../chainlink-alarm-clock)               | Ethereum                                     |


### PR DESCRIPTION
## Overview

Based on the team's feedback, `data category` is a crucial piece of information when understanding which information a particular provider can feed to the contract.