### PR TITLE
Fix api references and contracts titles

### DIFF
--- a/docs/Additional Information/api-reference.md
+++ b/docs/Additional Information/api-reference.md
@@ -1,8 +1,0 @@
----
-layout: nodes.liquid
-date: Last Modified
-title: "API Reference"
-permalink: "docs/api-reference/"
-type: "link"
-link_url: "/reference"
----

--- a/docs/Chainlink Node API/chainlink-node-api-reference.md
+++ b/docs/Chainlink Node API/chainlink-node-api-reference.md
@@ -1,0 +1,9 @@
+---
+layout: nodes.liquid
+date: Last Modified
+title: "Chainlink Node API Reference"
+permalink: "docs/chainlink-node-api-reference/"
+---
+The Chainlink Node API reference provides information on how to interact directly with a Chainlink node. If you are creating services which need direct communication with a Chainlink node, this information will be helpful for you. If you are wanting to connect an external resource (API) to a smart contract using Chainlink, please see the the [Developers section of external adapters](../developers/).
+
+Most endpoints of the Chainlink node require session authentication. You will need to [POST](ref:sessions) to `/session` to create a cookie to be used for subsequent requests.

--- a/docs/Introduction/architecture-overview/architecture-request-model.md
+++ b/docs/Introduction/architecture-overview/architecture-request-model.md
@@ -22,7 +22,7 @@ All source code is open source and available in our <a href="https://github.com/
 
 The client constructs and makes a request to a known Chainlink oracle through the `transferAndCall` function, implemented by the LINK token. This request contains encoded information that is required for the cycle to succeed. In the `ChainlinkClient` contract, this call is initiated with a call to `sendChainlinkRequestTo`.
 
-To build your own client contract using `ChainlinkClient`, see [Introduction to Using Any API](../request-and-receive-data/), or view the [API Reference](../chainlink-framework/) for the `ChainlinkClient` contract.
+To build your own client contract using `ChainlinkClient`, see [Introduction to Using Any API](../request-and-receive-data/), or view the [ChainlinkClient API Reference](../chainlink-framework/) for the `ChainlinkClient` contract.
 
 ## LINK Token
 

--- a/docs/Node Operators/configuration-variables.md
+++ b/docs/Node Operators/configuration-variables.md
@@ -332,7 +332,7 @@ Specifies the addresses/URLs of allowed connections to the API on `CLIENT_NODE_U
 
 - Default: `"6688"`
 
-Port used for the [API Reference](../api-reference/) and GUI.
+Port used for the [Chainlink Node API Reference](../chainlink-node-api-reference/) and GUI.
 
 
 ## CLIENT_NODE_URL

--- a/docs/Using Any API/chainlink-framework.md
+++ b/docs/Using Any API/chainlink-framework.md
@@ -2,7 +2,7 @@
 layout: nodes.liquid
 section: smartContract
 date: Last Modified
-title: "API Reference"
+title: "ChainlinkClient API Reference"
 permalink: "docs/chainlink-framework/"
 ---
 API reference for <a href="https://github.com/smartcontractkit/chainlink/blob/master/evm-contracts/src/v0.6/ChainlinkClient.sol" target="_blank">`ChainlinkClient`</a>.

--- a/docs/Using Price Feeds/get-the-latest-price.html
+++ b/docs/Using Price Feeds/get-the-latest-price.html
@@ -4,7 +4,7 @@ section: smartContract
 date: Last Modified
 title: "Get the Latest Price"
 permalink: "docs/get-the-latest-price/"
-whatsnext: {"Historical Price Data":"/docs/historical-price-data/", "API Reference":"/docs/price-feeds-api-reference/", "Contract Addresses":"/docs/reference-contracts/"}
+whatsnext: {"Historical Price Data":"/docs/historical-price-data/", "Price Feeds API Reference":"/docs/price-feeds-api-reference/", "Price Feeds Contract Addresses":"/docs/reference-contracts/"}
 metadata: 
   title: "Get the Latest Price of an Asset"
   description: "How to use Chainlink Price Feeds to retrieve the latest price of ETH in your smart contracts."
@@ -68,7 +68,7 @@ contract PriceConsumerV3 {
     </div>
 </div>
 
-The `latestRoundData` function returns five values representing information about the latest price data. See [API Reference](../price-feeds-api-reference/) for more details.
+The `latestRoundData` function returns five values representing information about the latest price data. See [Price Feeds API Reference](../price-feeds-api-reference/) for more details.
 
 ## Javascript
 ```javascript Kovan

--- a/docs/Using Price Feeds/price-feeds-api-reference.md
+++ b/docs/Using Price Feeds/price-feeds-api-reference.md
@@ -2,7 +2,7 @@
 layout: nodes.liquid
 section: smartContract
 date: Last Modified
-title: "API Reference"
+title: "Price Feeds API Reference"
 permalink: "docs/price-feeds-api-reference/"
 metadata: 
   description: "API reference for using Chainlink Price Feeds in smart contracts."

--- a/docs/Using Price Feeds/reference-contracts.md
+++ b/docs/Using Price Feeds/reference-contracts.md
@@ -2,7 +2,7 @@
 layout: nodes.liquid
 section: smartContract
 date: Last Modified
-title: "Contract Addresses"
+title: "Price Feeds Contract Addresses"
 permalink: "docs/reference-contracts/"
 whatsnext: {"ENS":"/docs/ens/", "Ethereum Price Feeds":"/docs/ethereum-addresses/", "Binance Smart Chain Price Feeds":"/docs/binance-smart-chain-addresses/", "Polygon (Matic) Price Feeds":"/docs/matic-addresses/", "xDai Price Feeds":"/docs/xdai-price-feeds/", "Huobi Eco Chain Price Feeds":"/docs/huobi-eco-chain-price-feeds/", "Avalanche Price Feeds":"/docs/avalanche-price-feeds/"}
 metadata: 

--- a/docs/Using Randomness/chainlink-vrf-api-reference.md
+++ b/docs/Using Randomness/chainlink-vrf-api-reference.md
@@ -2,7 +2,7 @@
 layout: nodes.liquid
 section: smartContract
 date: Last Modified
-title: "API Reference"
+title: "Chainlink VRF API Reference"
 permalink: "docs/chainlink-vrf-api-reference/"
 metadata: 
   title: "Chainlink VRF API Reference"

--- a/docs/Using Randomness/vrf-contracts.md
+++ b/docs/Using Randomness/vrf-contracts.md
@@ -2,7 +2,7 @@
 layout: nodes.liquid
 section: smartContract
 date: Last Modified
-title: "Contract Addresses"
+title: "Chainlink VRF Contract Addresses"
 permalink: "docs/vrf-contracts/"
 metadata: 
   title: "Chainlink VRF Contract Addresses"


### PR DESCRIPTION
## Overview

Pages for API References and Contract Addresses are named generic. This causes confusing search results and weakens our SEO. This PR fixes that.

<img width="1360" alt="Screenshot 2021-06-02 at 18 19 55" src="https://user-images.githubusercontent.com/5336968/120471681-0f1daf80-c3b6-11eb-8bab-c08dffa6ca34.png">
 