### PR TITLE
added draft pages. exclude examples page from build. remove redirect …

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -25,9 +25,10 @@ export default defineConfig({
     solidityRemixCode(),
     youtubeEmbed(),
     mdx(),
-    partytown(),
+    partytown({}),
   ],
   markdown: {
+    drafts: true,
     rehypePlugins: [
       rehypeSlug,
       [

--- a/src/pages/README.md
+++ b/src/pages/README.md
@@ -18,6 +18,7 @@ setup: |
   import { variables } from "@variables"
   import { Tabs } from "@components/Tabs"
   import { NetworkTabs, PackageManagerTabs, ClickToZoom } from "@components"
+draft: true
 ---
 
 ## Using Directives

--- a/src/pages/search-index.astro
+++ b/src/pages/search-index.astro
@@ -6,8 +6,8 @@ import fs from "node:fs"
 const pages = await Astro.glob("./**/*.astro")
 
 // import .md files
-const posts = [...(await Astro.glob("./**/*.md"))]
-const postsMdx = [...(await Astro.glob("./**/*.mdx"))]
+const posts = [...(await Astro.glob("./**/*.md")).filter((post) => !post.frontmatter.draft)]
+const postsMdx = [...(await Astro.glob("./**/*.mdx")).filter((post) => !post.frontmatter.draft)]
 const postsMdxWithContent = postsMdx.map((post) => {
   const url = new URL(post.file, import.meta.url)
   const content = fs.readFileSync(url, "utf-8")
@@ -43,4 +43,4 @@ const stringifiedJson = JSON.stringify({ index }, null, 2)
 fs.writeFileSync(`${process.cwd()}/public/search-index.json`, stringifiedJson)
 ---
 
-<meta http-equiv="refresh" content={`0; url=/search-index.json`} />
+<meta http-equiv="refresh" content={`0; url=/`} />


### PR DESCRIPTION
## Description

Enables creating pages in draft state using the frontmatter `draft: true` as per the [astro docs](https://docs.astro.build/en/guides/markdown-content/#markdown-drafts)

Also removes a dead redirect to the search-index.json