### PR TITLE
Modify the Fall 2021 Hackathon banner.

### DIFF
--- a/_includes/main.liquid
+++ b/_includes/main.liquid
@@ -69,15 +69,15 @@
             <div class="notification-info">
                 <span class="notification-close">X</span>
                 <span class="notification-text">
-                  <span class="notification-text-highlight">FALL 2021 HACKATHON</span> OCT 22 >> NOV 28 - Join us for our biggest hackathon yet. <a href="https://chain.link/hackathon">Sign up today!<a/>
+                  <span class="notification-text-highlight">NEW</span>The Chainlink Fall 2021 Hackathon kicks off October 22. <a href="https://chain.link/hackathon">Sign up today.<a/>
                 </span>
             </div>
         </div>
-        <div class="notification" key="fall-2021-hackathon" start="2021-10-22" end="2021-11-28">
+        <div class="notification" key="fall-2021-hackathon" start="2021-10-22" end="2021-10-31">
             <div class="notification-info">
                 <span class="notification-close">X</span>
                 <span class="notification-text">
-                  <span class="notification-text-highlight">FALL 2021 HACKATHON</span> OCT 22 >> NOV 28 - The hackathon is happening now. <a href="https://chain.link/hackathon">Check it out!<a/>
+                  The Chainlink Fall 2021 Hackathon is happening now. <a href="https://chain.link/hackathon">Check it out.<a/>
                 </span>
             </div>
         </div>


### PR DESCRIPTION
- Re-word the banner text to match the banner on https://chain.link.
- Change the dates for the second banner.