### PR TITLE
fix name of chainlink NPM package

### DIFF
--- a/docs/Using Price Feeds/using-chainlink-reference-contracts.md
+++ b/docs/Using Price Feeds/using-chainlink-reference-contracts.md
@@ -17,7 +17,7 @@ metadata:
 
 Chainlink Data Feeds are the quickest way to connect your smart contracts to the real-world data such as asset prices. One use for data feeds is to retrieve the latest pricing data of an asset in a single call and use that data either on-chain in a smart contract or off-chain in another application of your choice.
 
-If you already have a project started and would like to integrate Chainlink, you can [add Chainlink to your existing project](../create-a-chainlinked-project/#install-into-existing-projects) by using the [`chainlink` NPM package](https://www.npmjs.com/package/@chainlink/contracts).
+If you already have a project started and would like to integrate Chainlink, you can [add Chainlink to your existing project](../create-a-chainlinked-project/#install-into-existing-projects) by using the [`@chainlink/contracts` NPM package](https://www.npmjs.com/package/@chainlink/contracts).
 
 See the [Data Feeds Contract Addresses](/docs/reference-contracts/) page for a list of networks and proxy addresses.  
 


### PR DESCRIPTION
## Description

fix name of chainlink NPM package

...

## Changes
`chainlink` isn't the name of the package, `@chainlink/contracts` is the name.
