### PR TITLE
Minor misc fixes to Automation docs

### DIFF
--- a/src/pages/chainlink-automation/automation-economics.mdx
+++ b/src/pages/chainlink-automation/automation-economics.mdx
@@ -3,8 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Chainlink Automation Economics"
-isMdx: true
-whatsnext: { "FAQs": "/chainlink-automation/faqs/" }
+whatsnext: { "FAQs": "/chainlink-automation/faqs" }
 ---
 
 ## Cost of using Chainlink Automation
@@ -19,11 +18,11 @@ There is no registration fee or other fees for any off-chain computation.
 
 ![Automation Pricing Example](/images/automation/automation-pricing-example.png)
 
-## How Funding Works
+## How funding works
 
 Upkeeps have a LINK (ERC-677) balance. Every time an on-chain transaction is performed for your upkeep, its LINK balance will be reduced by the LINK fee.
 
-Your upkeep's balance must exceed the minimum balance. If this requirement is not met, the Automation Network will not perform on-chain transactions. You can add funds using the [Chainlink Automation App](https://automation.chain.link/) or by directly calling the `addFunds()` function on the `AutomationRegistry` contract. Anyone can call the `addFunds()` function.
+Your upkeep's balance must exceed the [minimum balance](#minimum-balance). If this requirement is not met, the Automation Network will not perform on-chain transactions. You can add funds using the [Chainlink Automation App](https://automation.chain.link/) or by directly calling the `addFunds()` function on the `AutomationRegistry` contract. Anyone can call the `addFunds()` function.
 
 ## Withdrawing funds
 
@@ -44,12 +43,12 @@ The minimum balance is calculated using the current fast gas price, the gas limi
 
 Follow [maintain a minimum balance](/chainlink-automation/manage-upkeeps/#maintain-a-minimum-balance) to ensure that your upkeep is funded.
 
-## Price selection and Gas Bumping
+## Price selection and gas bumping
 
 Automation Nodes select the gas price dynamically based on the prices of transactions within the last several blocks. This optimizes the gas price based on current network conditions. Automation Nodes are configured to select a price based on a target percentile.
 
 If the Automation Node does not see the `performUpkeep` transaction get confirmed within the next few blocks, it automatically replaces the transaction and bumps the gas price. This process repeats until the transaction is confirmed.
 
-## ERC-677 Link
+## ERC-677 LINK
 
 For funding on mainnet, you will need ERC-677 LINK. Many token bridges give you ERC-20 LINK tokens. Use PegSwap to [convert Chainlink tokens (LINK) to be ERC-677 compatible](https://pegswap.chain.link/). To fund on a supported testnet, get [LINK](/resources/link-token-contracts) for the testnet you are using from our [faucet](https://faucets.chain.link/).

--- a/src/pages/chainlink-automation/automation-release-notes.mdx
+++ b/src/pages/chainlink-automation/automation-release-notes.mdx
@@ -3,11 +3,10 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Chainlink Automation Release Notes"
-isMdx: true
 whatsnext:
   {
-    "Register a time-based upkeep": "/chainlink-automation/job-scheduler/",
-    "Register a Custom Logic Upkeep": "/chainlink-automation/register-upkeep/",
+    "Register a time-based upkeep": "/chainlink-automation/job-scheduler",
+    "Register a Custom Logic Upkeep": "/chainlink-automation/register-upkeep",
   }
 ---
 

--- a/src/pages/chainlink-automation/compatible-contract-best-practice.mdx
+++ b/src/pages/chainlink-automation/compatible-contract-best-practice.mdx
@@ -3,11 +3,10 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Best Practices for Compatible Contracts"
-isMdx: true
 whatsnext:
   {
-    "Build flexible contracts": "/chainlink-automation/flexible-upkeeps/",
-    "Manage your Upkeeps": "/chainlink-automation/manage-upkeeps/",
+    "Build flexible contracts": "/chainlink-automation/flexible-upkeeps",
+    "Manage your Upkeeps": "/chainlink-automation/manage-upkeeps",
   }
 ---
 

--- a/src/pages/chainlink-automation/compatible-contracts.mdx
+++ b/src/pages/chainlink-automation/compatible-contracts.mdx
@@ -28,7 +28,7 @@ Before you deploy contracts to use with Chainlink Automation, read the [Best Pra
 To use Chainlink Automation, contracts must meet the following requirements:
 
 - Import `AutomationCompatible.sol`. You can refer to the [Chainlink Contracts](https://github.com/smartcontractkit/chainlink/tree/develop/contracts/src) on GitHub to find the latest version.
-- Use the `AutomationCompatibleInterface` from the library to ensure your `checkUpkeep` and `performUpkeep`function definitions match the definitions expected by the Chainlink Automation Network.
+- Use the `AutomationCompatibleInterface` from the library to ensure your `checkUpkeep` and `performUpkeep` function definitions match the definitions expected by the Chainlink Automation Network.
 - Include a `checkUpkeep` function that contains the logic that will be executed off-chain to see if `performUpkeep` should be executed. `checkUpkeep` can use on-chain data and a specified `checkData` parameter to perform complex calculations off-chain and then send the result to `performUpkeep` as `performData`.
 - Include a `performUpkeep` function that will be executed on-chain when `checkUpkeep` returns `true`. Because `performUpkeep` is external, users are advised to revalidate conditions and performData.
 
@@ -68,7 +68,6 @@ Because `checkUpkeep` is only off-chain in simulation it is best to treat this a
 function checkUpkeep(
   bytes calldata checkData
 ) external view override returns (bool upkeepNeeded, bytes memory performData);
-
 ```
 
 Below are the parameters and return values of the `checkUpkeep` function. Click each value to learn more about its design patterns and best practices:
@@ -84,7 +83,7 @@ Below are the parameters and return values of the `checkUpkeep` function. Click 
 
 #### `checkData`
 
-You can pass information into your `checkUpkeep` function from your [upkeep registration](/chainlink-automation/register-upkeep) to execute different code paths. For example, to check the balance on an specific address, set the `checkData` to abi encode of the address. To learn how to create flexible upkeeps with checkData, please see out [flexible upkeeps](/chainlink-automation/flexible-upkeeps) page.
+You can pass information into your `checkUpkeep` function from your [upkeep registration](/chainlink-automation/register-upkeep) to execute different code paths. For example, to check the balance on an specific address, set the `checkData` to abi encode the address. To learn how to create flexible upkeeps with checkData, please see out [flexible upkeeps](/chainlink-automation/flexible-upkeeps) page.
 
 <CodeSample src="snippets/Automation/checkData.sol" />
 
@@ -110,7 +109,7 @@ When `checkUpkeep` returns `upkeepNeeded == true`, the Automation node broadcast
 
 <Aside type="note" title="Gas limits for performUpkeep">
 
-During registration you have to specify the maximum gas limit that we should allow your contract to use. We simulate `performUpkeep`during `checkUpkeep` and if the gas exceeds this limit the function will not execute on-chain. One method to determine your upkeep's gas limit is to simulate the `performUpkeep` function and add enough overhead to take into account increases that might happen due to changes in `performData` or on-chain data. The gas limit you specify cannot exceed the `performGasLimit` in the [configuration of the registry](/chainlink-automation/supported-networks/#configurations).
+During registration you have to specify the maximum gas limit that we should allow your contract to use. We simulate `performUpkeep` during `checkUpkeep` and if the gas exceeds this limit the function will not execute on-chain. One method to determine your upkeep's gas limit is to simulate the `performUpkeep` function and add enough overhead to take into account increases that might happen due to changes in `performData` or on-chain data. The gas limit you specify cannot exceed the `performGasLimit` in the [configuration of the registry](/chainlink-automation/supported-networks/#configurations).
 
 </Aside>
 
@@ -118,7 +117,6 @@ Ensure that your `performUpkeep` is _idempotent_. Your `performUpkeep` function 
 
 ```solidity
 function performUpkeep(bytes calldata performData) external override;
-
 ```
 
 **Parameters:**

--- a/src/pages/chainlink-automation/faqs.mdx
+++ b/src/pages/chainlink-automation/faqs.mdx
@@ -3,7 +3,6 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Frequently Asked Questions"
-isMdx: true
 ---
 
 ## Will Chainlink Automation work for my use case?

--- a/src/pages/chainlink-automation/flexible-upkeeps.mdx
+++ b/src/pages/chainlink-automation/flexible-upkeeps.mdx
@@ -15,7 +15,7 @@ Start by integrating an example contract to Chainlink Automation that has not ye
 
 ## Prerequisites
 
-This guide assumes you have a basic understanding of [Chainlink Automation](https://chain.link/keepers). If you are new to Keepers, complete the following guides first:
+This guide assumes you have a basic understanding of [Chainlink Automation](https://chain.link/automation). If you are new to Automation, complete the following guides first:
 
 - Know how to [deploy solidity contracts using Remix and Metamask](/getting-started/deploy-your-first-contract)
 - Learn how to make [compatible contracts](/chainlink-automation/compatible-contracts)

--- a/src/pages/chainlink-automation/introduction.mdx
+++ b/src/pages/chainlink-automation/introduction.mdx
@@ -34,7 +34,7 @@ To learn more about how the Chainlink Automation Network automates your smart co
 
 Chainlink Automation will reliably execute smart contract functions using a variety of triggers.
 
-- [Time-based trigger](/chainlink-automation/job-scheduler): Use a [time based trigger](/chainlink-automation/job-scheduler) to execute your function according to a time schedule. This feature is also called the Job Scheduler and it is a throwback to the Ethereum Alarm Clock. Time-based trigger contracts do not need to be [compatible](/chainlink-automation/compatible-contracts/#example-contract) with the `AutomationCompatibleInterface` contract.
+- [Time-based trigger](/chainlink-automation/job-scheduler): Use a [time-based trigger](/chainlink-automation/job-scheduler) to execute your function according to a time schedule. This feature is also called the Job Scheduler and it is a throwback to the Ethereum Alarm Clock. Time-based trigger contracts do not need to be [compatible](/chainlink-automation/compatible-contracts/#example-contract) with the `AutomationCompatibleInterface` contract.
 - [Custom logic trigger](/chainlink-automation/register-upkeep): Use a [custom logic trigger](/chainlink-automation/register-upkeep) to provide custom solidity logic that Automation Nodes evaluate (off-chain) to determine when to execute your function on-chain. Your contract must meet the requirements to be [compatible](/chainlink-automation/compatible-contracts) with the `AutomationCompatibleInterface` contract. Custom logic examples include checking the balance on a contract, only executing limit orders when their levels are met, any one of our [coded examples](/chainlink-automation/util-overview), and many more.
 
 ## Supported networks and costs

--- a/src/pages/chainlink-automation/job-scheduler.mdx
+++ b/src/pages/chainlink-automation/job-scheduler.mdx
@@ -84,7 +84,7 @@ To complete the upkeep registration process, you must enter some information abo
 
 ![Automation Upkeep Details](/images/contract-devs/automation/automation-upkeep-details.png)
 
-<Aside type="tip" title="ERC677 Link">
+<Aside type="tip" title="ERC-677 Link">
   For registration you must use ERC-677 LINK. Read our [LINK](/resources/link-token-contracts) page to determine where
   to acquire mainnet LINK, or visit [faucets.chain.link](https://faucets.chain.link/) to request testnet LINK.
 </Aside>

--- a/src/pages/chainlink-automation/manage-upkeeps.mdx
+++ b/src/pages/chainlink-automation/manage-upkeeps.mdx
@@ -15,7 +15,7 @@ Manage your Upkeeps to get the best performance.
 
 You must monitor the balance of your Upkeep. If the Upkeep LINK balance drops below the [minimum balance](/chainlink-automation/automation-economics/#minimum-balance), the Chainlink Automation Network will not perform the Upkeep.
 
-<Aside type="tip" title="ERC677 Link">
+<Aside type="tip" title="ERC-677 Link">
   For funding on Mainnet, you need ERC-677 LINK. Many token bridges give you ERC-20 LINK tokens. Use PegSwap to [convert
   Chainlink tokens (LINK) to be ERC-677 compatible](https://pegswap.chain.link/). To fund on a supported testnet, get
   [LINK](/resources/link-token-contracts) from [faucets.chain.link](https://faucets.chain.link/).

--- a/src/pages/chainlink-automation/overview.mdx
+++ b/src/pages/chainlink-automation/overview.mdx
@@ -9,7 +9,7 @@ whatsnext: { "FAQs": "/chainlink-automation/faqs/" }
 
 import { ClickToZoom } from "@components"
 
-Chainlink Automation enable you to execute smart contract functions based on conditions that you specify without having to create and maintain your own centralized stack. Chainlink Automation is highly reliable and decentralized, supported by an industry leading team, and enables developers to deploy applications faster.
+Chainlink Automation enables you to execute smart contract functions based on conditions that you specify without having to create and maintain your own centralized stack. Chainlink Automation is highly reliable and decentralized, supported by an industry leading team, and enables developers to deploy applications faster.
 
 There are three main actors in the ecosystem:
 

--- a/src/pages/chainlink-automation/register-upkeep.mdx
+++ b/src/pages/chainlink-automation/register-upkeep.mdx
@@ -36,6 +36,7 @@ This guide explains how to register a custom logic Upkeep that uses a [compatibl
    - **Your email address**: This email address will be encrypted and is used to send you an email when your upkeep is underfunded.
      {/* prettier-ignore */}
 
+     {" "}
      <Aside type="tip" title="Funding Upkeep">
        You should fund your contract with more LINK that you anticipate you will need. The network will not check or
        perform your Upkeep if your balance is too low based on current exchange rates. View the [Automation
@@ -44,17 +45,20 @@ This guide explains how to register a custom logic Upkeep that uses a [compatibl
      </Aside>
 
      {/* prettier-ignore */}
-     <Aside type="tip" title="ERC677 Link">
-       Fund your Upkeep with more LINK than you anticipate you will need. The network will not check or perform your
-       upkeep if your balance is too low based on current exchange rates. View the [Automation
-       Economics](/chainlink-automation/automation-economics) page to learn more about the cost of using Chainlink
-       Automation.
+
+     {" "}
+     <Aside type="tip" title="ERC-677 Link">
+       For funding on Mainnet, you need ERC-677 LINK. Many token bridges give you ERC-20 LINK tokens. Use PegSwap to
+       [convert Chainlink tokens (LINK) to be ERC-677 compatible](https://pegswap.chain.link/). To fund on a supported
+       testnet, get [LINK](/resources/link-token-contracts) from [faucets.chain.link](https://faucets.chain.link/).
      </Aside>
 
      {/* prettier-ignore */}
+
+     {" "}
      <Aside type="tip" title="Testing and best practices">
-       Follow the [best practices](/chainlink-automation/compatible-contract-best-practice) when creating a
-       compatible contract and test your upkeep on a testnet before deploying it to a mainnet.
+       Follow the [best practices](/chainlink-automation/compatible-contract-best-practice) when creating a compatible
+       contract and test your upkeep on a testnet before deploying it to a mainnet.
      </Aside>
 
 1. **Click `Register upkeep`** and confirm the transaction in MetaMask.

--- a/src/pages/chainlink-automation/supported-networks.mdx
+++ b/src/pages/chainlink-automation/supported-networks.mdx
@@ -3,9 +3,8 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Supported Blockchain Networks"
-isMdx: true
 whatsnext:
-  { "Automation Economics": "/chainlink-automation/automation-economics/", "FAQs": "/chainlink-automation/faqs/" }
+  { "Automation Economics": "/chainlink-automation/automation-economics", "FAQs": "/chainlink-automation/faqs" }
 ---
 
 import { AutomationConfigList } from "@features/chainlink-automation"

--- a/src/pages/chainlink-automation/tutorials/batch-nft.mdx
+++ b/src/pages/chainlink-automation/tutorials/batch-nft.mdx
@@ -3,11 +3,10 @@ layout: ../../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Batch NFT Reveal"
-whatsnext: { "FAQs": "/chainlink-automation/faqs/" }
+whatsnext: { "FAQs": "/chainlink-automation/faqs" }
 ---
 
 import { Aside, CodeSample } from "@components"
-
 
 Using [Chainlink VRF](https://docs.chain.link/vrf/v2/introduction/) in generative art NFT collections is de-facto the standard approach for getting provably random source in smart contracts. By batching the reveal process, instead of making VRF calls for each NFT we can save cost up to 100x (in a collection of 10,000 with batch size of 100).
 
@@ -322,5 +321,4 @@ contract NFTCollection is INFTCollection, Ownable, ERC721Enumerable, VRFConsumer
     return super.supportsInterface(interfaceId) || interfaceId == type(INFTCollection).interfaceId;
   }
 }
-
 ```

--- a/src/pages/chainlink-automation/tutorials/counting-dnft.mdx
+++ b/src/pages/chainlink-automation/tutorials/counting-dnft.mdx
@@ -3,7 +3,7 @@ layout: ../../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Counting dNFT"
-whatsnext: { "FAQs": "/chainlink-automation/faqs/" }
+whatsnext: { "FAQs": "/chainlink-automation/faqs" }
 ---
 
 import { Aside, CodeSample } from "@components"
@@ -102,5 +102,4 @@ contract CountSVG is ERC721, ERC721URIStorage, Ownable {
     return super.tokenURI(tokenId);
   }
 }
-
 ```

--- a/src/pages/chainlink-automation/tutorials/dynamic-nft.mdx
+++ b/src/pages/chainlink-automation/tutorials/dynamic-nft.mdx
@@ -3,12 +3,11 @@ layout: ../../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Dynamic NFTs"
-whatsnext: { "FAQs": "/chainlink-automation/faqs/" }
+whatsnext: { "FAQs": "/chainlink-automation/faqs" }
 ---
 
 import { Aside, CodeSample } from "@components"
 import { YouTube } from "@astro-community/astro-embed-youtube"
-
 
 Learn how to create NFTs that can change over time, based on user interaction, or any number of conditions by following along with this video tutorial.
 This repository supports the Chainlink Dynamic NFT tutorial:
@@ -16,4 +15,3 @@ This repository supports the Chainlink Dynamic NFT tutorial:
 <YouTube id="https://www.youtube.com/watch?v=E7Rm1LUKhj4" />
 
 View the template [here](https://github.com/smartcontractkit/smart-contract-examples/tree/main/dynamic-nft).
-

--- a/src/pages/chainlink-automation/tutorials/eth-balance.mdx
+++ b/src/pages/chainlink-automation/tutorials/eth-balance.mdx
@@ -9,11 +9,10 @@ whatsnext: { "FAQs": "/chainlink-automation/faqs/" }
 
 import { Aside, CodeSample } from "@components"
 
-Depending on your smart contract application, you may have to maintain some level of balance to ensure optimal operation. You can automate this using the decentralized Automation network offered by Chainlink Automation. Use these smart contracts to monitor and top-up balances on your smart contracts.
+Some smart contract applications require you to maintain a certain Ethereum balance to ensure optimal operation. You can automate this using the decentralized Automation network offered by Chainlink Automation. Use these smart contracts to monitor and top-up balances on your smart contracts.
 
 [ERC20 Balance Monitor](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/automation/upkeeps/ERC20BalanceMonitor.sol)
-[EVM Native`Eth` Gas Balance Monitor](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/automation/upkeeps/EthBalanceMonitor.sol)
-
+[EVM Native `Eth` Gas Balance Monitor](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/automation/upkeeps/EthBalanceMonitor.sol)
 
 Alternatively follow the detailed Native aka `Eth` Gas Balance Monitor guide below.
 
@@ -47,12 +46,13 @@ You can open the contract in Remix:
 
 Functions with an asterisk (`*`) denote features that only the owner can change. Click on each function to learn more about its parameters and design patterns:
 
-| Function Name                                                      | Description                                                                            |
+{/* prettier-ignore */}
+| Function Name                                                    | Description                                                                            |
 | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| [`setWatchList`\*](#setwatchlist-function)                         | Addresses to watch minimum balance and how much to top it up.                          |
-| [`setKeeperRegistryAddress`\*](#setkeeperregistryaddress-function) | Updates the `KeeperRegistry` address.                                                  |
-| [`setMinWaitPeriodSeconds`\*](#setminwaitperiodseconds-function)   | Updates the global minimum period between top ups.                                     |
-| [`topUp`](#topup-function)                                         | Used by `performUpkeep`. This function will only trigger top up if conditions are met. |
+| [`setWatchList`\*](#setwatchlist-function) | Addresses to watch minimum balance and how much to top it up. |
+| [`setKeeperRegistryAddress`\*](#setkeeperregistryaddress-function) | Updates the `KeeperRegistry` address. |
+| [`setMinWaitPeriodSeconds`\*](#setminwaitperiodseconds-function) | Updates the global minimum period between top ups. |
+| [`topUp`](#topup-function) | Used by `performUpkeep`. This function will only trigger top up if conditions are met. |
 
 Below are the feed functions in `EthBalanceMonitor`:
 

--- a/src/pages/chainlink-automation/tutorials/vault-harvester.mdx
+++ b/src/pages/chainlink-automation/tutorials/vault-harvester.mdx
@@ -3,11 +3,10 @@ layout: ../../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Vault Harvester"
-whatsnext: { "FAQs": "/chainlink-automation/faqs/" }
+whatsnext: { "FAQs": "/chainlink-automation/faqs" }
 ---
 
 import { Aside, CodeSample } from "@components"
-
 
 Harvesting and compounding is key to maximize yield in DeFi yield aggregators. Automate harvesting and compounding using Chainlink Automation's decentralized automation network.
 
@@ -433,7 +432,6 @@ abstract contract KeeperCompatibleHarvester is IHarvester, Ownable {
     token.safeTransfer(msg.sender, amount);
   }
 }
-
 ```
 
 This is an abstract contract that iterates vaults from a provided list and fits vaults within upkeep gas limit. The contract also provides helper functions to calculate gas consumption and estimate profit and contains a trigger mechanism can be time-based, profit-based or custom. Finally, the cotract reports profits, successful harvests, and failed harvests.

--- a/src/pages/chainlink-automation/tutorials/vrf-sub-monitor.mdx
+++ b/src/pages/chainlink-automation/tutorials/vrf-sub-monitor.mdx
@@ -3,11 +3,10 @@ layout: ../../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "VRF Subscription Monitor"
-whatsnext: { "FAQs": "/chainlink-automation/faqs/" }
+whatsnext: { "FAQs": "/chainlink-automation/faqs" }
 ---
 
 import { Aside, CodeSample } from "@components"
-
 
 Automatically top-up your VRF subscription balances using Chainlink Automation to ensure there is sufficient funding for requests.
 
@@ -293,5 +292,4 @@ contract VRFSubscriptionBalanceMonitor is ConfirmedOwner, Pausable, KeeperCompat
     _;
   }
 }
-
 ```

--- a/src/pages/chainlink-automation/util-overview.mdx
+++ b/src/pages/chainlink-automation/util-overview.mdx
@@ -3,8 +3,7 @@ layout: ../../layouts/MainLayout.astro
 section: automation
 date: Last Modified
 title: "Chainlink Automation Example Contracts"
-isMdx: true
-whatsnext: { "EthBalanceMonitor": "/chainlink-automation/tutorials/eth-balance/" }
+whatsnext: { "EthBalanceMonitor": "/chainlink-automation/tutorials/eth-balance" }
 ---
 
 import { YouTube } from "@astro-community/astro-embed-youtube"


### PR DESCRIPTION
* Spacing fixes
* Remove `isMdx` and trailing slashes in "What's next" links (missed in #1289 )
* Misc edits 