### PR TITLE
Adjust NetworkDropdown summary element style

### DIFF
--- a/src/features/ccip/components/NetworkDropdown.tsx
+++ b/src/features/ccip/components/NetworkDropdown.tsx
@@ -263,7 +263,7 @@ export const NetworkDropdown = ({ options, userAddress }: Props) => {
         tabIndex={dropdownDisabled ? -1 : undefined}
         className={[styles["network-selector-container"], ...(dropdownDisabled ? [styles.disabled] : [])].join(" ")}
       >
-        <summary>
+        <summary className={styles["network-selector-summary"]}>
           <div className={styles["network-selector"]}>
             {isNetworkChangePending ? (
               <>

--- a/src/features/ccip/components/networkDropdown.module.css
+++ b/src/features/ccip/components/networkDropdown.module.css
@@ -2,7 +2,7 @@ details {
   display: contents;
 }
 
-summary {
+.network-selector-summary {
   margin: 0 auto;
   width: 13.057rem;
   padding-top: 1rem;


### PR DESCRIPTION
## Closing issues

closes #1452 

## Description

The `summary` element style of the `NetworkDropdown` component used on the [ccip/test-tokens#mint-tokens-in-the-documentation](https://docs.chain.link/ccip/test-tokens) page adjusts the style of the `LeftSideBar`. We can avoid this issue by assigning a class name to the element. 

## Changes

The class name has been assigned to the `summary` element used in the `NetworkDropdown` component.

