### PR TITLE
remove DEFAULT_HTTP_ALLOW_UNRESTRICTED_NETWORK_ACCESS

### DIFF
--- a/docs/Node Operators/configuration-variables.md
+++ b/docs/Node Operators/configuration-variables.md
@@ -174,7 +174,6 @@ Your node applies configuration settings using following hierarchy:
     - [FM_SIMULATE_TRANSACTIONS](#fm_simulate_transactions)
     - [OCR_SIMULATE_TRANSACTIONS](#ocr_simulate_transactions)
 - [Job Pipeline and tasks](#job-pipeline-and-tasks)
-  - [DEFAULT_HTTP_ALLOW_UNRESTRICTED_NETWORK_ACCESS](#default_http_allow_unrestricted_network_access)
   - [DEFAULT_HTTP_LIMIT](#default_http_limit)
   - [DEFAULT_HTTP_TIMEOUT](#default_http_timeout)
   - [FEATURE_EXTERNAL_INITIATORS](#feature_external_initiators)
@@ -1394,16 +1393,6 @@ NOTE: This overrides the setting for _all_ chains, it is not currently possible 
 `OCR_SIMULATE_TRANSACTIONS` allows to enable transaction simulation for OCR.
 
 ## Job Pipeline and tasks
-
-### DEFAULT_HTTP_ALLOW_UNRESTRICTED_NETWORK_ACCESS
-
-- Default: `"false"`
-
-By default, Chainlink nodes do not allow the `http` adapter to connect to local IP addresses for security reasons (because the URL can come from on-chain, which is an untrusted source). This can be overridden on a per-task basis by setting the `AllowUnrestrictedNetworkAccess` key, or globally by setting the environment variable `DEFAULT_HTTP_ALLOW_UNRESTRICTED_NETWORK_ACCESS=true`.
-
-It is recommended that this be left disabled.
-
-NOTE: In older versions of Chainlink, it was required to set this in order to allow connections to bridges/external adapters on the local network. This requirement has been lifted and this environment variable now applies ONLY to `http` tasks. `bridge` tasks are always allows to connect to the local network.
 
 ### DEFAULT_HTTP_LIMIT
 


### PR DESCRIPTION
This was deprecated with `v0.10.8`, and removed from the code completely since.
> - It is no longer required to set `DEFAULT_HTTP_ALLOW_UNRESTRICTED_NETWORK_ACCESS=true` to enable local fetches on bridge or http tasks. If the URL for the http task is specified as a variable, then set the AllowUnrestrictedNetworkAccess option for this task. Please remove this if you had it set and no longer need it, since it introduces a slight security risk.

From https://github.com/smartcontractkit/chainlink/blob/develop/docs/CHANGELOG.md#0108---2021-06-21