### PR TITLE
attempt to fix multiple arguments support via latest sha

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       # Version 2.0.19 of linkcheck
       - name: Check docs links with linkcheck
-        uses: filiph/linkcheck@361180ff3ed7feb076d8094fb345238ef035a0c3
+        uses: filiph/linkcheck@342ae586489f6bf1113ba2ec793eb806896a3be1
         with:
           arguments: https://docs.chain.link/ -e
       - name: Check chain.link with linkcheck
-        uses: filiph/linkcheck@361180ff3ed7feb076d8094fb345238ef035a0c3
+        uses: filiph/linkcheck@342ae586489f6bf1113ba2ec793eb806896a3be1
         with:
           arguments: https://chain.link -e


### PR DESCRIPTION
Right now our schedule linkchecker fails with:

```Provided URLs failing:
https://docs.chain.link/%20-e (HTTP 404)


Stats:
       0 links
       1 destination URLs
       0 URLs ignored
       0 warnings
       1 errors
```

This attempts to fix this by moving to the latest version