### PR TITLE
Add Moonriver data feeds

### DIFF
--- a/_data/navigation.js
+++ b/_data/navigation.js
@@ -334,6 +334,10 @@ module.exports = {
                 title: 'Terra Data Feeds',
                 url: '/docs/terra/data-feeds-terra/',
               },
+              {
+                title: 'Moonriver Data Feeds',
+                url: '/docs/data-feeds-moonriver/',
+              },
             ],
           },
         ],

--- a/_tools/networks.ts
+++ b/_tools/networks.ts
@@ -170,5 +170,16 @@ export const NETWORKS = [
         source: "directory-terra-testnet-bombay.json",
       },
     ],
+  },
+  {
+    page: "data-feeds-moonriver",
+    title: "Moonriver Data Feeds",
+    networks: [
+      {
+        name: "Moonriver Mainnet",
+        url: "https://moonriver.moonscan.io/address/%s",
+        source: "directory-kusama-mainnet-moonriver.json",
+      },
+    ],
   }
 ];

--- a/docs/Using Price Feeds/data-feeds-moonriver.md
+++ b/docs/Using Price Feeds/data-feeds-moonriver.md
@@ -1,0 +1,15 @@
+---
+layout: feed.liquid
+title: "Moonriver Feeds"
+stub: data-feeds-moonriver
+permalink: "docs/data-feeds-moonriver/"
+metadata:
+  image:
+    0: "https://files.readme.io/8dc5d76-cl.png"
+    1: "cl.png"
+    2: 1459
+    3: 1459
+    4: "#dbe1f8"
+date: Last Modified
+---
+(content rendered programatically by layout)


### PR DESCRIPTION
Data feed tables generate after the merge. Looks good locally testing.

Preview here: https://deploy-preview-525--dreamy-villani-0e9e5c.netlify.app/docs/data-feeds-moonriver/