### PR TITLE
Fix/edit page link

### DIFF
--- a/src/pages/any-api/api-reference.mdx
+++ b/src/pages/any-api/api-reference.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: anyApi
 date: Last Modified
 title: "ChainlinkClient API Reference"
+isMdx: true
 permalink: "docs/any-api/api-reference/"
 ---
 

--- a/src/pages/any-api/data-providers/google-weather.mdx
+++ b/src/pages/any-api/data-providers/google-weather.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: anyApi
 date: Last Modified
 title: "Google Weather Oracle"
+isMdx: true
 permalink: "docs/any-api/data-providers/google-weather/"
 ---
 

--- a/src/pages/any-api/data-providers/introduction.mdx
+++ b/src/pages/any-api/data-providers/introduction.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: anyApi
 date: Last Modified
 title: "Data Provider Nodes"
+isMdx: true
 permalink: "docs/any-api/data-providers/introduction/"
 ---
 

--- a/src/pages/any-api/find-oracle.mdx
+++ b/src/pages/any-api/find-oracle.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: anyApi
 date: Last Modified
 title: "Find Existing Jobs"
+isMdx: true
 permalink: "docs/any-api/find-oracle/"
 whatsnext:
   {

--- a/src/pages/any-api/get-request/examples/array-response.mdx
+++ b/src/pages/any-api/get-request/examples/array-response.mdx
@@ -3,6 +3,7 @@ layout: ../../../../layouts/MainLayout.astro
 section: anyApi
 date: Last Modified
 title: "Array Response"
+isMdx: true
 permalink: "docs/any-api/get-request/examples/api-array-response/"
 whatsnext:
   {

--- a/src/pages/any-api/get-request/examples/existing-job-request.mdx
+++ b/src/pages/any-api/get-request/examples/existing-job-request.mdx
@@ -3,6 +3,7 @@ layout: ../../../../layouts/MainLayout.astro
 section: anyApi
 date: Last Modified
 title: "Existing Job Request"
+isMdx: true
 permalink: "docs/any-api/get-request/examples/existing-job-request/"
 whatsnext:
   {

--- a/src/pages/any-api/get-request/examples/large-responses.mdx
+++ b/src/pages/any-api/get-request/examples/large-responses.mdx
@@ -3,6 +3,7 @@ layout: ../../../../layouts/MainLayout.astro
 section: anyApi
 date: Last Modified
 title: "Large Responses"
+isMdx: true
 permalink: "docs/any-api/get-request/examples/large-responses/"
 whatsnext:
   {

--- a/src/pages/any-api/get-request/examples/multi-variable-responses.mdx
+++ b/src/pages/any-api/get-request/examples/multi-variable-responses.mdx
@@ -3,6 +3,7 @@ layout: ../../../../layouts/MainLayout.astro
 section: anyApi
 date: Last Modified
 title: "Multi-Variable Responses"
+isMdx: true
 permalink: "docs/any-api/get-request/examples/multi-variable-responses/"
 whatsnext:
   {

--- a/src/pages/any-api/get-request/examples/single-word-response.mdx
+++ b/src/pages/any-api/get-request/examples/single-word-response.mdx
@@ -3,6 +3,7 @@ layout: ../../../../layouts/MainLayout.astro
 section: anyApi
 date: Last Modified
 title: Single Word Response
+isMdx: true
 permalink: "docs/any-api/get-request/examples/single-word-response/"
 whatsnext:
   {

--- a/src/pages/any-api/get-request/introduction.mdx
+++ b/src/pages/any-api/get-request/introduction.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: anyApi
 date: Last Modified
 title: "Make a GET Request"
+isMdx: true
 permalink: "docs/any-api/get-request/introduction/"
 whatsnext:
   {

--- a/src/pages/any-api/introduction.mdx
+++ b/src/pages/any-api/introduction.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: anyApi
 date: Last Modified
 title: "Chainlink Any API Documentation"
+isMdx: true
 permalink: "docs/any-api/introduction/"
 whatsnext:
   {

--- a/src/pages/any-api/testnet-oracles.mdx
+++ b/src/pages/any-api/testnet-oracles.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: anyApi
 date: Last Modified
 title: "Testnet Oracles"
+isMdx: true
 permalink: "docs/any-api/testnet-oracles/"
 metadata:
   title: "Testnet Oracles"

--- a/src/pages/chainlink-automation/automation-economics.mdx
+++ b/src/pages/chainlink-automation/automation-economics.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Chainlink Automation Economics"
+isMdx: true
 whatsnext: { "FAQs": "/chainlink-automation/faqs/" }
 ---
 

--- a/src/pages/chainlink-automation/automation-release-notes.mdx
+++ b/src/pages/chainlink-automation/automation-release-notes.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Chainlink Automation Release Notes"
+isMdx: true
 whatsnext:
   {
     "Register a time-based upkeep": "/chainlink-automation/job-scheduler/",

--- a/src/pages/chainlink-automation/compatible-contracts.mdx
+++ b/src/pages/chainlink-automation/compatible-contracts.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Creating Compatible Contracts"
+isMdx: true
 whatsnext:
   {
     "Build flexible contracts": "/chainlink-automation/flexible-upkeeps/",

--- a/src/pages/chainlink-automation/faqs.mdx
+++ b/src/pages/chainlink-automation/faqs.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Frequently Asked Questions"
+isMdx: true
 ---
 
 ## Will Chainlink Automation work for my use case?

--- a/src/pages/chainlink-automation/flexible-upkeeps.mdx
+++ b/src/pages/chainlink-automation/flexible-upkeeps.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Making flexible, secure, and low-cost contracts"
+isMdx: true
 whatsnext: { "Example Contracts": "/chainlink-automation/util-overview/", "FAQs": "/chainlink-automation/faqs/" }
 ---
 

--- a/src/pages/chainlink-automation/introduction.mdx
+++ b/src/pages/chainlink-automation/introduction.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Introduction to Chainlink Automation"
+isMdx: true
 whatsnext:
   {
     "Register a time-based Upkeep": "/chainlink-automation/job-scheduler/",

--- a/src/pages/chainlink-automation/job-scheduler.mdx
+++ b/src/pages/chainlink-automation/job-scheduler.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Chainlink Automation Job Scheduler"
+isMdx: true
 whatsnext: { "Register a Custom Logic Upkeep": "/chainlink-automation/register-upkeep/" }
 ---
 

--- a/src/pages/chainlink-automation/manage-upkeeps.mdx
+++ b/src/pages/chainlink-automation/manage-upkeeps.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Managing Upkeeps"
+isMdx: true
 whatsnext: { "Automation economics": "/chainlink-automation/automation-economics/" }
 ---
 

--- a/src/pages/chainlink-automation/overview.mdx
+++ b/src/pages/chainlink-automation/overview.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Chainlink Automation Architecture"
+isMdx: true
 whatsnext: { "FAQs": "/chainlink-automation/faqs/" }
 ---
 

--- a/src/pages/chainlink-automation/register-upkeep.mdx
+++ b/src/pages/chainlink-automation/register-upkeep.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Register a Custom Logic Upkeep"
+isMdx: true
 whatsnext: { "Create a compatible contract for custom logic Upkeep": "/chainlink-automation/compatible-contracts/" }
 ---
 

--- a/src/pages/chainlink-automation/util-overview.mdx
+++ b/src/pages/chainlink-automation/util-overview.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Chainlink Automation Example Contracts"
+isMdx: true
 whatsnext: { "EthBalanceMonitor": "/chainlink-automation/utility-contracts/" }
 ---
 

--- a/src/pages/chainlink-automation/utility-contracts.mdx
+++ b/src/pages/chainlink-automation/utility-contracts.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "EthBalanceMonitor Contract"
+isMdx: true
 whatsnext: { "FAQs": "/chainlink-automation/faqs/" }
 ---
 

--- a/src/pages/chainlink-functions/api-reference/Functions.mdx
+++ b/src/pages/chainlink-functions/api-reference/Functions.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Functions library API Reference"
+isMdx: true
 ---
 
 Consumer contract developers use the [Functions library](https://github.com/smartcontractkit/functions-hardhat-starter-kit/blob/main/contracts/dev/functions/Functions.sol) to build their [requests](#request).

--- a/src/pages/chainlink-functions/api-reference/FunctionsClient.mdx
+++ b/src/pages/chainlink-functions/api-reference/FunctionsClient.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "FunctionsClient API Reference"
+isMdx: true
 ---
 
 Consumer contract developers inherit [FunctionsClient](https://github.com/smartcontractkit/functions-hardhat-starter-kit/blob/main/contracts/dev/functions/FunctionsClient.sol) to create Chainlink Functions requests.

--- a/src/pages/chainlink-functions/getting-started.mdx
+++ b/src/pages/chainlink-functions/getting-started.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Getting Started"
+isMdx: true
 metadata:
   linkToWallet: true
 whatsnext:

--- a/src/pages/chainlink-functions/index.mdx
+++ b/src/pages/chainlink-functions/index.mdx
@@ -4,6 +4,7 @@ section: chainlinkFunctions
 date: Last Modified
 title: "What is Chainlink Functions?"
 isIndex: true
+isMdx: true
 whatsnext:
   {
     "Learn the basics in the Getting Started guide.": "/chainlink-functions/getting-started",

--- a/src/pages/chainlink-functions/resources/add-functions-to-projects.mdx
+++ b/src/pages/chainlink-functions/resources/add-functions-to-projects.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Adding Chainlink Functions to an Existing Project"
+isMdx: true
 whatsnext:
   {
     "Try out the Chainlink Functions Tutorials": "/chainlink-functions/tutorials/",

--- a/src/pages/chainlink-functions/resources/architecture.mdx
+++ b/src/pages/chainlink-functions/resources/architecture.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Chainlink Functions Architecture"
+isMdx: true
 whatsnext: { "Billing": "/chainlink-functions/resources/billing/" }
 ---
 

--- a/src/pages/chainlink-functions/resources/billing.mdx
+++ b/src/pages/chainlink-functions/resources/billing.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Chainlink Functions Billing"
+isMdx: true
 whatsnext: { "What's next?": "/chainlink-functions/resources/service-limits/" }
 ---
 

--- a/src/pages/chainlink-functions/resources/concepts.mdx
+++ b/src/pages/chainlink-functions/resources/concepts.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Chainlink Functions Concepts"
+isMdx: true
 whatsnext: { "Architecture": "/chainlink-functions/resources/architecture" }
 ---
 

--- a/src/pages/chainlink-functions/resources/index.mdx
+++ b/src/pages/chainlink-functions/resources/index.mdx
@@ -4,6 +4,7 @@ section: chainlinkFunctions
 date: Last Modified
 title: "Chainlink Functions Resources"
 isIndex: true
+isMdx: true
 ---
 
 ## Topics

--- a/src/pages/chainlink-functions/resources/service-limits.mdx
+++ b/src/pages/chainlink-functions/resources/service-limits.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Chainlink Functions Service Limits"
+isMdx: true
 whatsnext: { "What's next?": "/chainlink-functions/tutorials/" }
 ---
 

--- a/src/pages/chainlink-functions/resources/subscriptions.mdx
+++ b/src/pages/chainlink-functions/resources/subscriptions.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Managing Subscriptions"
+isMdx: true
 ---
 
 import ChainlinkFunctions from "@features/chainlink-functions/common/ChainlinkFunctions.astro"

--- a/src/pages/chainlink-functions/supported-networks.mdx
+++ b/src/pages/chainlink-functions/supported-networks.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Supported Networks"
+isMdx: true
 ---
 
 import ResourcesCallout from "@features/resources/callouts/ResourcesCallout.astro"

--- a/src/pages/chainlink-functions/tutorials/api-custom-response.mdx
+++ b/src/pages/chainlink-functions/tutorials/api-custom-response.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Return Custom Data Types"
+isMdx: true
 ---
 
 import { Aside } from "@components"

--- a/src/pages/chainlink-functions/tutorials/api-multiple-calls.mdx
+++ b/src/pages/chainlink-functions/tutorials/api-multiple-calls.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Call Multiple Data Sources"
+isMdx: true
 ---
 
 import { Aside } from "@components"

--- a/src/pages/chainlink-functions/tutorials/api-post-data.mdx
+++ b/src/pages/chainlink-functions/tutorials/api-post-data.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "POST Data to an API"
+isMdx: true
 ---
 
 import { Aside } from "@components"

--- a/src/pages/chainlink-functions/tutorials/api-query-parameters.mdx
+++ b/src/pages/chainlink-functions/tutorials/api-query-parameters.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Call an API with HTTP Query Parameters"
+isMdx: true
 ---
 
 import { Aside } from "@components"

--- a/src/pages/chainlink-functions/tutorials/api-use-secrets-offchain.mdx
+++ b/src/pages/chainlink-functions/tutorials/api-use-secrets-offchain.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Using Off-chain Secrets in Requests"
+isMdx: true
 ---
 
 import { Aside } from "@components"

--- a/src/pages/chainlink-functions/tutorials/api-use-secrets.mdx
+++ b/src/pages/chainlink-functions/tutorials/api-use-secrets.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Using Secrets in Requests"
+isMdx: true
 ---
 
 import { Aside } from "@components"

--- a/src/pages/chainlink-functions/tutorials/automate-functions.mdx
+++ b/src/pages/chainlink-functions/tutorials/automate-functions.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Automate your Functions"
+isMdx: true
 ---
 
 import { Aside, ClickToZoom } from "@components"

--- a/src/pages/chainlink-functions/tutorials/index.mdx
+++ b/src/pages/chainlink-functions/tutorials/index.mdx
@@ -4,6 +4,7 @@ section: chainlinkFunctions
 date: Last Modified
 title: "Chainlink Functions Tutorials"
 isIndex: true
+isMdx: true
 ---
 
 ## Topics

--- a/src/pages/chainlink-functions/tutorials/simple-computation.mdx
+++ b/src/pages/chainlink-functions/tutorials/simple-computation.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: chainlinkFunctions
 date: Last Modified
 title: "Request Computation"
+isMdx: true
 ---
 
 import { Aside } from "@components"

--- a/src/pages/getting-started/advanced-tutorial.mdx
+++ b/src/pages/getting-started/advanced-tutorial.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: gettingStarted
 date: Last Modified
 title: "API Calls: Using Any API"
+isMdx: true
 permalink: "docs/advanced-tutorial/"
 excerpt: "Calling APIs from Smart Contracts"
 whatsnext:

--- a/src/pages/getting-started/conceptual-overview.mdx
+++ b/src/pages/getting-started/conceptual-overview.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: gettingStarted
 date: Last Modified
 title: "Chainlink Overview"
+isMdx: true
 permalink: "docs/conceptual-overview/"
 excerpt: "Smart Contracts and Chainlink"
 whatsnext:

--- a/src/pages/getting-started/consuming-data-feeds.mdx
+++ b/src/pages/getting-started/consuming-data-feeds.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: gettingStarted
 date: Last Modified
 title: "Consuming Data Feeds"
+isMdx: true
 permalink: "docs/consuming-data-feeds/"
 excerpt: "Smart Contracts and Chainlink"
 whatsnext:

--- a/src/pages/getting-started/deploy-your-first-contract.mdx
+++ b/src/pages/getting-started/deploy-your-first-contract.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: gettingStarted
 date: Last Modified
 title: "Deploy Your First Smart Contract"
+isMdx: true
 permalink: "docs/deploy-your-first-contract/"
 whatsnext: { "Consuming Data Feeds": "/getting-started/consuming-data-feeds/" }
 metadata:

--- a/src/pages/getting-started/intermediates-tutorial.mdx
+++ b/src/pages/getting-started/intermediates-tutorial.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: gettingStarted
 date: Last Modified
 title: "Random Numbers: Using Chainlink VRF"
+isMdx: true
 permalink: "docs/intermediates-tutorial/"
 excerpt: "Using Chainlink VRF"
 whatsnext:

--- a/src/pages/getting-started/other-tutorials.mdx
+++ b/src/pages/getting-started/other-tutorials.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: global
 date: Last Modified
 title: "Learning Resources"
+isMdx: true
 ---
 
 Welcome to the Resources page. This is a list of links and pages that you might need to help you throughout your learning journey. If you're new to Chainlink, start with the [Getting Started](/getting-started/conceptual-overview/) guide to better understand the products and services Chainlink offers. This page contains more resources, inspiration, and outreach information to further your learning.

--- a/src/pages/resources/acquire-link.mdx
+++ b/src/pages/resources/acquire-link.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: global
 date: Last Modified
 title: "Acquire testnet LINK"
+isMdx: true
 permalink: "docs/acquire-link/"
 whatsnext: { "Deploy your first contract": "/getting-started/deploy-your-first-contract/" }
 ---

--- a/src/pages/resources/bridge-risks.mdx
+++ b/src/pages/resources/bridge-risks.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: global
 date: Last Modified
 title: "Cross-chain bridges and associated risks"
+isMdx: true
 ---
 
 import { Aside } from "@components"

--- a/src/pages/resources/contributing-to-chainlink.mdx
+++ b/src/pages/resources/contributing-to-chainlink.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: global
 date: Last Modified
 title: "Contributing to Chainlink"
+isMdx: true
 permalink: "docs/contributing-to-chainlink/"
 ---
 

--- a/src/pages/resources/create-a-chainlinked-project.mdx
+++ b/src/pages/resources/create-a-chainlinked-project.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: global
 date: Last Modified
 title: "Install Frameworks"
+isMdx: true
 permalink: "docs/create-a-chainlinked-project/"
 whatsnext:
   {

--- a/src/pages/resources/developer-communications.mdx
+++ b/src/pages/resources/developer-communications.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: global
 date: Last Modified
 title: "Developer Communications"
+isMdx: true
 permalink: "docs/developer-communications/"
 metadata:
   title: "Developer Communications"

--- a/src/pages/resources/example-projects.mdx
+++ b/src/pages/resources/example-projects.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/MainLayout.astro
 date: Last Modified
 title: "Example Projects"
+isMdx: true
 permalink: "docs/example-projects/"
 section: global
 ---

--- a/src/pages/resources/fund-your-contract.mdx
+++ b/src/pages/resources/fund-your-contract.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: global
 date: Last Modified
 title: "Fund Your Contracts"
+isMdx: true
 permalink: "docs/fund-your-contract/"
 ---
 

--- a/src/pages/resources/getting-help.mdx
+++ b/src/pages/resources/getting-help.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: global
 date: Last Modified
 title: "Getting Help"
+isMdx: true
 permalink: "docs/getting-help/"
 ---
 

--- a/src/pages/resources/glossary.mdx
+++ b/src/pages/resources/glossary.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/MainLayout.astro
 date: Last Modified
 title: "Glossary"
+isMdx: true
 permalink: "docs/glossary/"
 section: global
 ---

--- a/src/pages/resources/hackathon-resources.mdx
+++ b/src/pages/resources/hackathon-resources.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: global
 date: Last Modified
 title: "Hackathon Resources"
+isMdx: true
 permalink: "docs/hackathon-resources/"
 ---
 

--- a/src/pages/resources/hackathon-rules-waiver-and-release.mdx
+++ b/src/pages/resources/hackathon-rules-waiver-and-release.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: global
 date: Last Modified
 title: "Hackathon Rules, Waiver & Release, and Code of Conduct"
+isMdx: true
 permalink: "docs/hackathon-rules-waiver-release-and-code-of-conduct/"
 ---
 

--- a/src/pages/resources/link-token-contracts.mdx
+++ b/src/pages/resources/link-token-contracts.mdx
@@ -3,6 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: global
 date: Last Modified
 title: "LINK Token Contracts"
+isMdx: true
 permalink: "docs/link-token-contracts/"
 metadata:
   title: "LINK Token Contracts"


### PR DESCRIPTION
## Closing issues

closes #1226

...

## Description

This pull request aims to fix the "Edit this page" link for .mdx files in the Chainlink documentation. Currently, when users click on the "Edit this page" link on a documentation page with an .mdx file, they encounter a 404 error because the link points to an .md file instead of the correct .mdx file.

To resolve this issue, I have added the isMdx: true property to the frontmatter of all .mdx files in the repository. The existing logic in MainLayout.astro uses this property to determine the correct file extension when constructing the "Edit this page" link.

By making these changes, the "Edit this page" link should now point to the correct file on GitHub for both .md and .mdx files.

...

## Changes

Added isMdx: true property to the frontmatter of all .mdx files in the repository
