### PR TITLE
Fix typo EOA address by EOA in CCIP page

### DIFF
--- a/src/pages/ccip/best-practices.mdx
+++ b/src/pages/ccip/best-practices.mdx
@@ -32,7 +32,7 @@ When you implement the `ccipReceive` [method](/ccip/api-reference/CCIPReceiver#c
 
 The `gasLimit` specifies the maximum amount of gas CCIP can consume to execute `ccipReceive()` on the contract located on the destination blockchain. It is the main factor in determining the fee to send a message. Unspent gas is not refunded.
 
-To transfer tokens directly to an EOA address as a _receiver_ on the destination blockchain, the `gasLimit` should be set to `0` since there is no `ccipReceive()` implementation to call.
+To transfer tokens directly to an EOA as a _receiver_ on the destination blockchain, the `gasLimit` should be set to `0` since there is no `ccipReceive()` implementation to call.
 
 To estimate the accurate gas limit for your destination contract, consider the following options:
 


### PR DESCRIPTION
## Description
Follow-up of the previous PR about EOA address typo to change it to EOA in CCIP page.

## Changes
Applied the same fix to Best Practices tab in https://docs.chain.link/ccip/best-practices#setting-gaslimit