### PR TITLE
Add Metis to wallet

### DIFF
--- a/_src/reference/chains.json
+++ b/_src/reference/chains.json
@@ -243,6 +243,19 @@
     "explorers": [{ "name": "ftmscan", "url": "https://ftmscan.com", "icon": "ftmscan", "standard": "EIP3091" }]
   },
   {
+    "name": "Metis Andromeda Mainnet",
+    "chain": "ETH",
+    "rpc": ["https://andromeda.metis.io/?owner=1088"],
+    "faucets": [],
+    "nativeCurrency": { "name": "Metis", "symbol": "METIS", "decimals": 18 },
+    "infoURL": "https://www.metis.io",
+    "shortName": "metis-andromeda",
+    "chainId": 1088,
+    "networkId": 1088,
+    "explorers": [{ "name": "blockscout", "url": "https://andromeda-explorer.metis.io", "standard": "EIP3091" }],
+    "parent": { "type": "L2", "chain": "eip155-1", "bridges": [{ "url": "https://bridge.metis.io" }] }
+  },
+  {
     "name": "Moonbeam",
     "chain": "MOON",
     "rpc": ["https://rpc.api.moonbeam.network", "wss://wss.api.moonbeam.network"],

--- a/_src/reference/linkNameSymbol.json
+++ b/_src/reference/linkNameSymbol.json
@@ -9,6 +9,7 @@
   "80001": { "name": "ChainLink Token", "symbol": "LINK" },
   "30": { "name": "rLINK", "symbol": "rLINK" },
   "100": { "name": "ChainLink Token on xDai", "symbol": "LINK" },
+  "1088": { "name": "ChainLink Token", "symbol": "LINK" },
   "43114": { "name": "Chainlink Token", "symbol": "LINK.e" },
   "43113": { "name": "ChainLink Token", "symbol": "LINK" },
   "250": { "name": "ChainLink Token", "symbol": "anyLINK" },

--- a/docs/Developer Reference/link-token-contracts.md
+++ b/docs/Developer Reference/link-token-contracts.md
@@ -45,7 +45,6 @@ The LINK token is an ERC677 token that inherits functionality from the ERC20 tok
 | Symbol         | LINK                                                                                                                                                                                                         |
 | Decimals       | 18                                                                                                                                                                                                           |
 
-
 ## Rinkeby
 
 > 🚰 Rinkeby Faucets
@@ -370,17 +369,16 @@ GLMR is used to pay transaction fees on Moonbeam mainnet.
 | Symbol         | LINK                                                                                                                                                                                                             |
 | Decimals       | 18                                                                                                                                                                                                               |
 
-
 ## Metis
 
 ### Mainnet
 
 METIS is the currency that you use to pay for transactions on Metis mainnet. You can use the [Metis Bridge](https://bridge.metis.io/) to transfer METIS and LINK from Ethereum Mainnet to Metis mainnet.
 
-| Parameter      | Value                                                                                                                                                                                                            |
-| :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ETH_CHAIN_ID` | `1088`                                                                                                                                                                                                           |
-| Address        | <a href="https://andromeda-explorer.metis.io/address/0x79892E8A3Aea66C8F6893fa49eC6208ef07EC046">`0x79892E8A3Aea66C8F6893fa49eC6208ef07EC046`</a> |
-| Name           | Chainlink Token on Metis Mainnet                                                                                                                                                                              |
-| Symbol         | LINK                                                                                                                                                                                                             |
-| Decimals       | 18                                                                                                                                                                                                               |
+| Parameter      | Value                                                                                                                                                                                                                             |
+| :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ETH_CHAIN_ID` | `1088`                                                                                                                                                                                                                            |
+| Address        | <a class="erc-token-address" id="1088_0x79892E8A3Aea66C8F6893fa49eC6208ef07EC046"  href="https://andromeda-explorer.metis.io/address/0x79892E8A3Aea66C8F6893fa49eC6208ef07EC046">`0x79892E8A3Aea66C8F6893fa49eC6208ef07EC046`</a> |
+| Name           | Chainlink Token on Metis Mainnet                                                                                                                                                                                                  |
+| Symbol         | LINK                                                                                                                                                                                                                              |
+| Decimals       | 18                                                                                                                                                                                                                                |


### PR DESCRIPTION
## Description

Metis chains was added to supported networks. However, chains.json & linkNameSymbol.json were not updated. Thus, not allowing users to add metis token to their metamask wallet from docs.chain.link