### PR TITLE
any-api: put back goerli samples

### DIFF
--- a/public/samples/APIRequests/APIConsumer.sol
+++ b/public/samples/APIRequests/APIConsumer.sol
@@ -11,8 +11,10 @@ import "@chainlink/contracts/src/v0.8/ConfirmedOwner.sol";
 
 /**
  * THIS IS AN EXAMPLE CONTRACT WHICH USES HARDCODED VALUES FOR CLARITY.
- * PLEASE DO NOT USE THIS CODE IN PRODUCTION.
+ * THIS EXAMPLE USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
  */
+
 contract APIConsumer is ChainlinkClient, ConfirmedOwner {
     using Chainlink for Chainlink.Request;
 
@@ -25,15 +27,15 @@ contract APIConsumer is ChainlinkClient, ConfirmedOwner {
     /**
      * @notice Initialize the link token and target oracle
      *
-     * Rinkeby Testnet details:
-     * Link Token: 0x01BE23585060835E02B77ef475b0Cc51aA1e0709
-     * Oracle: 0xf3FBB7f3391F62C8fe53f89B41dFC8159EE9653f (Chainlink DevRel)
+     * Goerli Testnet details:
+     * Link Token: 0x326C977E6efc84E512bB9C30f76E30c160eD06FB
+     * Oracle: 0xCC79157eb46F5624204f47AB42b3906cAA40eaB7 (Chainlink DevRel)
      * jobId: ca98366cc7314957b8c012c72f05aeeb
      *
      */
     constructor() ConfirmedOwner(msg.sender) {
-        setChainlinkToken(0x01BE23585060835E02B77ef475b0Cc51aA1e0709);
-        setChainlinkOracle(0xf3FBB7f3391F62C8fe53f89B41dFC8159EE9653f);
+        setChainlinkToken(0x326C977E6efc84E512bB9C30f76E30c160eD06FB);
+        setChainlinkOracle(0xCC79157eb46F5624204f47AB42b3906cAA40eaB7);
         jobId = "ca98366cc7314957b8c012c72f05aeeb";
         fee = (1 * LINK_DIVISIBILITY) / 10; // 0,1 * 10**18 (Varies by network and job)
     }

--- a/public/samples/APIRequests/ATestnetConsumer.sol
+++ b/public/samples/APIRequests/ATestnetConsumer.sol
@@ -4,6 +4,11 @@ pragma solidity ^0.8.7;
 import "@chainlink/contracts/src/v0.8/ChainlinkClient.sol";
 import "@chainlink/contracts/src/v0.8/ConfirmedOwner.sol";
 
+/**
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
+ */
+
 contract ATestnetConsumer is ChainlinkClient, ConfirmedOwner {
     using Chainlink for Chainlink.Request;
 
@@ -28,12 +33,12 @@ contract ATestnetConsumer is ChainlinkClient, ConfirmedOwner {
     );
 
     /**
-     *  Rinkeby
-     *@dev LINK address in Rinkeby network: 0x01BE23585060835E02B77ef475b0Cc51aA1e0709
+     *  Goerli
+     *@dev LINK address in Goerli network: 0x326C977E6efc84E512bB9C30f76E30c160eD06FB
      * @dev Check https://docs.chain.link/docs/link-token-contracts/ for LINK address for the right network
      */
     constructor() ConfirmedOwner(msg.sender) {
-        setChainlinkToken(0x01BE23585060835E02B77ef475b0Cc51aA1e0709);
+        setChainlinkToken(0x326C977E6efc84E512bB9C30f76E30c160eD06FB);
     }
 
     function requestEthereumPrice(

--- a/public/samples/APIRequests/FetchFromArray.sol
+++ b/public/samples/APIRequests/FetchFromArray.sol
@@ -10,9 +10,11 @@ import "@chainlink/contracts/src/v0.8/ConfirmedOwner.sol";
  */
 
 /**
- * THIS IS AN EXAMPLE CONTRACT WHICH USES HARDCODED VALUES FOR CLARITY.
- * PLEASE DO NOT USE THIS CODE IN PRODUCTION.
+ * THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
  */
+
 contract FetchFromArray is ChainlinkClient, ConfirmedOwner {
     using Chainlink for Chainlink.Request;
 
@@ -26,15 +28,15 @@ contract FetchFromArray is ChainlinkClient, ConfirmedOwner {
     /**
      * @notice Initialize the link token and target oracle
      *
-     * Rinkeby Testnet details:
-     * Link Token: 0x01BE23585060835E02B77ef475b0Cc51aA1e0709
-     * Oracle: 0xf3FBB7f3391F62C8fe53f89B41dFC8159EE9653f (Chainlink DevRel)
+     * Goerli Testnet details:
+     * Link Token: 0x326C977E6efc84E512bB9C30f76E30c160eD06FB
+     * Oracle: 0xCC79157eb46F5624204f47AB42b3906cAA40eaB7 (Chainlink DevRel)
      * jobId: 7d80a6386ef543a3abb52817f6707e3b
      *
      */
     constructor() ConfirmedOwner(msg.sender) {
-        setChainlinkToken(0x01BE23585060835E02B77ef475b0Cc51aA1e0709);
-        setChainlinkOracle(0xf3FBB7f3391F62C8fe53f89B41dFC8159EE9653f);
+        setChainlinkToken(0x326C977E6efc84E512bB9C30f76E30c160eD06FB);
+        setChainlinkOracle(0xCC79157eb46F5624204f47AB42b3906cAA40eaB7);
         jobId = "7d80a6386ef543a3abb52817f6707e3b";
         fee = (1 * LINK_DIVISIBILITY) / 10; // 0,1 * 10**18 (Varies by network and job)
     }

--- a/public/samples/APIRequests/GenericBigWord.sol
+++ b/public/samples/APIRequests/GenericBigWord.sol
@@ -10,8 +10,11 @@ import "@chainlink/contracts/src/v0.8/ConfirmedOwner.sol";
  */
 
 /**
- * @notice DO NOT USE THIS CODE IN PRODUCTION. This is an example contract.
+ * THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
  */
+
 contract GenericLargeResponse is ChainlinkClient, ConfirmedOwner {
     using Chainlink for Chainlink.Request;
 
@@ -27,15 +30,15 @@ contract GenericLargeResponse is ChainlinkClient, ConfirmedOwner {
      * @dev The oracle address must be an Operator contract for multiword response
      *
      *
-     * Rinkeby Testnet details:
-     * Link Token: 0x01BE23585060835E02B77ef475b0Cc51aA1e0709
-     * Oracle: 0xf3FBB7f3391F62C8fe53f89B41dFC8159EE9653f (Chainlink DevRel)
+     * Goerli Testnet details:
+     * Link Token: 0x326C977E6efc84E512bB9C30f76E30c160eD06FB
+     * Oracle: 0xCC79157eb46F5624204f47AB42b3906cAA40eaB7 (Chainlink DevRel)
      * jobId: 7da2702f37fd48e5b1b9a5715e3509b6
      *
      */
     constructor() ConfirmedOwner(msg.sender) {
-        setChainlinkToken(0x01BE23585060835E02B77ef475b0Cc51aA1e0709);
-        setChainlinkOracle(0xf3FBB7f3391F62C8fe53f89B41dFC8159EE9653f);
+        setChainlinkToken(0x326C977E6efc84E512bB9C30f76E30c160eD06FB);
+        setChainlinkOracle(0xCC79157eb46F5624204f47AB42b3906cAA40eaB7);
         jobId = "7da2702f37fd48e5b1b9a5715e3509b6";
         fee = (1 * LINK_DIVISIBILITY) / 10; // 0,1 * 10**18 (Varies by network and job)
     }

--- a/public/samples/APIRequests/GetGasPrice.sol
+++ b/public/samples/APIRequests/GetGasPrice.sol
@@ -10,9 +10,11 @@ import "@chainlink/contracts/src/v0.8/ConfirmedOwner.sol";
  */
 
 /**
- * THIS IS AN EXAMPLE CONTRACT WHICH USES HARDCODED VALUES FOR CLARITY.
- * PLEASE DO NOT USE THIS CODE IN PRODUCTION.
+ * THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
  */
+
 contract GetGasPrice is ChainlinkClient, ConfirmedOwner {
     using Chainlink for Chainlink.Request;
 
@@ -33,15 +35,15 @@ contract GetGasPrice is ChainlinkClient, ConfirmedOwner {
     /**
      * @notice Initialize the link token and target oracle
      *
-     * Rinkeby Testnet details:
-     * Link Token: 0x01BE23585060835E02B77ef475b0Cc51aA1e0709
-     * Oracle: 0xf3FBB7f3391F62C8fe53f89B41dFC8159EE9653f (Chainlink DevRel)
+     * Goerli Testnet details:
+     * Link Token: 0x326C977E6efc84E512bB9C30f76E30c160eD06FB
+     * Oracle: 0xCC79157eb46F5624204f47AB42b3906cAA40eaB7 (Chainlink DevRel)
      * jobId: 7223acbd01654282865b678924126013
      *
      */
     constructor() ConfirmedOwner(msg.sender) {
-        setChainlinkToken(0x01BE23585060835E02B77ef475b0Cc51aA1e0709);
-        setChainlinkOracle(0xf3FBB7f3391F62C8fe53f89B41dFC8159EE9653f);
+        setChainlinkToken(0x326C977E6efc84E512bB9C30f76E30c160eD06FB);
+        setChainlinkOracle(0xCC79157eb46F5624204f47AB42b3906cAA40eaB7);
         jobId = "7223acbd01654282865b678924126013";
         fee = (1 * LINK_DIVISIBILITY) / 10; // 0,1 * 10**18 (Varies by network and job)
     }

--- a/public/samples/APIRequests/MultiWordConsumer.sol
+++ b/public/samples/APIRequests/MultiWordConsumer.sol
@@ -10,9 +10,11 @@ import "@chainlink/contracts/src/v0.8/ConfirmedOwner.sol";
  */
 
 /**
- * THIS IS AN EXAMPLE CONTRACT WHICH USES HARDCODED VALUES FOR CLARITY.
- * PLEASE DO NOT USE THIS CODE IN PRODUCTION.
+ * THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
  */
+
 contract MultiWordConsumer is ChainlinkClient, ConfirmedOwner {
     using Chainlink for Chainlink.Request;
 
@@ -36,15 +38,15 @@ contract MultiWordConsumer is ChainlinkClient, ConfirmedOwner {
      * @dev The oracle address must be an Operator contract for multiword response
      *
      *
-     * Rinkeby Testnet details:
-     * Link Token: 0x01BE23585060835E02B77ef475b0Cc51aA1e0709
-     * Oracle: 0xf3FBB7f3391F62C8fe53f89B41dFC8159EE9653f (Chainlink DevRel)
+     * Goerli Testnet details:
+     * Link Token: 0x326C977E6efc84E512bB9C30f76E30c160eD06FB
+     * Oracle: 0xCC79157eb46F5624204f47AB42b3906cAA40eaB7 (Chainlink DevRel)
      * jobId: 53f9755920cd451a8fe46f5087468395
      *
      */
     constructor() ConfirmedOwner(msg.sender) {
-        setChainlinkToken(0x01BE23585060835E02B77ef475b0Cc51aA1e0709);
-        setChainlinkOracle(0xf3FBB7f3391F62C8fe53f89B41dFC8159EE9653f);
+        setChainlinkToken(0x326C977E6efc84E512bB9C30f76E30c160eD06FB);
+        setChainlinkOracle(0xCC79157eb46F5624204f47AB42b3906cAA40eaB7);
         jobId = "53f9755920cd451a8fe46f5087468395";
         fee = (1 * LINK_DIVISIBILITY) / 10; // 0,1 * 10**18 (Varies by network and job)
     }


### PR DESCRIPTION
There was an issue during docs migration: Rinkeby samples are being used in ANY API while they are obsolete