### PR TITLE
Update VRF sample contracts to Sepolia; add MetaMask clarification on gas limit

### DIFF
--- a/public/samples/VRF/VRFD20.sol
+++ b/public/samples/VRF/VRFD20.sol
@@ -28,15 +28,15 @@ contract VRFD20 is VRFConsumerBaseV2 {
     // Your subscription ID.
     uint64 s_subscriptionId;
 
-    // Goerli coordinator. For other networks,
+    // Sepolia coordinator. For other networks,
     // see https://docs.chain.link/docs/vrf-contracts/#configurations
-    address vrfCoordinator = 0x2Ca8E0C643bDe4C2E08ab1fA0da3401AdAD7734D;
+    address vrfCoordinator = 0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625;
 
     // The gas lane to use, which specifies the maximum gas price to bump to.
     // For a list of available gas lanes on each network,
     // see https://docs.chain.link/docs/vrf-contracts/#configurations
     bytes32 s_keyHash =
-        0x79d3d8832d904592c0bf9818b621522c988bb8b0c05cdc3b15aea1b6e8db0c15;
+        0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c;
 
     // Depends on the number of requested values that you want sent to the
     // fulfillRandomWords() function. Storing each word costs about 20,000 gas,
@@ -65,7 +65,7 @@ contract VRFD20 is VRFConsumerBaseV2 {
     /**
      * @notice Constructor inherits VRFConsumerBaseV2
      *
-     * @dev NETWORK: Goerli
+     * @dev NETWORK: Sepolia
      *
      * @param subscriptionId subscription id that this consumer contract can use
      */

--- a/public/samples/VRF/VRFv2Consumer.sol
+++ b/public/samples/VRF/VRFv2Consumer.sol
@@ -41,7 +41,7 @@ contract VRFv2Consumer is VRFConsumerBaseV2, ConfirmedOwner {
     // For a list of available gas lanes on each network,
     // see https://docs.chain.link/docs/vrf/v2/subscription/supported-networks/#configurations
     bytes32 keyHash =
-        0x79d3d8832d904592c0bf9818b621522c988bb8b0c05cdc3b15aea1b6e8db0c15;
+        0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c;
 
     // Depends on the number of requested values that you want sent to the
     // fulfillRandomWords() function. Storing each word costs about 20,000 gas,
@@ -59,17 +59,17 @@ contract VRFv2Consumer is VRFConsumerBaseV2, ConfirmedOwner {
     uint32 numWords = 2;
 
     /**
-     * HARDCODED FOR GOERLI
-     * COORDINATOR: 0x2Ca8E0C643bDe4C2E08ab1fA0da3401AdAD7734D
+     * HARDCODED FOR SEPOLIA
+     * COORDINATOR: 0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625
      */
     constructor(
         uint64 subscriptionId
     )
-        VRFConsumerBaseV2(0x2Ca8E0C643bDe4C2E08ab1fA0da3401AdAD7734D)
+        VRFConsumerBaseV2(0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625)
         ConfirmedOwner(msg.sender)
     {
         COORDINATOR = VRFCoordinatorV2Interface(
-            0x2Ca8E0C643bDe4C2E08ab1fA0da3401AdAD7734D
+            0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625
         );
         s_subscriptionId = subscriptionId;
     }

--- a/public/samples/VRF/VRFv2DirectFundingConsumer.sol
+++ b/public/samples/VRF/VRFv2DirectFundingConsumer.sol
@@ -53,11 +53,11 @@ contract VRFv2DirectFundingConsumer is
     // Cannot exceed VRFV2Wrapper.getConfig().maxNumWords.
     uint32 numWords = 2;
 
-    // Address LINK - hardcoded for Goerli
-    address linkAddress = 0x326C977E6efc84E512bB9C30f76E30c160eD06FB;
+    // Address LINK - hardcoded for Sepolia
+    address linkAddress = 0x779877A7B0D9E8603169DdbD7836e478b4624789;
 
-    // address WRAPPER - hardcoded for Goerli
-    address wrapperAddress = 0x708701a1DfF4f478de54383E49a627eD4852C816;
+    // address WRAPPER - hardcoded for Sepolia
+    address wrapperAddress = 0xab18414CD93297B0d12ac29E63Ca20f515b3DB46;
 
     constructor()
         ConfirmedOwner(msg.sender)

--- a/public/samples/VRF/VRFv2MultiplePaths.sol
+++ b/public/samples/VRF/VRFv2MultiplePaths.sol
@@ -18,17 +18,17 @@ contract VRFv2MultiplePaths is VRFConsumerBaseV2 {
     // Your subscription ID.
     uint64 s_subscriptionId;
 
-    // Goerli coordinator. For other networks,
+    // Sepolia coordinator. For other networks,
     // see https://docs.chain.link/docs/vrf/v2/supported-networks/#configurations
-    address vrfCoordinator = 0x2Ca8E0C643bDe4C2E08ab1fA0da3401AdAD7734D;
+    address vrfCoordinator = 0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625;
 
     // The gas lane to use, which specifies the maximum gas price to bump to.
     // For a list of available gas lanes on each network,
     // see https://docs.chain.link/docs/vrf/v2/supported-networks/#configurations
     bytes32 keyHash =
-        0x79d3d8832d904592c0bf9818b621522c988bb8b0c05cdc3b15aea1b6e8db0c15;
+        0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c;
 
-    uint32 callbackGasLimit = 100_000;
+    uint32 callbackGasLimit = 100000;
 
     // The default is 3, but you can set this higher.
     uint16 requestConfirmations = 3;

--- a/public/samples/VRF/VRFv2SubscriptionManager.sol
+++ b/public/samples/VRF/VRFv2SubscriptionManager.sol
@@ -21,19 +21,19 @@ contract VRFv2SubscriptionManager is VRFConsumerBaseV2 {
     VRFCoordinatorV2Interface COORDINATOR;
     LinkTokenInterface LINKTOKEN;
 
-    // Goerli coordinator. For other networks,
+    // Sepolia coordinator. For other networks,
     // see https://docs.chain.link/docs/vrf-contracts/#configurations
-    address vrfCoordinator = 0x2Ca8E0C643bDe4C2E08ab1fA0da3401AdAD7734D;
+    address vrfCoordinator = 0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625;
 
-    // Goerli LINK token contract. For other networks, see
+    // Sepolia LINK token contract. For other networks, see
     // https://docs.chain.link/docs/vrf-contracts/#configurations
-    address link_token_contract = 0x326C977E6efc84E512bB9C30f76E30c160eD06FB;
+    address link_token_contract = 0x779877A7B0D9E8603169DdbD7836e478b4624789;
 
     // The gas lane to use, which specifies the maximum gas price to bump to.
     // For a list of available gas lanes on each network,
     // see https://docs.chain.link/docs/vrf-contracts/#configurations
     bytes32 keyHash =
-        0x79d3d8832d904592c0bf9818b621522c988bb8b0c05cdc3b15aea1b6e8db0c15;
+        0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c;
 
     // A reasonable default is 100000, but this value could be different
     // on other networks.

--- a/src/pages/vrf/v2/direct-funding/examples/get-a-random-number.md
+++ b/src/pages/vrf/v2/direct-funding/examples/get-a-random-number.md
@@ -78,7 +78,7 @@ The deployed contract requests random values from Chainlink VRF, receives those 
 
    First, [enable **Advanced gas controls** in your MetaMask settings](https://support.metamask.io/hc/en-us/articles/360022895972).
 
-   Before confirming your transaction in MetaMask, navigate to the screen where you can edit the gas fee: Select **Site suggested** > **Advanced** > **Advanced gas controls** and select **Edit** next to the **Gas limit** amount. Update the **Gas limit** value to _400000_ and select **Save**. Finally, confirm the transaction.
+   Before confirming your transaction in MetaMask, navigate to the screen where you can edit the gas limit: Select **Site suggested** > **Advanced** > **Advanced gas controls** and select **Edit** next to the **Gas limit** amount. Update the **Gas limit** value to _400000_ and select **Save**. Finally, confirm the transaction.
    :::
    After you approve the transaction, Chainlink VRF processes your request. Chainlink VRF fulfills the request and returns the random values to your contract in a callback to the `fulfillRandomWords()` function. At this point, a new key `requestId` is added to the mapping `s_requests`. Depending on current testnet conditions, it might take a few minutes for the callback to return the requested random values to your contract.
 

--- a/src/pages/vrf/v2/direct-funding/examples/get-a-random-number.md
+++ b/src/pages/vrf/v2/direct-funding/examples/get-a-random-number.md
@@ -58,7 +58,10 @@ Build and deploy the contract on Sepolia.
 
 ## Fund Your Contract
 
-Requests for randomness will fail unless your consuming contract has enough LINK. Learn how to [Acquire testnet LINK](/resources/acquire-link/) and [Fund your contract](/resources/fund-your-contract/). For this example, funding with 2 LINK should be sufficient.
+Requests for randomness will fail unless your consuming contract has enough LINK.
+
+1. [Acquire testnet LINK](/resources/acquire-link/).
+1. [Fund your contract with testnet LINK](/resources/fund-your-contract/). For this example, funding your contract with 2 LINK should be sufficient.
 
 ## Request random values
 
@@ -67,9 +70,15 @@ The deployed contract requests random values from Chainlink VRF, receives those 
 1. Return to Remix and view your deployed contract functions in the **Deployed Contracts** list.
 
 1. Click the `requestRandomWords()` function to send the request for random values to Chainlink VRF. MetaMask opens and asks you to confirm the transaction.
-   :::note[Remix IDE: gas limit setup]
-   Remix IDE doesn't set the right gas limit. For this example to work, set a
-   gas limit of _400,000_ as explained [here](https://metamask.zendesk.com/hc/en-us/articles/360022895972).
+   :::note[Set your gas limit in MetaMask]
+   Remix IDE doesn't set the right gas limit, so you must [edit the
+   gas limit in MetaMask](https://support.metamask.io/hc/en-us/articles/360022895972) within the **Advanced gas controls** settings.
+
+   For this example to work, set the gas limit to _400,000_ in MetaMask.
+
+   First, [enable **Advanced gas controls** in your MetaMask settings](https://support.metamask.io/hc/en-us/articles/360022895972).
+
+   Before confirming your transaction in MetaMask, navigate to the screen where you can edit the gas fee: Select **Site suggested** > **Advanced** > **Advanced gas controls** and select **Edit** next to the **Gas limit** amount. Update the **Gas limit** value to _400000_ and select **Save**. Finally, confirm the transaction.
    :::
    After you approve the transaction, Chainlink VRF processes your request. Chainlink VRF fulfills the request and returns the random values to your contract in a callback to the `fulfillRandomWords()` function. At this point, a new key `requestId` is added to the mapping `s_requests`. Depending on current testnet conditions, it might take a few minutes for the callback to return the requested random values to your contract.
 


### PR DESCRIPTION
## Description

- Update VRF's docs sample contracts from Goerli to Sepolia
- Add clarification in [Direct funding tutorial](https://docs.chain.link/vrf/v2/direct-funding/examples/get-a-random-number/) on how to set the gas limit in MetaMask; their docs and UI changed within the last 2 days.

## Changes

The recent updates from Goerli to Sepolia had not included the VRF code sample contracts, so this is the follow-up update.

The MetaMask gas limit clarifications, plus info that the latest MetaMask docs didn't include:
<img width="629" alt="Screen Shot 2023-02-22 at 7 15 26 PM" src="https://user-images.githubusercontent.com/5498502/220801343-76a1d898-3365-4273-a9b6-f8f3e1a81825.png">

