### PR TITLE
Update evm-performance-configuration.md

### DIFF
--- a/docs/chainlink-nodes/evm-performance-configuration.md
+++ b/docs/chainlink-nodes/evm-performance-configuration.md
@@ -202,7 +202,7 @@ RPCGasCap = 0
 RPCTxFeeCap = 0.0
 ```
 
-### *Arbitrum Differences
+### Arbitrum differences
 
 Arbitrum Nitro runs a fork of go-ethereum internally, but the original flags are not valid. These modified flags are equivalent:
 

--- a/docs/chainlink-nodes/evm-performance-configuration.md
+++ b/docs/chainlink-nodes/evm-performance-configuration.md
@@ -195,6 +195,9 @@ The recommended way to scale is to use more keys rather than increasing throughp
 By default, go-ethereum rejects transactions that exceed its built-in RPC gas or txfee caps. Chainlink nodes fatally error transactions if this happens. If you ever exceed the caps, your node will miss transactions.
 
 Disable the default RPC gas and txfee caps on your ETH node in the config using the TOML snippet shown below, or by running go-ethereum with the command line arguments: `--rpc.gascap=0 --rpc.txfeecap=0`.
+<details><summary>:warning: Arbitrum Differences</summary>
+`--node.rpc.gas-cap 0 --node.rpc.tx-fee-cap 0`
+</details>
 
 ```text
 [Eth]

--- a/docs/chainlink-nodes/evm-performance-configuration.md
+++ b/docs/chainlink-nodes/evm-performance-configuration.md
@@ -195,15 +195,19 @@ The recommended way to scale is to use more keys rather than increasing throughp
 By default, go-ethereum rejects transactions that exceed its built-in RPC gas or txfee caps. Chainlink nodes fatally error transactions if this happens. If you ever exceed the caps, your node will miss transactions.
 
 Disable the default RPC gas and txfee caps on your ETH node in the config using the TOML snippet shown below, or by running go-ethereum with the command line arguments: `--rpc.gascap=0 --rpc.txfeecap=0`.
-<details><summary>:warning: Arbitrum Differences</summary>
-`--node.rpc.gas-cap 0 --node.rpc.tx-fee-cap 0`
-</details>
 
 ```text
 [Eth]
 RPCGasCap = 0
 RPCTxFeeCap = 0.0
 ```
+
+### *Arbitrum Differences
+
+Arbitrum Nitro runs a fork of go-ethereum internally, but the original flags are not valid. These modified flags are equivalent:
+
+`--node.rpc.gas-cap 0 --node.rpc.tx-fee-cap 0`
+
 
 ## Adjusting minimum outgoing confirmations for high throughput jobs
 


### PR DESCRIPTION
Arbitrum Nitro runs a fork of geth internally, but the normal geth flags don't work. We should document this difference alongside the regular flags.