### PR TITLE
Explicit using statement on Any API contracts

### DIFF
--- a/docs/Using Any API/existing-job-request.md
+++ b/docs/Using Any API/existing-job-request.md
@@ -40,6 +40,8 @@ import "@chainlink/contracts/src/v0.6/ChainlinkClient.sol";
  * PLEASE DO NOT USE THIS CODE IN PRODUCTION.
  */
 contract OpenWeatherConsumer is ChainlinkClient {
+    using Chainlink for Chainlink.Request;
+
     address private oracle;
     bytes32 private jobId;
     uint256 private fee;

--- a/docs/Using Any API/make-a-http-get-request.md
+++ b/docs/Using Any API/make-a-http-get-request.md
@@ -38,6 +38,7 @@ import "@chainlink/contracts/src/v0.6/ChainlinkClient.sol";
  * PLEASE DO NOT USE THIS CODE IN PRODUCTION.
  */
 contract APIConsumer is ChainlinkClient {
+    using Chainlink for Chainlink.Request;
   
     uint256 public volume;
     


### PR DESCRIPTION
Whilst this line is not strictly necessary for v0.6 contracts, later versions of Solidity have removed the inheritance of `using` statements by default. 

Users who copy and paste this code into a newer version of Solidity are prompted with a compilation error.