### PR TITLE
Update get-a-random-number.md

### DIFF
--- a/docs/Using Randomness/get-a-random-number.md
+++ b/docs/Using Randomness/get-a-random-number.md
@@ -62,7 +62,7 @@ Now that you have a funded subscription account and your subscription ID, [creat
 
 For this example, use the [VRFv2Consumer.sol](https://remix.ethereum.org/#url=https://docs.chain.link/samples/VRF/VRFv2Consumer.sol) sample contract. This contract imports the following dependencies:
 
-- [VRFConsumerBaseV2.sol](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/dev/VRFConsumerBaseV2.sol)
+- [VRFConsumerBaseV2.sol](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/VRFConsumerBaseV2.sol)
 - [VRFCoordinatorV2Interface.sol](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/interfaces/VRFCoordinatorV2Interface.sol)
 - [LinkTokenInterface.sol](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/interfaces/LinkTokenInterface.sol)
 

--- a/docs/Using Randomness/vrf-migration-v1-v2.md
+++ b/docs/Using Randomness/vrf-migration-v1-v2.md
@@ -30,7 +30,7 @@ To modify your existing smart contract code to work with VRF v2, complete the fo
 
 1. Set up and fund a subscription in the [Subscription Manager](https://vrf.chain.link) application.
 
-1. Import the new [`VRFConsumerBaseV2.sol` contract](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/dev/VRFConsumerBaseV2.sol) and remove the v1 `VRFConsumerBase.sol` import. This contract includes the `fulfillRandomWords` function.
+1. Import the new [`VRFConsumerBaseV2.sol` contract](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/VRFConsumerBaseV2.sol) and remove the v1 `VRFConsumerBase.sol` import. This contract includes the `fulfillRandomWords` function.
 
 1. Import the [`VRFCoordinatorV2Interface.sol`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/interfaces/VRFCoordinatorV2Interface.sol) interface. This interface includes the new `requestRandomWords` function.
 


### PR DESCRIPTION
_VRFConsumerBaseV2.sol_ [link](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/dev/VRFConsumerBaseV2.sol) is not correct; Hence readers are redirected to this page:

![image](https://user-images.githubusercontent.com/4503543/154931633-e6d38dd5-18b7-4445-b2c4-8b3b5e39e34e.png)

the correct link is :
https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/VRFConsumerBaseV2.sol
