### PR TITLE
Correct the description of divide task

### DIFF
--- a/docs/Oracle Jobs/Task Types/task_divide.md
+++ b/docs/Oracle Jobs/Task Types/task_divide.md
@@ -6,7 +6,7 @@ title: "Divide Task"
 permalink: "docs/jobs/task-types/divide/"
 ---
 
-Divides the provided `input` and `times` values.
+Divides the provided `input` by `divisor` and returns the result precisely to the `precision` value .
 
 **Parameters**
 


### PR DESCRIPTION
Currently the description of `divide` task is same as `multiply` task.
So this change will correct it to divide specific description.