### PR TITLE
Fix broken link to chainlink contract library

### DIFF
--- a/docs/Introduction/tutorials/intermediates-tutorial.md
+++ b/docs/Introduction/tutorials/intermediates-tutorial.md
@@ -77,7 +77,7 @@ The contract will have the following functions:
 [/block]
 ## 4a. Importing `VRFConsumerBase`
 
-Chainlink maintains a <a href="https://github.com/smartcontractkit/chainlink/tree/develop/evm-contracts" target="_blank">library of contracts</a> that make consuming data from oracles easier. For Chainlink VRF, we use a contract called <a href="https://github.com/smartcontractkit/chainlink/blob/master/evm-contracts/src/v0.6/VRFConsumerBase.sol" target="_blank">`VRFConsumerBase`</a>, which needs to be imported and extended from.
+Chainlink maintains a <a href="https://github.com/smartcontractkit/chainlink/tree/develop/contracts" target="_blank">library of contracts</a> that make consuming data from oracles easier. For Chainlink VRF, we use a contract called <a href="https://github.com/smartcontractkit/chainlink/blob/master/evm-contracts/src/v0.6/VRFConsumerBase.sol" target="_blank">`VRFConsumerBase`</a>, which needs to be imported and extended from.
 
 ```javascript
 pragma solidity 0.6.6;


### PR DESCRIPTION
The link in the documentation to the evm-contracts library is broken. This change is to point to the current location of the chainlink contracts. 