### PR TITLE
Prevent docsat stars from wrapping when page titles are very long.

### DIFF
--- a/_src/docs.css
+++ b/_src/docs.css
@@ -274,7 +274,8 @@ hr {
   flex-grow: 1;
 }
 .title .corner-floated {
-  width: 160px;
+  white-space: nowrap;
+  width: 170px;
   margin-top: 40px;
   text-align: right;
 }


### PR DESCRIPTION
Fixes #375

Long page titles and also narrow browser windows were causing doc satisfaction stars to wrap.

Staging: https://deploy-preview-378--dreamy-villani-0e9e5c.netlify.app/docs/hackathon-rules-waiver-release-and-code-of-conduct/