### PR TITLE
add links for IaC solutions

### DIFF
--- a/docs/chainlink-nodes/best-security-practices.md
+++ b/docs/chainlink-nodes/best-security-practices.md
@@ -93,7 +93,7 @@ The following are suggestions for job specifications and configuration settings 
 Running a Chainlink node works well if you template out your infrastructure using tools like Kubernetes or Terraform. The following repositories can assist you with doing that:
 
 - [Pega88's Kubernetes & Terraform setup](https://github.com/Pega88/chainlink-gcp)
-- [SDL Chainlink Kubernetes Deployment](https://github.com/mycelium-ethereums/ChainlinkKubernetes)
+- [SDL Chainlink Kubernetes Deployment](https://github.com/mycelium-ethereum/ChainlinkKubernetes)
 - [LinkPool's Terraform Provider](https://github.com/linkpoolio/terraform-provider-chainlink)
 - [Ansible hardened Chainlink](https://github.com/WilsonBillkia/bane)
 - [Terraform module for serverless OCR node on AWS](https://github.com/ChainOrion/terraform-aws-chainlink-node)

--- a/docs/chainlink-nodes/best-security-practices.md
+++ b/docs/chainlink-nodes/best-security-practices.md
@@ -93,7 +93,7 @@ The following are suggestions for job specifications and configuration settings 
 Running a Chainlink node works well if you template out your infrastructure using tools like Kubernetes or Terraform. The following repositories can assist you with doing that:
 
 - [Pega88's Kubernetes & Terraform setup](https://github.com/Pega88/chainlink-gcp)
-- [SDL Chainlink Kubernetes Deployment](https://github.com/securedatalinks/ChainlinkKubernetes)
+- [SDL Chainlink Kubernetes Deployment](https://github.com/mycelium-ethereums/ChainlinkKubernetes)
 - [LinkPool's Terraform Provider](https://github.com/linkpoolio/terraform-provider-chainlink)
 - [Ansible hardened Chainlink](https://github.com/WilsonBillkia/bane)
 - [Terraform module for serverless OCR node on AWS](https://github.com/ChainOrion/terraform-aws-chainlink-node)

--- a/docs/chainlink-nodes/best-security-practices.md
+++ b/docs/chainlink-nodes/best-security-practices.md
@@ -96,3 +96,5 @@ Running a Chainlink node works well if you template out your infrastructure usin
 - [SDL Chainlink Kubernetes Deployment](https://github.com/securedatalinks/ChainlinkKubernetes)
 - [LinkPool's Terraform Provider](https://github.com/linkpoolio/terraform-provider-chainlink)
 - [Ansible hardened Chainlink](https://github.com/WilsonBillkia/bane)
+- [Terraform module for serverless OCR node on AWS](https://github.com/ChainOrion/terraform-aws-chainlink-node)
+- [Terraform module for serverless adapters on AWS](https://github.com/ChainOrion/terraform-aws-chainlink-ea)

--- a/docs/resources/example-projects.md
+++ b/docs/resources/example-projects.md
@@ -72,7 +72,7 @@ Read our [blog post here](https://blog.chain.link/showcasing-the-winning-project
 
 | Name                          | Description                                                                                    | GitHub                                                         |
 | :---------------------------- | :--------------------------------------------------------------------------------------------- | :------------------------------------------------------------- |
-| **InsuraLink**<br />🥇        | Data-driven insurance agreements that use Chainlink oracles to bridge IoT and smart contracts. | [Go](https://github.com/mycelium-ethereums/insuralink-contracts)  |
+| **InsuraLink**<br />🥇        | Data-driven insurance agreements that use Chainlink oracles to bridge IoT and smart contracts. | [Go](https://github.com/mycelium-ethereum/insuralink-contracts)  |
 | **1x.ag**<br />🥈             | Build leveraged trade positions across different lending platforms.                            | [Go](https://github.com/1x-ag/solidity-contracts)              |
 | **We Watch in Public Spaces** | Tracking system for calculating event attendance.                                              | [Go](https://github.com/iainnash/ethdenver-we-watch-in-public) |
 
@@ -85,7 +85,7 @@ Read our [blog post here](https://blog.chain.link/winners-of-the-chainlink-virtu
 | **LinkPal**<br />🥇           | A smart contract uses Chainlink oracles to confirm that the PayPal invoice has been paid.      | [Go](https://github.com/vvoluom/LinkPal)                                                |
 | **Cerebus Wallet**<br />🥈    | Two-factor authorization for crypto transactions using phone push notifications.               | [Go](https://github.com/MikaelLazarev/cerberus)                                         |
 | **Flyt**<br />🥉              | Flight insurance.                                                                              | [Go](https://github.com/robin-thomas/flyt)                                              |
-| **Link Total Return Swap**    | A Defi platform which enables Chainlink Node Operators to hedge against LINK price volatility. | [Go](https://github.com/mycelium-ethereums/LinkTRS)                                        |
+| **Link Total Return Swap**    | A Defi platform which enables Chainlink Node Operators to hedge against LINK price volatility. | [Go](https://github.com/mycelium-ethereum/LinkTRS)                                        |
 | **Smart Marketing Campaigns** | Use Google Analytics data to make payments to marketing agencies.                              | [Go](https://coinlist.co/build/chainlink/projects/6106f616-f9d8-4fec-85d7-c9f98bf8bd9e) |
 | **Steam Trader**              | Trustless trading of digital items.                                                            | [Go](https://github.com/brent-riva/Steam-Trader)                                        |
 | **Contractor**                | Constructor of smart contracts.                                                                | [Go](https://github.com/alekcangp/ChainLinkContractor)                                  |

--- a/docs/resources/example-projects.md
+++ b/docs/resources/example-projects.md
@@ -72,7 +72,7 @@ Read our [blog post here](https://blog.chain.link/showcasing-the-winning-project
 
 | Name                          | Description                                                                                    | GitHub                                                         |
 | :---------------------------- | :--------------------------------------------------------------------------------------------- | :------------------------------------------------------------- |
-| **InsuraLink**<br />🥇        | Data-driven insurance agreements that use Chainlink oracles to bridge IoT and smart contracts. | [Go](https://github.com/securedatalinks/insuralink-contracts)  |
+| **InsuraLink**<br />🥇        | Data-driven insurance agreements that use Chainlink oracles to bridge IoT and smart contracts. | [Go](https://github.com/mycelium-ethereums/insuralink-contracts)  |
 | **1x.ag**<br />🥈             | Build leveraged trade positions across different lending platforms.                            | [Go](https://github.com/1x-ag/solidity-contracts)              |
 | **We Watch in Public Spaces** | Tracking system for calculating event attendance.                                              | [Go](https://github.com/iainnash/ethdenver-we-watch-in-public) |
 
@@ -85,7 +85,7 @@ Read our [blog post here](https://blog.chain.link/winners-of-the-chainlink-virtu
 | **LinkPal**<br />🥇           | A smart contract uses Chainlink oracles to confirm that the PayPal invoice has been paid.      | [Go](https://github.com/vvoluom/LinkPal)                                                |
 | **Cerebus Wallet**<br />🥈    | Two-factor authorization for crypto transactions using phone push notifications.               | [Go](https://github.com/MikaelLazarev/cerberus)                                         |
 | **Flyt**<br />🥉              | Flight insurance.                                                                              | [Go](https://github.com/robin-thomas/flyt)                                              |
-| **Link Total Return Swap**    | A Defi platform which enables Chainlink Node Operators to hedge against LINK price volatility. | [Go](https://github.com/securedatalinks/LinkTRS)                                        |
+| **Link Total Return Swap**    | A Defi platform which enables Chainlink Node Operators to hedge against LINK price volatility. | [Go](https://github.com/mycelium-ethereums/LinkTRS)                                        |
 | **Smart Marketing Campaigns** | Use Google Analytics data to make payments to marketing agencies.                              | [Go](https://coinlist.co/build/chainlink/projects/6106f616-f9d8-4fec-85d7-c9f98bf8bd9e) |
 | **Steam Trader**              | Trustless trading of digital items.                                                            | [Go](https://github.com/brent-riva/Steam-Trader)                                        |
 | **Contractor**                | Constructor of smart contracts.                                                                | [Go](https://github.com/alekcangp/ChainLinkContractor)                                  |


### PR DESCRIPTION
## Closing issues

closes #859

## Description

It could be helpful for new node operators or existing operators not taking an IaC. With those modules, it's possible to create highly available, fault-tolerant, and scalable serverless infrastructure on AWS for both Chainlink OCR node and Chainlink External Adapters.

Used by Orion operator on Eth mainnet and reviewed by Mycelium and Chorus operators.

## Changes

- added links to Terraform modules for serverless setup for Chainlink OCR node and adapters on AWS
