### PR TITLE
Fix markdown header formatting in Using Data Feeds

### DIFF
--- a/docs/Using Price Feeds/get-the-latest-price.html
+++ b/docs/Using Price Feeds/get-the-latest-price.html
@@ -101,10 +101,12 @@ If you require a denomination other than what is provided, you can use two data 
 ```solidity
 {% include samples/PriceFeeds/PriceConverter.sol %}
 ```
+
 <div class="remix-callout">
       <a href="https://remix.ethereum.org/#url=https://docs.chain.link/samples/PriceFeeds/PriceConverter.sol" target="_blank" >Open in Remix</a>
       <a href="/docs/conceptual-overview/#what-is-remix">What is Remix?</a>
 </div>
+
 ## How Do Data Feeds Get Their Data?
 
 Data Feeds are aggregated from many data sources by a decentralized set of independent Node Operators. The [Decentralized Data Model](../architecture-decentralized-model/) describes this in detail.


### PR DESCRIPTION
Fix following the bug introduced by PR #651

<img width="1707" alt="image" src="https://user-images.githubusercontent.com/4503543/157840918-8cf8177d-da5f-4794-ae9e-5ca2e707ce06.png">
