### PR TITLE
Typo fix in "what's next" section

### DIFF
--- a/docs/getting-started/consuming-data-feeds.md
+++ b/docs/getting-started/consuming-data-feeds.md
@@ -5,7 +5,7 @@ date: Last Modified
 title: "Consuming Data Feeds"
 permalink: "docs/consuming-data-feeds/"
 excerpt: "Smart Contracts and Chainlink"
-whatsnext: {"Random Numbers: Using Chainlink VRF":"/docs/intermediates-tutorial/", "Connect contracts to Any API":"/docs/advanced-tutorial/", "Chaink Automation":"/docs/chainlink-automation/introduction/"}
+whatsnext: {"Random Numbers: Using Chainlink VRF":"/docs/intermediates-tutorial/", "Connect contracts to Any API":"/docs/advanced-tutorial/", "Chainlink Automation":"/docs/chainlink-automation/introduction/"}
 metadata:
   title: "Consuming Data Feeds"
   description: "Learn how to consume Chainlink Data Feeds in your smart contracts."


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.Any change needs to be discussed before proceeding.**

## Closing issues
closes #1010 

## Description
Typo fix in "What's next" section


## Changes

https://documentation-git-fork-thedriftofwords-patch-1-chainlinklabs.vercel.app/docs/consuming-data-feeds/

Fixes this typo ("Chaink Automation"):

<img width="805" alt="Screen Shot 2022-10-03 at 3 31 54 PM" src="https://user-images.githubusercontent.com/5498502/193662950-2c1a74da-60c1-4577-8a9c-8dbdc4c5a479.png">
