### PR TITLE
feat: Update avalanche explorer link to Snowtrace

### DIFF
--- a/_tools/networks.ts
+++ b/_tools/networks.ts
@@ -80,12 +80,12 @@ export const NETWORKS = [
     networks: [
       {
         name: "Avalanche Mainnet",
-        url: "https://cchain.explorer.avax.network/address/%s",
+        url: "https://snowtrace.io/address/%s",
         source: "directory-avalanche-mainnet.json",
       },
       {
         name: "Avalanche Testnet",
-        url: "https://cchain.explorer.avax-test.network/address/%s",
+        url: "https://testnet.snowtrace.io/address/%s",
         source: "directory-avalanche-fuji-testnet.json",
       },
     ],

--- a/docs/Developer Reference/link-token-contracts.md
+++ b/docs/Developer Reference/link-token-contracts.md
@@ -178,7 +178,7 @@ You can also <a href="https://www.youtube.com/watch?v=WKvIGkBWRUA" target="_blan
 |Parameter|Value|
 |:---|:---|
 |`ETH_CHAIN_ID`|`43114`|
-|Address|[`0x5947BB275c521040051D82396192181b413227A3`](https://cchain.explorer.avax.network/address/0x5947BB275c521040051D82396192181b413227A3)|
+|Address|[`0x5947BB275c521040051D82396192181b413227A3`](https://snowtrace.io/address/0x5947BB275c521040051D82396192181b413227A3)|
 |Name|ChainLink Token on Avalanche|
 |Symbol|LINK|
 |Decimals|18|
@@ -193,7 +193,7 @@ You can also <a href="https://www.youtube.com/watch?v=WKvIGkBWRUA" target="_blan
 |Parameter|Value|
 |:---|:---|
 |`ETH_CHAIN_ID`|`43113`|
-|Address|[`0x0b9d5D9136855f6FEc3c0993feE6E9CE8a297846`](https://cchain.explorer.avax-test.network/address/0x0b9d5D9136855f6FEc3c0993feE6E9CE8a297846)|
+|Address|[`0x0b9d5D9136855f6FEc3c0993feE6E9CE8a297846`](https://testnet.snowtrace.io/address/0x0b9d5D9136855f6FEc3c0993feE6E9CE8a297846)|
 |Name|ChainLink Token on Avalanche|
 |Symbol|LINK|
 |Decimals|18|


### PR DESCRIPTION
Ava Labs recently announced Snowtrace. A blockchain explorer build a la Etherscan that will replace the old cchain.explorer .

https://medium.com/avalancheavax/snowtrace-bringing-etherscan-to-the-avalanche-community-f8463e0d80d3

The old one (used at the moment in this doc) will be deprecated in a few days.

https://testnet.snowtrace.io/
https://snowtrace.io/