### PR TITLE
bug/2225: Running a Chainlink Node: clarifying the options for order of parameters in v2 nodes

### DIFF
--- a/src/pages/chainlink-nodes/v1/running-a-chainlink-node.mdx
+++ b/src/pages/chainlink-nodes/v1/running-a-chainlink-node.mdx
@@ -171,7 +171,7 @@ This guide will teach you how to run a Chainlink node locally using [Docker](#us
      _never_ do this on a production node.
    </Aside>
 
-1. Start the Chainlink Node. Now you can run the Docker image. Change the version number in `smartcontract/chainlink:2.0.0` with the version of the Docker image that you need to run. For most new nodes, use version `2.0.0` or later. Tag versions are available in the [Chainlink docker hub](https://hub.docker.com/r/smartcontract/chainlink/tags). _The `latest` version does not work._ Chainlink Nodes running `2.0.0` and later require the `-config` and `-secrets` flags after the `node start` part of the command. Versions `1.13.1` and earlier require the `-config` and `-secrets` flags to be placed before `node start`.
+1. Start the Chainlink Node. Now you can run the Docker image. Change the version number in `smartcontract/chainlink:2.0.0` with the version of the Docker image that you need to run. For most new nodes, use version `2.0.0` or later. Tag versions are available in the [Chainlink docker hub](https://hub.docker.com/r/smartcontract/chainlink/tags). _The `latest` version does not work._ Chainlink Nodes running `2.0.0` and later require the `-config` and `-secrets` flags after the `node` part of the command. Versions `1.13.1` and earlier require the `-config` and `-secrets` flags to be placed before `node start`.
 
    {/* prettier-ignore */}
    <Tabs client:visible>
@@ -181,12 +181,12 @@ This guide will teach you how to run a Chainlink node locally using [Docker](#us
       <Fragment slot="tab.4">Goerli on Nodes \<=1.13.1</Fragment>
       <Fragment slot="panel.1">
       ```shell Sepolia
-      cd ~/.chainlink-sepolia && docker run --platform linux/x86_64/v8 --name chainlink -v ~/.chainlink-sepolia:/chainlink -it -p 6688:6688 --add-host=host.docker.internal:host-gateway smartcontract/chainlink:2.0.0 node start -config /chainlink/config.toml -secrets /chainlink/secrets.toml 
+      cd ~/.chainlink-sepolia && docker run --platform linux/x86_64/v8 --name chainlink -v ~/.chainlink-sepolia:/chainlink -it -p 6688:6688 --add-host=host.docker.internal:host-gateway smartcontract/chainlink:2.0.0 node -config /chainlink/config.toml -secrets /chainlink/secrets.toml start
       ```
       </Fragment>
       <Fragment slot="panel.2">
       ```shell Goerli
-      cd ~/.chainlink-goerli && docker run --platform linux/x86_64/v8 --name chainlink -v ~/.chainlink-goerli:/chainlink -it -p 6688:6688 --add-host=host.docker.internal:host-gateway smartcontract/chainlink:2.0.0 node start -config /chainlink/config.toml -secrets /chainlink/secrets.toml
+      cd ~/.chainlink-goerli && docker run --platform linux/x86_64/v8 --name chainlink -v ~/.chainlink-goerli:/chainlink -it -p 6688:6688 --add-host=host.docker.internal:host-gateway smartcontract/chainlink:2.0.0 node -config /chainlink/config.toml -secrets /chainlink/secrets.toml start
       ```
       </Fragment>
       <Fragment slot="panel.3">


### PR DESCRIPTION

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #1278 

...

## Description

Updating the Running a Chainlink Node documentation to specify the correct two options for server and node config parameters. 

...

## Changes

<!--Explain the **details** for making this change. What existing problem does the pull request solve? -->

- Updated the step 4 bullet point, and the relevant code fragments
