### PR TITLE
Format job example to allow translation

### DIFF
--- a/src/content/chainlink-nodes/oracle-jobs/all-jobs.mdx
+++ b/src/content/chainlink-nodes/oracle-jobs/all-jobs.mdx
@@ -374,8 +374,13 @@ See [shared fields](/chainlink-nodes/oracle-jobs/jobs/#shared-fields).
 - `contractAddress`: The address of the `OffchainReportingAggregator` contract.
 - `evmChainID`: The chain ID of the EVM chain in which the job will operate.
 - `p2pPeerID`: The base58-encoded libp2p public key of this node.
-- `p2pBootstrapPeers`: A list of libp2p dial addresses of the other bootstrap nodes helping oracle nodes find one another on the network. It is used with P2P networking stack V1 as follows: `p2pBootstrapPeers = [ "/dns4/<host name or ip>/tcp/<port>/p2p/<bootstrap node's P2P ID>" ]`
-- `p2pv2Boostrappers`: A list of libp2p dial addresses of the other bootstrap nodes helping oracle nodes find one another on the network. It is used with P2P networking stack V2 as follows: `p2pv2Boostrappers = [ "<bootstrap node's P2P ID>@<host name or ip>:<port>" ]`
+- `p2pBootstrapPeers`: A list of libp2p dial addresses of the other bootstrap nodes helping oracle nodes find one another on the network. It is used with P2P networking stack V1 as follows:
+  `p2pBootstrapPeers = [ "/dns4/<host name or ip>/tcp/<port>/p2p/<bootstrap node's P2P ID>" ]`
+
+- `p2pv2Boostrappers`: A list of libp2p dial addresses of the other bootstrap nodes helping oracle nodes find one another on the network. It is used with P2P networking stack V2 as follows:
+
+  `p2pv2Boostrappers = [ "<bootstrap node's P2P ID>@<host name or ip>:<port>" ]`
+
 - `keyBundleID`: The hash of the OCR key bundle to be used by this node. The Chainlink node keystore manages these key bundles. Use the node **Key Management** UI or the `chainlink keys ocr` sub-commands in the CLI to create and manage key bundles.
 - `monitoringEndpoint`: The URL of the telemetry endpoint to send OCR metrics to.
 - `transmitterAddress`: The Ethereum address from which to send aggregated submissions to the OCR contract.

--- a/src/content/chainlink-nodes/oracle-jobs/all-jobs.mdx
+++ b/src/content/chainlink-nodes/oracle-jobs/all-jobs.mdx
@@ -303,8 +303,14 @@ See [shared fields](/chainlink-nodes/oracle-jobs/jobs/#shared-fields).
 
 - `contractAddress`: The address of the `OffchainReportingAggregator` contract.
 - `evmChainID`: The chain ID of the EVM chain in which the job will operate.
-- `p2pBootstrapPeers`: A list of libp2p dial addresses of the other bootstrap nodes helping oracle nodes find one another on the network. It is used with P2P networking stack V1 as follows: `p2pBootstrapPeers = [ "/dns4/<host name or ip>/tcp/<port>/p2p/<bootstrap node's P2P ID>" ]`
-- `p2pv2Boostrappers`: A list of libp2p dial addresses of the other bootstrap nodes helping oracle nodes find one another on the network. It is used with P2P networking stack V2 as follows: `p2pv2Boostrappers = [ "<bootstrap node's P2P ID>@<host name or ip>:<port>" ]`
+- `p2pBootstrapPeers`: A list of libp2p dial addresses of the other bootstrap nodes helping oracle nodes find one another on the network. It is used with P2P networking stack V1 as follows:
+
+  `p2pBootstrapPeers = [ "/dns4/<host name or ip>/tcp/<port>/p2p/<bootstrap node's P2P ID>" ]`
+
+- `p2pv2Boostrappers`: A list of libp2p dial addresses of the other bootstrap nodes helping oracle nodes find one another on the network. It is used with P2P networking stack V2 as follows:
+
+  `p2pv2Boostrappers = [ "<bootstrap node's P2P ID>@<host name or ip>:<port>" ]`
+
 - `isBootstrapPeer`: This must be set to `true`.
 
 #### Job type specific pipeline variables


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.Any change needs to be discussed before proceeding.**

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #DOC-281

...

## Description

Weglot uses < as an codeblock character and set to ignore those for translation. Any bullet that contains this will be ignored. So far this only seems to be the case in [Job Types | Chainlink Documentation](https://docs.chain.link/chainlink-nodes/oracle-jobs/all-jobs#unique-fields-4) .

The linked PR updates the formatting to add a break prior to the codeblock sample, thus allowing the preceding bullet to be translated.
