### PR TITLE
Fix broken Denominations link

### DIFF
--- a/docs/Using Price Feeds/feed-registry.html
+++ b/docs/Using Price Feeds/feed-registry.html
@@ -55,7 +55,7 @@ latestRoundData(0xa36085f69e2889c224210f603d836748e7dc0088, 0xEeeeeEeeeEeEeeEeEe
 
 ## Denominations library
 
-A <a href="https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/dev/Denominations.sol" target="_blank">`Denominations`</a> Solidity library is available for you to query common denominations:
+A <a href="https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/Denominations.sol" target="_blank">`Denominations`</a> Solidity library is available for you to query common denominations:
 
 
 ```javascript Solidity 8


### PR DESCRIPTION
Updates the link to `Denominations.sol`. The contract has been moved from the `dev/` directory https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/Denominations.sol