### PR TITLE
Fixes two callout issues

### DIFF
--- a/src/pages/getting-started/consuming-data-feeds.md
+++ b/src/pages/getting-started/consuming-data-feeds.md
@@ -44,7 +44,9 @@ The contract has the following components:
 
 ## Compile, deploy, and run the contract
 
-:::caution[ If you have not already configured your MetaMask wallet and funded it with testnet ETH, follow the instructions in the Deploy Your First Smart Contract to set that up. You can get testnet ETH at one of the available [Goerli faucets](/resources/link-token-contracts/#goerli-testnet).]
+:::caution[ Configure and fund your wallet]
+
+If you have not already configured your MetaMask wallet and funded it with testnet ETH, follow the instructions in the Deploy Your First Smart Contract to set that up. You can get testnet ETH at one of the available [Goerli faucets](/resources/link-token-contracts/#goerli-testnet).
 
 :::
 

--- a/src/pages/vrf/v2/security.md
+++ b/src/pages/vrf/v2/security.md
@@ -8,8 +8,6 @@ setup: |
   import VrfCommon from "@features/vrf/v2/common/VrfCommon.astro"
 ---
 
-<VrfCommon callout="common"/>
-
 Gaining access to high quality randomness on-chain requires a solution like Chainlink's VRF, but it also requires you to understand some of the ways that miners or validators can potentially manipulate randomness generation. Here are some of the top security considerations you should review in your project.
 
 - [Use `requestId` to match randomness requests with their fulfillment in order](#use-requestid-to-match-randomness-requests-with-their-fulfillment-in-order)


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.Any change needs to be discussed before proceeding.**

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #1110

...

## Description

Fixes two callout issues.

Previews:

- https://documentation-git-fork-thedriftofwords-main-chainlinklabs.vercel.app/getting-started/consuming-data-feeds#compile-deploy-and-run-the-contract
- https://documentation-git-fork-thedriftofwords-main-chainlinklabs.vercel.app/vrf/v2/security

## Changes

- Deletes the unnecessary self-linking callout at the top of the [VRF Security Considerations](https://docs.chain.link/vrf/v2/security/) page.
- Sets a title for a callout in [Consuming Data Feeds](https://docs.chain.link/getting-started/consuming-data-feeds#compile-deploy-and-run-the-contract).
