### PR TITLE
Chainlink Node Release 1.8.0

### DIFF
--- a/_data/navigation.js
+++ b/_data/navigation.js
@@ -600,8 +600,16 @@ module.exports = {
                 url: '/docs/jobs/task-types/hexdecode/',
               },
               {
+                title: 'Hex Encode',
+                url: '/docs/jobs/task-types/hexencode/',
+              },
+              {
                 title: 'Base64 Decode',
                 url: '/docs/jobs/task-types/base64decode/',
+              },
+              {
+                title: 'Base64 Encode',
+                url: '/docs/jobs/task-types/base64encode/',
               },
               {
                 title: 'Uppercase',

--- a/docs/chainlink-nodes/configuration-variables.md
+++ b/docs/chainlink-nodes/configuration-variables.md
@@ -1058,7 +1058,7 @@ Set to zero to disable poll checking.
 
 - Default: `"HighestHead"`
 
-Controls controls node picking strategy. Supported values:
+Controls node picking strategy. Supported values:
 
 - `HighestHead` (default) mode picks a node having the highest reported head number among other alive nodes. When several nodes have the same latest head number, the strategy sticks to the last used node. This mode requires `NODE_NO_NEW_HEADS_THRESHOLD` to be configured, otherwise it will always use the first alive node.
 - `RoundRobin` mode simply iterates among available alive nodes. This was the default behavior prior to this release. 

--- a/docs/chainlink-nodes/configuration-variables.md
+++ b/docs/chainlink-nodes/configuration-variables.md
@@ -139,6 +139,7 @@ Your node applies configuration settings using following hierarchy:
   - [NODE_NO_NEW_HEADS_THRESHOLD](#node_no_new_heads_threshold)
   - [NODE_POLL_FAILURE_THRESHOLD](#node_poll_failure_threshold)
   - [NODE_POLL_INTERVAL](#node_poll_interval)
+  - [NODE_SELECTION_MODE](#node_selection_mode)
 - [EVM Gas Controls](#evm-gas-controls)
   - [Configuring your ETH node](#configuring-your-eth-node)
     - [go-ethereum](#go-ethereum)
@@ -1052,6 +1053,15 @@ Set to zero to disable poll checking.
 Controls how often to poll the node to check for liveness.
 
 Set to zero to disable poll checking.
+
+### NODE_SELECTION_MODE
+
+- Default: `"HighestHead"`
+
+Controls controls node picking strategy. Supported values:
+
+- `HighestHead` (default) mode picks a node having the highest reported head number among other alive nodes. When several nodes have the same latest head number, the strategy sticks to the last used node. This mode requires `NODE_NO_NEW_HEADS_THRESHOLD` to be configured, otherwise it will always use the first alive node.
+- `RoundRobin` mode simply iterates among available alive nodes. This was the default behavior prior to this release. 
 
 ## EVM Gas Controls
 

--- a/docs/chainlink-nodes/node-versions.md
+++ b/docs/chainlink-nodes/node-versions.md
@@ -21,7 +21,7 @@ You can find a list of release notes for Chainlink nodes in the [smartcontractki
 - Added the `hexencode` and `base64encode` tasks (pipeline). See the [Hex Encode Task](/docs/jobs/task-types/hexencode/) and [Hex Decode Task](/docs/jobs/task-types/hexdecode/) pages for examples.
 - `forwardingAllowed` per job attribute to allow forwarding txs submitted by the job.
 - Added `Arbitrum Goerli` configuration support.
-- Added the [`NODE_SELECTION_MODE` (`EVM.NodePool.SelectionMode`) environment variable](/docs/configuration-variables/#advisory_lock_check_interval#node_selection_mode), which controls node picking strategy. Supported values:
+- Added the [`NODE_SELECTION_MODE` (`EVM.NodePool.SelectionMode`) environment variable](/docs/configuration-variables/#node_selection_mode), which controls node picking strategy. Supported values:
   - `HighestHead` (default) mode picks a node having the highest reported head number among other alive nodes. When several nodes have the same latest head number, the strategy sticks to the last used node. This mode requires `NODE_NO_NEW_HEADS_THRESHOLD` to be configured, otherwise it will always use the first alive node.
   - `RoundRobin` mode simply iterates among available alive nodes. This was the default behavior prior to this release. 
 - New `evm keys chain` command. This can also be accessed at `/v2/keys/evm/chain`. This command has the following uses:
@@ -37,12 +37,12 @@ You can find a list of release notes for Chainlink nodes in the [smartcontractki
 
 - `chainlink admin users update` command is replaced with `chainlink admin users chrole` (only the role can be changed for a user)
 - Keypath now supports paths with any depth, instead of limiting it to 2.
-- `Arbitrum` chains are no longer restricted to only `FixedPrice` `GAS_ESTIMATOR_MODE`
+- `Arbitrum` chains are no longer restricted to only `FixedPrice` `GAS_ESTIMATOR_MODE`.
 - Updated `Arbitrum Rinkeby & Mainnet` configurations for Nitro.
 
 ### Removed
 
-- The `setnextnonce` local client command has been removed, and replaced by a more general key/chain client command.
+- The `setnextnonce` local client command is removed and is replaced by the more general `evm keys chain` command client command.
 
 
 ## Changes in v1.7.1 nodes

--- a/docs/chainlink-nodes/node-versions.md
+++ b/docs/chainlink-nodes/node-versions.md
@@ -12,6 +12,39 @@ metadata:
 
 You can find a list of release notes for Chainlink nodes in the [smartcontractkit GitHub repository](https://github.com/smartcontractkit/chainlink/releases). Docker images are available in the [Chainlink Docker hub](https://hub.docker.com/r/smartcontract/chainlink/tags).
 
+## Changes in v1.8.0 nodes
+
+**[v1.8.0 release notes](https://github.com/smartcontractkit/chainlink/releases/tag/v1.8.0)**
+
+### Added
+
+- Added the `hexencode` and `base64encode` tasks (pipeline). See the [Hex Encode Task](/docs/jobs/task-types/hexencode/) and [Hex Decode Task](/docs/jobs/task-types/hexdecode/) pages for examples.
+- `forwardingAllowed` per job attribute to allow forwarding txs submitted by the job.
+- Added `Arbitrum Goerli` configuration support.
+- Added the [`NODE_SELECTION_MODE` (`EVM.NodePool.SelectionMode`) environment variable](/docs/configuration-variables/#advisory_lock_check_interval#node_selection_mode), which controls node picking strategy. Supported values:
+  - `HighestHead` (default) mode picks a node having the highest reported head number among other alive nodes. When several nodes have the same latest head number, the strategy sticks to the last used node. This mode requires `NODE_NO_NEW_HEADS_THRESHOLD` to be configured, otherwise it will always use the first alive node.
+  - `RoundRobin` mode simply iterates among available alive nodes. This was the default behavior prior to this release. 
+- New `evm keys chain` command. This can also be accessed at `/v2/keys/evm/chain`. This command has the following uses:
+    - Manually set or reset a nonce:
+      - `chainlink evm keys chain --address "0xEXAMPLE" --evmChainID 99 --setNextNonce 42`
+    - Enable a key for a particular chain:
+      - `chainlink evm keys chain --address "0xEXAMPLE" --evmChainID 99 --setEnabled true`
+    - Disable a key for a particular chain:
+      - `chainlink evm keys chain --address "0xEXAMPLE" --evmChainID 99 --setEnabled false`
+- It is now possible to use the same key across multiple chains.
+
+### Changed
+
+- `chainlink admin users update` command is replaced with `chainlink admin users chrole` (only the role can be changed for a user)
+- Keypath now supports paths with any depth, instead of limiting it to 2.
+- `Arbitrum` chains are no longer restricted to only `FixedPrice` `GAS_ESTIMATOR_MODE`
+- Updated `Arbitrum Rinkeby & Mainnet` configurations for Nitro.
+
+### Removed
+
+- The `setnextnonce` local client command has been removed, and replaced by a more general key/chain client command.
+
+
 ## Changes in v1.7.1 nodes
 
 **[v1.7.1 release notes](https://github.com/smartcontractkit/chainlink/releases/tag/v1.7.1)**

--- a/docs/chainlink-nodes/node-versions.md
+++ b/docs/chainlink-nodes/node-versions.md
@@ -21,21 +21,18 @@ You can find a list of release notes for Chainlink nodes in the [smartcontractki
 - Added the `hexencode` and `base64encode` tasks (pipeline). See the [Hex Encode Task](/docs/jobs/task-types/hexencode/) and [Hex Decode Task](/docs/jobs/task-types/hexdecode/) pages for examples.
 - `forwardingAllowed` per job attribute to allow forwarding txs submitted by the job.
 - Added `Arbitrum Goerli` configuration support.
-- Added the [`NODE_SELECTION_MODE` (`EVM.NodePool.SelectionMode`) environment variable](/docs/configuration-variables/#node_selection_mode), which controls node picking strategy. Supported values:
-  - `HighestHead` (default) mode picks a node having the highest reported head number among other alive nodes. When several nodes have the same latest head number, the strategy sticks to the last used node. This mode requires `NODE_NO_NEW_HEADS_THRESHOLD` to be configured, otherwise it will always use the first alive node.
-  - `RoundRobin` mode simply iterates among available alive nodes. This was the default behavior prior to this release. 
+- Added the [`NODE_SELECTION_MODE` (`EVM.NodePool.SelectionMode`) environment variable](/docs/configuration-variables/#node_selection_mode), which controls node picking strategy. Supported values are:
+  - `HighestHead` is the default mode, which picks a node that has the highest reported head number among other alive nodes. When several nodes have the same latest head number, the strategy sticks to the last used node. This mode requires `NODE_NO_NEW_HEADS_THRESHOLD` to be configured, otherwise it will always use the first alive node.
+  - `RoundRobin` mode iterates among available alive nodes. This was the default behavior prior to this release. 
 - New `evm keys chain` command. This can also be accessed at `/v2/keys/evm/chain`. This command has the following uses:
-    - Manually set or reset a nonce:
-      - `chainlink evm keys chain --address "0xEXAMPLE" --evmChainID 99 --setNextNonce 42`
-    - Enable a key for a particular chain:
-      - `chainlink evm keys chain --address "0xEXAMPLE" --evmChainID 99 --setEnabled true`
-    - Disable a key for a particular chain:
-      - `chainlink evm keys chain --address "0xEXAMPLE" --evmChainID 99 --setEnabled false`
+    - Manually set or reset a nonce: `chainlink evm keys chain --address "0xEXAMPLE" --evmChainID 99 --setNextNonce 42`
+    - Enable a key for a particular chain: `chainlink evm keys chain --address "0xEXAMPLE" --evmChainID 99 --setEnabled true`
+    - Disable a key for a particular chain: `chainlink evm keys chain --address "0xEXAMPLE" --evmChainID 99 --setEnabled false`
 - It is now possible to use the same key across multiple chains.
 
 ### Changed
 
-- `chainlink admin users update` command is replaced with `chainlink admin users chrole` (only the role can be changed for a user)
+- The `chainlink admin users update` command is replaced with `chainlink admin users chrole`. Only the role can be changed for a user.
 - Keypath now supports paths with any depth, instead of limiting it to 2.
 - `Arbitrum` chains are no longer restricted to only `FixedPrice` `GAS_ESTIMATOR_MODE`.
 - Updated `Arbitrum Rinkeby & Mainnet` configurations for Nitro.

--- a/docs/chainlink-nodes/node-versions.md
+++ b/docs/chainlink-nodes/node-versions.md
@@ -18,7 +18,7 @@ You can find a list of release notes for Chainlink nodes in the [smartcontractki
 
 ### Added
 
-- Added the `hexencode` and `base64encode` tasks (pipeline). See the [Hex Encode Task](/docs/jobs/task-types/hexencode/) and [Hex Decode Task](/docs/jobs/task-types/hexdecode/) pages for examples.
+- Added the `hexencode` and `base64encode` tasks (pipeline). See the [Hex Encode Task](/docs/jobs/task-types/hexencode/) and [Base64 Encode Task](/docs/jobs/task-types/base64encode/) pages for examples.
 - `forwardingAllowed` per job attribute to allow forwarding txs submitted by the job.
 - Added `Arbitrum Goerli` configuration support.
 - Added the [`NODE_SELECTION_MODE` (`EVM.NodePool.SelectionMode`) environment variable](/docs/configuration-variables/#node_selection_mode), which controls node picking strategy. Supported values are:

--- a/docs/chainlink-nodes/oracle-jobs/task-types/task_base64encode.md
+++ b/docs/chainlink-nodes/oracle-jobs/task-types/task_base64encode.md
@@ -1,0 +1,25 @@
+---
+layout: nodes.liquid
+section: nodeOperator
+date: Last Modified
+title: "Base64 Encode Task"
+permalink: "docs/jobs/task-types/base64encode/"
+---
+
+Encodes bytes/string into a Base64 string.
+
+**Parameters**
+
+- `input`: Byte array or string to be encoded.
+
+**Outputs**
+
+String with Base64 encoding of input.
+
+**Example**
+
+```jpv2
+my_base64encode_task [type="base64encode" input="Hello, playground"]
+```
+
+Given the input string "Hello, playground", the task will return "SGVsbG8sIHBsYXlncm91bmQ=".

--- a/docs/chainlink-nodes/oracle-jobs/task-types/task_hexencode.md
+++ b/docs/chainlink-nodes/oracle-jobs/task-types/task_hexencode.md
@@ -1,0 +1,25 @@
+---
+layout: nodes.liquid
+section: nodeOperator
+date: Last Modified
+title: "Hex Encode Task"
+permalink: "docs/jobs/task-types/hexencode/"
+---
+
+Encodes bytes/string/integer into a hexadecimal string.
+
+**Parameters**
+
+- `input`: Byte array, string or integer to be encoded.
+
+**Outputs**
+
+Hexadecimal string prefixed with "0x" (or empty string if input was empty).
+
+**Example**
+
+```jpv2
+my_hexencode_task [type="hexencode" input="xyz"]
+```
+
+Given the input string "xyz", the task will return "0x78797a", which are the ascii values of characters in the string.


### PR DESCRIPTION
- hexencode and base64encode tasks: https://github.com/smartcontractkit/documentation/pull/909
- Add release notes for 1.8.0