### PR TITLE
Fix issue where supported network link did not work for certain netwo…

### DIFF
--- a/src/features/vrf/v2/components/CostTable.tsx
+++ b/src/features/vrf/v2/components/CostTable.tsx
@@ -542,7 +542,7 @@ export const CostTable = ({ mainChain, chain, method }: Props) => {
           </>
         )}
         <p>
-          To see these parameters in more details, read the
+          To see these parameters in greater detail, read the
           <a href={`/vrf/v2/${kebabize(method)}/supported-networks/#${getsupportedNetworkShortcut()}`} target="_blank">
             {" "}
             Supported Networks{" "}


### PR DESCRIPTION
## Description

In https://docs.chain.link/vrf/v2/estimating-costs, when clicking on the supported networks link after selecting a network, the link does not directly go to the network chosen by the user. Also, There are some typos for the subscription method

## Changes

- Fixed supported networks link issue.
- Fixed typos.