### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/Introduction/tutorials/intermediates-tutorial.md
+++ b/docs/Introduction/tutorials/intermediates-tutorial.md
@@ -19,7 +19,7 @@ metadata:
 
 > 🚧 Note
 >
-> The video uses a seed phrase to request randomness, this has been depreciated. Please use the code here.
+> The video uses a seed phrase to request randomness, this has been deprecated. Please use the code here.
 
 # Introduction
 


### PR DESCRIPTION
Typo: "depreciated" instead of "deprecated"