### PR TITLE
comment out unused vars from PriceConsumerV3 and RandomNumberConsumer

### DIFF
--- a/_includes/samples/PriceFeeds/PriceConsumerV3.sol
+++ b/_includes/samples/PriceFeeds/PriceConsumerV3.sol
@@ -21,11 +21,11 @@ contract PriceConsumerV3 {
      */
     function getLatestPrice() public view returns (int) {
         (
-            uint80 roundID, 
+            /* uint80 roundID */,
             int price,
-            uint startedAt,
-            uint timeStamp,
-            uint80 answeredInRound
+            /* uint startedAt */,
+            /* uint timeStamp */,
+            /* uint80 answeredInRound */
         ) = priceFeed.latestRoundData();
         return price;
     }

--- a/_includes/samples/VRF/RandomNumberConsumer.sol
+++ b/_includes/samples/VRF/RandomNumberConsumer.sol
@@ -43,7 +43,7 @@ contract RandomNumberConsumer is VRFConsumerBase {
     /**
      * Callback function used by VRF Coordinator
      */
-    function fulfillRandomness(bytes32 requestId, uint256 randomness) internal override {
+    function fulfillRandomness(bytes32 /* requestId */, uint256 randomness) internal override {
         randomResult = randomness;
     }
 


### PR DESCRIPTION
`PriceConsumerV3.sol` and `RandomNumberConsumer.sol` contain unused variables which ~prevents compiling and deploying as-is~ produce compiler warnings:
![Screenshot from 2021-09-07 07-41-35](https://user-images.githubusercontent.com/1194128/132346371-e2a1cbce-1f2d-4176-a10b-8f39297aeb6e.png)
This change comments them out to ~allow for compiling without modification~ suppress the warning while keeping the type and name info for reference.