### PR TITLE
Add basic support for Solana Devnet in our documentation.

### DIFF
--- a/_includes/feed.liquid
+++ b/_includes/feed.liquid
@@ -4,12 +4,12 @@ section: smartContract
 ---
 
 {% if metadata.solanafeeds %}
-    <p>The program address for this feed is publicly available in the <a href="https://explorer.solana.com/address/2yqG9bzKHD59MxD9q7ExLvnDhNycB3wkvKXFQSpBoiaE?cluster=devnet">Solana Devnet Explorer</a>.</p>
+    <p>To learn how to implement these feeds, see the <a href="../get-the-latest-price/#solana-network-examples">Solana Examples for Consuming Price Feeds</a>.</p>
+    <p>To learn how to obtain SOL tokens on the Solana Devnet, see the <a href="https://docs.solana.com/cli/transfer-tokens#airdrop-some-tokens-to-get-started">Solana Documentation</a>.</p>
 {% else %}
-    <p>For implementation instructions, please refer to <a href="../get-the-latest-price/">Get the Latest Price</a>.</p>
+    <p>To learn how to implement these feeds, see the <a href="../get-the-latest-price/#ethereum-network-examples">Ethereum Examples for Consuming Price Feeds</a>.</p>
+    <p>For LINK token and Faucet details, see the <a href="../link-token-contracts/">LINK Token Contracts</a> page.</p>
 {% endif %}
-
-<p>For LINK token and Faucet details, please refer to <a href="../link-token-contracts/">LINK Token Contracts</a>.</p>
 
 <p>Note, off-chain equity and ETF assets are only traded during standard market hours (9:30 am - 4 pm ET M-F). Using these feeds outside of those windows is not recommended.</p>
 

--- a/docs/Using Price Feeds/get-the-latest-price.html
+++ b/docs/Using Price Feeds/get-the-latest-price.html
@@ -14,14 +14,14 @@ metadata:
  {% markdown %}
 
 Price data feeds are available on the following networks:
-- EVM-compatible networks: [Ethereum](/docs/ethereum-addresses/), [Binance Smart Chain](/docs/binance-smart-chain-addresses/), [Polygon](/docs/matic-addresses/), [xDai](/docs/xdai-price-feeds/), [Huobi Eco Chain](/docs/huobi-eco-chain-price-feeds/), [Avalanche](/docs/avalanche-price-feeds/), [Fantom](/docs/fantom-price-feeds/), [Arbitrum](/docs/arbitrum-price-feeds/), [Harmony](/docs/harmony-price-feeds/)
-- Other networks: [Solana](/docs/solana-price-feeds/)
+- [EVM-compatible networks](#ethereum-network-examples)
+- [Solana networks](#solana-network-examples)
+
+To get a full list of supported blockchains for price feeds, see the [Price Feeds Contract Addresses](../reference-contracts/) page.
 
 > 📘 Note
 >
 > The full list of price feeds for each network are available from [Price Feed Contracts](../reference-contracts/).
-
-## Code Examples
 
 > 📘 New Feed Registry
 > You can now use the [Feed Registry](../feed-registry/) to reference price feed assets by name or currency identifier instead of pair/proxy address.
@@ -84,6 +84,30 @@ The `latestRoundData` function returns five values representing information abou
 <div class="row cl-button-container">
     <div class="col-xs-12 col-md-12">
     <a href="https://repl.it/@alexroan/GetLatestPriceWeb3PY" class="cl-button--ghost python-tracked">Run this python ↗</a>
+    </div>
+</div>
+
+## Solana network examples
+
+Chainlink Price Feeds run live on the [Solana Devnet](https://explorer.solana.com/?cluster=devnet) with sub-second updates. Chainlink’s Solana deployment has no dependencies on external blockchain networks such as Ethereum.
+
+To get the full list of Chainlink Price Feeds running on the Solana Devnet, see the [Solana Feeds](/docs/solana-price-feeds/) page.
+
+You can view the program ID that owns these price feeds in the [Solana Devnet Explorer](https://explorer.solana.com/address/2yqG9bzKHD59MxD9q7ExLvnDhNycB3wkvKXFQSpBoiaE?cluster=devnet).
+
+### Rust
+
+To learn how to deploy and interact with these price feeds using Solana and Rust, follow the README instructions on the [Devnet Deployment Demo](https://github.com/smartcontractkit/chainlink-solana-demo).
+
+This demo shows you how to complete the following tasks:
+- Deploy your own program that uses Chainlink Data Feeds
+- Interact with an account that stores state from a deployed program
+
+In comparison to Solidity, the combination of an account and a program is equivalent to a smart contract on an EVM chain. The demo shows you how to work with a program that you deploy, but you can refactor the client section to work with a program ID of your choice. State and logic are separated in Solana.
+
+<div class="row cl-button-container">
+    <div class="col-xs-12 col-md-12">
+    <a href="https://github.com/smartcontractkit/chainlink-solana-demo" class="cl-button--ghost python-tracked">Start the Solana Devnet Deployment Demo ↗</a>
     </div>
 </div>
 


### PR DESCRIPTION
- Add a Solana network examples section with links to the GitHub Solana demo.
- Update the URLs to direct customers to the Solana Network Examples section.

Next steps will be to pull the documentation out of GitHub into a full set of documentation for the Solana demo with code sample explanations.