### PR TITLE
Update ethstats links

### DIFF
--- a/.eleventy/_tools/networks.ts
+++ b/.eleventy/_tools/networks.ts
@@ -2,7 +2,7 @@ export const NETWORKS = [
   {
     page: "ethereum",
     title: "Ethereum Data Feeds",
-    networkStatusUrl: "https://ethstats.net/",
+    networkStatusUrl: "https://ethstats.dev/",
     networks: [
       {
         name: "Ethereum Mainnet",

--- a/.eleventy/docs/resources/link-token-contracts.md
+++ b/.eleventy/docs/resources/link-token-contracts.md
@@ -45,7 +45,7 @@ The LINK token is an ERC677 token that inherits functionality from the ERC20 tok
 | Name           | Chainlink Token                                                                                                                                                                                              |
 | Symbol         | LINK                                                                                                                                                                                                         |
 | Decimals       | 18                                                                                                                                                                                                           |
-| Network status | [ethstats.net](https://ethstats.net/)                                                                                                                                                                        |
+| Network status | [ethstats.dev](https://ethstats.dev/)                                                                                                                                                                        |
 
 ### Goerli testnet
 

--- a/scripts/networks.ts
+++ b/scripts/networks.ts
@@ -2,7 +2,7 @@ export const NETWORKS = [
   {
     page: "ethereum",
     title: "Ethereum Data Feeds",
-    networkStatusUrl: "https://ethstats.net/",
+    networkStatusUrl: "https://ethstats.dev/",
     networks: [
       {
         name: "Ethereum Mainnet",

--- a/src/features/feeds/data/chains.ts
+++ b/src/features/feeds/data/chains.ts
@@ -24,7 +24,7 @@ export const CHAINS: Chain[] = [
     page: "ethereum",
     title: "Ethereum Data Feeds",
     img: "/assets/chains/ethereum.svg",
-    networkStatusUrl: "https://ethstats.net/",
+    networkStatusUrl: "https://ethstats.dev/",
     tags: ["default", "proofOfReserve", "nftFloorPrice"],
     networks: [
       {
@@ -327,7 +327,7 @@ export const ALL_CHAINS: Chain[] = [
     page: "deprecated",
     title: "All chains",
     img: "/assets/chains/ethereum.svg",
-    networkStatusUrl: "https://ethstats.net/",
+    networkStatusUrl: "https://ethstats.dev/",
     tags: ["default", "proofOfReserve", "nftFloorPrice"],
     networks: [
       {

--- a/src/pages/resources/link-token-contracts.md
+++ b/src/pages/resources/link-token-contracts.md
@@ -36,7 +36,7 @@ The LINK token is an ERC677 token that inherits functionality from the ERC20 tok
 | Name           | Chainlink Token                                                                                                                                                                                              |
 | Symbol         | LINK                                                                                                                                                                                                         |
 | Decimals       | 18                                                                                                                                                                                                           |
-| Network status | [ethstats.net](https://ethstats.net/)                                                                                                                                                                        |
+| Network status | [ethstats.dev](https://ethstats.dev/)                                                                                                                                                                        |
 
 ### Sepolia testnet
 


### PR DESCRIPTION
## Description

Update ethstats links: ethstats.net --> ethstats.dev

...

## Changes

ethstats.dev is the new link for ethstats.

See:
- https://geth.ethereum.org/docs/monitoring/ethstats#ethstats
- [internet archive results for ethstats.net](https://web.archive.org/web/20220601000000*/ethstats.net) stopping in mid-November 2022
