### PR TITLE
Fix Avalanche Mainnet name

### DIFF
--- a/docs/Developer Reference/link-token-contracts.md
+++ b/docs/Developer Reference/link-token-contracts.md
@@ -172,7 +172,7 @@ You can also <a href="https://www.youtube.com/watch?v=WKvIGkBWRUA" target="_blan
 
 ## Avalanche
 
-### Fuji Mainnet
+### Mainnet
 
 |Parameter|Value|
 |:---|:---|


### PR DESCRIPTION
Avalanche Mainnet has no particular name, Fuji is the name of the Testnet.