### PR TITLE
Fix typos in RBAC documentation

### DIFF
--- a/docs/chainlink-nodes/miscellaneous.md
+++ b/docs/chainlink-nodes/miscellaneous.md
@@ -97,7 +97,7 @@ Each user has a specific role assigned to their account. There are four roles: `
 
 If there are multiple users who need specific access to manage the Chainlink Node instance, permissions and level of access can be set here.
 
-User management is configured through the use of the admin `chainlink admin users` command. Run `chainlink adamin login` before you set user roles for other accounts. For example, a read-only user can be created with the following command:
+User management is configured through the use of the admin `chainlink admin users` command. Run `chainlink admin login` before you set user roles for other accounts. For example, a read-only user can be created with the following command:
 
 ```shell
 chainlink admin users create --email=operator-ui-read-only@test.com --role=view
@@ -105,7 +105,7 @@ chainlink admin users create --email=operator-ui-read-only@test.com --role=view
 
 Specific actions are enabled to check role-based access before they execute. The following table lists the actions that have role-based access and the role that is required to run that action:
 
-| Action | Read | Run | Run | Admin |
+| Action | Read | Run | Edit | Admin |
 |:--- | :---: | :---: | :---: | :---: |
 | Update password  | X | X | X | X |
 | Create self API token  | X | X | X | X |

--- a/docs/chainlink-nodes/node-versions.md
+++ b/docs/chainlink-nodes/node-versions.md
@@ -89,7 +89,7 @@ You can find a list of release notes for Chainlink nodes in the [smartcontractki
     - [hyperledger/besu/issues/4114](https://github.com/hyperledger/besu/issues/4114)
 
 - Added [Multi-user and Role Based Access Control](/docs/miscellaneous/#multi-user-and-role-based-access-control-rbac) functionality. This allows the root admin CLI user and additional admin users to create and assign tiers of role-based access to new users. These new API users are able to log in to the Operator UI independently and can each have specific roles tied to their account. There are four roles: `admin`, `edit`, `run`, and `view`.
-  - User management can be configured through the use of the new admin CLI command `chainlink admin users`. Be sure to run `chainlink adamin login`. For example, a readonly user can be created with: `chainlink admin users create --email=operator-ui-read-only@test.com --role=view`.
+  - User management can be configured through the use of the new admin CLI command `chainlink admin users`. Be sure to run `chainlink admin login`. For example, a readonly user can be created with: `chainlink admin users create --email=operator-ui-read-only@test.com --role=view`.
   - Updated documentation repo with a break down of actions to required role level
 
 - Added gas limit control for individual job specs and individual job types. The following rule of precedence is applied:


### PR DESCRIPTION
Fix minor typos in RBAC md ("adamin" in command, incorrect column)