### PR TITLE
Enable docsHidden and transmissionsAccount on process-data.ts

### DIFF
--- a/_tools/process-data.ts
+++ b/_tools/process-data.ts
@@ -21,6 +21,7 @@ interface DataFile {
         relativeDeviationThresholdPPB: string;
       };
       docsHidden?: boolean;
+      transmissionsAccount?: string;
     };
   };
   proxies: {
@@ -135,7 +136,7 @@ for (let page of targetData) {
           // End conditional
 
           proxyList.push({
-            pair: 
+            pair:
               // Only insert 'v1' if this isn't an index
               !/index/i.test(proxy.name) &&
               // Only insert 'v1' if this isn't already a versioned OHM
@@ -151,13 +152,16 @@ for (let page of targetData) {
     } else {
       for (let contractKey of Object.keys(contents.contracts)) {
         const contract = contents.contracts[contractKey];
-        proxyList.push({
-          pair: contract.name,
-          deviationThreshold: liveContracts[contractKey].deviationThreshold,
-          heartbeat: liveContracts[contractKey].heartbeat,
-          decimals: liveContracts[contractKey].decimals,
-          proxy: contractKey,
-        });
+        if (!contract.docsHidden) {
+          proxyList.push({
+            pair: contract.name,
+            deviationThreshold: liveContracts[contractKey].deviationThreshold,
+            heartbeat: liveContracts[contractKey].heartbeat,
+            decimals: liveContracts[contractKey].decimals,
+            // Use transmissionsAccount for Solana OCR2; contractKey otherwise
+            proxy: contract.transmissionsAccount || contractKey,
+          });
+        }
       }
     }
     // Save the data into our final output


### PR DESCRIPTION
This is required to correctly process the new Solana Devnet feeds. The docs are [currently hard-coded](https://github.com/smartcontractkit/documentation/blob/main/docs/Solana/DataFeeds/data-feeds-solana.md?plain=1), so this PR does not affect them.

We already use `docsHidden` for Proxy addresses, so this PR just applies them to Contract addresses.

`transmissionsAccount` is required to correctly process the new Solana feeds.