### PR TITLE
Fix Firefox compatability issues

### DIFF
--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -199,7 +199,7 @@ const section = frontmatter?.section ?? undefined
     const parentSection = new URLSearchParams(window.location.search).get("parent") || "gettingStarted"
     if (window.location.pathname !== "/" && !document.querySelectorAll('a[aria-current="true"]')[0]) {
       let elem = document.getElementById(parentSection)
-      elem.ariaCurrent = "true"
+      elem.setAttribute("aria-current", "true")
     }
   })
 </script>

--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -28,7 +28,6 @@ const removeSlashes = function (url: string) {
   if (sanitizedUrl.charAt(0) == "/") sanitizedUrl = sanitizedUrl.substr(1)
   if (sanitizedUrl.charAt(sanitizedUrl.length - 1) == "/")
     sanitizedUrl = sanitizedUrl.substr(0, sanitizedUrl.length - 1)
-
   return sanitizedUrl
 }
 
@@ -193,7 +192,7 @@ const currentPageMatch = removeSlashes(currentPage.slice(1))
     const parentSection = new URLSearchParams(window.location.search).get("parent") || "gettingStarted"
     if (parentSection) {
       for (let elem of document.querySelectorAll(`.parent-${parentSection}`)) {
-        elem.ariaHidden = "false"
+        elem.setAttribute("aria-hidden", "false")
       }
     }
   })

--- a/src/hooks/useQueryString.ts
+++ b/src/hooks/useQueryString.ts
@@ -6,7 +6,7 @@ const setQueryStringWithoutPageReload = (qsValue) => {
 
   const newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + qsValue
 
-  window.history.pushState({ path: newurl }, "", newurl)
+  window.history.replaceState({ path: newurl }, "", newurl)
 }
 const setQueryStringValue = (key, value, queryString = window.location.search) => {
   if (!window) return


### PR DESCRIPTION
Aria attributes are not supported on FireFox:

- https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaHidden
- https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaCurrent

`window.history.pushState` also seems to have issues.

This PR resolves those issues.