### PR TITLE
[Fixed #1226 ] : Fix broken link for "Edit this page" on Chainlink documentation site

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/documentation.iml
+++ b/.idea/documentation.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/documentation.iml" filepath="$PROJECT_DIR$/.idea/documentation.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -8,6 +8,8 @@ import RightSidebar from "../components/RightSidebar/RightSidebar.astro"
 import * as CONFIG from "../config"
 import { NewsletterCTA } from "../components/Footer/NewsletterCTA.tsx"
 import Footer from "~/components/Footer/Footer.astro"
+import path from "path"
+import fs from "fs"
 
 const { content = {}, frontmatter } = Astro.props
 
@@ -16,9 +18,24 @@ const headings = Astro.props?.headings || Astro.props?.content?.astro.headings
 
 const currentPage = new URL(Astro.request.url).pathname
 
-const currentFile = `src/pages${currentPage.replace(/\/$/, "")}${
-  content?.isIndex || frontmatter?.isIndex ? "/index" : ""
-}.${frontmatter?.isMdx ? "mdx" : "md"}`
+const baseDirectory = "src/pages"
+
+let currentFilePath = path.join(
+  baseDirectory,
+  currentPage.replace(/\/$/, ""),
+  content?.isIndex || frontmatter?.isIndex ? "index" : ""
+)
+
+let currentFile = `${currentFilePath}.mdx`
+
+if (!fs.existsSync(currentFile)) {
+  const fallbackFile = `${currentFilePath}.md`
+  if (fs.existsSync(fallbackFile)) {
+    currentFile = fallbackFile
+  } else {
+    currentFile = `${currentFilePath}.mdx`
+  }
+}
 const githubEditUrl = CONFIG.GITHUB_EDIT_URL + currentFile
 const formattedContentTitle = content.title
   ? `${content.title} | ${CONFIG.SITE.title}`


### PR DESCRIPTION

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #1226 

## Description
Hello 👋🏻 Maintainers,

I have fixed the bug or broken link on the "Edit this page" feature. It was not responding well and throwing an error for all ".mdx" files. I kindly request the maintainers of this project to review my pull request and merge it if it is correct. 

Happy to contribute 😇 Thank you!



## Result

Sharing screenshots for quick understanding
- for all "**.md** and "**.mdx**" files 
![image](https://user-images.githubusercontent.com/99068989/229248474-4fad4988-4287-4e57-bbd4-0c5aebfda932.png)

## Changes

<!--Explain the **details** for making this change. What existing problem does the pull request solve? -->

![image](https://user-images.githubusercontent.com/99068989/229249133-30803801-3a6f-4c57-82fa-1a79f37cd41c.png)

- The code checks if the ".mdx" file exists using the fs.existsSync method. 
- If it doesn't exist, the code constructs the fallback file name with ".md" extension 
and checks if it exists using the fs.existsSync method.
