### PR TITLE
Add expanded documentation for Solana data feeds.

### DIFF
--- a/_data/navigation.js
+++ b/_data/navigation.js
@@ -194,7 +194,12 @@ module.exports = {
             title: 'Introduction to Price Feeds',
             url: '/docs/using-chainlink-reference-contracts/',
           },
-          { title: 'Get the Latest Price', url: '/docs/get-the-latest-price/' },
+          { title: 'Get the Latest Price (EVM)',
+            url: '/docs/get-the-latest-price/'
+          },
+          { title: 'Get the Latest Price (Solana)',
+            url: '/docs/get-the-latest-price-solana/'
+          },
           {
             title: 'Historical Price Data',
             url: '/docs/historical-price-data/',

--- a/_includes/feed.liquid
+++ b/_includes/feed.liquid
@@ -4,10 +4,10 @@ section: smartContract
 ---
 
 {% if metadata.solanafeeds %}
-    <p>To learn how to implement these feeds, see the <a href="../get-the-latest-price/#solana-network-examples">Solana Examples for Consuming Price Feeds</a>.</p>
+    <p>To learn how to implement these feeds, see the <a href="../get-the-latest-price-solana/">Solana Examples for Consuming Price Feeds</a>.</p>
     <p>To learn how to obtain SOL tokens on the Solana Devnet, see the <a href="https://docs.solana.com/cli/transfer-tokens#airdrop-some-tokens-to-get-started">Solana Documentation</a>.</p>
 {% else %}
-    <p>To learn how to implement these feeds, see the <a href="../get-the-latest-price/#ethereum-network-examples">Ethereum Examples for Consuming Price Feeds</a>.</p>
+    <p>To learn how to implement these feeds, see the <a href="../get-the-latest-price/">Ethereum Examples for Consuming Price Feeds</a>.</p>
     <p>For LINK token and Faucet details, see the <a href="../link-token-contracts/">LINK Token Contracts</a> page.</p>
 {% endif %}
 
@@ -98,7 +98,7 @@ section: smartContract
             })
         );
     }
-    // If you are developing locally, use a local version of this file, 
+    // If you are developing locally, use a local version of this file,
     // Otherwise pull from the cron-generated web version
     let path = 'https://cl-docs-addresses.web.app/addresses.json';
     if(window.location.host === 'localhost:4200') {

--- a/docs/Using Price Feeds/get-the-latest-price-solana.md
+++ b/docs/Using Price Feeds/get-the-latest-price-solana.md
@@ -1,0 +1,237 @@
+---
+layout: nodes.liquid
+section: smartContract
+date: Last Modified
+title: "Consuming Price Feeds (Solana)"
+permalink: "docs/get-the-latest-price-solana/"
+whatsnext: {"Historical Price Data":"/docs/historical-price-data/", "Price Feeds API Reference":"/docs/price-feeds-api-reference/", "Price Feeds Contract Addresses":"/docs/reference-contracts/"}
+metadata:
+  title: "Consuming Price Feeds (Solana)"
+  description: "How to use Chainlink Price Feeds in your smart contracts."
+  image:
+    0: "/files/OpenGraph_V3.png"
+---
+
+Price data feeds are available on the following networks:
+- **Solana network**
+- [EVM-compatible networks](../get-the-latest-price/)
+
+The full list of price data feeds for each network is available on the [Price Feed Contracts](../reference-contracts/) page.
+
+Chainlink Price Feeds are live on the [Solana Devnet](https://explorer.solana.com/?cluster=devnet) with sub-second updates. Chainlink’s Solana deployment has no dependencies on external blockchain networks such as Ethereum. To learn more about the Solana programming model, see the [Solana Documentation](https://docs.solana.com/developing/programming-model/overview).
+
+To get the full list of Chainlink Price Feeds running on the Solana Devnet, see the [Solana Feeds](/docs/solana-price-feeds/) page.
+
+You can view the program ID that owns these feeds in the [Solana Devnet Explorer](https://explorer.solana.com/address/2yqG9bzKHD59MxD9q7ExLvnDhNycB3wkvKXFQSpBoiaE?cluster=devnet).
+
+> 📘 Note
+>
+> This guide shows you how to deploy and retrieve price data using the Solana network. If you need to use EVM-compatible networks, see [Consuming Price Feeds (EVM)](../get-the-latest-price/).
+
+## Overview
+
+Solana supports on-chain programs in the [Rust](https://docs.solana.com/developing/on-chain-programs/developing-rust) or [C](https://docs.solana.com/developing/on-chain-programs/developing-c) languages. This guide demonstrates the following tasks:
+
+- Write and deploy programs to the Solana Devnet using Rust.
+- Retrieve price data using the [Solana Web3 JavaScript API](https://www.npmjs.com/package/@solana/web3.js) with Node and Yarn.
+
+In Solana, storage and smart contract logic are separate. Programs store all the logic similar to an EVM smart contract. The accounts store all the data. Solana programs are stateless, so you don't always need to deploy your program to the network to test it. Compared to Solidity, the combination of an account and a program is equivalent to a smart contract on an EVM chain. State and logic are separate in Solana. This example shows you how to work with a program that you deploy, but you can refactor the client section to work with a program ID of your choice.
+
+## Requirements
+
+This guide requires the following tools:
+
+- Build and deploying Solana programs:
+  - [Rust](https://www.rust-lang.org/tools/install)
+  - [The Solana CLI](https://docs.solana.com/cli/install-solana-cli-tools#use-solanas-install-tool)
+  - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- Call the deployed program to read from the [SOL / USD price data feed](https://explorer.solana.com/address/FmAmfoyPXiA8Vhhe6MZTr3U6rZfEZ1ctEHay1ysqCqcf?cluster=devnet):
+  - [Node.js 12 or higher](https://nodejs.org/en/download/)
+  - [Yarn](https://classic.yarnpkg.com/en/docs/install/)
+
+## Create and deploy a program to the Solana Devnet
+
+1. Clone the [chainlink-solana-demo](https://github.com/smartcontractkit/chainlink-solana-demo) repository:
+
+    ```bash
+    git clone https://github.com/smartcontractkit/chainlink-solana-demo
+    ```
+
+    ```bash
+    cd chainlink-solana-demo
+    ```
+
+1. Set the Solana cluster (network) to [Devnet](https://docs.solana.com/clusters#devnet):
+
+    ```bash
+    solana config set --url https://api.devnet.solana.com
+    ```
+
+1. Create a [keypair](https://docs.solana.com/terminology#keypair) for your account that you can use for testing and development. For production deployments, follow the security best practices for [Command Line Wallets](https://docs.solana.com/wallet-guide/cli#file-system-wallet-security).
+
+    ```bash
+    mkdir solana-wallet
+    ```
+
+    ```bash
+    solana-keygen new --outfile ./solana-wallet/keypair.json
+    ```
+
+1. Fund your account. On Devnet, you can use `solana airdrop` to add tokens to your account:
+
+    ```bash
+    solana airdrop 5 $(solana-keygen pubkey solana-wallet/keypair.json)
+    ```
+
+    - If the command line faucet doesn't work, use `solana-keygen pubkey` to see your public key value and request tokens from [SolFaucet](https://solfaucet.com/):
+
+        ```bash
+        solana-keygen pubkey ./solana-wallet/keypair.json
+        ```
+
+1. Build the program using the [Solana BPF](https://docs.solana.com/developing/on-chain-programs/developing-rust#how-to-build):
+
+    ```bash
+    cargo build-bpf
+    ```
+
+1. Deploy the program. The output from the previous step will give you the command to execute to deploy the program. It should look similar to this:
+
+    ```bash
+    solana program deploy target/deploy/chainlink_solana_demo.so --keypair solana-wallet/keypair.json
+    ```
+
+    If the deployment is successful, it prints your program ID:
+
+    ```bash
+    RPC URL: https://api.devnet.solana.com
+    Default Signer Path: solana-wallet/keypair.json
+    Commitment: confirmed
+    Program Id: AZRurZi6N2VTPpFJZ8DB45rCBn2MsBBYaHJfuAS7Tm4v
+    ```
+
+1. Copy the program ID and look it up in the [Solana Devnet Explorer](https://explorer.solana.com/?cluster=devnet).
+
+## Call a deployed program
+
+After you deploy the program, you can use it to retrieve data from a feed. The code for this part of the guide is in the `client` folder from the [chainlink-solana-demo](https://github.com/smartcontractkit/chainlink-solana-demo) repository.
+
+1. Change to the `client` directory and run `yarn` to install Node.js dependencies:
+
+    ```bash
+    cd client
+    ```
+
+    ```bash
+    yarn
+    ```
+
+1. Run `yarn start` to execute the script:
+
+    ```bash
+    yarn start
+    ```
+    The script completes the following steps. This does require SOL tokens. If the script cannot run due to insufficient funds, airdrop more funds to your Devnet account again.
+
+    If the script executes correctly, you will see output with the current price of SOL/USD.
+
+## Review the example code
+
+You can view the Rust code and Typescript for this example on GitHub. See the [chainlink-solana-demo](https://github.com/smartcontractkit/chainlink-solana-demo) repository. The example code has a few main components:
+
+- The [client Typescript files](https://github.com/smartcontractkit/chainlink-solana-demo/tree/main/client/src) that establish a connection to the deployed program, determine the fees associated with retrieving the feed data, handle serialization and deserialization of data, and report the returned price from the specified price data feed. In this case, the script tells your deployed Solana program to retrieve the price of SOL / USD from [FmAmfoyPXiA8Vhhe6MZTr3U6rZfEZ1ctEHay1ysqCqcf](https://explorer.solana.com/address/FmAmfoyPXiA8Vhhe6MZTr3U6rZfEZ1ctEHay1ysqCqcf?cluster=devnet).
+- The [`./src/lib.rs`](https://github.com/smartcontractkit/chainlink-solana-demo/blob/main/src/lib.rs) file that defines the on-chain program for retrieving price data from a specified [Solana Price Feed](../solana-price-feeds/). This program also imports some methods from the main [smartcontractkit/chainlink-solana](https://github.com/smartcontractkit/chainlink-solana) repository.
+- The program imports some dependencies from the [chainlink-solana](https://github.com/smartcontractkit/chainlink-solana) repository.
+
+The example code operates using the following process:
+
+1. The client [`main.ts`](https://github.com/smartcontractkit/chainlink-solana-demo/blob/main/client/src/main.ts) script defines the process for connecting to the cluster, establishing fee payment, and verifying that your Solana program deployed correctly. The script also calls `getPrice` and `reportPrice` in the [`hello_world.ts`](https://github.com/smartcontractkit/chainlink-solana-demo/blob/main/client/src/hello_world.ts) file.
+
+1. The `getPrice` function defines `const priceFeedAccount` to specify which price data feed to use. Then, it creates `const instruction` with a formatted [transaction](https://docs.solana.com/terminology#transaction) that your deployed Solana program can process. The script sends that instruction and waits for the transaction to confirm that it is complete.
+
+    ```Typescript
+    export async function getPrice(): Promise<void> {
+      console.log('Getting data from ', readingPubkey.toBase58())
+      const priceFeedAccount = "FmAmfoyPXiA8Vhhe6MZTr3U6rZfEZ1ctEHay1ysqCqcf"
+      const AggregatorPublicKey = new PublicKey(priceFeedAccount)
+      const instruction = new TransactionInstruction({
+        keys: [{ pubkey: readingPubkey, isSigner: false, isWritable: true },
+        { pubkey: AggregatorPublicKey, isSigner: false, isWritable: false }],
+        programId,
+        data: Buffer.alloc(0), // All instructions are hellos
+      })
+      await sendAndConfirmTransaction(
+        connection,
+        new Transaction().add(instruction),
+        [payer],
+      )
+    }
+    ```
+
+1. Your deployed program receives the request and starts processing at the [`entrypoint` in `src/lib.rs`](https://github.com/smartcontractkit/chainlink-solana-demo/blob/main/src/lib.rs#L45). This is the Rust program that you built and deployed to the Solana Devnet.
+
+1. The `process_instruction` function in `lib.rs` receives the transaction with the specified feed address and handles the steps to retrieve and store the price data on-chain. The function also calls `get_price()` from the [chainlink-solana](https://github.com/smartcontractkit/chainlink-solana) package, which gets imported from GitHub in the `Cargo.toml` file. See the [`Cargo.toml`](https://github.com/smartcontractkit/chainlink-solana-demo/blob/main/Cargo.toml#L19) file, which maps the `chainlink-solana` package to `chainlink`.
+
+    ```rust
+    pub fn process_instruction(
+        _program_id: &Pubkey, // Ignored
+        accounts: &[AccountInfo], // Public key of the account to read price data from
+        _instruction_data: &[u8], // Ignored
+    ) -> ProgramResult {
+        msg!("Chainlink Solana Demo program entrypoint");
+
+        let accounts_iter = &mut accounts.iter();
+        // This is the account of our our account
+        let my_account = next_account_info(accounts_iter)?;
+        // This is the account of the price feed data
+        let feed_account = next_account_info(accounts_iter)?;
+
+        const DECIMALS: u32 = 9;
+
+        let price = chainlink::get_price(&chainlink::id(), feed_account)?;
+
+        if let Some(price) = price {
+            let decimal = Decimal::new(price, DECIMALS);
+            msg!("Price is {}", decimal);
+        } else {
+            msg!("No current price");
+        }
+
+         // Store the price ourselves
+         let mut price_data_account = PriceFeedAccount::try_from_slice(&my_account.data.borrow())?;
+         price_data_account.answer = price.unwrap_or(0);
+         price_data_account.serialize(&mut &mut my_account.data.borrow_mut()[..])?;
+
+
+        Ok(())
+    }
+    ```
+
+1. After the deployed Solana program finishes storing the data on-chain, the script retrieves the price data from the on-chain storage and prints it to the console.
+
+    ```rust
+    export async function reportPrice(): Promise<void> {
+      // const priceFeedAccount = "FmAmfoyPXiA8Vhhe6MZTr3U6rZfEZ1ctEHay1ysqCqcf"
+      // const AggregatorPublicKey = new PublicKey(priceFeedAccount)
+      const accountInfo = await connection.getAccountInfo(readingPubkey)
+      if (accountInfo === null) {
+        throw new Error('Error: cannot find the aggregator account')
+      }
+      const latestPrice = borsh.deserialize(
+        AggregatorSchema,
+        AggregatorAccount,
+        accountInfo.data,
+      )
+      console.log("Current price of SOL/USD is: ", latestPrice.answer.toString())
+    }
+    ```
+
+In addition to the main functions of this example, several smaller components are required:
+
+- The [`solana-program` crate](https://lib.rs/crates/solana-program) provides necessary functions for on-chain transactions.
+- The communications between the script and the deployed program are serialized and deserialized using [Borsh](https://borsh.io/).
+- The [Solana JavaScript API](https://solana-labs.github.io/solana-web3.js/) handles RPCs required to retrieve account data.
+
+If you want to experiment with the code yourself to learn how it works, see this [example code on GitHub](https://github.com/smartcontractkit/chainlink-solana-demo/).
+
+To learn more about Solana, see the [Solana Documentation](https://docs.solana.com/).

--- a/docs/Using Price Feeds/get-the-latest-price.html
+++ b/docs/Using Price Feeds/get-the-latest-price.html
@@ -2,43 +2,39 @@
 layout: nodes.liquid
 section: smartContract
 date: Last Modified
-title: "Consuming Price Feeds"
+title: "Consuming Price Feeds (EVM)"
 permalink: "docs/get-the-latest-price/"
 whatsnext: {"Historical Price Data":"/docs/historical-price-data/", "Price Feeds API Reference":"/docs/price-feeds-api-reference/", "Price Feeds Contract Addresses":"/docs/reference-contracts/"}
 metadata:
-  title: "Consuming Price Feeds"
+  title: "Consuming Price Feeds (EVM)"
   description: "How to use Chainlink Price Feeds in your smart contracts."
   image:
     0: "/files/OpenGraph_V3.png"
 ---
- {% markdown %}
+{% markdown %}
 
-Price data feeds are available on the following networks:
-- [EVM-compatible networks](#ethereum-network-examples)
-- [Solana network](#solana-network-examples)
+Data feeds are available on the following networks:
+- **EVM-compatible networks**
+- [Solana network](../get-the-latest-price-solana/)
 
-To get a full list of supported blockchains for price feeds, see the [Price Feeds Contract Addresses](../reference-contracts/) page.
+You can use smart contracts to get asset prices on EVM-compatible networks. These examples show you how to get the price of Ethereum (ETH) on the Ethereum network, but you can modify the examples to work on other EVM-compatible networks as well. The list of price feeds for each network are available on the [Price Feed Contracts](../reference-contracts/) page. For development, use testnet feeds such as the [ETH/USD Price Feed](https://kovan.etherscan.io/address/0x9326BFA02ADD2366b30bacB125260Af641031331) on the Kovan testnet.
+
+> 📘 New Feed Registry
+> You can use the [Feed Registry](../feed-registry/) to reference price feed assets by name or currency identifier instead of by pair/proxy address.
+
+You can write smart contracts that consume data feeds using several languages, but this guide shows you the following examples:
+
+- [Solidity](#solidity)
+- [Javascript](#javascript) with [web3.js](https://web3js.readthedocs.io/)
+- [Python](#python) with [Web3.py](https://web3py.readthedocs.io/en/stable/)
 
 > 📘 Note
 >
-> The full list of price feeds for each network are available from [Price Feed Contracts](../reference-contracts/).
+> This guide shows you how to deploy and interact with data feeds using EVM networks. To learn how to use Solana networks, see [Solana networks](../get-the-latest-price-solana/).
 
-> 📘 New Feed Registry
-> You can now use the [Feed Registry](../feed-registry/) to reference price feed assets by name or currency identifier instead of pair/proxy address.
+## Solidity
 
-## Ethereum network examples
-
-You can get the latest price of Ethereum (ETH) inside smart contracts. For development and testing, use the [ETH/USD Price Feed](https://kovan.etherscan.io/address/0x9326BFA02ADD2366b30bacB125260Af641031331) on the Kovan testnet.
-
-You can consume price feed data using examples from one of the following languages:
-
-- [Solidity](#solidity)
-- [Javascript](#javascript)
-- [Python](#python)
-
-### Solidity
-
-To consume price data, your smart contract should reference [`AggregatorV3Interface`](https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.6/interfaces/AggregatorV3Interface.sol), which defines the external functions implemented by Price Feeds.
+Your smart contract should reference the [`AggregatorV3Interface`](https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.6/interfaces/AggregatorV3Interface.sol) to retrieve price data. This interface defines the external functions implemented by data feeds.
 
 ```solidity Kovan
 {% include samples/PriceFeeds/PriceConsumerV3.sol %}
@@ -53,15 +49,17 @@ To consume price data, your smart contract should reference [`AggregatorV3Interf
     </div>
 </div>
 
-The `latestRoundData` function returns five values representing information about the latest price data. See [Price Feeds API Reference](../price-feeds-api-reference/) for more details.
+The `latestRoundData` function returns five values representing information about the latest data. See [Price Feeds API Reference](../price-feeds-api-reference/) for more details.
 
-### Javascript
+## Javascript
+
+This example uses [web3.js](https://web3js.readthedocs.io/) to retrieve feed data from the [ETH / USD feed](https://kovan.etherscan.io/address/0x9326BFA02ADD2366b30bacB125260Af641031331) on the Ethereum network.
 
 ```javascript Kovan
 {% include samples/PriceFeeds/PriceConsumerV3.js %}
 ```
 
- {% endmarkdown %}
+{% endmarkdown %}
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/web3/1.3.0/web3.min.js" integrity="sha512-ppuvbiAokEJLjOUQ24YmpP7tTaLRgzliuldPRZ01ul6MhRC+B8LzcVkXmUsDee7ne9chUfApa9/pWrIZ3rwTFQ==" crossorigin="anonymous"></script>
 <script src="/get-latest-price.js"></script>
@@ -73,9 +71,12 @@ The `latestRoundData` function returns five values representing information abou
     <input id="get-price-field" type="number" placeholder="Latest Price">
 	</div>
 </div>
- {% markdown %}
 
-### Python
+{% markdown %}
+
+## Python
+
+This example uses [Web3.py](https://web3py.readthedocs.io/en/stable/) to retrieve feed data from the [ETH / USD feed](https://kovan.etherscan.io/address/0x9326BFA02ADD2366b30bacB125260Af641031331) on the Ethereum network.
 
 ```python Kovan
 {% include samples/PriceFeeds/PriceConsumerV3.py %}
@@ -87,36 +88,12 @@ The `latestRoundData` function returns five values representing information abou
     </div>
 </div>
 
-## Solana network examples
-
-Chainlink Price Feeds run live on the [Solana Devnet](https://explorer.solana.com/?cluster=devnet) with sub-second updates. Chainlink’s Solana deployment has no dependencies on external blockchain networks such as Ethereum.
-
-To get the full list of Chainlink Price Feeds running on the Solana Devnet, see the [Solana Feeds](/docs/solana-price-feeds/) page.
-
-You can view the program ID that owns these price feeds in the [Solana Devnet Explorer](https://explorer.solana.com/address/2yqG9bzKHD59MxD9q7ExLvnDhNycB3wkvKXFQSpBoiaE?cluster=devnet).
-
-### Rust
-
-To learn how to deploy and interact with these price feeds using Solana and Rust, follow the README instructions on the [Devnet Deployment Demo](https://github.com/smartcontractkit/chainlink-solana-demo).
-
-This demo shows you how to complete the following tasks:
-- Deploy your own program that uses Chainlink Data Feeds
-- Interact with an account that stores state from a deployed program
-
-In comparison to Solidity, the combination of an account and a program is equivalent to a smart contract on an EVM chain. The demo shows you how to work with a program that you deploy, but you can refactor the client section to work with a program ID of your choice. State and logic are separated in Solana.
-
-<div class="row cl-button-container">
-    <div class="col-xs-12 col-md-12">
-    <a href="https://github.com/smartcontractkit/chainlink-solana-demo" class="cl-button--ghost python-tracked">Start the Solana Devnet Deployment Demo ↗</a>
-    </div>
-</div>
-
 ## How Do Price Feeds Get Their Data?
 
 Price Feeds are aggregated from many data sources by a decentralized set of independent Node Operators. The [Decentralized Data Model](../architecture-decentralized-model/) describes this in detail.
 
 ## More Aggregator Functions
 
-Getting the latest price is not the only data that can be retrieved from aggregators. You can also retrieve historical price data. To find out more, move on to [Historical Price Data](../historical-price-data/).
+Getting the latest price is not the only data that aggregators can retrieve. You can also retrieve historical price data. To learn more, see the [Historical Price Data](../historical-price-data/) page.
 
 {% endmarkdown %}


### PR DESCRIPTION
Sharing this draft to get feedback.

Changes:
- Split "Getting Price Feeds" into two documents. One document is for EVM, and another for Solana.
- Expand on the process documented in the README files
- Provide additional conceptual information and links to relevant Solana documentation.
- Walk through the main components of the code to explain the logic.