### PR TITLE
Remove hard-coded Solidity versions from Remix links.

### DIFF
--- a/_src/deploy-to-github.js
+++ b/_src/deploy-to-github.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const host = window.location.hostname;
   if (host !== 'docs.chain.link') {
     // Rewrite Remix URLs with current hostname
-    // eg https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/VRF/VRFD20.sol
+    // eg https://remix.ethereum.org/#url=https://docs.chain.link/samples/VRF/VRFD20.sol
 
     for (let item of document.links) {
       if (item.href.startsWith('https://remix.ethereum.org')) {

--- a/docs/Data Provider Nodes/chainlink-alarm-clock.md
+++ b/docs/Data Provider Nodes/chainlink-alarm-clock.md
@@ -4,13 +4,13 @@ section: smartContract
 date: Last Modified
 title: "Chainlink Alarm Clock (Testnet)"
 permalink: "docs/chainlink-alarm-clock/"
-metadata: 
-  image: 
+metadata:
+  image:
     0: "/files/807bfbc-cl.png"
 ---
 
 > 🚧 Note
-> 
+>
 > Chainlink Alarm Clock is is an outdated way of automating time-based requests. Please, consider using [Keepers](../chainlink-keepers/introduction/) instead.
 
 
@@ -20,7 +20,7 @@ You can use Chainlink to trigger a smart contract at a specified time. Using thi
 
 - Write and deploy your [Chainlinked](../intermediates-tutorial/)  contract using the network details below
 - Fund it with [LINK](../link-token-contracts/) (0.1 LINK is required per-request/)
-- Call your [request method](./#chainlink-examples) 
+- Call your [request method](./#chainlink-examples)
 
 # Chainlink Network Details
 
@@ -50,12 +50,12 @@ contract ChainlinkAlarmClock is ChainlinkClient {
     oraclePayment = _oraclePayment;
   }
   // Additional functions here:
-  
+
 }
 ```
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/DataProviders/AlarmClock.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/DataProviders/AlarmClock.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 
@@ -74,7 +74,7 @@ contract ChainlinkAlarmClock is ChainlinkClient {
 The timestamp for which the Chainlink node will wait to respond.
 
 > 🚧 `now` keyword"
-> 
+>
 > Solidity 0.7.0 deprecated the now keyword. For contracts ^0.7.0, you must use `block.timestamp`
 
 #### Solidity example

--- a/docs/Data Provider Nodes/dns-ownership-oracle.md
+++ b/docs/Data Provider Nodes/dns-ownership-oracle.md
@@ -17,7 +17,7 @@ This oracle checks Google’s DNS service to determine if a given domain is owne
 
 #### Ethereum Mainnet
 Payment Amount: 1 LINK  
-LINK Token Address: `{{variables.MAINNET_LINK_TOKEN}}` 
+LINK Token Address: `{{variables.MAINNET_LINK_TOKEN}}`
 Oracle Address: `0x240BaE5A27233Fd3aC5440B5a598467725F7D1cd`  
 JobID: `6ca2e68622bd421d98c648f056ee7c76`
 
@@ -35,7 +35,7 @@ JobID: `fb06afd5a9df4e6cb156f6b797b63a24`
 
 #### Polygon (Matic) Mainnet
 Payment Amount: 0.1 LINK  
-LINK Token Address: `{{variables.MATIC_MAINNET_LINK_TOKEN}}` 
+LINK Token Address: `{{variables.MATIC_MAINNET_LINK_TOKEN}}`
 Oracle Address: `0x63B72AF260E8b40A7b89E238FeB53448A97b03D2`  
 JobID: `f3daed2990114e98906aaf21c4172da3`  
 
@@ -49,15 +49,15 @@ pragma solidity ^0.4.24;
 import "@chainlink/contracts/v0.4/ChainlinkClient.sol";
 
 contract DnsOwnershipChainlink is ChainlinkClient {
-  
+
   uint256 oraclePayment;
-  
+
   constructor(uint256 _oraclePayment) public {
     setPublicChainlinkToken();
     oraclePayment = _oraclePayment;
   }
   // Additional functions here:
-  
+
 }
 ```
 ```solidity Solidity 5
@@ -66,15 +66,15 @@ pragma solidity ^0.5.0;
 import "@chainlink/contracts/v0.5/ChainlinkClient.sol";
 
 contract DnsOwnershipChainlink is ChainlinkClient {
-  
+
   uint256 oraclePayment;
-  
+
   constructor(uint256 _oraclePayment) public {
     setPublicChainlinkToken();
     oraclePayment = _oraclePayment;
   }
   // Additional functions here:
-  
+
 }
 ```
 ```solidity Solidity 6
@@ -83,20 +83,20 @@ pragma solidity ^0.6.0;
 import "@chainlink/contracts/v0.6/ChainlinkClient.sol";
 
 contract DnsOwnershipChainlink is ChainlinkClient {
-  
+
   uint256 oraclePayment;
-  
+
   constructor(uint256 _oraclePayment) public {
     setPublicChainlinkToken();
     oraclePayment = _oraclePayment;
   }
   // Additional functions here:
-  
+
 }
 ```
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/DataProviders/DnsOwnership.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/DataProviders/DnsOwnership.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 
@@ -134,9 +134,9 @@ function requestProof
   string memory _txt,
   string memory _name,
   string memory _record
-) 
-  public 
-  onlyOwner 
+)
+  public
+  onlyOwner
 {
   Chainlink.Request memory req = buildChainlinkRequest(_jobId, address(this), this.fulfill.selector);
   req.add("type", _txt);

--- a/docs/Data Provider Nodes/finage-global-market-data-oracle.md
+++ b/docs/Data Provider Nodes/finage-global-market-data-oracle.md
@@ -18,7 +18,7 @@ Finage is a leading real-time stock, forex, and cryptocurrency data provider. Th
 
 #### Ethereum Mainnet
 Payment Amount: 1 LINK  
-LINK Token Address: `{{variables.MAINNET_LINK_TOKEN}}` 
+LINK Token Address: `{{variables.MAINNET_LINK_TOKEN}}`
 Oracle Address: `0xE98dFc0C36408b54326Fa11235D573574B1e8eC3`  
 JobID: `3e478404a3ca4cf5abd2820efe7c1913`  
 
@@ -44,15 +44,15 @@ pragma solidity ^0.4.24;
 import "@chainlink/contracts/v0.4/ChainlinkClient.sol";
 
 contract FinageChainlink is ChainlinkClient {
-  
+
   uint256 oraclePayment;
-  
+
   constructor(uint256 _oraclePayment) public {
     setPublicChainlinkToken();
     oraclePayment = _oraclePayment;
   }
   // Additional functions here:
-  
+
 }
 ```
 ```solidity Solidity 5
@@ -61,15 +61,15 @@ pragma solidity ^0.5.0;
 import "@chainlink/contracts/v0.5/ChainlinkClient.sol";
 
 contract FinageChainlink is ChainlinkClient {
-  
+
   uint256 oraclePayment;
-  
+
   constructor(uint256 _oraclePayment) public {
     setPublicChainlinkToken();
     oraclePayment = _oraclePayment;
   }
   // Additional functions here:
-  
+
 }
 ```
 ```solidity Solidity 6
@@ -78,20 +78,20 @@ pragma solidity ^0.6.0;
 import "@chainlink/contracts/v0.6/ChainlinkClient.sol";
 
 contract FinageChainlink is ChainlinkClient {
-  
+
   uint256 oraclePayment;
-  
+
   constructor(uint256 _oraclePayment) public {
     setPublicChainlinkToken();
     oraclePayment = _oraclePayment;
   }
   // Additional functions here:
-  
+
 }
 ```
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/DataProviders/Finage.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+    <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/DataProviders/Finage.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Data Provider Nodes/google-weather.md
+++ b/docs/Data Provider Nodes/google-weather.md
@@ -11,7 +11,7 @@ You can use Chainlink to digest weather information using [Google Cloud Public D
 
 ## Parameters and External Adapters Details
 
-These jobs are using a custom external adapter. Please see the [Google weather external adapter](https://github.com/smartcontractkit/external-adapters-js/tree/develop/packages/composites/google-weather) to see information about parameters that can be used with these jobs. 
+These jobs are using a custom external adapter. Please see the [Google weather external adapter](https://github.com/smartcontractkit/external-adapters-js/tree/develop/packages/composites/google-weather) to see information about parameters that can be used with these jobs.
 
 # Chainlink Network Details
 
@@ -49,20 +49,20 @@ You will need to use the following LINK token address, oracle address, and JobSp
 # Steps For Using This Oracle
 
 - Write and deploy your [Chainlinked](../intermediates-tutorial/)  contract using the network details above.
-- Fund it with [LINK](../link-token-contracts/) 
+- Fund it with [LINK](../link-token-contracts/)
 - Call your request method
 
 
 # Create your Chainlinked contract
 
-Import `ChainlinkClient.sol` into your contract so you can inherit the `ChainlinkClient` behavior. Below is a sample that can call the hail, rain, and average temperature jobs to fetch weather data from Bergen, Norway. 
+Import `ChainlinkClient.sol` into your contract so you can inherit the `ChainlinkClient` behavior. Below is a sample that can call the hail, rain, and average temperature jobs to fetch weather data from Bergen, Norway.
 
 ```solidity
 {% include samples/DataProviders/GoogleWeather.sol %}
 ```
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.12+commit.27d51765.js&optimize=false&evmVersion=null&runs=200&url=https://docs.chain.link/samples/DataProviders/GoogleWeather.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/DataProviders/GoogleWeather.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 
@@ -251,4 +251,4 @@ Import `ChainlinkClient.sol` into your contract so you can inherit the `Chainlin
 |     ✅     |  `field`   |                                                                          Which column to fetch data from                                                                           | [Data available](https://github.com/smartcontractkit/external-adapters-js/tree/develop/packages/composites/google-weather#data-available) |             |
 |           |  `units`   | What unit system to return the result in ([conversions](https://github.com/smartcontractkit/external-adapters-js/tree/develop/packages/composites/google-weather#unit-conversion)) |                                                           `imperial`, `metric`                                                            | `imperial`  |
 
-Please see the [Google weather external adapter](https://github.com/smartcontractkit/external-adapters-js/tree/develop/packages/composites/google-weather) to see information about parameters that can be used with these jobs. 
+Please see the [Google weather external adapter](https://github.com/smartcontractkit/external-adapters-js/tree/develop/packages/composites/google-weather) to see information about parameters that can be used with these jobs.

--- a/docs/Data Provider Nodes/kraken-rates-oracle-node.md
+++ b/docs/Data Provider Nodes/kraken-rates-oracle-node.md
@@ -4,17 +4,17 @@ section: smartContract
 date: Last Modified
 title: "Kraken Rates Oracle Node"
 permalink: "docs/kraken-rates-oracle-node/"
-metadata: 
-  image: 
+metadata:
+  image:
     0: "/files/2713d5c-cl.png"
 ---
-This Chainlink has a dedicated connection to <a href="https://blog.cfbenchmarks.com/rest-api/" target="_blank">Kraken's Prices</a> API. 
+This Chainlink has a dedicated connection to <a href="https://blog.cfbenchmarks.com/rest-api/" target="_blank">Kraken's Prices</a> API.
 
 # Steps for using this oracle
 
 - Write and deploy your [Chainlink](../intermediates-tutorial/)  contract using the network details below
 - Fund it with [LINK](../link-token-contracts/)
-- Call your [request method](./#chainlink-examples) 
+- Call your [request method](./#chainlink-examples)
 
 # Network Details
 
@@ -23,19 +23,19 @@ You will need to use the following LINK token address, oracle address, and Job I
 #### Rinkeby
 Payment amount: 1 LINK
 LINK Token address: `{{variables.RINKEBY_LINK_TOKEN}}`
-Oracle address: `{{variables.RINKEBY_CHAINLINK_ORACLE}}` 
+Oracle address: `{{variables.RINKEBY_CHAINLINK_ORACLE}}`
 JobID: `49ea116156cd44be997e7670a5dde80d`
 
 #### Kovan
 Payment amount: 1 LINK
 LINK Token address: `{{variables.KOVAN_LINK_TOKEN}}`
-Oracle address: `{{variables.KOVAN_CHAINLINK_ORACLE}}` 
+Oracle address: `{{variables.KOVAN_CHAINLINK_ORACLE}}`
 JobID: `8f4eeda1a8724077a0560ee84eb006b4`
 
 #### Mainnet
 Payment amount: 0.5 LINK
 LINK Token address: `{{variables.MAINNET_LINK_TOKEN}}`
-Oracle address: `{{variables.MAINNET_CHAINLINK_ORACLE}}` 
+Oracle address: `{{variables.MAINNET_CHAINLINK_ORACLE}}`
 JobID: contact `dataproviders@chain.link` for details
 
 # Create your contract
@@ -48,15 +48,15 @@ pragma solidity ^0.4.24;
 import "@chainlink/contracts/v0.4/ChainlinkClient.sol";
 
 contract KrakenChainlink is ChainlinkClient {
-  
+
   uint256 oraclePayment;
-  
+
   constructor(uint256 _oraclePayment) public {
     setPublicChainlinkToken();
     oraclePayment = _oraclePayment;
   }
   // Additional functions here:
-  
+
 }
 ```
 ```solidity Solidity 5
@@ -65,15 +65,15 @@ pragma solidity ^0.5.0;
 import "@chainlink/contracts/v0.5/ChainlinkClient.sol";
 
 contract KrakenChainlink is ChainlinkClient {
-  
+
   uint256 oraclePayment;
-  
+
   constructor(uint256 _oraclePayment) public {
     setPublicChainlinkToken();
     oraclePayment = _oraclePayment;
   }
   // Additional functions here:
-  
+
 }
 ```
 ```solidity Solidity 6
@@ -82,20 +82,20 @@ pragma solidity ^0.6.0;
 import "@chainlink/contracts/v0.6/ChainlinkClient.sol";
 
 contract KrakenChainlink is ChainlinkClient {
-  
+
   uint256 oraclePayment;
-  
+
   constructor(uint256 _oraclePayment) public {
     setPublicChainlinkToken();
     oraclePayment = _oraclePayment;
   }
   // Additional functions here:
-  
+
 }
 ```
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/DataProviders/Kraken.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/DataProviders/Kraken.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 
@@ -121,7 +121,7 @@ req.add("index", "DEFI_KXBTUSD");
 ```
 
 Index identifiers include:
- 
+
 - DEFI_KXBTUSD
 - DEFI_KETHUSD
 - DEFI_KBCHUSD

--- a/docs/Data Provider Nodes/lcx-testnet.md
+++ b/docs/Data Provider Nodes/lcx-testnet.md
@@ -4,17 +4,17 @@ section: smartContract
 date: Last Modified
 title: "LCX (Testnet)"
 permalink: "docs/lcx-testnet/"
-metadata: 
-  image: 
+metadata:
+  image:
     0: "/files/OpenGraph_V3.png"
 ---
-This Chainlink has a dedicated connection to <a href="https://www.lcx.com/Cryptocurrency-Reference-Price-Services/" target="_blank">LCX's Cryptocurrency Reference Prices</a> API. This service offers reliable daily reference prices of the U.S. dollar price and Euro price of one Bitcoin and one Ethereum. 
+This Chainlink has a dedicated connection to <a href="https://www.lcx.com/Cryptocurrency-Reference-Price-Services/" target="_blank">LCX's Cryptocurrency Reference Prices</a> API. This service offers reliable daily reference prices of the U.S. dollar price and Euro price of one Bitcoin and one Ethereum.
 
 # Steps for using this oracle
 
 - Write and deploy your [Chainlink](../intermediates-tutorial/)  contract using the network details below
 - Fund it with [LINK](../link-token-contracts/) (1 LINK is required per-request/)
-- Call your [request method](./#chainlink-examples) 
+- Call your [request method](./#chainlink-examples)
 
 # Network Details
 
@@ -22,12 +22,12 @@ You will need to use the following LINK token address, oracle address, and Job I
 
 #### Rinkeby
 LINK Token address: {{variables.RINKEBY_LINK_TOKEN}}
-Oracle address: {{variables.RINKEBY_CHAINLINK_ORACLE}} 
+Oracle address: {{variables.RINKEBY_CHAINLINK_ORACLE}}
 JobID: eb3b27aac93e4bf68406f164b86b049e
 
 #### Kovan
 LINK Token address: {{variables.KOVAN_LINK_TOKEN}}
-Oracle address: {{variables.KOVAN_CHAINLINK_ORACLE}} 
+Oracle address: {{variables.KOVAN_CHAINLINK_ORACLE}}
 JobID: 81c63592d97a4485b1d1339b3578e07f
 
 # Create your contract
@@ -40,15 +40,15 @@ pragma solidity ^0.4.24;
 import "@chainlink/contracts/src/v0.4/ChainlinkClient.sol";
 
 contract LCXChainlink is ChainlinkClient {
-  
+
   uint256 oraclePayment;
-  
+
   constructor(uint256 _oraclePayment) public {
     setPublicChainlinkToken();
     oraclePayment = _oraclePayment;
   }
   // Additional functions here:
-  
+
 }
 ```
 ```solidity Solidity 5
@@ -57,15 +57,15 @@ pragma solidity ^0.5.0;
 import "@chainlink/contracts/src/v0.5/ChainlinkClient.sol";
 
 contract LCXChainlink is ChainlinkClient {
-  
+
   uint256 oraclePayment;
-  
+
   constructor(uint256 _oraclePayment) public {
     setPublicChainlinkToken();
     oraclePayment = _oraclePayment;
   }
   // Additional functions here:
-  
+
 }
 ```
 ```solidity Solidity 6
@@ -74,20 +74,20 @@ pragma solidity ^0.6.0;
 import "@chainlink/contracts/src/v0.6/ChainlinkClient.sol";
 
 contract LCXChainlink is ChainlinkClient {
-  
+
   uint256 oraclePayment;
-  
+
   constructor(uint256 _oraclePayment) public {
     setPublicChainlinkToken();
     oraclePayment = _oraclePayment;
   }
   // Additional functions here:
-  
+
 }
 ```
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/DataProviders/LCX.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/DataProviders/LCX.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 
@@ -104,7 +104,7 @@ contract LCXChainlink is ChainlinkClient {
 
 **Required**
 
-The symbol for the cryptocurrency. 
+The symbol for the cryptocurrency.
 
 Must be ETH or BTC
 

--- a/docs/Developer Reference/user-guides/deploy-your-first-contract.md
+++ b/docs/Developer Reference/user-guides/deploy-your-first-contract.md
@@ -17,7 +17,7 @@ Remix is a web IDE (integrated development environment) for creating, running, a
 
 ## Create and deploy your first contract
 
-* Navigate to Remix: <a href="https://remix.ethereum.org/#version=soljson-v0.6.0+commit.26b70077.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/APIRequests/ATestnetConsumer.sol" target="_blank" rel="noreferrer, noopener">https://remix.ethereum.org</a>
+* Navigate to Remix: <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/APIRequests/ATestnetConsumer.sol" target="_blank" rel="noreferrer, noopener">https://remix.ethereum.org</a>
 
 * Remix opens up with an empty interface, or possible with a default contract
 
@@ -40,7 +40,7 @@ Remix is a web IDE (integrated development environment) for creating, running, a
 ![Remix Click Compile](/files/b8774fe-Screen_Shot_2020-09-08_at_7.10.07_AM.png)
 
 > 🚧
-> 
+>
 > If you get errors after compiling, make sure your compiler is set to one of the **0.6.0** compilers. If you used the link to Remix within this guide above, this would have been set for you.
 
 * Now select the `Deploy & run transactions` tab in the left-hand of Remix.
@@ -53,10 +53,10 @@ Remix is a web IDE (integrated development environment) for creating, running, a
 ![Metamask Confirm a Transaction Screen](/files/d082799-metamask.png)
 
 > 🚧 Metamask doesn't pop up?
-> 
+>
 > If Metamask does not prompt you and instead displays the error below, you will need to disable "Privacy Mode" in Metamask. You can do this by clicking on your unique account icon at the top-right, then go to the Settings. Privacy Mode will be a switch near the bottom. The error: **Send transaction failed: invalid address. If you use an injected provider, please check it is properly unlocked.**
 
-* A transaction link will be displayed at the bottom of Remix that displays deployment status. 
+* A transaction link will be displayed at the bottom of Remix that displays deployment status.
 It will take a few moments for the contract to be deployed. The Remix UI will update upon completion.
 
 ![Remix Transaction Confirmation Message](/files/8ff4abe-remix7.jpg)

--- a/docs/Introduction/tutorials/advanced-tutorial.md
+++ b/docs/Introduction/tutorials/advanced-tutorial.md
@@ -6,8 +6,8 @@ title: "API Calls Tutorial"
 permalink: "docs/advanced-tutorial/"
 excerpt: "Calling APIs from Smart Contracts"
 whatsnext: {"Make a GET Request":"/docs/make-a-http-get-request/", "Make an Existing Job Request":"/docs/existing-job-request/"}
-metadata: 
-  image: 
+metadata:
+  image:
     0: "/files/04b8e56-cl.png"
 ---
 
@@ -51,7 +51,7 @@ Let's walk through a real example, where we retrieve 24 volume of the <a href="h
 
 ### Core Adapters Example
 
-1. [HttpGet](../core-adapters/#httpget) - Calls the API and returns the body of an HTTP GET result for [ETH/USD pair](https://min-api.cryptocompare.com/data/pricemultifull?fsyms=ETH&tsyms=USD).  Example: 
+1. [HttpGet](../core-adapters/#httpget) - Calls the API and returns the body of an HTTP GET result for [ETH/USD pair](https://min-api.cryptocompare.com/data/pricemultifull?fsyms=ETH&tsyms=USD).  Example:
 ```json
 {"RAW":
   {"ETH":
@@ -87,7 +87,7 @@ Let's see what this looks like in a contract.
 ```
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/APIRequests/APIConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/APIRequests/APIConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 
@@ -97,7 +97,7 @@ Let's walk through what's happening here:
 3. `fulfill` - Where the result is sent once the Oracle job is complete
 
 > 📘 Important
-> 
+>
 > The calling contract should own enough LINK to pay the specified fee (by default 0.1 LINK). You can use [this tutorial](../fund-your-contract/) to fund your contract.
 
 This was an example of a basic HTTP GET request. However, it requires defining the API URL directly in the smart contract. This can, in fact, be extracted and configured on the Job level inside the Oracle.
@@ -131,7 +131,7 @@ function requestVolumeData() public returns (bytes32 requestId) {
     Chainlink.Request memory request = buildChainlinkRequest(jobId, address(this), this.fulfill.selector);
 
     // Extra parameters don't need to be defined here because they are already defined in the job
-        
+
     return sendChainlinkRequestTo(oracle, request, fee);
 }
 ```

--- a/docs/Introduction/tutorials/beginners-tutorial.md
+++ b/docs/Introduction/tutorials/beginners-tutorial.md
@@ -6,10 +6,10 @@ title: "The Basics Tutorial"
 permalink: "docs/beginners-tutorial/"
 excerpt: "Smart Contracts and Chainlink"
 whatsnext: {"Get the Latest Price":"/docs/get-the-latest-price/", "Deploy your first contract":"/docs/deploy-your-first-contract/", "Random Numbers Tutorial":"/docs/intermediates-tutorial/"}
-metadata: 
+metadata:
   title: "The Basics Tutorial"
   description: "Learn what smart contracts are, how to write them, and how to use Chainlink data feeds to deploy your very own Chainlink smart contract."
-  image: 
+  image:
     0: "/files/1a63254-link.png"
 ---
 
@@ -41,7 +41,7 @@ A valuable feature of smart contracts is that they can store and manage on-chain
 
 # 2. What language is a smart contract written in?
 
-The most popular language for writing smart contracts on Ethereum is <a href="https://docs.soliditylang.org/en/v0.6.7/" target="_blank">Solidity</a>. It was created by the Ethereum Foundation specifically for smart contract development and is constantly being updated.
+The most popular language for writing smart contracts on Ethereum is <a href="https://docs.soliditylang.org/en/v0.8.7/" target="_blank">Solidity</a>. It was created by the Ethereum Foundation specifically for smart contract development and is constantly being updated.
 
 If you've ever written Javascript or similar languages, Solidity should be easy to understand.
 
@@ -50,7 +50,7 @@ If you've ever written Javascript or similar languages, Solidity should be easy 
 The structure of a smart contract is similar to that of a _class_ in Javascript, with a few differences. Let's take a look at this `HelloWorld` example.
 
 ```solidity
-pragma solidity 0.6.7;
+pragma solidity 0.8.7;
 
 contract HelloWorld {
     string public message;
@@ -67,7 +67,7 @@ contract HelloWorld {
 
 ## 3a. Define the version `pragma solidity ...`
 
-The first thing that every solidity file must have is the Solidity version definition. The version HelloWorld.sol is using is 0.6.6, defined by `pragma solidity 0.6.6;`
+The first thing that every solidity file must have is the Solidity version definition. The version HelloWorld.sol is using is 0.8.7, defined by `pragma solidity 0.8.7;`
 
 You can see the latest versions of the Solidity compiler <a href="https://github.com/ethereum/solc-bin/blob/gh-pages/bin/list.txt" target="_blank">here</a>.
 
@@ -77,7 +77,7 @@ Next, the `HelloWorld` contract is defined by using the keyword `contract`. Thin
 
 ## 3c. State variables `string public ...`
 
-Again, like Javascript, contracts can have state variables and local variables. To find out more about all the types of variables you can use within Solidity, check out the <a href="https://docs.soliditylang.org/en/v0.6.7/" target="_blank">Solidity documentation</a>.
+Again, like Javascript, contracts can have state variables and local variables. To find out more about all the types of variables you can use within Solidity, check out the <a href="https://docs.soliditylang.org/en/v0.8.7/" target="_blank">Solidity documentation</a>.
 
 There are also different _modifiers_ you can use depending on what should have access to those variables.
 
@@ -121,7 +121,7 @@ The following code is from the [Get the Latest Price](../get-the-latest-price/) 
 
 On the 3rd line, the code imports an interface called `AggregatorV3Interface`. An interface is another concept that will be familiar to programmers of other languages. Interfaces define functions without their implementation, leaving inheriting contracts to define the actual implementation themselves.
 
-Interfaces make it easier for calling contracts to know what functions to call. For example, in this case, `AggregatorV3Interface` defines that all V3 Aggregators will have the function `latestRoundData`. We can see all of the functions that a V3 Aggregator exposes in the <a href="https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.6/interfaces/AggregatorV3Interface.sol" target="_blank">`AggregatorV3Interface` file on Github.</a>
+Interfaces make it easier for calling contracts to know what functions to call. For example, in this case, `AggregatorV3Interface` defines that all V3 Aggregators will have the function `latestRoundData`. We can see all of the functions that a V3 Aggregator exposes in the <a href="https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol" target="_blank">`AggregatorV3Interface` file on Github.</a>
 
 Our contract is initialized with the hard-coded address of the Kovan data feed for ETH / USD prices. Then in `getLatestPrice` it uses `latestRoundData` to obtain the most recent round of price data. We're interested in the price, so the function returns that.
 
@@ -129,23 +129,23 @@ Our contract is initialized with the hard-coded address of the Kovan data feed f
 
 There are a few things that are needed to deploy a contract to a testnet:
 
-- [x] Smart contract code 
-- [ ] A Solidity compiler 
-- [ ] An address to deploy from 
-- [ ] Some ETH (in our case, testnet ETH, which is free) 
+- [x] Smart contract code
+- [ ] A Solidity compiler
+- [ ] An address to deploy from
+- [ ] Some ETH (in our case, testnet ETH, which is free)
 
 We have the code. What we need next is a compiler.
 
 ## 7a. The Remix IDE
 
-- [ ] A Solidity compiler 
+- [ ] A Solidity compiler
 
 <a href="https://remix.ethereum.org/" target="_blank">Remix</a> is an online IDE which enables anyone to write, compile and deploy smart contracts from the browser.
 
 Fortunately for us, Remix also has support for gist. This means that Remix can load code from Github, and in this case, `PriceConsumerV3.sol` Click the button below to open a new tab, then once Remix has loaded, find the `gists` folder in the File Explorer on the left-hand side, and click on the file to open the code in the editor.
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/PriceFeeds/PriceConsumerV3.sol" target="_blank" class="cl-button--ghost">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/PriceFeeds/PriceConsumerV3.sol" target="_blank" class="cl-button--ghost">Deploy this contract using Remix ↗</a>
   <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 
@@ -153,11 +153,11 @@ Fortunately for us, Remix also has support for gist. This means that Remix can l
 
 Have a play around with the contract. This is what we'll use for the compiler.
 
-- [x] A Solidity compiler 
+- [x] A Solidity compiler
 
 ## 7b. Metamask wallet
 
-- [ ] An address to deploy from 
+- [ ] An address to deploy from
 
 Contracts are deployed by addresses on the network, so to deploy our own we need an address. Not only that, but we need one which we can easily use with Remix. Fortunately, Metamask is just what is needed. Metamask allows anyone to create an address, store funds and interact with Ethereum compatible blockchains from a browser extension.
 
@@ -169,7 +169,7 @@ Once that's done, hop over to the Kovan testnet inside Metamask extension, as se
 
 We now have an address to deploy to the Kovan testnet from.
 
-- [x] An address to deploy from 
+- [x] An address to deploy from
 
 ## 7c. Obtaining testnet ETH
 

--- a/docs/Introduction/tutorials/intermediates-tutorial.md
+++ b/docs/Introduction/tutorials/intermediates-tutorial.md
@@ -6,10 +6,10 @@ title: "Random Numbers Tutorial"
 permalink: "docs/intermediates-tutorial/"
 excerpt: "Using Chainlink VRF"
 whatsnext: {"Get a Random Number":"/docs/get-a-random-number/", "API Calls tutorial":"/docs/advanced-tutorial/"}
-metadata: 
+metadata:
   title: "Random Numbers Tutorial"
   description: "Learn how to use randomness in your smart contracts using Chainlink VRF."
-  image: 
+  image:
     0: "/files/2a242f1-link.png"
 ---
 
@@ -18,8 +18,8 @@ metadata:
 </p>
 
 > 🚧 Note
-> 
-> The video uses a seed phrase to request randomness, this has been depreciated. Please use the code here. 
+>
+> The video uses a seed phrase to request randomness, this has been depreciated. Please use the code here.
 
 # Introduction
 
@@ -48,7 +48,7 @@ Randomness, on the other hand, cannot be reference data. If the result of random
 In return for providing this service of generating a random number, Oracles need to be paid in [LINK](../link-token-contracts/). This is paid by the contract that requests the randomness, and payment occurs during the request.
 
 > 📘 ERC-677 Token Standard
-> 
+>
 > LINK conforms to the ERC-677 token standard, and extension of ERC-20. This standard is what enables data to be encoded in token transfers. This is integral to the Request and Receive cycle. [Click here](https://github.com/ethereum/EIPs/issues/677) to learn more about ERC-677.
 
 # 3. Interacting with Chainlink Oracles
@@ -71,12 +71,12 @@ The contract will have the following functions:
 - `house`: To see the assigned house of an address
 
 > 📘 Open Full Contract
-> 
-> To jump straight to the entire implementation, you can [open this contract](https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/VRF/VRFD20.sol) in remix</a>.
+>
+> To jump straight to the entire implementation, you can [open this contract](https://remix.ethereum.org/#url=https://docs.chain.link/samples/VRF/VRFD20.sol) in remix</a>.
 
 ## 4a. Importing `VRFConsumerBase`
 
-Chainlink maintains a <a href="https://github.com/smartcontractkit/chainlink/tree/master/contracts" target="_blank">library of contracts</a> that make consuming data from oracles easier. For Chainlink VRF, we use a contract called <a href="https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.6/VRFConsumerBase.sol" target="_blank">`VRFConsumerBase`</a>, which needs to be imported and extended from.
+Chainlink maintains a <a href="https://github.com/smartcontractkit/chainlink/tree/master/contracts" target="_blank">library of contracts</a> that make consuming data from oracles easier. For Chainlink VRF, we use a contract called <a href="https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.8/VRFConsumerBase.sol" target="_blank">`VRFConsumerBase`</a>, which needs to be imported and extended from.
 
 ```solidity
 pragma solidity 0.6.7;
@@ -139,13 +139,13 @@ As you can see, `VRFConsumerBase` needs to know the address of the vrfCoordinato
 uint256 private constant ROLL_IN_PROGRESS = 42;
 
 // ...
-// { variables we've already written } 
+// { variables we've already written }
 // ...
 
 event DiceRolled(bytes32 indexed requestId, address indexed roller);
 
 /// ...
-// { constructor } 
+// { constructor }
 // ...
 
 function rollDice(address roller) public onlyOwner returns (bytes32 requestId) {
@@ -226,7 +226,7 @@ function getHouseName(uint256 id) private pure returns (string memory) {
 See the full contract in Remix! (We've added a few helper functions in there which should make using the contract easier and more flexible. Have a play around with it to understand all the internal workings).
 
 <div class="remix-callout">
-  <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/VRF/VRFD20.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+  <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/VRF/VRFD20.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 
@@ -247,10 +247,10 @@ Click the caret arrow on the right hand side of "Deploy" to expand the parameter
 - `0x6c3699283bda56ad74f6b855546325b68d482e983852a7a82979cc4807b641f4`
 - `100000000000000000`
 
-These are the coordinator address, LINK address, key hash, and fee. Click deploy and use your Metamask account to confirm the transaction. 
+These are the coordinator address, LINK address, key hash, and fee. Click deploy and use your Metamask account to confirm the transaction.
 
 > 📘 Address, Key Hashes and more
-> 
+>
 > For a full reference of the addresses, key hashes and fees for each network, see [VRF Contracts](../vrf-contracts/).
 
 (Note: you should <a href="/docs/beginners-tutorial#7c-obtaining-testnet-eth" target="_blank">have some Kovan ETH in your Metamask account</a> to pay for the GAS).

--- a/docs/Node Operators/fulfilling-requests.md
+++ b/docs/Node Operators/fulfilling-requests.md
@@ -29,7 +29,7 @@ Your node works with several different types of addresses. Each address type has
 
 ## Deploy your own Oracle contract
 
-1. Go to Remix and [open the `Oracle.sol` smart contract](https://remix.ethereum.org/#optimize=true&version=soljson-v0.4.24+commit.e67f0147.js&url=https://docs.chain.link/samples/NodeOperators/Oracle.sol).
+1. Go to Remix and [open the `Oracle.sol` smart contract](https://remix.ethereum.org/#url=https://docs.chain.link/samples/NodeOperators/Oracle.sol).
 
     ![The Remix file explorer showing Oracle.sol.](/files/05f12f3-00eeef4-remix001.jpg)
 

--- a/docs/Using Any API/existing-job-request.md
+++ b/docs/Using Any API/existing-job-request.md
@@ -5,10 +5,10 @@ date: Last Modified
 title: "Make an Existing Job Request"
 permalink: "docs/existing-job-request/"
 whatsnext: {"Find Existing Jobs":"/docs/listing-services/", "API Reference":"/docs/chainlink-framework/", "Contract Addresses":"/docs/decentralized-oracles-ethereum-mainnet/"}
-metadata: 
+metadata:
   title: "Make an Existing Job Request"
   description: "Learn how to utilize existing Chainlink external adapters to make calls to APIs from smart contracts."
-  image: 
+  image:
     0: "/files/OpenGraph_V3.png"
 ---
 Using an *existing* Oracle Job makes your smart contract code more succinct. This page explains how to retrieve the current weather temperature (in Kelvin) for a defined city using an existing Oracle job.
@@ -26,7 +26,7 @@ This example uses the <a href="https://market.link/nodes/ef076e87-49f4-486b-9878
 > Making a job request will fail unless your deployed contract has enough LINK to pay for it. **Learn how to [Acquire testnet LINK](../acquire-link/) and [Fund your contract](../fund-your-contract/)**.
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/APIRequests/OpenWeatherConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+    <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/APIRequests/OpenWeatherConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Using Any API/large-responses.md
+++ b/docs/Using Any API/large-responses.md
@@ -15,10 +15,10 @@ To consume an API with a large responses, your contract should inherit from [Cha
 >❗️ Remember to fund your contract with LINK!
 >
 > Making a GET request will fail unless your deployed contract has enough LINK to pay for it. **Learn how to [Acquire testnet LINK](../acquire-link/) and [Fund your contract](../fund-your-contract/)**.
-> 
+>
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#optimize=false&evmVersion=null&runs=200&version=soljson-v0.8.6+commit.11564f7e.js&url=https://docs.chain.link/samples/APIRequests/GenericBigWord.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+    <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/APIRequests/GenericBigWord.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 
@@ -27,13 +27,13 @@ To consume an API with a large responses, your contract should inherit from [Cha
 ```
 
 > 📘 Job Spec
-> The job spec for the Chainlink node in this example can be [found here](../example-job-spec-large/). 
+> The job spec for the Chainlink node in this example can be [found here](../example-job-spec-large/).
 
 If the LINK address for targeted blockchain is not [publicly available](../link-token-contracts/) yet, replace [setPublicChainlinkToken(/)](../chainlink-framework/#setpublicchainlinktoken) with [setChainlinkToken(_address)](../chainlink-framework/#setchainlinktoken) in the constructor, where `_address` is a corresponding LINK token contract.
 
 # Choosing an Oracle and JobId
 
-The `oracle` keyword refers to a specific Chainlink node that a contract makes an API call from, and the `specId` refers to a specific job for that node to run. Each job is unique and returns different types of data. 
+The `oracle` keyword refers to a specific Chainlink node that a contract makes an API call from, and the `specId` refers to a specific job for that node to run. Each job is unique and returns different types of data.
 
 For example, a job that returns a `bytes32` variable from an API would have a different `specId` than a job that retrieved the same data, but in the form of a `uint256` variable.
 

--- a/docs/Using Any API/make-a-http-get-request.md
+++ b/docs/Using Any API/make-a-http-get-request.md
@@ -5,10 +5,10 @@ date: Last Modified
 title: "Make a GET Request"
 permalink: "docs/make-a-http-get-request/"
 whatsnext: {"Make an Existing Job Request":"/docs/existing-job-request/", "API Reference":"/docs/chainlink-framework/", "Contract Addresses":"/docs/decentralized-oracles-ethereum-mainnet/", "Multi-Variable Responses":"/docs/multi-variable-responses/"}
-metadata: 
+metadata:
   title: "Make a GET Request"
   description: "Learn how to make a GET request to an API from a smart contract, using Chainlink."
-  image: 
+  image:
     0: "/files/930cbb7-link.png"
 ---
 This page explains how to make an HTTP GET request to an external API from a smart contract, using Chainlink's [Request & Receive Data](../request-and-receive-data/) cycle.
@@ -24,7 +24,7 @@ Currently, any return value must fit within 32 bytes, if the value is bigger tha
 > Making a GET request will fail unless your deployed contract has enough LINK to pay for it. **Learn how to [Acquire testnet LINK](../acquire-link/) and [Fund your contract](../fund-your-contract/)**.
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/APIRequests/APIConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+    <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/APIRequests/APIConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 
@@ -36,7 +36,7 @@ If the LINK address for targeted blockchain is not [publicly available](../link-
 
 # Choosing an Oracle and JobId
 
-The `oracle` keyword refers to a specific Chainlink node that a contract makes an API call from, and the `jobId` refers to a specific job for that node to run. Each job is unique and returns different types of data. 
+The `oracle` keyword refers to a specific Chainlink node that a contract makes an API call from, and the `jobId` refers to a specific job for that node to run. Each job is unique and returns different types of data.
 
 For example, a job that returns a `bytes32` variable from an API would have a different `jobId` than a job that retrieved the same data, but in the form of a `uint256` variable.
 
@@ -44,7 +44,7 @@ For example, a job that returns a `bytes32` variable from an API would have a di
 
 # Supported APIs
 
-The `APIConsumer` in the example above is flexible enough to call any public API, so long as the URL in the "get" adapter parameter is correct, and the format of the response is known. 
+The `APIConsumer` in the example above is flexible enough to call any public API, so long as the URL in the "get" adapter parameter is correct, and the format of the response is known.
 
 ## Response Data
 
@@ -73,7 +73,7 @@ The code example above returns an unsigned integer from the oracle response, but
 
 If you need to return a string, use `bytes32`. <a href="https://gist.github.com/alexroan/a8caf258218f4065894ecd8926de39e7" target="_blank">Here's one method</a> of converting `bytes32` to `string`. Currently any return value must fit within 32 bytes, if the value is bigger than that multiple requests will need to be made.
 
-The data type returned by a specific job depends on the [adapters](../core-adapters/) that it supports. Make sure to choose an oracle job that supports the data type that your contract needs to consume. 
+The data type returned by a specific job depends on the [adapters](../core-adapters/) that it supports. Make sure to choose an oracle job that supports the data type that your contract needs to consume.
 
 # Choosing an Oracle Job without specifying the URL
 

--- a/docs/Using Any API/multi-variable-responses.md
+++ b/docs/Using Any API/multi-variable-responses.md
@@ -8,11 +8,11 @@ whatsnext: {"Make an Existing Job Request":"/docs/existing-job-request/", "API R
 ---
 This page explains how to make an HTTP GET request to an external API from a smart contract, using Chainlink's [Request & Receive Data](../request-and-receive-data/) cycle and then receive multiple responses.
 
-This is known as **multi-variable** or **multi-word** responses. 
+This is known as **multi-variable** or **multi-word** responses.
 
 > ⚠️ NOTE
-> 
-> This feature is available as of Chainlink `0.10.10` but can only be customized with different URLs and responses on the node operator side. In `0.10.11` generic jobs will be available for solidity as well. Please see [Make an API Call](../make-a-http-get-request/) for more information on making API calls. 
+>
+> This feature is available as of Chainlink `0.10.10` but can only be customized with different URLs and responses on the node operator side. In `0.10.11` generic jobs will be available for solidity as well. Please see [Make an API Call](../make-a-http-get-request/) for more information on making API calls.
 
 # MultiWord
 
@@ -21,10 +21,10 @@ To consume an API with multiple responses, your contract should inherit from [Ch
 >❗️ Remember to fund your contract with LINK!
 >
 > Making a GET request will fail unless your deployed contract has enough LINK to pay for it. **Learn how to [Acquire testnet LINK](../acquire-link/) and [Fund your contract](../fund-your-contract/)**.
-> 
+>
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#optimize=false&evmVersion=null&runs=200&version=soljson-v0.8.6+commit.11564f7e.js&url=https://docs.chain.link/samples/APIRequests/MultiWordConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy a Multi-Word Contract Example in Remix ↗</a>
+    <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/APIRequests/MultiWordConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy a Multi-Word Contract Example in Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 
@@ -33,14 +33,14 @@ To consume an API with multiple responses, your contract should inherit from [Ch
 ```
 
 > 📘 Note
-> 
-> The job spec for the Chainlink node in this example can be [found here](../example-job-spec-multi-word/). 
+>
+> The job spec for the Chainlink node in this example can be [found here](../example-job-spec-multi-word/).
 
 If the LINK address for targeted blockchain is not [publicly available](../link-token-contracts/) yet, replace [setPublicChainlinkToken(/)](../chainlink-framework/#setpublicchainlinktoken) with [setChainlinkToken(_address)](../chainlink-framework/#setchainlinktoken) in the constructor, where `_address` is a corresponding LINK token contract.
 
 # Choosing an Oracle and JobId
 
-The `oracle` keyword refers to a specific Chainlink node that a contract makes an API call from, and the `specId` refers to a specific job for that node to run. Each job is unique and returns different types of data. 
+The `oracle` keyword refers to a specific Chainlink node that a contract makes an API call from, and the `specId` refers to a specific job for that node to run. Each job is unique and returns different types of data.
 
 For example, a job that returns a `bytes32` variable from an API would have a different `specId` than a job that retrieved the same data, but in the form of a `uint256` variable.
 

--- a/docs/Using Price Feeds/feed-registry.html
+++ b/docs/Using Price Feeds/feed-registry.html
@@ -4,10 +4,10 @@ section: smartContract
 date: Last Modified
 title: "Feed Registry"
 permalink: "docs/feed-registry/"
-metadata: 
+metadata:
   title: "How to Use Chainlink Feed Registry"
   description: "The Chainlink Feed Registry is an on-chain mapping of assets to feeds. It allows users and DeFi protocols to query Chainlink data feeds from a given pair of asset and denomination addresses."
-  image: 
+  image:
     0: "/files/OpenGraph_V3.png"
 ---
 {% markdown %}
@@ -70,7 +70,7 @@ To consume price data from the Feed Registry, your smart contract should referen
 
 <div class="row cl-button-container">
     <div class="col-xs-12 col-md-12">
-      <a href="https://remix.ethereum.org/#optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.6+commit.11564f7e.js&url=https://docs.chain.link/samples/FeedRegistry/PriceConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+      <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/FeedRegistry/PriceConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     </div>
     <div class="col-xs-12 col-md-12">
       <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
@@ -82,7 +82,7 @@ To consume price data from the Feed Registry, your smart contract should referen
 ## Solidity Hardhat Example
 
 > 📘 Note
-> 
+>
 > You can find a working Feed Registry Hardhat project [here](https://github.com/smartcontractkit/feed-registry-example). Clone the repo and follow the setup instructions to run the example locally.
 
 
@@ -106,7 +106,7 @@ To consume price data from the Feed Registry, your smart contract should referen
 
 {% markdown %}
 
-# Contract Addresses 
+# Contract Addresses
 
 This section lists the blockchains that Chainlink Feed Registry are currently available on.
 
@@ -180,12 +180,12 @@ function description(address base, address quote) external view returns (string 
 Get data about a specific round, using the `roundId`.
 
 ```solidity
-function getRoundData(address base, address quote, uint80 _roundId) external view 
+function getRoundData(address base, address quote, uint80 _roundId) external view
     returns (
-        uint80 roundId, 
-        int256 answer, 
-        uint256 startedAt, 
-        uint256 updatedAt, 
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
         uint80 answeredInRound
     )
 ```
@@ -209,12 +209,12 @@ function getRoundData(address base, address quote, uint80 _roundId) external vie
 Get the price from the latest round.
 
 ```solidity
-function latestRoundData(address base, address quote) external view 
+function latestRoundData(address base, address quote) external view
     returns (
-        uint80 roundId, 
-        int256 answer, 
-        uint256 startedAt, 
-        uint256 updatedAt, 
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
         uint80 answeredInRound
     )
 ```
@@ -271,7 +271,7 @@ function getFeed(
 
 ## getPhaseFeed
 
-Returns the underlying aggregator address of a base / quote pair at a specified phase. Note that on-chain contracts cannot read from aggregators directly, only through Feed Registry or Proxy contracts. 
+Returns the underlying aggregator address of a base / quote pair at a specified phase. Note that on-chain contracts cannot read from aggregators directly, only through Feed Registry or Proxy contracts.
 Phase ids start at `1`. You can get the current Phase by calling `getCurrentPhaseId()`.
 
 ```solidity
@@ -322,7 +322,7 @@ function isFeedEnabled(
 
 ## getPhase
 
-Returns the starting and ending aggregator round ids of a base / quote pair. 
+Returns the starting and ending aggregator round ids of a base / quote pair.
 
 ```solidity
 function getPhase(
@@ -386,7 +386,7 @@ Returns the underlying aggregator address of a base / quote pair at a specified 
 
 ## getPhaseRange
 
-Returns the starting and ending round ids of a base / quote pair at a specified phase. 
+Returns the starting and ending round ids of a base / quote pair at a specified phase.
 
 Please note that this `roundId` is calculated from the phase id and the underlying aggregator's round id. To get the raw aggregator round ids of a phase for indexing purposes, please use `getPhase()`.
 

--- a/docs/Using Price Feeds/get-the-latest-price.html
+++ b/docs/Using Price Feeds/get-the-latest-price.html
@@ -35,7 +35,7 @@ You can write smart contracts that consume data feeds using several languages, b
 
 ## Solidity
 
-To consume price data, your smart contract should reference [`AggregatorV3Interface`](https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.6/interfaces/AggregatorV3Interface.sol), which defines the external functions implemented by Data Feeds.
+To consume price data, your smart contract should reference [`AggregatorV3Interface`](https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol), which defines the external functions implemented by Data Feeds.
 
 ```solidity Kovan
 {% include samples/PriceFeeds/PriceConsumerV3.sol %}
@@ -43,7 +43,7 @@ To consume price data, your smart contract should reference [`AggregatorV3Interf
 
 <div class="row cl-button-container">
     <div class="col-xs-12 col-md-12">
-      <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/PriceFeeds/PriceConsumerV3.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+      <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/PriceFeeds/PriceConsumerV3.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     </div>
     <div class="col-xs-12 col-md-12">
       <a href="../deploy-your-first-contract/">What is Remix?</a>

--- a/docs/Using Price Feeds/historical-price-data.html
+++ b/docs/Using Price Feeds/historical-price-data.html
@@ -5,17 +5,17 @@ date: Last Modified
 title: "Historical Price Data"
 permalink: "docs/historical-price-data/"
 whatsnext: {"API Reference":"/docs/price-feeds-api-reference/", "Contract Addresses":"/docs/reference-contracts/"}
-metadata: 
+metadata:
   title: "Get Historical Price Data"
   description: "How to use Chainlink Data Feeds to retrieve historical price data of ETH in your smart contracts."
-  image: 
+  image:
     0: "/files/OpenGraph_V3.png"
 ---
 
 
 {% markdown %}
 
-The most common use case for Data Feeds is to [Get the Latest Price](../get-the-latest-price/). However, <a href="https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.6/interfaces/AggregatorV3Interface.sol" target="_blank" rel="noreferrer, noopener">`AggregatorV3Interface`</a> also exposes functions which can be used to retrieve price data of a previous round ID.
+The most common use case for Data Feeds is to [Get the Latest Price](../get-the-latest-price/). However, <a href="https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol" target="_blank" rel="noreferrer, noopener">`AggregatorV3Interface`</a> also exposes functions which can be used to retrieve price data of a previous round ID.
 
 > 📘 Decentralized Data Model
 >
@@ -23,16 +23,16 @@ The most common use case for Data Feeds is to [Get the Latest Price](../get-the-
 
 # Historical Rounds
 
-Data Feeds are updated in rounds. Rounds are identified by their `roundId`, which increases with each new round (please note that the increase may not be monotonic). Knowing the `roundId` of a previous round allows contracts to consume historical price data. 
+Data Feeds are updated in rounds. Rounds are identified by their `roundId`, which increases with each new round (please note that the increase may not be monotonic). Knowing the `roundId` of a previous round allows contracts to consume historical price data.
 
 > 🚧 Important
-> 
+>
 > If you are deriving a round id without having observed it before, the round may or may not be complete. To check if it is, you must validate that the timestamp on that round is not 0.
 
 ## Solidity
 
 <div class="remix-callout">
-      <a href="https://remix.ethereum.org/#version=soljson-v0.6.7+commit.b8d736ae.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/PriceFeeds/HistoricalPriceConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+      <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/PriceFeeds/HistoricalPriceConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
       <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/Using Randomness/get-a-random-number.md
+++ b/docs/Using Randomness/get-a-random-number.md
@@ -5,16 +5,16 @@ date: Last Modified
 title: "Get a Random Number"
 permalink: "docs/get-a-random-number/"
 whatsnext: {"API Reference":"/docs/chainlink-vrf-api-reference/", "Contract Addresses":"/docs/vrf-contracts/"}
-metadata: 
+metadata:
   description: "How to generate a random number inside a smart contract using Chainlink VRF."
-  image: 
+  image:
     0: "/files/OpenGraph_V3.png"
 ---
 This page explains how to get a random number inside a smart contract using Chainlink VRF.
 
 # Random Number Consumer
 
-Chainlink VRF follows the [Request & Receive Data](../request-and-receive-data/) cycle. To consume randomness, your contract should inherit from <a href="https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.6/VRFConsumerBase.sol" target="_blank">`VRFConsumerBase`</a> and define two required functions
+Chainlink VRF follows the [Request & Receive Data](../request-and-receive-data/) cycle. To consume randomness, your contract should inherit from <a href="https://github.com/smartcontractkit/chainlink/blob/master/contracts/src/v0.8/VRFConsumerBase.sol" target="_blank">`VRFConsumerBase`</a> and define two required functions
 
 1. `requestRandomness`, which makes the initial request for randomness.
 2. `fulfillRandomness`, which is the function that receives and does something with verified randomness.
@@ -36,7 +36,7 @@ Note, the below values have to be configured correctly for VRF requests to work.
 > Requesting randomness will fail unless your deployed contract has enough LINK to pay for it. **Learn how to [Acquire testnet LINK](../acquire-link/) and [Fund your contract](../fund-your-contract/)**.
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#version=soljson-v0.6.6+commit.6c089d02.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/VRF/RandomNumberConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+    <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/VRF/RandomNumberConsumer.sol" target="_blank" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 

--- a/docs/chainlink-keepers/compatible-contracts.md
+++ b/docs/chainlink-keepers/compatible-contracts.md
@@ -28,7 +28,7 @@ The Keeper node runs this method as an [`eth_call`](https://eth.wiki/json-rpc/AP
 
 > ⚠️ Important Note
 > The check that is run is subject to the `checkGasLimit` in the [configuration of the registry](/docs/chainlink-keepers/overview/#configuration).
-> 
+>
 > Since `checkUpkeep` is only ever performed off-chain in simulation, for most cases it is best to treat this as a `view` function and not modify any state.
 
 ```solidity
@@ -57,7 +57,7 @@ When your checkUpkeep returns `upkeepNeeded == true`, the Keeper node broadcasts
 
 > ⚠️ Important note
 > The Upkeep that is performed is subject to the `callGasLimit` in the [configuration of the registry](/docs/chainlink-keepers/overview/#configuration).
-> 
+>
 > Ensure your `performUpkeep` is idempotent. Your `performUpkeep` should change state such that `checkUpkeep` will not return `true` for the same subset of work once said work is complete. Otherwise the Upkeep will remain eligible and result in multiple performances by the Keeper Network on the exactly same subset of work.
 
 
@@ -76,7 +76,7 @@ When your checkUpkeep returns `upkeepNeeded == true`, the Keeper node broadcasts
 The example below represents a simple counter contract. Each time `performUpkeep` is called, it increments its counter by one.
 
 <div class="remix-callout">
-    <a href="https://remix.ethereum.org/#version=soljson-v0.6.6+commit.6c089d02.js&optimize=false&evmVersion=null&url=https://docs.chain.link/samples/Keepers/KeepersCounter.sol" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
+    <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/Keepers/KeepersCounter.sol" class="cl-button--ghost solidity-tracked">Deploy this contract using Remix ↗</a>
     <a href="../../deploy-your-first-contract/" title="">What is Remix?</a>
 </div>
 


### PR DESCRIPTION
- Remove hard-coded Solidity versions from Remix links. Allow Remix to automatically select the compiler version from `pragma`.
- Update the version numbers for https://github.com/smartcontractkit/chainlink/blob/master/contracts/ files where necessary.
- Auto-remove trailing whitespace.