### PR TITLE
Update VRFv2SubscriptionManager.sol

### DIFF
--- a/_includes/samples/VRF/VRFv2SubscriptionManager.sol
+++ b/_includes/samples/VRF/VRFv2SubscriptionManager.sol
@@ -69,12 +69,9 @@ contract VRFv2SubscriptionManager is VRFConsumerBaseV2 {
 
   // Create a new subscription when the contract is initially deployed.
   function createNewSubscription() private onlyOwner {
-    // Create a subscription with a new subscription ID.
-    address[] memory consumers = new address[](1);
-    consumers[0] = address(this);
     s_subscriptionId = COORDINATOR.createSubscription();
     // Add this contract as a consumer of its own subscription.
-    COORDINATOR.addConsumer(s_subscriptionId, consumers[0]);
+    COORDINATOR.addConsumer(s_subscriptionId, address(this));
   }
 
   // Assumes this contract owns link.


### PR DESCRIPTION
No reason to create an array, add a single member to it, and then pass the first element in. I assume this is vestigial from a point where this had to be passed as an array or some-such.