### PR TITLE
Add link to custom logic automation guide in getting started page

### DIFF
--- a/src/pages/chainlink-automation/compatible-contracts.mdx
+++ b/src/pages/chainlink-automation/compatible-contracts.mdx
@@ -40,7 +40,7 @@ Compile and deploy your own Automation Counter onto a [supported Testnet](/chain
 
 1. In the Remix example, select the compile tab on the left and press the compile button. Make sure that your contract compiles without any errors. Note that the Warning messages in this example are acceptable and will not block the deployment.
 1. Select the **Deploy** tab and deploy the `Counter` smart contract in the `injected web3` environment. When deploying the contract, specify the `updateInterval` value. For this example, set a short interval of 60. This is the interval at which the `performUpkeep` function will be called.
-1. After deployment is complete, copy the address of the deployed contract. This address is required to register your upkeep.
+1. After deployment is complete, copy the address of the deployed contract. This address is required to register your upkeep in the automation UI. The example in this document uses the [custom logic](/chainlink-automation/register-upkeep) automation.
 
 To see more complex examples, go to the [utility contracts](/chainlink-automation/tutorials/eth-balance) page.
 

--- a/src/pages/chainlink-automation/compatible-contracts.mdx
+++ b/src/pages/chainlink-automation/compatible-contracts.mdx
@@ -40,7 +40,7 @@ Compile and deploy your own Automation Counter onto a [supported Testnet](/chain
 
 1. In the Remix example, select the compile tab on the left and press the compile button. Make sure that your contract compiles without any errors. Note that the Warning messages in this example are acceptable and will not block the deployment.
 1. Select the **Deploy** tab and deploy the `Counter` smart contract in the `injected web3` environment. When deploying the contract, specify the `updateInterval` value. For this example, set a short interval of 60. This is the interval at which the `performUpkeep` function will be called.
-1. After deployment is complete, copy the address of the deployed contract. This address is required to register your upkeep in the automation UI. The example in this document uses the [custom logic](/chainlink-automation/register-upkeep) automation.
+1. After deployment is complete, copy the address of the deployed contract. This address is required to register your upkeep in the automation UI. The example in this document uses [custom logic](/chainlink-automation/register-upkeep) automation.
 
 To see more complex examples, go to the [utility contracts](/chainlink-automation/tutorials/eth-balance) page.
 

--- a/src/pages/chainlink-automation/compatible-contracts.mdx
+++ b/src/pages/chainlink-automation/compatible-contracts.mdx
@@ -40,7 +40,7 @@ Compile and deploy your own Automation Counter onto a [supported Testnet](/chain
 
 1. In the Remix example, select the compile tab on the left and press the compile button. Make sure that your contract compiles without any errors. Note that the Warning messages in this example are acceptable and will not block the deployment.
 1. Select the **Deploy** tab and deploy the `Counter` smart contract in the `injected web3` environment. When deploying the contract, specify the `updateInterval` value. For this example, set a short interval of 60. This is the interval at which the `performUpkeep` function will be called.
-1. After deployment is complete, copy the address of the deployed contract. This address is required to register your upkeep in the automation UI. The example in this document uses [custom logic](/chainlink-automation/register-upkeep) automation.
+1. After deployment is complete, copy the address of the deployed contract. This address is required to register your upkeep in the [Automation UI](https://automation.chain.link/). The example in this document uses [custom logic](/chainlink-automation/register-upkeep) automation.
 
 To see more complex examples, go to the [utility contracts](/chainlink-automation/tutorials/eth-balance) page.
 


### PR DESCRIPTION
## Description

In the link https://docs.chain.link/chainlink-automation/compatible-contracts#example-contract, step 3 of the tutorial says to copy the deployed contract address to be able to register the user's upkeep. However, there's no next steps afterwards. The next step is to actually go to the page https://docs.chain.link/chainlink-automation/register-upkeep but there's no mention of it. 

...

## Changes
At step 3 of the getting started tutorial for chainlink-automation, Link added to navigate to the appropriate page so that the user will be able to register its upkeep and see an example of how chainlink automation works.
