### PR TITLE
Update links and navigation.

### DIFF
--- a/_data/navigation.js
+++ b/_data/navigation.js
@@ -255,16 +255,8 @@ module.exports = {
             url: '/docs/using-chainlink-reference-contracts/',
           },
           {
-            title: 'Using Data Feeds (EVM)',
+            title: 'Using Data Feeds',
             url: '/docs/get-the-latest-price/'
-          },
-          {
-            title: 'Using Data Feeds (Solana)',
-            url: '/docs/solana/using-data-feeds-solana/'
-          },
-          {
-            title: 'Using Data Feeds (Terra)',
-            url: '/docs/terra/using-data-feeds-terra/'
           },
           {
             title: 'Historical Price Data',
@@ -323,20 +315,16 @@ module.exports = {
                 url: '/docs/harmony-price-feeds/',
               },
               {
-                title: 'Solana Data Feeds',
-                url: '/docs/solana/data-feeds-solana/',
-              },
-              {
                 title: 'Optimism Data Feeds',
                 url: '/docs/optimism-price-feeds/',
               },
               {
-                title: 'Terra Data Feeds',
-                url: '/docs/terra/data-feeds-terra/',
-              },
-              {
                 title: 'Moonriver Data Feeds',
                 url: '/docs/data-feeds-moonriver/',
+              },
+              {
+                title: 'Non-EVM Data Feeds ↗',
+                url: '/non-evm/',
               },
             ],
           },
@@ -508,7 +496,7 @@ module.exports = {
             url: '/docs/solana/using-data-feeds-solana/',
           },
           {
-            title: 'Contract Addresses',
+            title: 'Solana Data Feeds',
             url: '/docs/solana/data-feeds-solana/',
           },
 
@@ -526,7 +514,7 @@ module.exports = {
             url: '/docs/terra/using-data-feeds-terra/',
           },
           {
-            title: 'Contract Addresses',
+            title: 'Terra Data Feeds',
             url: '/docs/terra/data-feeds-terra/',
           },
         ],

--- a/_tools/networks.ts
+++ b/_tools/networks.ts
@@ -42,12 +42,12 @@ export const NETWORKS = [
     networks: [
       {
         name: "Polygon Mainnet",
-        url: "https://explorer-mainnet.maticvigil.com/address/%s",
+        url: "https://polygonscan.com/address/%s",
         source: "directory-matic-mainnet.json",
       },
       {
         name: "Mumbai Testnet",
-        url: "https://explorer-mumbai.maticvigil.com/address/%s",
+        url: "https://mumbai.polygonscan.com/address/%s",
         source: "directory-matic-testnet.json",
       },
     ],

--- a/docs/Developer Reference/link-token-contracts.md
+++ b/docs/Developer Reference/link-token-contracts.md
@@ -47,7 +47,7 @@ The LINK token is an ERC677 token that inherits functionality from the ERC20 tok
 >
 > Testnet LINK is available from https://faucets.chain.link/rinkeby
 > Testnet ETH is available from: https://faucets.chain.link/rinkeby
-> Backup Testnet ETH Faucets: https://rinkeby-faucet.com/, https://app.mycrypto.com/faucet 
+> Backup Testnet ETH Faucets: https://rinkeby-faucet.com/, https://app.mycrypto.com/faucet
 
 |Parameter|Value|
 |:---|:---|
@@ -107,7 +107,7 @@ LINK is native to Ethereum, so to use LINK on other chains, it must be bridged. 
 
 > 📘 Important
 >
-> The LINK provided by the [Polygon (Matic) Bridge](https://wallet.matic.network/bridge) is not ERC-677 compatible, so cannot be used with Chainlink oracles. However, it can be [**converted to the official LINK token on Polygon (Matic) using Chainlink's PegSwap service**](https://pegswap.chain.link/)
+> The LINK provided by the [Polygon (Matic) Bridge](https://wallet.polygon.technology/bridge) is not ERC-677 compatible, so cannot be used with Chainlink oracles. However, it can be [**converted to the official LINK token on Polygon (Matic) using Chainlink's PegSwap service**](https://pegswap.chain.link/)
 
 You can also <a href="https://www.youtube.com/watch?v=WKvIGkBWRUA" target="_blank"> watch this video </a>.
 
@@ -116,7 +116,7 @@ You can also <a href="https://www.youtube.com/watch?v=WKvIGkBWRUA" target="_blan
 |Parameter|Value|
 |:---|:---|
 |`ETH_CHAIN_ID`|`137`|
-|Address|<a href="https://explorer.matic.network/address/0xb0897686c545045afc77cf20ec7a532e3120e0f1" target="_blank" rel="noreferrer, noopener">`0xb0897686c545045afc77cf20ec7a532e3120e0f1`</a>|
+|Address|<a href="https://polygonscan.com/address/0xb0897686c545045afc77cf20ec7a532e3120e0f1" target="_blank" rel="noreferrer, noopener">`0xb0897686c545045afc77cf20ec7a532e3120e0f1`</a>|
 |Name|ChainLink Token|
 |Symbol|LINK|
 |Decimals|18|
@@ -130,7 +130,7 @@ You can also <a href="https://www.youtube.com/watch?v=WKvIGkBWRUA" target="_blan
 |Parameter|Value|
 |:---|:---|
 |`ETH_CHAIN_ID`|`80001`|
-|Address|<a href="https://explorer-mumbai.maticvigil.com/address/0x326C977E6efc84E512bB9C30f76E30c160eD06FB" target="_blank" rel="noreferrer, noopener">`0x326C977E6efc84E512bB9C30f76E30c160eD06FB `</a>|
+|Address|<a href="https://mumbai.polygonscan.com/address/0x326C977E6efc84E512bB9C30f76E30c160eD06FB" target="_blank" rel="noreferrer, noopener">`0x326C977E6efc84E512bB9C30f76E30c160eD06FB `</a>|
 |Name|ChainLink Token|
 |Symbol|LINK|
 |Decimals|18|

--- a/docs/Using Price Feeds/reference-contracts.md
+++ b/docs/Using Price Feeds/reference-contracts.md
@@ -28,6 +28,7 @@ Chainlink Data Feed contracts are updated on a regular basis by multiple Chainli
   - [Arbitrum Data Feeds](../arbitrum-price-feeds/)
   - [Harmony Data Feeds](../harmony-price-feeds/)
   - [Optimism Data Feeds](../optimism-price-feeds/)
+  - [Moonriver Data Feeds](../data-feeds-moonriver/)
 - Non-EVM networks
   - [Solana Data Feeds](/docs/solana/data-feeds-solana/)
   - [Terra Data Feeds](/docs/terra/data-feeds-terra/)

--- a/docs/Using Randomness/vrf-contracts.md
+++ b/docs/Using Randomness/vrf-contracts.md
@@ -17,7 +17,7 @@ For implementation details, read [Introduction to Chainlink VRF](../chainlink-vr
 
 > 📘 Important
 >
-> The LINK provided by the [Polygon (Matic) Bridge](https://wallet.matic.network/bridge) is not ERC-677 compatible, so cannot be used with Chainlink oracles. However, it can be [**converted to the official LINK token on Polygon (Matic) using Chainlink's PegSwap service**](https://pegswap.chain.link/)
+> The LINK provided by the [Polygon (Matic) Bridge](https://wallet.polygon.technology/bridge) is not ERC-677 compatible, so cannot be used with Chainlink oracles. However, it can be [**converted to the official LINK token on Polygon (Matic) using Chainlink's PegSwap service**](https://pegswap.chain.link/)
 
 |Item|Value|
 |---|---|
@@ -107,7 +107,7 @@ For implementation details, read [Introduction to Chainlink VRF](../chainlink-vr
 >
 > Testnet LINK is available from https://faucets.chain.link/rinkeby
 > Testnet ETH is available from: https://faucets.chain.link/rinkeby
-> Backup Testnet ETH Faucets: https://rinkeby-faucet.com/, https://app.mycrypto.com/faucet 
+> Backup Testnet ETH Faucets: https://rinkeby-faucet.com/, https://app.mycrypto.com/faucet
 
 |Item|Value|
 |---|---|

--- a/docs/Using Randomness/vrf-security-considerations.md
+++ b/docs/Using Randomness/vrf-security-considerations.md
@@ -40,7 +40,7 @@ On proof-of-stake blockchains (e.g. BSC, Polygon), what block confirmation time 
 For further details, take a look at the consensus documentation for the chain you want to use:
 - [Ethereum Consensus Mechanisms](https://ethereum.org/en/developers/docs/consensus-mechanisms/)
 - [Binance Consensus Docs](https://docs.binance.org/smart-chain/guides/concepts/consensus.html)
-- [Polygon Consensus Docs](https://docs.matic.network/docs/contribute/bor/consensus/)
+- [Polygon Consensus Docs](https://docs.polygon.technology/docs/contribute/bor/consensus/)
 
 Understanding the blockchains you build your application on is very important. You should take time to understand [chain reorganization](https://blog.ethereum.org/2015/08/08/chain-reorganisation-depth-expectations/) which will also result in a different VRF output, which could be exploited.
 


### PR DESCRIPTION
- Update Polygon https://wallet.matic.network URLs to https://wallet.polygon.technology.
- Update Polygon explorer URLs.
- Move Terra and Solana data feeds navigation exclusively to non-EVM section.
- Add Moonriver link to the reference contracts overview.