### PR TITLE
Fix repetition and _ccipReceive link in getting started tab of ccip docs

### DIFF
--- a/src/pages/ccip/getting-started.mdx
+++ b/src/pages/ccip/getting-started.mdx
@@ -186,7 +186,7 @@ The `sendMessage` function completes several operations:
 
    - The `receiver` address is encoded in bytes format to accommodate non-EVM destination blockchains with distinct address formats. The encoding is achieved through [abi.encode](https://docs.soliditylang.org/en/develop/abi-spec.html).
    - The `data` is encoded from a string text to bytes using [abi.encode](https://docs.soliditylang.org/en/develop/abi-spec.html).
-   - The `tokenAmounts` is an array. Each each element comprises a [struct](/ccip/api-reference/Client#evmtokenamount) that contains the token address and amount. In this example, the array is empty because no tokens are sent.
+   - The `tokenAmounts` is an array. Each element comprises a [struct](/ccip/api-reference/Client#evmtokenamount) that contains the token address and amount. In this example, the array is empty because no tokens are sent.
    - The `extraArgs` specify the `gasLimit` for relaying the CCIP message to the recipient contract on the destination blockchain and a `strict` parameter. In this example, the `gasLimit` is set to `200000` and `strict` is set to `false`. **Note**: If `strict` is true and `ccipReceive` reverts on the destination blockchain, subsequent CCIP messages from the same sender will be blocked by CCIP until the reverted CCIP message can be executed.
    - The `feeToken` designates the token address used for CCIP fees. Here, `address(linkToken)` signifies payment in LINK.
 
@@ -221,8 +221,8 @@ When you deploy the contract, you define the router address. The receiver contra
 On the destination blockchain:
 
 1. The CCIP Router invokes the `ccipReceive` [function](/ccip/api-reference/CCIPReceiver#ccipreceive). **Note**: This function is protected by the `onlyRouter` [modifier](/ccip/api-reference/CCIPReceiver#onlyrouter), which ensures that only the router can call the receiver contract.
-1. The `ccipReceive` [function](/ccip/api-reference/CCIPReceiver#ccipreceive) calls an internal function `_ccipReceive` [function](/ccip/api-reference/CCIPReceiver#ccipreceive). The receiver contract implements this function.
-1. This `_ccipReceive` [function](/ccip/api-reference/CCIPReceiver#ccipreceive) expects an `Any2EVMMessage` [struct](/ccip/api-reference/Client#any2evmmessage) that contains the following values:
+1. The `ccipReceive` [function](/ccip/api-reference/CCIPReceiver#ccipreceive) calls an internal function `_ccipReceive` [function](/ccip/api-reference/CCIPReceiver#_ccipreceive). The receiver contract implements this function.
+1. This `_ccipReceive` [function](/ccip/api-reference/CCIPReceiver#_ccipreceive) expects an `Any2EVMMessage` [struct](/ccip/api-reference/Client#any2evmmessage) that contains the following values:
 
    - The CCIP `messageId`.
    - The `sourceChainSelector`.


### PR DESCRIPTION
## Description
Words repeated and _ccipReceive link redirect to ccipRecive function instead of _ccipReceive in getting started tab of CCIP docs.

## Changes
Fixed the issues.
