### PR TITLE
Add a banner for the Fall 2021 Hackathon.

### DIFF
--- a/_includes/main.liquid
+++ b/_includes/main.liquid
@@ -49,7 +49,7 @@
 
         <link href="https://assets-global.website-files.com/5f6b7190899f41fb70882d08/5fa97474da20bc75f63bfdc4_Chainlink-favicon-32.png" rel="shortcut icon" type="image/x-icon">
         <link href="https://assets-global.website-files.com/5f6b7190899f41fb70882d08/5fa973e31adbc3414aa8f77d_Chainlink-webclip.png" rel="apple-touch-icon">
-        
+
         <!-- Google Tag Manager -->
             <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -57,7 +57,7 @@
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
             })(window,document,'script','dataLayer','GTM-N6DQ47T');</script>
         <!-- End Google Tag Manager -->
-        
+
 
     </head>
 
@@ -65,27 +65,19 @@
         <!-- Google Tag Manager (noscript) -->
             <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N6DQ47T" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <!-- End Google Tag Manager (noscript) -->
-        <div class="notification" key="dev-survey-2021" start="2021-05-01" end="2021-06-30">
+        <div class="notification" key="fall-2021-hackathon" start="2021-09-17" end="2021-10-21">
             <div class="notification-info">
                 <span class="notification-close">X</span>
                 <span class="notification-text">
-                    Make your voice heard, take the <b><a href="https://chn.lk/dev-survey-2021">2021 Chainlink Developer Survey</b></a>!
+                  <span class="notification-text-highlight">FALL 2021 HACKATHON</span> OCT 22 >> NOV 28 - Join us for our biggest hackathon yet. <a href="https://chain.link/hackathon">Sign up today!<a/>
                 </span>
             </div>
         </div>
-        <div class="notification" key="smartcon-2021" start="2021-07-09" end="2021-08-04">
+        <div class="notification" key="fall-2021-hackathon" start="2021-10-22" end="2021-11-28">
             <div class="notification-info">
                 <span class="notification-close">X</span>
                 <span class="notification-text">
-                    SmartCon is back August 5-7. <a href="https://hopin.com/events/smart-contract-summit-1?ref=252e0a3dfb0a">Join us</a> for 3 days of workshops, panels, AMAs, and more.
-                </span>
-            </div>
-        </div>
-        <div class="notification" key="smartcon-live-2021" start="2021-08-05" end="2021-08-07">
-            <div class="notification-info">
-                <span class="notification-close">X</span>
-                <span class="notification-text">
-                    SmartCon is happening right now. Come <a href="https://www.smartcontractsummit.io/">watch live<a/>!
+                  <span class="notification-text-highlight">FALL 2021 HACKATHON</span> OCT 22 >> NOV 28 - The hackathon is happening now. <a href="https://chain.link/hackathon">Check it out!<a/>
                 </span>
             </div>
         </div>
@@ -101,14 +93,14 @@
                     <div class="tab"><a href="/chainlink-nodes/" {% unless section == "smartContract" %} class="active" {% endunless %}>Node Operators</a></div>
                 </div>
                 <span style="flex-grow:1;"></span>
-                
+
 
                 {% include _search.html %}
                 <a href="https://github.com/smartcontractkit/documentation/" id="github-button"><img src="/github.svg" style="height:32px;margin:0 0 0 8px;"></a>
             </nav>
         </div>
 
-   
+
 
 
         <div id="page">
@@ -143,8 +135,8 @@
                 </div>
             </div>
         </section>
-        
-        
+
+
         <footer class="footer">
             <div class="container">
                 <div class="w-layout-grid footer-grid">
@@ -299,7 +291,7 @@
 
 
         <script>
-            
+
             document.addEventListener('DOMContentLoaded', () => {
                 // Detect highlighting
                 let lastEvent = 0;
@@ -332,7 +324,7 @@
                         if(!links[i].href.startsWith("javascript:")) {
                             if (links[i].hostname != window.location.hostname) {
                                 links[i].target = '_blank';
-                            } 
+                            }
                         }
                     }
 

--- a/_src/docs.css
+++ b/_src/docs.css
@@ -231,6 +231,16 @@ navigation .menu {
   font-size: 16px;
 }
 
+.notification-text-highlight {
+    margin-right: 8px;
+    padding: 8px 8px 8px 8px;
+    border-radius: 4px;
+    background-color: #375bd2;
+    color: #fff;
+    font-size: 16px;
+    letter-spacing: 1px;
+}
+
 .notification-close {
   float: right;
   padding-top: 5px;


### PR DESCRIPTION
- Add a 2021-09-17 to 2021-10-21 notice to sign up.
- Add a 2021-10-22 to 2021-11-28 notice that the hackathon is ongoing.
- Remove previous events.

If the banner doesn't appear in the preview, open the preview in a private tab.

Preview: https://deploy-preview-380--dreamy-villani-0e9e5c.netlify.app