### PR TITLE
Change ./samples/ links to point to the GitHub URLs.

### DIFF
--- a/docs/Data Provider Nodes/chainlink-alarm-clock.md
+++ b/docs/Data Provider Nodes/chainlink-alarm-clock.md
@@ -55,7 +55,7 @@ contract ChainlinkAlarmClock is ChainlinkClient {
 ```
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/DataProviders/AlarmClock.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/DataProviders/AlarmClock.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Data Provider Nodes/dns-ownership-oracle.md
+++ b/docs/Data Provider Nodes/dns-ownership-oracle.md
@@ -96,7 +96,7 @@ contract DnsOwnershipChainlink is ChainlinkClient {
 ```
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/DataProviders/DnsOwnership.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/DataProviders/DnsOwnership.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Data Provider Nodes/finage-global-market-data-oracle.md
+++ b/docs/Data Provider Nodes/finage-global-market-data-oracle.md
@@ -91,7 +91,7 @@ contract FinageChainlink is ChainlinkClient {
 ```
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/DataProviders/Finage.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+    <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/DataProviders/Finage.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Data Provider Nodes/google-weather.md
+++ b/docs/Data Provider Nodes/google-weather.md
@@ -62,7 +62,7 @@ Import `ChainlinkClient.sol` into your contract so you can inherit the `Chainlin
 ```
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.12+commit.27d51765.js&optimize=false&evmVersion=null&runs=200&url=https://docs.chain.link/samples/DataProviders/GoogleWeather.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#version=soljson-v0.6.12+commit.27d51765.js&optimize=false&evmVersion=null&runs=200&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/DataProviders/GoogleWeather.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Data Provider Nodes/kraken-rates-oracle-node.md
+++ b/docs/Data Provider Nodes/kraken-rates-oracle-node.md
@@ -95,7 +95,7 @@ contract KrakenChainlink is ChainlinkClient {
 ```
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/DataProviders/Kraken.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/DataProviders/Kraken.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Data Provider Nodes/lcx-testnet.md
+++ b/docs/Data Provider Nodes/lcx-testnet.md
@@ -87,7 +87,7 @@ contract LCXChainlink is ChainlinkClient {
 ```
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/DataProviders/LCX.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/DataProviders/LCX.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Developer Reference/user-guides/deploy-your-first-contract.md
+++ b/docs/Developer Reference/user-guides/deploy-your-first-contract.md
@@ -17,7 +17,7 @@ Remix is a web IDE (integrated development environment) for creating, running, a
 
 ## Create and deploy your first contract
 
-* Navigate to Remix: <a href="https://remix.ethereum.org/#version=soljson-v0.6.0+commit.26b70077.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/APIRequests/ATestnetConsumer.sol" target="_blank" rel="noreferrer, noopener">https://remix.ethereum.org</a>
+* Navigate to Remix: <a href="https://remix.ethereum.org/#version=soljson-v0.6.0+commit.26b70077.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/APIRequests/ATestnetConsumer.sol" target="_blank" rel="noreferrer, noopener">https://remix.ethereum.org</a>
 
 * Remix opens up with an empty interface, or possible with a default contract
 

--- a/docs/Introduction/tutorials/advanced-tutorial.md
+++ b/docs/Introduction/tutorials/advanced-tutorial.md
@@ -87,7 +87,7 @@ Let's see what this looks like in a contract.
 ```
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/APIRequests/APIConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/APIRequests/APIConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Introduction/tutorials/beginners-tutorial.md
+++ b/docs/Introduction/tutorials/beginners-tutorial.md
@@ -145,7 +145,7 @@ We have the code. What we need next is a compiler.
 Fortunately for us, Remix also has support for gist. This means that Remix can load code from Github, and in this case, `PriceConsumerV3.sol` Click the button below to open a new tab, then once Remix has loaded, find the `gists` folder in the File Explorer on the left-hand side, and click on the file to open the code in the editor.
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/PriceFeeds/PriceConsumerV3.sol" target="_blank" class="cl-button--ghost">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/PriceFeeds/PriceConsumerV3.sol" target="_blank" class="cl-button--ghost">Deploy this contract using Remix ↗</a>
   <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Introduction/tutorials/intermediates-tutorial.md
+++ b/docs/Introduction/tutorials/intermediates-tutorial.md
@@ -72,7 +72,7 @@ The contract will have the following functions:
 
 > 📘 Open Full Contract
 > 
-> To jump straight to the entire implementation, you can [open this contract](https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/VRF/VRFD20.sol) in remix</a>.
+> To jump straight to the entire implementation, you can [open this contract](https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/VRF/VRFD20.sol) in remix</a>.
 
 ## 4a. Importing `VRFConsumerBase`
 
@@ -226,7 +226,7 @@ function getHouseName(uint256 id) private pure returns (string memory) {
 See the full contract in Remix! (We've added a few helper functions in there which should make using the contract easier and more flexible. Have a play around with it to understand all the internal workings).
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/VRF/VRFD20.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/VRF/VRFD20.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Node Operators/fulfilling-requests.md
+++ b/docs/Node Operators/fulfilling-requests.md
@@ -4,7 +4,7 @@ date: Last Modified
 title: "Fulfilling Requests"
 permalink: "docs/fulfilling-requests/"
 whatsnext: {"Performing System Maintenance":"/docs/performing-system-maintenance/", "Miscellaneous":"/docs/miscellaneous/", "Best Security and Operating Practices":"/docs/best-security-practices/"}
-metadata: 
+metadata:
   title: "Chainlink Node Operators: Fulfilling Requests"
   description: "Deploy your own Oracle contract and add jobs to your node so that it can provide data to smart contracts."
 ---
@@ -15,19 +15,19 @@ With your own Oracle contract, you can use your own node to fulfill requests. Th
 - Going through the [Beginner Walkthrough](../beginners-tutorial) will help you obtain Testnet LINK and set up Metamask- [Run an Ethereum Client](../run-an-ethereum-client/) - [Running a Chainlink Node](../running-a-chainlink-node/)
 
 > 👍 Make sure to fund your node address!
-> 
-> In the `keys` tab, you'll see at the bottom `Account Addresses`. The address of your node is the `regular` one. 
-> 
+>
+> In the `keys` tab, you'll see at the bottom `Account Addresses`. The address of your node is the `regular` one.
+>
 > IN OLDER VERSIONS: Go to `configuration` in your node. You'll see `ACCOUNT_ADDRESS`. This is the address of your node. Send this address ETH. You can find testnet ETH on various [faucets](../link-token-contracts/). If you don't see `ACCOUNT_ADDRESS` there, check the 'Keys' tab and scroll down
 
 ## Deploy your own Oracle contract
 
-- Go to [Remix](https://remix.ethereum.org/optimize=true&version=soljson-v0.4.24+commit.e67f0147.js&url=https://docs.chain.link/samples/NodeOperators/Oracle.sol) and expand the gist menu
+- Go to [Remix](https://remix.ethereum.org/#optimize=true&version=soljson-v0.4.24+commit.e67f0147.js&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/NodeOperators/Oracle.sol) and expand the gist menu
 
 ![Remix File Explorer](/files/05f12f3-00eeef4-remix001.jpg)
 
 > 📘 Important
-> 
+>
 > If you open Remix for the first time, you should chose the **Environments** to **Solidity**
 
 - Click on Oracle.sol. The contents of this file will be very minimal, since we only need to import the code hosted on Github.- On the Compile tab, click on the "Compile Oracle.sol" button near the left
@@ -53,9 +53,9 @@ With your own Oracle contract, you can use your own node to fulfill requests. Th
 - Click Deploy. Metamask will prompt you to Confirm the Transaction
 
 > 🚧 Metamask doesn't pop up?
-> 
-> If Metamask does not prompt you and instead displays the error below, you will need to disable "Privacy Mode" in Metamask. You can do this by clicking on your unique account icon at the top-right, then go to the Settings. Privacy Mode will be a switch near the bottom. 
-> 
+>
+> If Metamask does not prompt you and instead displays the error below, you will need to disable "Privacy Mode" in Metamask. You can do this by clicking on your unique account icon at the top-right, then go to the Settings. Privacy Mode will be a switch near the bottom.
+>
 > The error: **Send transaction failed: invalid address. If you use an injected provider, please check it is properly unlocked.**
 
 A link to Etherscan will display at the bottom, you can open that in a new tab to keep track of the transaction
@@ -67,7 +67,7 @@ Once successful, you should have a new address for the deployed contract
 ![Remix Deployed Contract Address](/files/6858cf3-remix006.jpg)
 
 > 📘 Important
-> 
+>
 > Keep note of the Oracle contract's address, you will need it for your consuming contract later.
 
 ## Add your node to the Oracle contract
@@ -91,13 +91,13 @@ Once you call the `setFulfillmentPermission` function, Confirm it in Metamask an
 Adding jobs to the node is easily accomplished via the GUI. We have example [Job Specifications](../job-specifications/) below.
 
 > ❗️ Required
-> 
+>
 > Replace `YOUR_ORACLE_CONTRACT_ADDRESS` below with the address of your deployed oracle contract address from the previous steps. Note that this is different than the `ACCOUNT_ADDRESS` from your node.
 
-If using Chainlink version `0.9.4` or above, you can add a `name` to your job spec. 
+If using Chainlink version `0.9.4` or above, you can add a `name` to your job spec.
 
 ```json EthBytes32 (GET)
-{ 
+{
   "name": "Get > Bytes32",
   "initiators": [
     {
@@ -124,7 +124,7 @@ If using Chainlink version `0.9.4` or above, you can add a `name` to your job sp
 }
 ```
 ```json EthBytes32 (POST)
-{ 
+{
   "name": "POST > Bytes32",
   "initiators": [
     {
@@ -253,16 +253,16 @@ If using Chainlink version `0.9.4` or above, you can add a `name` to your job sp
 - Repeat this process for each of the jobs above.
 
 > 📘 Note
-> 
+>
 > The address for the jobs will auto-populate with the zero-address. This means the Chainlink node will listen to your Job ID from any address. You can also specify an address in the params object of the RunLog initiator for your oracle contract.
 
 ## Create a request to your node
 
 > 📘 Important
-> 
+>
 > If you're going through this guide on Ethereum mainnet, the TestnetConsumer.sol contract will still work. However, understand that you're sending real LINK to yourself. **Be sure to practice on the test networks multiple times before attempting to run a node on mainnet.**
 
-With the jobs added, you can now use your node to fulfill requests. This last section shows what requesters will do when they send requests to your node. It is also a way to test and make sure that your node is functioning correctly.- In Remix, create a new file named TestnetConsumer.sol and copy and paste the [TestnetConsumer.sol](https://docs.chain.link/samples/APIRequests/ATestnetConsumer.sol) contract into it.- Click "Start to compile".
+With the jobs added, you can now use your node to fulfill requests. This last section shows what requesters will do when they send requests to your node. It is also a way to test and make sure that your node is functioning correctly.- In Remix, create a new file named TestnetConsumer.sol and copy and paste the [TestnetConsumer.sol](https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/APIRequests/ATestnetConsumer.sol) contract into it.- Click "Start to compile".
 
 ![Remix Click Compile](/files/a8a5ecd-Screenshot_from_2019-05-16_15-39-05.png)
 

--- a/docs/Using Any API/existing-job-request.md
+++ b/docs/Using Any API/existing-job-request.md
@@ -26,7 +26,7 @@ This example uses the <a href="https://market.link/nodes/ef076e87-49f4-486b-9878
 > Making a job request will fail unless your deployed contract has enough LINK to pay for it. **Learn how to [Acquire testnet LINK](../acquire-link/) and [Fund your contract](../fund-your-contract/)**.
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/APIRequests/OpenWeatherConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+    <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/APIRequests/OpenWeatherConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Using Any API/large-responses.md
+++ b/docs/Using Any API/large-responses.md
@@ -18,7 +18,7 @@ To consume an API with a large responses, your contract should inherit from [Cha
 > 
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#optimize=false&evmVersion=null&runs=200&version=soljson-v0.8.6+commit.11564f7e.js&url=https://docs.chain.link/samples/APIRequests/GenericBigWord.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+    <a href="https://remix.ethereum.org/#optimize=false&evmVersion=null&runs=200&version=soljson-v0.8.6+commit.11564f7e.js&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/APIRequests/GenericBigWord.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Using Any API/make-a-http-get-request.md
+++ b/docs/Using Any API/make-a-http-get-request.md
@@ -24,7 +24,7 @@ Currently, any return value must fit within 32 bytes, if the value is bigger tha
 > Making a GET request will fail unless your deployed contract has enough LINK to pay for it. **Learn how to [Acquire testnet LINK](../acquire-link/) and [Fund your contract](../fund-your-contract/)**.
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/APIRequests/APIConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+    <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/APIRequests/APIConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Using Any API/multi-variable-responses.md
+++ b/docs/Using Any API/multi-variable-responses.md
@@ -24,7 +24,7 @@ To consume an API with multiple responses, your contract should inherit from [Ch
 > 
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#optimize=false&evmVersion=null&runs=200&version=soljson-v0.8.6+commit.11564f7e.js&url=https://docs.chain.link/samples/APIRequests/MultiWordConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy a Multi-Word Contract Example in Remix ↗</a>
+    <a href="https://remix.ethereum.org/#optimize=false&evmVersion=null&runs=200&version=soljson-v0.8.6+commit.11564f7e.js&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/APIRequests/MultiWordConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy a Multi-Word Contract Example in Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Using Price Feeds/feed-registry.html
+++ b/docs/Using Price Feeds/feed-registry.html
@@ -70,7 +70,7 @@ To consume price data from the Feed Registry, your smart contract should referen
 
 <div class="row cl-button-container">
     <div class="col-xs-12 col-md-12">
-      <a href="https://remix.ethereum.org/#optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.6+commit.11564f7e.js&url=https://docs.chain.link/samples/FeedRegistry/PriceConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+      <a href="https://remix.ethereum.org/#optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.6+commit.11564f7e.js&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/FeedRegistry/PriceConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     </div>
     <div class="col-xs-12 col-md-12">
       <a href="../deploy-your-first-contract/" title="">What is Remix?</a>

--- a/docs/Using Price Feeds/get-the-latest-price.html
+++ b/docs/Using Price Feeds/get-the-latest-price.html
@@ -34,7 +34,7 @@ To consume price data, your smart contract should reference [`AggregatorV3Interf
 
 <div class="row cl-button-container">
     <div class="col-xs-12 col-md-12">
-      <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/PriceFeeds/PriceConsumerV3.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+      <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/PriceFeeds/PriceConsumerV3.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     </div>
     <div class="col-xs-12 col-md-12">
       <a href="../deploy-your-first-contract/">What is Remix?</a>

--- a/docs/Using Price Feeds/historical-price-data.html
+++ b/docs/Using Price Feeds/historical-price-data.html
@@ -32,7 +32,7 @@ Price Feeds are updated in rounds. Rounds are identified by their `roundId`, whi
 ## Solidity
 
 <div class="remix-callout">
-      <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/PriceFeeds/HistoricalPriceConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+      <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/PriceFeeds/HistoricalPriceConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
       <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Using Randomness/get-a-random-number.md
+++ b/docs/Using Randomness/get-a-random-number.md
@@ -36,7 +36,7 @@ Note, the below values have to be configured correctly for VRF requests to work.
 > Requesting randomness will fail unless your deployed contract has enough LINK to pay for it. **Learn how to [Acquire testnet LINK](../acquire-link/) and [Fund your contract](../fund-your-contract/)**.
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#version=soljson-v0.6.6+commit.6c089d02.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/VRF/RandomNumberConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+    <a href="https://remix.ethereum.org/#version=soljson-v0.6.6+commit.6c089d02.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/VRF/RandomNumberConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/chainlink-keepers/compatible-contracts.md
+++ b/docs/chainlink-keepers/compatible-contracts.md
@@ -76,7 +76,7 @@ When your checkUpkeep returns `upkeepNeeded == true`, the Keeper node broadcasts
 The example below represents a simple counter contract. Each time `performUpkeep` is called, it increments its counter by one.
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#version=soljson-v0.6.6+commit.6c089d02.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/Keepers/KeepersCounter.sol" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+    <a href="https://remix.ethereum.org/#version=soljson-v0.6.6+commit.6c089d02.js&optimize=false&evmVersion=null&url=https://github.com/smartcontractkit/documentation/blob/main/_includes/samples/Keepers/KeepersCounter.sol" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 


### PR DESCRIPTION
The samples at https://docs.chain.link/samples/ are not functioning properly in Remix URLs.

Change these URLs back to GitHub for now until we can resolve the issue.