### PR TITLE
Replace fulfillRandomness external with internal function type

### DIFF
--- a/docs/Using Randomness/chainlink-vrf-api-reference.md
+++ b/docs/Using Randomness/chainlink-vrf-api-reference.md
@@ -64,7 +64,7 @@ Called by VRFCoordinator when it receives a valid VRF proof. Override this funct
 
 ```javascript Solidity
 function fulfillRandomness(bytes32 requestId, uint256 randomness)
-    external virtual;
+    internal virtual;
 ```
 
 * `requestId`: The Id initially returned by `requestRandomness`.


### PR DESCRIPTION
Docs [here](https://docs.chain.link/docs/chainlink-vrf-api-reference/#requestrandomness) mention `external` function type for `fulfillRandomness`.

![image](https://user-images.githubusercontent.com/11096226/149620968-4d76511c-2cd3-4334-a2fd-fe5fd3b9f372.png)

If this function definition is used, it could ofc have security implications allowing an external malicious call with pre-cooked input.