### PR TITLE
Update example in the "Architecture decentralized data model" section of the docs

### DIFF
--- a/docs/Introduction/architecture-overview/architecture-decentralized-model.md
+++ b/docs/Introduction/architecture-overview/architecture-decentralized-model.md
@@ -39,9 +39,9 @@ Each price feed is built and funded by the community of users who rely on accura
 
 ## Decentralized Oracle Network
 
-Each price feed is updated by a decentralized oracle network. Each oracle operator is rewarded for publishing price data. The number of oracles contributing to each feed varies. For example, in the ETH/USD Price Feed, there are 21 oracles.
+Each price feed is updated by a decentralized oracle network. Each oracle operator is rewarded for publishing price data. The number of oracles contributing to each feed varies. For example, in the ETH/USD Price Feed, there are 31 oracles.
 
-In order for an update to take place, the price feed contract must receive responses from a minimum number of oracles. For example, 14 / 21 oracles. Otherwise, the latest answer will not be updated.
+In order for an update to take place, the price feed contract must receive responses from a minimum number of oracles. For example, 21 / 31 oracles. Otherwise, the latest answer will not be updated.
 
 Each oracle in the set publishes answers to the latest price of an asset during an aggregation round. The answers are validated and aggregated by a smart contract, which forms the feed's latest and trusted answer. Developers wishing to use an asset's latest and trusted answer can do so easily by following the [Get the Latest Price](../get-the-latest-price/) page.
 


### PR DESCRIPTION
Update the number of oracles in the docs from 21 oracles to 31 oracles for the ETH/USD feed example. Current ETH/USD price feed has 31 oracles actively serving data requests.
Source: https://data.chain.link/ethereum/mainnet/crypto-usd/eth-usd