### PR TITLE
Update hardcoded Goerli variables to Sepolia in VRF intro tutorial

### DIFF
--- a/src/pages/getting-started/intermediates-tutorial.mdx
+++ b/src/pages/getting-started/intermediates-tutorial.mdx
@@ -97,8 +97,8 @@ This example is adapted for [Sepolia testnet](/vrf/v2/subscription/supported-net
 {/* prettier-ignore */}
 ```solidity
 uint64 s_subscriptionId;
-address vrfCoordinator = 0x2Ca8E0C643bDe4C2E08ab1fA0da3401AdAD7734D;
-bytes32 s_keyHash = 0x79d3d8832d904592c0bf9818b621522c988bb8b0c05cdc3b15aea1b6e8db0c15;
+address vrfCoordinator = 0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625;
+bytes32 s_keyHash = 0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c;
 uint32 callbackGasLimit = 40000;
 uint16 requestConfirmations = 3;
 uint32 numWords =  1;


### PR DESCRIPTION
Updates incorrect hardcoded variables for the coordinator address and keyhash in the [VRF intro tutorial](https://docs.chain.link/getting-started/intermediates-tutorial#contract-variables). 

Follow-up to #1125 and #1163.