### PR TITLE
Remove misleading API reference page and redirect to node configuration

### DIFF
--- a/docs/Chainlink Node API/chainlink-node-api-reference.md
+++ b/docs/Chainlink Node API/chainlink-node-api-reference.md
@@ -1,9 +1,0 @@
----
-layout: nodes.liquid
-date: Last Modified
-title: "Chainlink Node API Reference"
-permalink: "docs/chainlink-node-api-reference/"
----
-The Chainlink Node API reference provides information on how to interact directly with a Chainlink node. If you are creating services which need direct communication with a Chainlink node, this information will be helpful for you. If you are wanting to connect an external resource (API) to a smart contract using Chainlink, please see the the [Developers section of external adapters](../developers/).
-
-Most endpoints of the Chainlink node require session authentication. You will need to [POST](ref:sessions) to `/session` to create a cookie to be used for subsequent requests.

--- a/docs/Node Operators/configuration-variables.md
+++ b/docs/Node Operators/configuration-variables.md
@@ -539,7 +539,7 @@ Do not change this setting unless you know what you are doing.
 
 - Default: `"6688"`
 
-Port used for the [Chainlink Node API](../chainlink-node-api-reference/) and GUI.
+Port used for the Chainlink Node API, CLI, and GUI.
 
 ### SECURE_COOKIES
 

--- a/docs/Node Operators/configuration-variables.md
+++ b/docs/Node Operators/configuration-variables.md
@@ -18,7 +18,7 @@ The environment variables listed here are explicitly supported and current as of
 
 As of Chainlink node v1.1.0 and up, the way nodes manage configuration is changing. Previously, environment variables exclusively handled all node configuration. Although this configuration method worked well in the past, it has its limitations. Notably, it doesn't mesh well with chain-specific configuration profiles.
 
-For this reason, Chainlink nodes are moving towards a model where you set variables using the API, CLI, or GUI, and the configuration is saved in the database. We encourage you to become familiar with this model because it is likely that nodes will continue to move away from environment variable configuration in the future.
+For this reason, Chainlink nodes are moving towards a model where you set variables using the API, [CLI](/docs/configuration-variables/#cli-client), or GUI, and the configuration is saved in the database. We encourage you to become familiar with this model because it is likely that nodes will continue to move away from environment variable configuration in the future.
 
 As of v1.1.0, Chainlink nodes still support environment variables to configure node settings and chain-specific settings. If the environment variable is set, it overrides any chain-specific, job-specific, or database configuration setting. The log displays a warning to indicate when an override happens, so you know when variables lower in the hierarchy are being ignored.
 
@@ -539,7 +539,7 @@ Do not change this setting unless you know what you are doing.
 
 - Default: `"6688"`
 
-Port used for the Chainlink Node API, CLI, and GUI.
+Port used for the Chainlink Node API, [CLI](/docs/configuration-variables/#cli-client), and GUI.
 
 ### SECURE_COOKIES
 
@@ -621,17 +621,17 @@ The location of the TLS private key file. Example: `/home/$USER/.chainlink/tls/s
 
 Previous Chainlink node versions supported only one chain. From v1.1.0 and up, Chainlink nodes support multiple EVM and non-EVM chains, so the way that chains and nodes are configured has changed.
 
-The preferred way of configuring Chainlink nodes as of v1.1.0 and up is to use the API, CLI, or UI to set chain-specific configuration and create nodes.
+The preferred way of configuring Chainlink nodes as of v1.1.0 and up is to use the API, [CLI](/docs/configuration-variables/#cli-client), or UI to set chain-specific configuration and create nodes.
 
 The old way of specifying chains using environment variables is still supported, but discouraged. It works as follows:
 
 If you set any value for `ETH_URL`, the values of `ETH_CHAIN_ID`, `ETH_URL`, `ETH_HTTP_URL` and `ETH_SECONDARY_URLS` will be used to create and update chains and nodes representing these values in the database. If an existing chain or node is found, it will be overwritten. This mode is used mainly to ease the process of upgrading. On subsequent runs (once your old settings have been written to the database) it is recommended to unset `ETH_URL` and use the API commands exclusively to administer chains and nodes.
 
-In the future, support for the `ETH_URL` and associated environment variables might be removed, so it is recommended to use the API, CLI, or GUI instead to setup chains and nodes.
+In the future, support for the `ETH_URL` and associated environment variables might be removed, so it is recommended to use the API, [CLI](/docs/configuration-variables/#cli-client), or GUI instead to setup chains and nodes.
 
 ### ETH_URL
 
-(Setting this will enable "legacy eth ENV" mode which is not compatible with multichain, prefer to configure in the CLI/API/GUI instead)
+Setting this will enable "legacy eth ENV" mode, which is not compatible with multi-chain. It is better to configure settings using the API, [CLI](/docs/configuration-variables/#cli-client), or GUI instead.
 
 - Default: _none_
 
@@ -641,7 +641,7 @@ NOTE: It is also required to set `ETH_CHAIN_ID` if you set ETH_URL.
 
 ### ETH_HTTP_URL
 
-(Only has effect if `ETH_URL` set to something, otherwise can be set in the CLI/API/GUI)
+Only has effect if `ETH_URL` set. Otherwise, it can be set in the API, [CLI](/docs/configuration-variables/#cli-client), or GUI.
 
 - Default: _none_
 
@@ -649,7 +649,7 @@ This should be set to the HTTP URL that points to the same ETH node as the prima
 
 ### ETH_SECONDARY_URLS
 
-(Only has effect if `ETH_URL` set to something, otherwise can be set in the CLI/API/GUI)
+Only has effect if `ETH_URL` set. Otherwise, it can be set in the API, [CLI](/docs/configuration-variables/#cli-client), or GUI.
 
 - Default: _none_
 
@@ -709,7 +709,7 @@ This might be useful on fast chains and if only recent chain events are relevant
 
 ### ETH_TX_REAPER_INTERVAL
 
-NOTE: This overrides the setting for _all_ chains, you might want to set this on a per-chain basis using the API, CLI, or GUI instead.
+NOTE: This overrides the setting for _all_ chains, you might want to set this on a per-chain basis using the API, [CLI](/docs/configuration-variables/#cli-client), or GUI instead
 
 - Default: `"1h"`
 
@@ -730,7 +730,7 @@ Setting to `0` disables the reaper.
 
 ### ETH_TX_RESEND_AFTER_THRESHOLD
 
-NOTE: This overrides the setting for _all_ chains, you might want to set this on a per-chain basis using the API, CLI, or GUI instead.
+NOTE: This overrides the setting for _all_ chains, you might want to set this on a per-chain basis using the API, [CLI](/docs/configuration-variables/#cli-client), or GUI instead.
 
 - Default: _automatically set based on Chain ID, typically 1m_
 
@@ -832,7 +832,7 @@ For jobs that use the `EthTx` adapter, this is the minimum payment amount in ord
 
 These settings allow you to tune your node's gas limits and pricing. In most cases, leaving these values at their defaults should give good results.
 
-As of Chainlink node v1.1.0, it is recommended to use the API, CLI, or GUI to configure gas controls because you might want to use different settings for different chains. Setting the environment variable typically overrides the setting for all chains.
+As of Chainlink node v1.1.0, it is recommended to use the API, [CLI](/docs/configuration-variables/#cli-client), or GUI to configure gas controls because you might want to use different settings for different chains. Setting the environment variable typically overrides the setting for all chains.
 
 ### Configuring your ETH node
 
@@ -1061,7 +1061,7 @@ Chainlink nodes will automatically try to sync its local nonce with the remote c
 
 These settings allow you to configure how your node calculates gas prices. In most cases, leaving these values at their defaults should give good results.
 
-As of Chainlink node v1.1.0, it is recommended to use the API, CLI, or GUI to configure gas controls because you might want to use different settings for different chains. Setting the environment variable typically overrides the setting for all chains.
+As of Chainlink node v1.1.0, it is recommended to use the API, [CLI](/docs/configuration-variables/#cli-client), or GUI to configure gas controls because you might want to use different settings for different chains. Setting the environment variable typically overrides the setting for all chains.
 
 Chainlink nodes decide what gas price to use using an `Estimator`. It ships with several simple and battle-hardened built-in estimators that should work well for almost all use-cases. Note that estimators will change their behaviour slightly depending on if you are in EIP-1559 mode or not.
 

--- a/firebase.json
+++ b/firebase.json
@@ -231,6 +231,16 @@
         "source": "/docs/faq",
         "destination": "/ethereum/",
         "type": 301
+      },
+      {
+        "source": "/docs/chainlink-node-api-reference/",
+        "destination": "/docs/configuration-variables/",
+        "type": 301
+      },
+      {
+        "source": "/docs/chainlink-node-api-reference",
+        "destination": "/docs/configuration-variables/",
+        "type": 301
       }
     ]
   }


### PR DESCRIPTION
This page is not useful. Remove it and point to the config page which has at least some relevant information.