### PR TITLE
Fix typo in vrf subscription introduction page

### DIFF
--- a/src/content/vrf/v2/subscription/index.mdx
+++ b/src/content/vrf/v2/subscription/index.mdx
@@ -73,7 +73,7 @@ Set up your consuming contract:
 
 1. Your contract must inherit [VRFConsumerBaseV2](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/VRFConsumerBaseV2.sol).
 
-1. Your contract must implement the implement the `fulfillRandomWords` function, which is the _callback VRF function_. Here, you add logic to handle the random values after they are returned to your contract.
+1. Your contract must implement the `fulfillRandomWords` function, which is the _callback VRF function_. Here, you add logic to handle the random values after they are returned to your contract.
 
 1. Submit your VRF request by calling `requestRandomWords` of the [VRF Coordinator](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/VRFCoordinatorV2.sol). Include the following parameters in your request:
 


### PR DESCRIPTION
## Closing issues

closes #1514 

## Description
There is a repetition of 'implement the' in the vrf subscription introduction page here https://docs.chain.link/vrf/v2/subscription/#set-up-your-contract-and-request in the second step.


## Changes
Removed the repetition.
