### PR TITLE
Update VRF / Arbitrum cost estimation docs

### DIFF
--- a/src/pages/vrf/v2/direct-funding/supported-networks.mdx
+++ b/src/pages/vrf/v2/direct-funding/supported-networks.mdx
@@ -276,7 +276,7 @@ VRF v2 coordinators for direct funding are available on several networks. To see
 | Wrapper Gas overhead       | 40000                                                                                                                                                                                                             |
 | Coordinator Gas Overhead   | 90000                                                                                                                                                                                                             |
 
-### Arbitrum testnet
+### Arbitrum Goerli testnet
 
 <Aside type="note" title="Arbitrum Goerli Testnet Faucet">
   Testnet LINK is available from https://faucets.chain.link/arbitrum-goerli

--- a/src/pages/vrf/v2/direct-funding/supported-networks.mdx
+++ b/src/pages/vrf/v2/direct-funding/supported-networks.mdx
@@ -260,3 +260,37 @@ VRF v2 coordinators for direct funding are available on several networks. To see
 | Maximum Random Values      | 10                                                                                                                                                                                                                       |
 | Wrapper Gas overhead       | 40000                                                                                                                                                                                                                    |
 | Coordinator Gas Overhead   | 90000                                                                                                                                                                                                                    |
+
+### Arbitrum mainnet
+
+| Item                       | Value                                                                                                                                                                                                             |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| LINK Token                 | <a class="erc-token-address" id="42161_0xf97f4df75117a78c1A5a0DBb814Af92458539FB4" href="https://arbiscan.io/address/0xf97f4df75117a78c1A5a0DBb814Af92458539FB4">`0xf97f4df75117a78c1A5a0DBb814Af92458539FB4`</a> |
+| VRF Coordinator            | [`0x41034678D6C633D8a95c75e1138A360a28bA15d1`](https://arbiscan.io/address/0x41034678D6C633D8a95c75e1138A360a28bA15d1)                                                                                            |
+| VRF Wrapper                | [`0x2D159AE3bFf04a10A355B608D22BDEC092e934fa`](https://arbiscan.io/address/0x2D159AE3bFf04a10A355B608D22BDEC092e934fa)                                                                                            |
+| Wrapper Premium Percentage | 0                                                                                                                                                                                                                 |
+| Coordinator Flat Fee       | 0.0005 LINK                                                                                                                                                                                                       |
+| Minimum Confirmations      | 1                                                                                                                                                                                                                 |
+| Maximum Confirmations      | 200                                                                                                                                                                                                               |
+| Maximum Random Values      | 10                                                                                                                                                                                                                |
+| Wrapper Gas overhead       | 40000                                                                                                                                                                                                             |
+| Coordinator Gas Overhead   | 90000                                                                                                                                                                                                             |
+
+### Arbitrum testnet
+
+<Aside type="note" title="Arbitrum Goerli Testnet Faucet">
+  Testnet LINK is available from https://faucets.chain.link/arbitrum-goerli
+</Aside>
+
+| Item                       | Value                                                                                                                                                                                                                      |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| LINK Token                 | <a class="erc-token-address" id="421613_0xd14838A68E8AFBAdE5efb411d5871ea0011AFd28" href="https://testnet.arbiscan.io/address/0xd14838A68E8AFBAdE5efb411d5871ea0011AFd28">`0xd14838A68E8AFBAdE5efb411d5871ea0011AFd28`</a> |
+| VRF Coordinator            | [`0x6D80646bEAdd07cE68cab36c27c626790bBcf17f`](https://testnet.arbiscan.io/address/0x6D80646bEAdd07cE68cab36c27c626790bBcf17f)                                                                                             |
+| VRF Wrapper                | [`0x674Cda1Fef7b3aA28c535693D658B42424bb7dBD`](https://goerli.arbiscan.io/address/0x674Cda1Fef7b3aA28c535693D658B42424bb7dBD)                                                                                              |
+| Wrapper Premium Percentage | 0                                                                                                                                                                                                                          |
+| Coordinator Flat Fee       | 0.0005 LINK                                                                                                                                                                                                                |
+| Minimum Confirmations      | 1                                                                                                                                                                                                                          |
+| Maximum Confirmations      | 200                                                                                                                                                                                                                        |
+| Maximum Random Values      | 10                                                                                                                                                                                                                         |
+| Wrapper Gas overhead       | 40000                                                                                                                                                                                                                      |
+| Coordinator Gas Overhead   | 90000                                                                                                                                                                                                                      |

--- a/src/pages/vrf/v2/estimating-costs.mdx
+++ b/src/pages/vrf/v2/estimating-costs.mdx
@@ -274,3 +274,26 @@ This example request would cost 3.125 LINK.
 The total transaction costs for using Arbitrum involve both L2 gas costs and L1 costs. Arbitrum transactions are [posted in batches to L1 Ethereum](https://developer.arbitrum.io/inside-arbitrum-nitro/#how-the-sequencer-publishes-the-sequence), which incurs an L1 cost. For an individual transaction, the total cost includes part of the L1 cost incurred to post the batch that included the transaction.
 
 To learn how to estimate gas costs for Arbitrum, refer to the [**Arbitrum gas estimation tutorial**](https://developer.arbitrum.io/devs-how-tos/how-to-estimate-gas) and the full [**Arbitrum gas estimation script**](https://github.com/OffchainLabs/arbitrum-tutorials/tree/master/packages/gas-estimation) using their SDK.
+
+#### Estimating Arbitrum gas costs with VRF
+
+VRF gas costs are calculated based on the amount of verification gas and callback gas used, multiplied by the gas price:
+
+```
+(Gas price * (Verification gas + Callback gas)) = total gas cost
+```
+
+For your callback gas limit on VRF Arbitrum transactions, include a buffer for the L1 cost:
+
+```
+(L2 gas price
+   * (Verification gas
+      + (L2 callback gas + L1 buffer for callback gas))) = total estimated gas cost
+```
+
+The L1 cost of posting your transaction depends on the size of the data. According to the [Arbitrum gas estimation tutorial](https://developer.arbitrum.io/devs-how-tos/how-to-estimate-gas#breaking-down-the-formula), this is how you calculate the L1 buffer:
+
+```
+L1 Estimated Cost (L1C) = L1 price per byte of data (L1P) * Size of data to be posted in bytes (L1S)
+Extra Buffer (B) = L1 Estimated Cost (L1C) / L2 Gas Price (P)
+```

--- a/src/pages/vrf/v2/estimating-costs.mdx
+++ b/src/pages/vrf/v2/estimating-costs.mdx
@@ -16,7 +16,7 @@ isMdx: true
 
 import VrfCommon from "@features/vrf/v2/common/VrfCommon.astro"
 import { Tabs } from "@components/Tabs"
-import { Aside } from "@components"
+import { Aside, CodeSample } from "@components"
 
 This guide explains how to estimate VRF costs for both the subscription and direct funding methods.
 
@@ -360,3 +360,63 @@ This conversion allows us to estimate the L1 callback gas cost and incorporate i
 
 </Fragment>
 </Tabs>
+
+#### Arbitrum and VRF gas estimation code
+
+This sample extends the original [**Arbitrum gas estimation script**](https://github.com/OffchainLabs/arbitrum-tutorials/tree/master/packages/gas-estimation) to estimate gas costs for VRF subscription and direct funding requests on Arbitrum.
+
+To run this code, see the [full script that includes VRF](https://github.com/thedriftofwords/arbitrum-tutorials/tree/vrf/packages/gas-estimation).
+
+```typescript
+// VRF variables and calculations
+// ---------------------------------
+const maxVerificationGas = 200000
+const avgVerificationGas = 115000
+
+// L1 Calldata size includes:
+// Arbitrum's static 140 bytes for transaction metadata
+// VRF V2's 580 fulfillment tx bytes
+const VRFCallDataSizeBytes = 140 + 580
+
+// For direct funding only. Coordinator gas is verification gas
+const wrapperGasOverhead = 40000
+const coordinatorGasOverhead = 90000
+
+// VRF user settings
+const callbackGasLimit = 175000
+
+// Estimate VRF L1 buffer
+const VRFL1CostEstimate = L1P.mul(VRFCallDataSizeBytes)
+const VRFL1Buffer = VRFL1CostEstimate.div(P)
+
+// VRF Subscription gas estimate
+// L2 gas price (P) * (avgVerificationGas + callbackGasLimit + VRFL1Buffer)
+const VRFL2SubscriptionGasSubtotal = BigNumber.from(avgVerificationGas + callbackGasLimit)
+const VRFSubscriptionGasTotal = VRFL2SubscriptionGasSubtotal.add(VRFL1Buffer)
+const VRFSubscriptionGasEstimate = P.mul(VRFSubscriptionGasTotal)
+
+// VRF Direct funding gas estimate
+// L2 gas price (P) * (coordinatorGasOverhead + callbackGasLimit + wrapperGasOverhead + VRFL1Buffer)
+const VRFL2DirectFundingGasSubtotal = BigNumber.from(coordinatorGasOverhead + wrapperGasOverhead + callbackGasLimit)
+const VRFDirectFundingGasTotal = VRFL2DirectFundingGasSubtotal.add(VRFL1Buffer)
+const VRFDirectFundingGasEstimate = P.mul(VRFDirectFundingGasTotal)
+
+console.log("VRF transaction summary")
+console.log("-------------------")
+console.log(`P (L2 Gas Price) = ${utils.formatUnits(P, "gwei")} gwei`)
+console.log(
+  `VRFL2SubscriptionGasSubtotal (avgVerificationGas + callbackGasLimit)  = ${VRFL2SubscriptionGasSubtotal.toNumber()} units`
+)
+console.log(
+  `VRFL2DirectFundingGasSubtotal (coordinatorGasOverhead + wrapperGasOverhead + callbackGasLimit)  = ${VRFL2DirectFundingGasSubtotal.toNumber()} units`
+)
+console.log(`VRFL1Buffer = ${VRFL1Buffer}`)
+console.log(`L1P (raw value) = ${L1P}`)
+console.log(`L1P (L1 estimated calldata price per byte) = ${utils.formatUnits(L1P, "gwei")} gwei`)
+console.log(`VRFCallDataSizeBytes (L1 Calldata size in bytes) = ${VRFCallDataSizeBytes} bytes`)
+console.log("-------------------")
+console.log(`VRF Subscription transaction estimated fees to pay = ${utils.formatEther(VRFSubscriptionGasEstimate)} ETH`)
+console.log(
+  `VRF Direct funding transaction estimated fees to pay = ${utils.formatEther(VRFDirectFundingGasEstimate)} ETH`
+)
+```

--- a/src/pages/vrf/v2/estimating-costs.mdx
+++ b/src/pages/vrf/v2/estimating-costs.mdx
@@ -268,7 +268,7 @@ This example request would cost 3.125 LINK.
 
 The total transaction costs for using Arbitrum involve both L2 gas costs and L1 costs. Arbitrum transactions are [posted in batches to L1 Ethereum](https://developer.arbitrum.io/inside-arbitrum-nitro/#how-the-sequencer-publishes-the-sequence), which incurs an L1 cost. For an individual transaction, the total cost includes part of the L1 cost incurred to post the batch that included the transaction.
 
-To learn how to estimate gas costs for Arbitrum, refer to the [**Arbitrum gas estimation tutorial**](https://developer.arbitrum.io/devs-how-tos/how-to-estimate-gas) and the full [**Arbitrum gas estimation script**](https://github.com/OffchainLabs/arbitrum-tutorials/tree/master/packages/gas-estimation) using their SDK.
+To learn how to estimate gas costs for Arbitrum, refer to the [Arbitrum gas estimation tutorial](https://developer.arbitrum.io/devs-how-tos/how-to-estimate-gas) and the full [Arbitrum gas estimation script](https://github.com/OffchainLabs/arbitrum-tutorials/tree/master/packages/gas-estimation) using their SDK. There is also a [**version of Arbitrum's gas estimation script extended to include VRF calculations**](#arbitrum-and-vrf-gas-estimation-code).
 
 #### Estimating Arbitrum gas costs with VRF
 
@@ -363,19 +363,24 @@ This conversion allows us to estimate the L1 callback gas cost and incorporate i
 
 #### Arbitrum and VRF gas estimation code
 
-This sample extends the original [**Arbitrum gas estimation script**](https://github.com/OffchainLabs/arbitrum-tutorials/tree/master/packages/gas-estimation) to estimate gas costs for VRF subscription and direct funding requests on Arbitrum.
+This sample extends the [original Arbitrum gas estimation script](https://github.com/OffchainLabs/arbitrum-tutorials/tree/master/packages/gas-estimation) to estimate gas costs for VRF subscription and direct funding requests on Arbitrum.
 
-To run this code, see the [full script that includes VRF](https://github.com/thedriftofwords/arbitrum-tutorials/tree/vrf/packages/gas-estimation).
+To run this code, use the [**full gas estimation script that includes VRF calculations**](https://github.com/thedriftofwords/arbitrum-tutorials/tree/vrf/packages/gas-estimation).
 
 ```typescript
 // VRF variables and calculations
 // ---------------------------------
+// Full script: https://github.com/thedriftofwords/arbitrum-tutorials/tree/vrf/packages/gas-estimation
+// ---------------------------------
+// Estimated upper bound of verification gas for VRF subscription.
+// To see an estimate with an average amount of verification gas,
+// adjust this to 115000.
 const maxVerificationGas = 200000
-const avgVerificationGas = 115000
 
-// L1 Calldata size includes:
+// The L1 Calldata size includes:
 // Arbitrum's static 140 bytes for transaction metadata
-// VRF V2's 580 fulfillment tx bytes
+// VRF V2's static 580 bytes, the size of a fulfillment's calldata abi-encoded in bytes
+// (from s_fulfillmentTxSizeBytes in VRFV2Wrapper.sol)
 const VRFCallDataSizeBytes = 140 + 580
 
 // For direct funding only. Coordinator gas is verification gas
@@ -390,8 +395,8 @@ const VRFL1CostEstimate = L1P.mul(VRFCallDataSizeBytes)
 const VRFL1Buffer = VRFL1CostEstimate.div(P)
 
 // VRF Subscription gas estimate
-// L2 gas price (P) * (avgVerificationGas + callbackGasLimit + VRFL1Buffer)
-const VRFL2SubscriptionGasSubtotal = BigNumber.from(avgVerificationGas + callbackGasLimit)
+// L2 gas price (P) * (maxVerificationGas + callbackGasLimit + VRFL1Buffer)
+const VRFL2SubscriptionGasSubtotal = BigNumber.from(maxVerificationGas + callbackGasLimit)
 const VRFSubscriptionGasTotal = VRFL2SubscriptionGasSubtotal.add(VRFL1Buffer)
 const VRFSubscriptionGasEstimate = P.mul(VRFSubscriptionGasTotal)
 
@@ -400,23 +405,4 @@ const VRFSubscriptionGasEstimate = P.mul(VRFSubscriptionGasTotal)
 const VRFL2DirectFundingGasSubtotal = BigNumber.from(coordinatorGasOverhead + wrapperGasOverhead + callbackGasLimit)
 const VRFDirectFundingGasTotal = VRFL2DirectFundingGasSubtotal.add(VRFL1Buffer)
 const VRFDirectFundingGasEstimate = P.mul(VRFDirectFundingGasTotal)
-
-console.log("VRF transaction summary")
-console.log("-------------------")
-console.log(`P (L2 Gas Price) = ${utils.formatUnits(P, "gwei")} gwei`)
-console.log(
-  `VRFL2SubscriptionGasSubtotal (avgVerificationGas + callbackGasLimit)  = ${VRFL2SubscriptionGasSubtotal.toNumber()} units`
-)
-console.log(
-  `VRFL2DirectFundingGasSubtotal (coordinatorGasOverhead + wrapperGasOverhead + callbackGasLimit)  = ${VRFL2DirectFundingGasSubtotal.toNumber()} units`
-)
-console.log(`VRFL1Buffer = ${VRFL1Buffer}`)
-console.log(`L1P (raw value) = ${L1P}`)
-console.log(`L1P (L1 estimated calldata price per byte) = ${utils.formatUnits(L1P, "gwei")} gwei`)
-console.log(`VRFCallDataSizeBytes (L1 Calldata size in bytes) = ${VRFCallDataSizeBytes} bytes`)
-console.log("-------------------")
-console.log(`VRF Subscription transaction estimated fees to pay = ${utils.formatEther(VRFSubscriptionGasEstimate)} ETH`)
-console.log(
-  `VRF Direct funding transaction estimated fees to pay = ${utils.formatEther(VRFDirectFundingGasEstimate)} ETH`
-)
 ```

--- a/src/pages/vrf/v2/estimating-costs.mdx
+++ b/src/pages/vrf/v2/estimating-costs.mdx
@@ -266,16 +266,16 @@ This example request would cost 3.125 LINK.
 
 ### Arbitrum
 
-<Aside type="note">
-  Only the [subscription method](/vrf/v2/subscription) is currently supported on Arbitrum. [Direct
-  funding](/vrf/v2/direct-funding) is not supported on Arbitrum.
-</Aside>
-
 The total transaction costs for using Arbitrum involve both L2 gas costs and L1 costs. Arbitrum transactions are [posted in batches to L1 Ethereum](https://developer.arbitrum.io/inside-arbitrum-nitro/#how-the-sequencer-publishes-the-sequence), which incurs an L1 cost. For an individual transaction, the total cost includes part of the L1 cost incurred to post the batch that included the transaction.
 
 To learn how to estimate gas costs for Arbitrum, refer to the [**Arbitrum gas estimation tutorial**](https://developer.arbitrum.io/devs-how-tos/how-to-estimate-gas) and the full [**Arbitrum gas estimation script**](https://github.com/OffchainLabs/arbitrum-tutorials/tree/master/packages/gas-estimation) using their SDK.
 
 #### Estimating Arbitrum gas costs with VRF
+
+<Tabs sharedStore="vrfMethod" client:visible>
+<Fragment slot="tab.1">Subscription</Fragment>
+<Fragment slot="tab.2">Direct funding</Fragment>
+<Fragment slot="panel.1">
 
 VRF gas costs are calculated based on the amount of verification gas and callback gas used, multiplied by the gas price:
 
@@ -314,3 +314,49 @@ This conversion allows us to estimate the L1 callback gas cost and incorporate i
       + Callback gas
       + ((calldataSizeBytes * L1PricePerByte) / L2GasPrice)))) = total estimated gas cost
 ```
+
+</Fragment>
+<Fragment slot="panel.2">
+
+VRF gas costs are calculated based on the amount of verification gas, callback gas and wrapper gas overhead, multiplied by the gas price:
+
+```
+(Gas price * (Verification gas + Callback gas + Wrapper gas overhead)) = total gas cost
+```
+
+For VRF Arbitrum transactions, add a buffer to estimate the additional L1 cost:
+
+```
+(L2GasPrice
+   * (Verification gas
+      + Callback gas
+      + Wrapper gas overhead
+      + L1 calldata gas buffer))) = total estimated gas cost
+```
+
+To calculate the L1 callback gas buffer:
+
+- `calldataSizeBytes`: A static size for the transaction's calldata in bytes. Total: 720 bytes.
+  - The amount Arbitrum adds to account for the static part of the transaction, fixed at 140 bytes.
+  - The size of an ABI-encoded VRF V2 fulfillment, fixed at 580 bytes (`fulfillmentTxSizeBytes`).
+- `L1PricePerByte`: The estimated cost of posting 1 byte of data on L1, which varies with L1 network gas prices.
+- `L2GasPrice`: The L2 gas price, which varies with L2 network gas prices.
+
+```
+L1 calldata gas buffer = (calldataSizeBytes * L1PricePerByte) / L2GasPrice
+
+ = (720 * L1PricePerByte) / L2GasPrice
+```
+
+This conversion allows us to estimate the L1 callback gas cost and incorporate it into the overall L2 gas estimate. You can add this estimated L1 callback gas buffer directly to the verification, callback, and wrapper gas:
+
+```
+(L2GasPrice
+   * (Verification gas
+      + Callback gas
+      + Wrapper gas overhead
+      + ((calldataSizeBytes * L1PricePerByte) / L2GasPrice)))) = total estimated gas cost
+```
+
+</Fragment>
+</Tabs>

--- a/src/pages/vrf/v2/estimating-costs.mdx
+++ b/src/pages/vrf/v2/estimating-costs.mdx
@@ -283,17 +283,34 @@ VRF gas costs are calculated based on the amount of verification gas and callbac
 (Gas price * (Verification gas + Callback gas)) = total gas cost
 ```
 
-For your callback gas limit on VRF Arbitrum transactions, include a buffer for the L1 cost:
+For VRF Arbitrum transactions, add a buffer to estimate the additional L1 cost:
 
 ```
-(L2 gas price
+(L2GasPrice
    * (Verification gas
-      + (L2 callback gas + L1 buffer for callback gas))) = total estimated gas cost
+      + Callback gas
+      + L1 calldata gas buffer))) = total estimated gas cost
 ```
 
-The L1 cost of posting your transaction depends on the size of the data. According to the [Arbitrum gas estimation tutorial](https://developer.arbitrum.io/devs-how-tos/how-to-estimate-gas#breaking-down-the-formula), this is how you calculate the L1 buffer:
+To calculate the L1 callback gas buffer:
+
+- `calldataSizeBytes`: A static size for the transaction's calldata in bytes. Total: 720 bytes.
+  - The amount Arbitrum adds to account for the static part of the transaction, fixed at 140 bytes.
+  - The size of an ABI-encoded VRF V2 fulfillment, fixed at 580 bytes (`fulfillmentTxSizeBytes`).
+- `L1PricePerByte`: The estimated cost of posting 1 byte of data on L1, which varies with L1 network gas prices.
+- `L2GasPrice`: The L2 gas price, which varies with L2 network gas prices.
 
 ```
-L1 Estimated Cost (L1C) = L1 price per byte of data (L1P) * Size of data to be posted in bytes (L1S)
-Extra Buffer (B) = L1 Estimated Cost (L1C) / L2 Gas Price (P)
+L1 calldata gas buffer = (calldataSizeBytes * L1PricePerByte) / L2GasPrice
+
+ = (720 * L1PricePerByte) / L2GasPrice
+```
+
+This conversion allows us to estimate the L1 callback gas cost and incorporate it into the overall L2 gas estimate. You can add this estimated L1 callback gas buffer directly to the verification and callback gas:
+
+```
+(L2GasPrice
+   * (Verification gas
+      + Callback gas
+      + ((calldataSizeBytes * L1PricePerByte) / L2GasPrice)))) = total estimated gas cost
 ```


### PR DESCRIPTION
* Combine Arb estimate formula with VRF costs
* Add extended explanation of formulas and direct funding section
* Add new wrapper addresses for direct funding 
* Add [modified version](https://github.com/thedriftofwords/arbitrum-tutorials/tree/master/packages/gas-estimation) of [Arbitrum's gas estimation code sample](https://github.com/OffchainLabs/arbitrum-tutorials/tree/master/packages/gas-estimation)

TODO: For sample, switch out link to personal fork to [this repo](https://github.com/smartcontractkit/smart-contract-examples)