### PR TITLE
Add KEEPER_REGISTRY_SYNC_UPKEEP_QUEUE_SIZE Env Var to configuration-variables.md

### DIFF
--- a/docs/Node Operators/configuration-variables.md
+++ b/docs/Node Operators/configuration-variables.md
@@ -37,6 +37,7 @@ The env variables listed here are explicitly supported and current as of Chainli
   - [KEEPER_REGISTRY_CHECK_GAS_OVERHEAD](#keeper_registry_check_gas_overhead)
   - [KEEPER_REGISTRY_PERFORM_GAS_OVERHEAD](#keeper_registry_perform_gas_overhead)
   - [KEEPER_REGISTRY_SYNC_INTERVAL](#keeper_registry_sync_interval)
+  - [KEEPER_REGISTRY_SYNC_UPKEEP_QUEUE_SIZE](#keeper_registry_sync_upkeep_queue_size)
 - [TLS](#tls)
   - [CHAINLINK_TLS_HOST](#chainlink_tls_host)
   - [CHAINLINK_TLS_PORT](#chainlink_tls_port)
@@ -254,6 +255,12 @@ The amount of extra gas to provide performUpkeep() calls to account for the gas 
 - Default: `"30m"`
 
 The interval in which the RegistrySynchronizer performs a full sync of the keeper registry contract it is tracking.
+
+## KEEPER_REGISTRY_SYNC_UPKEEP_QUEUE_SIZE
+
+- Default: `"10"`
+
+The maximum number of upkeeps that can be synced in parallel.
 
 # TLS
 


### PR DESCRIPTION
Add KEEPER_REGISTRY_SYNC_UPKEEP_QUEUE_SIZE Environment Variable to the Node Operators documentation matching the changes from this PR already merged to the chainlink main repo: https://github.com/smartcontractkit/chainlink/pull/5162

See story for more details: https://app.shortcut.com/chainlinklabs/story/9028/make-synchupkeepqueue-size-configurable