### PR TITLE
Update the Ethereum client guide

### DIFF
--- a/_data/navigation.js
+++ b/_data/navigation.js
@@ -447,14 +447,16 @@ module.exports = {
           {
             title: 'Running a Chainlink Node',
             url: '/docs/running-a-chainlink-node/',
+            children: [
+              {
+                title: 'Run an Ethereum Client',
+                url: '/docs/run-an-ethereum-client/',
+              },
+            ],
           },
           {
             title: 'Fulfilling Requests',
             url: '/docs/fulfilling-requests/',
-          },
-          {
-            title: 'Run an Ethereum Client',
-            url: '/docs/run-an-ethereum-client/',
           },
           {
             title: 'Performing System Maintenance',

--- a/docs/chainlink-nodes/run-an-ethereum-client.md
+++ b/docs/chainlink-nodes/run-an-ethereum-client.md
@@ -11,7 +11,7 @@ whatsnext:
   }
 ---
 
-Chainlink nodes must be able to connect to an Ethereum client with an active websocket connection. This is accomplished by running both an execution client and a concensus client. You can run these clients yourself, butrunning Ethereum clients requires significant storage and network resources. Optionally, you can use [External Services](#external-services) that handle management of these clients for you.
+Chainlink nodes must be able to connect to an Ethereum client with an active websocket connection. This is accomplished by running both an execution client and a consensus client. You can run these clients yourself, but running Ethereum clients requires significant storage and network resources. Optionally, you can use [External Services](#external-services) that manage these clients for you.
 
 > 📘 If you run these clients yourself, you must enable the websockets API. The websockets API is required for the Chainlink node to communicate with the Ethereum blockchain.
 

--- a/docs/chainlink-nodes/run-an-ethereum-client.md
+++ b/docs/chainlink-nodes/run-an-ethereum-client.md
@@ -11,7 +11,7 @@ whatsnext:
   }
 ---
 
-In order to run a Chainlink node, it must be able to connect to an Ethereum client with an active websocket connection. This is accomplished by running both an execution client and a concensus client. Running Ethereum execution and concensus clients requires significant storage and network resources.
+Chainlink nodes must be able to connect to an Ethereum client with an active websocket connection. This is accomplished by running both an execution client and a concensus client. You can run these clients yourself, butrunning Ethereum clients requires significant storage and network resources. Optionally, you can use [External Services](#external-services) that handle management of these clients for you.
 
 > 📘 If you run these clients yourself, you must enable the websockets API. The websockets API is required for the Chainlink node to communicate with the Ethereum blockchain.
 

--- a/docs/chainlink-nodes/run-an-ethereum-client.md
+++ b/docs/chainlink-nodes/run-an-ethereum-client.md
@@ -2,22 +2,22 @@
 layout: nodes.liquid
 section: nodeOperator
 date: Last Modified
-title: "Run an Ethereum Client"
-permalink: "docs/run-an-ethereum-client/"
-whatsnext: {
-  "Running a Chainlink Node":"/docs/running-a-chainlink-node/",
-  "Optimizing Performance":"/docs/evm-performance-configuration/",
-}
+title: 'Run an Ethereum Client'
+permalink: 'docs/run-an-ethereum-client/'
+whatsnext:
+  {
+    'Running a Chainlink Node': '/docs/running-a-chainlink-node/',
+    'Optimizing Performance': '/docs/evm-performance-configuration/',
+  }
 ---
-In order to run a Chainlink node, it must be able to connect to an Ethereum client with an active websocket connection. This is accomplished by running either [Geth](https://geth.ethereum.org/), [Nethermind](https://nethermind.io/), or using a 3rd party connection. The examples below show how to run Geth and Nethermind in their official Docker containers for each network that they support.
 
-We would recommend to use one of the external services for your Ethereum client, since running one on your own managed machine will consume a lot of resources. If you do choose to run either Geth, or Nethermind with their native clients, please be sure to enable the websockets API, since it is required for the Chainlink node to communicate with the Ethereum blockchain.
+In order to run a Chainlink node, it must be able to connect to an Ethereum client with an active websocket connection. This is accomplished by running both an execution client and a concensus client.
+
+Running an ethereum client on your own managed machine will consume a lot of resources. If you do choose to run either Geth, or Nethermind with their native clients, please be sure to enable the websockets API, since it is required for the Chainlink node to communicate with the Ethereum blockchain.
 
 ## Geth
 
-[Geth's Documentation](https://geth.ethereum.org/docs/)
-
-*The Geth client can be used for the Rinkeby test network, as well as the Ethereum main network.*
+You can use the [Geth client](https://geth.ethereum.org/docs/) for the Goerli testnet and the Ethereum Mainnet. See the [Geth Documentation](https://geth.ethereum.org/docs/interface/peer-to-peer/) for a list of supported networks.
 
 Download the latest version:
 
@@ -51,7 +51,7 @@ docker run --name eth -p 8546:8546 -v ~/.geth-rinkeby:/geth -it \
 ```
 ```shell Mainnet
 docker run --name eth -p 8546:8546 -v ~/.geth:/geth -it \
-           ethereum/client-go --syncmode fast --ws --ipcdisable \
+           ethereum/client-go --ws --ipcdisable \
            --ws.addr 0.0.0.0 --ws.origins="*" --datadir /geth
 ```
 
@@ -63,13 +63,13 @@ If the container was stopped and you need to run it again, you can simply use th
 docker start -i eth
 ```
 
+Follow Geth's instructions for [Connecting to Consensus Clients](https://geth.ethereum.org/docs/interface/consensus-clients). This will require some additional configuration settings for the Docker command that runs Geth.
+
 Return to [Running a Chainlink Node](../running-a-chainlink-node/).
 
 ## Nethermind
 
-[Nethermind's Documentation](https://docs.nethermind.io/nethermind/)
-
-The Nethermind client can be used for Ethereum Mainnet and test networks. To see a full list of supported networks, see the [Nethermind supported network configurations](https://docs.nethermind.io/nethermind/ethereum-client/docker#available-configurations) page.
+You can use the [Nethermind client](https://docs.nethermind.io/nethermind/) for the Goerli testnet and the Ethereum Mainnet. See the [Nethermind supported network configurations](https://docs.nethermind.io/nethermind/ethereum-client/docker#available-configurations) page for a list of supported networks.
 
 Download the latest version:
 
@@ -120,6 +120,8 @@ If the container was stopped and you need to run it again, use the following com
 ```shell
 docker start -i eth
 ```
+
+Follow Nethermind's instructions for [Installing and configuring the Consensus Client](https://docs.nethermind.io/nethermind/guides-and-helpers/validator-setup/eth2-validator#setup). This will require some additional configuration settings for the Docker command that runs Nethermind.
 
 Return to [Running a Chainlink Node](../running-a-chainlink-node/).
 

--- a/docs/chainlink-nodes/run-an-ethereum-client.md
+++ b/docs/chainlink-nodes/run-an-ethereum-client.md
@@ -11,9 +11,9 @@ whatsnext:
   }
 ---
 
-In order to run a Chainlink node, it must be able to connect to an Ethereum client with an active websocket connection. This is accomplished by running both an execution client and a concensus client.
+In order to run a Chainlink node, it must be able to connect to an Ethereum client with an active websocket connection. This is accomplished by running both an execution client and a concensus client. Running Ethereum execution and concensus clients requires significant storage and network resources.
 
-Running an ethereum client on your own managed machine will consume a lot of resources. If you do choose to run either Geth, or Nethermind with their native clients, please be sure to enable the websockets API, since it is required for the Chainlink node to communicate with the Ethereum blockchain.
+> 📘 If you run these clients yourself, you must enable the websockets API. The websockets API is required for the Chainlink node to communicate with the Ethereum blockchain.
 
 ## Geth
 

--- a/docs/chainlink-nodes/running-a-chainlink-node.md
+++ b/docs/chainlink-nodes/running-a-chainlink-node.md
@@ -2,25 +2,26 @@
 layout: nodes.liquid
 section: nodeOperator
 date: Last Modified
-title: "Running a Chainlink Node"
-permalink: "docs/running-a-chainlink-node/"
-whatsnext: {
-  "Fulfilling Requests":"/docs/fulfilling-requests/",
-  "Optimizing EVN Performance":"/docs/evm-performance-configuration/",
-  "Performing System Maintenance":"/docs/performing-system-maintenance/",
-  "Miscellaneous":"/docs/miscellaneous/",
-  "Security and Operation Best Practices":"/docs/best-security-practices/"
-}
+title: 'Running a Chainlink Node'
+permalink: 'docs/running-a-chainlink-node/'
+whatsnext:
+  {
+    'Fulfilling Requests': '/docs/fulfilling-requests/',
+    'Optimizing EVN Performance': '/docs/evm-performance-configuration/',
+    'Performing System Maintenance': '/docs/performing-system-maintenance/',
+    'Miscellaneous': '/docs/miscellaneous/',
+    'Security and Operation Best Practices': '/docs/best-security-practices/',
+  }
 metadata:
-  title: "Running a Chainlink Node"
-  description: "Run your own Chainlink node using this guide which explains the requirements and basics for getting started."
+  title: 'Running a Chainlink Node'
+  description: 'Run your own Chainlink node using this guide which explains the requirements and basics for getting started.'
 ---
 
-In this section, we'll explain the requirements and basics for running your own Chainlink node.
+This page explains the requirements and basic instructions for running your own Chainlink node.
 
-It's important to note that nodes can fulfill requests for open APIs out-of-the-box using our [Tasks](/docs/tasks/) without needing any additional configuration.
+Note that nodes can fulfill requests for open APIs out-of-the-box using [Tasks](/docs/tasks/) without needing any additional configuration.
 
-If you would like to provide data from an authenticated API, you can add an [external adapter](../external-adapters/) to enable connectivity through the Chainlink node.
+To provide data from an authenticated API, add an [external adapter](../external-adapters/) to enable connectivity through the Chainlink node.
 
 ![Chainlink Node Diagram](/files/ab5762f-end-to-end-diagram.png)
 
@@ -37,7 +38,7 @@ Requesters can specify an amount of LINK that all nodes must deposit as a penalt
 Your Chainlink node should be run on a server that has a public IP address, and meets the following CPU and memory requirements:
 
 - Minimum: To get started running a Chainlink node, you will need a machine with at least **2 cores** and **4 GB of RAM**.
-- Recommended: The requirements for running a Chainlink node scale as the number of jobs your node services also scales. For nodes with over 100 jobs, you will need at least **4 cores** and **8GB of RAM**.  
+- Recommended: The requirements for running a Chainlink node scale as the number of jobs your node services also scales. For nodes with over 100 jobs, you will need at least **4 cores** and **8GB of RAM**.
 
 ### PostgreSQL Database Requirements
 
@@ -100,10 +101,7 @@ It's recommended to run the Chainlink node with [Docker](https://www.docker.com/
   # log in again
   ```
 
-- A fully synced Ethereum client with websockets enabled. Client specific instructions can be found below:
-  - [Run Geth](../run-an-ethereum-client/#geth)
-  - [Run Nethermind](../run-an-ethereum-client/#nethermind)
-  - [Use an external service](../run-an-ethereum-client/#external-services)
+- A fully synced Ethereum execution client with websockets enabled and a connected consensus client. See [Running an Ethereum Client](/docs/run-an-ethereum-client/) for details. Optionally, you can [use an external service](/docs/run-an-ethereum-client/#external-services) as your client.
 
 #### Create a directory
 
@@ -121,7 +119,7 @@ mkdir ~/.chainlink-rinkeby
 mkdir ~/.chainlink
 ```
 
-> **_Other Supported Networks:_**  Chainlink is blockchain agnostic technology. The [LINK Token Contracts](../link-token-contracts/) page details networks which support the LINK token. You can setup your node to provide data to any of these blockchains.
+> **_Other Supported Networks:_** Chainlink is blockchain agnostic technology. The [LINK Token Contracts](../link-token-contracts/) page details networks which support the LINK token. You can setup your node to provide data to any of these blockchains.
 
 #### Create an Environment File
 
@@ -208,7 +206,7 @@ You will need to connect your Chainlink node with a remote PostgreSQL database. 
 
 > 🚧 Important
 >
-> If you're testing you can add `?sslmode=disable` to the end of your `DATABASE_URL`. However you should *never* do this on a production node.
+> If you're testing you can add `?sslmode=disable` to the end of your `DATABASE_URL`. However you should _never_ do this on a production node.
 
 ```shell Goerli
 echo "DATABASE_URL=postgresql://$USERNAME:$PASSWORD@$SERVER:$PORT/$DATABASE" >> ~/.chainlink-goerli/.env
@@ -222,7 +220,7 @@ echo "DATABASE_URL=postgresql://$USERNAME:$PASSWORD@$SERVER:$PORT/$DATABASE" >> 
 
 #### Start the Chainlink Node
 
-Now you can run the Docker image. Replace `<version>` with your desired version. Tag versions are available in the [Chainlink docker hub](https://hub.docker.com/r/smartcontract/chainlink/tags). *The `latest` version does not work.*
+Now you can run the Docker image. Replace `<version>` with your desired version. Tag versions are available in the [Chainlink docker hub](https://hub.docker.com/r/smartcontract/chainlink/tags). _The `latest` version does not work._
 
 ```shell Goerli
 cd ~/.chainlink-goerli && docker run -p 6688:6688 -v ~/.chainlink-goerli:/chainlink -it --env-file=.env smartcontract/chainlink:<version> local n


### PR DESCRIPTION
- Add updates to point to consensus client guides
- Remove `--syncmode fast` which is now deprecated. `snap` is the new default.
- Move Running an Ethereum Node under the Chainlink node page in the nav.