### PR TITLE
CCIP token transfer tutorial revert error fix add more LINK for fee

### DIFF
--- a/src/components/CopyText.tsx
+++ b/src/components/CopyText.tsx
@@ -8,7 +8,7 @@ export type Props = {
 
 const CopyContainer = ({ text, code }: Props) => {
   return (
-    <div className="copyContainer">
+    <span className="copyContainer">
       {code ? <code>{text}</code> : text}
       <button
         className={clsx("copyBtn", "copy-iconbutton")}
@@ -32,7 +32,7 @@ const CopyContainer = ({ text, code }: Props) => {
           color: var(--color-text-link);
         }
       `}</style>
-    </div>
+    </span>
   )
 }
 

--- a/src/pages/ccip/getting-started.mdx
+++ b/src/pages/ccip/getting-started.mdx
@@ -119,7 +119,7 @@ Send a `Hello World!` string from your contract on _Ethereum Sepolia_ to the con
       style="max-width: 70%;"
     />
 
-1.  Click the **transact** button to run the function. MetaMask prompts you to confirm the transaction.
+1.  Click the **transact** button to run the function. MetaMask prompts you to confirm the transaction. **Note**: During gas price spikes, your transaction might fail, requiring more than _0.01 LINK_ to proceed. If your transaction fails, fund your contract with more _LINK_ tokens and try again.
 1.  After the transaction is successful, note the transaction hash. Here is an [example](https://sepolia.etherscan.io/tx/0x4f9290591ba6686af9936a76b5d974612794e14f9d57c28e22c7758b2dd32d39) of a successful transaction on _Ethereum Sepolia_.
 
 After the transaction is finalized on the source chain, it will take a few minutes for CCIP to deliver the data to _Polygon Mumbai_ and call the `ccipReceive` function on your receiver contract. You can use the [CCIP explorer](https://ccip.chain.link/) to see the status of your CCIP transaction and then read data stored by your receiver contract.

--- a/src/pages/ccip/tutorials/cross-chain-tokens.mdx
+++ b/src/pages/ccip/tutorials/cross-chain-tokens.mdx
@@ -71,8 +71,6 @@ You will transfer _0.001 CCIP-BnM_. The CCIP fees for using CCIP will be paid in
 
 1.  Transfer CCIP-BnM from _Ethereum Sepolia_:
 
-    Note: if the transaction is expected to fail, you might need to send more LINK tokens to TokenTransferor.sol, since the LINK fee possibly increased. 
-
     1. Open MetaMask and select the network _Ethereum Sepolia_.
     1. In Remix IDE, under _Deploy & Run Transactions_, open the list of transactions of your smart contract deployed on _Ethereum Sepolia_.
 
@@ -89,6 +87,8 @@ You will transfer _0.001 CCIP-BnM_. The CCIP fees for using CCIP will be paid in
 
     1. Click the **transact** button and confirm the transaction on MetaMask.
     1. Once the transaction is successful, note the transaction hash. Here is an [example](https://sepolia.etherscan.io/tx/0xb423ad5650648f2856f67f6d8a9c0aa809aa7a86ab4e27b34721497e3a1d647c) of a transaction on _Ethereum Sepolia_.
+
+    **Note**: During gas price spikes, your transaction might fail, requiring more than _0.01 LINK_ to proceed. If your transaction fails, fund your contract with more _LINK_ tokens and try again.
 
 1.  Open the [CCIP explorer](https://ccip.chain.link/) and search your cross-chain transaction using the transaction hash.
 
@@ -147,6 +147,8 @@ You will transfer _0.001 CCIP-BnM_. The CCIP fees for using CCIP will be paid in
 
     1. Click the **transact** button and confirm the transaction on MetaMask.
     1. Once the transaction is successful, note the transaction hash. Here is an [example](https://sepolia.etherscan.io/tx/0x1c02435cce19a9b59d43f1ccc91f120abeb93b3962f4dd08a8ac8974d7ce6c70) of a transaction on _Ethereum Sepolia_.
+
+    **Note**: During gas price spikes, your transaction might fail, requiring more than _0.01 ETH_ to proceed. If your transaction fails, fund your contract with more _ETH_ and try again.
 
 1.  Open the [CCIP explorer](https://ccip.chain.link/) and search your cross-chain transaction using the transaction hash.
 

--- a/src/pages/ccip/tutorials/cross-chain-tokens.mdx
+++ b/src/pages/ccip/tutorials/cross-chain-tokens.mdx
@@ -71,6 +71,8 @@ You will transfer _0.001 CCIP-BnM_. The CCIP fees for using CCIP will be paid in
 
 1.  Transfer CCIP-BnM from _Ethereum Sepolia_:
 
+    Note: if the transaction is expected to fail, you might need to send more LINK tokens to TokenTransferor.sol, since the LINK fee possibly increased. 
+
     1. Open MetaMask and select the network _Ethereum Sepolia_.
     1. In Remix IDE, under _Deploy & Run Transactions_, open the list of transactions of your smart contract deployed on _Ethereum Sepolia_.
 

--- a/src/pages/ccip/tutorials/programmable-token-transfers.mdx
+++ b/src/pages/ccip/tutorials/programmable-token-transfers.mdx
@@ -105,6 +105,8 @@ You will transfer _0.001 CCIP-BnM_ and a text. The CCIP fees for using CCIP will
     1.  Click on `transact` and confirm the transaction on MetaMask.
     1.  After the transaction is successful, record the transaction hash. Here is an [example](https://sepolia.etherscan.io/tx/0x807ef3a86828f3e7e7bed6fa38f770c39a67704221ece124c55ca1ba8b771992) of a transaction on _Ethereum Sepolia_.
 
+    **Note**: During gas price spikes, your transaction might fail, requiring more than _0.01 LINK_ to proceed. If your transaction fails, fund your contract with more _LINK_ tokens and try again.
+
 1.  Open the [CCIP explorer](https://ccip.chain.link/) and search your cross-chain transaction using the transaction hash.
 
                 <br />
@@ -164,6 +166,8 @@ You will transfer _0.001 CCIP-BnM_ and a text. The CCIP fees for using CCIP will
 
     1.  Click on `transact` and confirm the transaction on MetaMask.
     1.  Once the transaction is successful, note the transaction hash. Here is an [example](https://sepolia.etherscan.io/tx/0x1484af3c9d0fc1cb5b93d22117f29bf24b9ec3604dea25502f0a68370136a1be) of a transaction on _Ethereum Sepolia_.
+
+    **Note**: During gas price spikes, your transaction might fail, requiring more than _0.01 ETH_ to proceed. If your transaction fails, fund your contract with more _ETH_ and try again.
 
 1.  Open the [CCIP explorer](https://ccip.chain.link/) and search your cross-chain transaction using the transaction hash.
 

--- a/src/pages/ccip/tutorials/send-arbitrary-data.mdx
+++ b/src/pages/ccip/tutorials/send-arbitrary-data.mdx
@@ -90,6 +90,8 @@ You will use CCIP to send a text. The CCIP fees for using CCIP will be paid in L
     1.  Click on `transact` and confirm the transaction on MetaMask.
     1.  Once the transaction is successful, note the transaction hash. Here is an [example](https://sepolia.etherscan.io/tx/0x6e0fde707448c02c363c74a4b37826d34fa31d82a66ee2fb90f4ac7f54d83f7e) of a transaction on _Ethereum Sepolia_.
 
+    **Note**: During gas price spikes, your transaction might fail, requiring more than _0.01 LINK_ to proceed. If your transaction fails, fund your contract with more _LINK_ tokens and try again.
+
 1.  Open the [CCIP explorer](https://ccip.chain.link/) and search your cross-chain transaction using the transaction hash.
 
                 <br />
@@ -147,6 +149,8 @@ You will use CCIP to send a text. The CCIP fees for using CCIP will be paid in n
 
     1.  Click on `transact` and confirm the transaction on MetaMask.
     1.  Once the transaction is successful, note the transaction hash. Here is an [example](https://sepolia.etherscan.io/tx/0xb777743b414fdb05041c2bf1fbe312ab55f2999687bf4601f75d363fc73ddc8a) of a transaction on _Ethereum Sepolia_.
+
+    **Note**: During gas price spikes, your transaction might fail, requiring more than _0.01 ETH_ to proceed. If your transaction fails, fund your contract with more _ETH_ and try again.
 
 1.  Open the [CCIP explorer](https://ccip.chain.link/) and search your cross-chain transaction using the transaction hash.
 


### PR DESCRIPTION
## Closing issues

https://github.com/smartcontractkit/documentation/issues/1407

## Description

My CCIP token transfer expected to revert since the LINK fee increased. 

## Changes

Helps new users debug the CCIP transfer revert issue due to LINK fee increasing by giving them a warning. 


