### PR TITLE
Consistent position of the copy button

### DIFF
--- a/src/scripts/copy-to-clipboard.ts
+++ b/src/scripts/copy-to-clipboard.ts
@@ -33,7 +33,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         container.appendChild(copyButton)
 
-        codeBlock.insertAdjacentElement("beforebegin", container)
+        codeBlock.insertAdjacentElement("afterbegin", container)
         observer.unobserve(codeBlock)
       }
     })

--- a/src/styles/copy-to-clipboard.css
+++ b/src/styles/copy-to-clipboard.css
@@ -7,6 +7,7 @@
   position: absolute;
   transform: translateY(5px);
   right: 0;
+  top: 0;
 }
 
 .copy-code-button-wrapper > button {


### PR DESCRIPTION
## Closing issues

closes #1412

## Description

Currently, the copy button is not in the right position in some places. Currently, the `copy button` is placed inside the parent element of the `pre` element and positioned relative to the parent element's position. By moving the copy button inside the `pre` element, the copy button can be positioned relative to the `pre` element's position.

## Changes

Copy button is inserted inside the `pre` element, before its first child.
