### PR TITLE
Config vars: List chains where the default minimumContractPayment is 0.1

### DIFF
--- a/docs/Node Operators/configuration-variables.md
+++ b/docs/Node Operators/configuration-variables.md
@@ -820,7 +820,7 @@ This can be overridden on a per-task basis by setting the `MinRequiredOutgoingCo
 > ⚠️ NOTE
 > This has replaced the formerly used MINIMUM_CONTRACT_PAYMENT
 
-- Default: _automatically set based on Chain ID, typically 10000000000000 (0.00001 LINK) on all chains except mainnet, where it is 0.1 LINK_
+- Default: _automatically set based on Chain ID, typically 10000000000000 (0.00001 LINK) on all chains except ETH Mainnet, Kovan, Goerli, and Rinkeby, where it is 100000000000000000 (0.1 LINK)._
 
 For jobs that use the `EthTx` adapter, this is the minimum payment amount in order for the node to accept and process the job. Since there are no decimals on the EVM, the value is represented like wei.
 


### PR DESCRIPTION
The `minimumContractPayment` var applies to more chains than ETH mainnet. https://github.com/smartcontractkit/chainlink/blob/120d9ff657dfd11c6eaaf581e13f4aaf947bd692/core/chains/evm/config/chain_specific_config.go#L152

Update the docs with the correct list.