### PR TITLE
Add new section in documentation for explanation, examples, and permissions set of optional multiuser and RBAC functionality

### DIFF
--- a/docs/Node Operators/miscellaneous.md
+++ b/docs/Node Operators/miscellaneous.md
@@ -88,6 +88,75 @@ It will ask for your old password first, then ask for the new password and a con
 
 Once complete, you should see a message "Password updated."
 
+
+## Multi-user and Role Based Access Control (RBAC)
+
+The Chainlink node has the functionality to allow the root admin CLI user (and any additional admin users created) to create and assign tiers of role based access to new users. These new API users will be able to log in to the Operator UI independently.
+
+Users have a specific role tied to their account. There are four roles: `admin`, `edit`, `edit-minimal`, and `view`.
+
+If there are multiple users who need specific access to manage the Chainlink node instance, permissions and level of access can be set here.
+
+User management is configured through the use of the admin `chainlink admin users` command. Be sure to run `chainlink adamin login`. For example, a readonly user can be created with: `chainlink admin users create --email=operator-ui-read-only@test.com --role=view`.
+
+Below is a table of RBAC enabled actions and required permissions for each:
+
+| Action | Read | Edit Minimal | Edit | Admin |
+|:--- | :---: | :---: | :---: | :---: |
+| Update password  | X | X | X | X |
+| Create self API token  | X | X | X | X |
+| Delete self API token  | X | X | X | X |
+| List external initiators  | X | X | X | X |
+| Create external initiator  |   |   | X | X |
+| Delete external initiator  |   |   | X | X |
+| List bridges  | X | X | X | X |
+| View bridge  | X | X | X | X |
+| Create bridge  |   |   | X | X |
+| Edit bridge  |   |   | X | X |
+| Delete bridge  |   |   | X | X |
+| View config  | X | X | X | X |
+| Update config  |   |   |   | X |
+| Dump env/config  |   |   |   | X |
+| View transaction attempts  | X | X | X | X |
+| View transaction attempts EVM  | X | X | X | X |
+| View transactions  | X | X | X | X |
+| Replay a specific block number  |  | X | X | X |
+| List keys (CSA,ETH,OCR(2),P2P,Solana,Terra)  | X | X | X | X |
+| Create keys (CSA,ETH,OCR(2),P2P,Solana,Terra)  |   |   | X | X |
+| Delete keys (CSA,ETH,OCR(2),P2P,Solana,Terra)  |   |   |   | X |
+| Import keys (CSA,ETH,OCR(2),P2P,Solana,Terra)  |   |   |   | X |
+| Export keys (CSA,ETH,OCR(2),P2P,Solana,Terra)  |   |   |   | X |
+| List jobs | X | X | X | X |
+| View job | X | X | X | X |
+| Create job |  |  | X | X |
+| Delete job |  |   | X | X |
+| List pipeline runs | X | X | X | X |
+| View job runs | X | X | X | X |
+| Delete job spec errors |  |  | X | X |
+| View features | X | X | X | X |
+| View log | X | X | X | X |
+| Update log |   |   |   | X |
+| List chains | X | X | X | X |
+| View chain | X | X | X | X |
+| Create chain |   |   | X | X |
+| Update chain |   |   | X | X |
+| Delete chain |   |   | X | X |
+| View nodes | X | X | X | X |
+| Create node |  |  | X | X |
+| Update node |  |  | X | X |
+| Delete node |  |  | X | X |
+| View forwarders | X | X | X | X |
+| Create forwarder |   |   | X | X |
+| Delete forwarder |   |   | X | X |
+| Create job run |   | X | X | X |
+| Create Transfer EVM  |   |   |   | X |
+| Create Transfer Terra  |   |   |   | X |
+| Create Transfer Solana  |   |   |   | X |
+| Create user  |   |   |   | X |
+| Delete user  |   |   |   | X |
+| Edit user  |   |   |   | X |
+
+
 ## Use Named Chainlink Container
 
 Instead of allowing Docker to generate a name for your running container for you, you can provide a name with the `--name` option in your run command. For example, without the `--name` option, `docker ps` could reveal a name like:

--- a/docs/Node Operators/miscellaneous.md
+++ b/docs/Node Operators/miscellaneous.md
@@ -101,7 +101,7 @@ User management is configured through the use of the admin `chainlink admin user
 
 Below is a table of RBAC enabled actions and required permissions for each:
 
-| Action | Read | Run | Edit | Admin |
+| Action | Read | Run | Run | Admin |
 |:--- | :---: | :---: | :---: | :---: |
 | Update password  | X | X | X | X |
 | Create self API token  | X | X | X | X |
@@ -155,6 +155,9 @@ Below is a table of RBAC enabled actions and required permissions for each:
 | Create user  |   |   |   | X |
 | Delete user  |   |   |   | X |
 | Edit user  |   |   |   | X |
+
+
+The run command allows for minimal interaction, only enabling the ability to replay a specific block number and kick off a job run. 
 
 
 ## Use Named Chainlink Container

--- a/docs/Node Operators/miscellaneous.md
+++ b/docs/Node Operators/miscellaneous.md
@@ -93,7 +93,7 @@ Once complete, you should see a message "Password updated."
 
 The Chainlink node has the functionality to allow the root admin CLI user (and any additional admin users created) to create and assign tiers of role based access to new users. These new API users will be able to log in to the Operator UI independently.
 
-Users have a specific role tied to their account. There are four roles: `admin`, `edit`, `edit-minimal`, and `view`.
+Users have a specific role tied to their account. There are four roles: `admin`, `edit`, `run`, and `view`.
 
 If there are multiple users who need specific access to manage the Chainlink node instance, permissions and level of access can be set here.
 
@@ -101,7 +101,7 @@ User management is configured through the use of the admin `chainlink admin user
 
 Below is a table of RBAC enabled actions and required permissions for each:
 
-| Action | Read | Edit Minimal | Edit | Admin |
+| Action | Read | Run | Edit | Admin |
 |:--- | :---: | :---: | :---: | :---: |
 | Update password  | X | X | X | X |
 | Create self API token  | X | X | X | X |


### PR DESCRIPTION
## Context

This PR add documentation for the multiuser and role based access control functionality in the core node: https://github.com/smartcontractkit/chainlink/pull/6843

## Description

The core node will now optionally support multiuser sessions with role backed authorization. Update documentation with usage examples and state what each role can do.

## Changes

This PR adds a section on the miscellaneous page describing how to set it up and enumerates all actions that each role is permitted to do.