### PR TITLE
Changed Core Adapters primary URL

### DIFF
--- a/docs/Oracle Jobs/adapters.md
+++ b/docs/Oracle Jobs/adapters.md
@@ -2,7 +2,7 @@
 layout: nodes.liquid
 date: Last Modified
 title: "Core Adapters"
-permalink: "docs/adapters/"
+permalink: "docs/core-adapters/"
 whatsnext: {"Introduction to External Adapters":"/docs/external-adapters/", "Initiators":"/docs/initiators/"}
 ---
 Core adapters are the built-in functionality that every Chainlink node supports. Strung together, they act as tasks that need to be performed to complete a Job.

--- a/firebase.json
+++ b/firebase.json
@@ -4,12 +4,12 @@
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "redirects": [
       {
-        "source": "/docs",
+        "source": "/docs/",
         "destination": "/",
         "type": 301
       },
       {
-        "source": "/docs/getting-started",
+        "source": "/docs/getting-started/",
         "destination": "/",
         "type": 301
       },
@@ -21,6 +21,11 @@
       {
         "source": "/docs/kovan-keeper-network-beta/",
         "destination": "/docs/chainlink-keepers/introduction/",
+        "type": 301
+      },
+      {
+        "source": "/docs/adapters/",
+        "destination": "/docs/core-adapters/",
         "type": 301
       }
     ]


### PR DESCRIPTION
Put old URL in firebase.json so backlinks still work.