### PR TITLE
Fix typo in script name in lootbox quickstart

### DIFF
--- a/src/content/quickstarts/vrf-enabled-lootbox-pack.mdx
+++ b/src/content/quickstarts/vrf-enabled-lootbox-pack.mdx
@@ -221,7 +221,7 @@ Now that your example is configured, you can test, deploy, and run the example. 
 Run the `npx hardhat run` command and replace `<network>` with the network that you want to deploy to. The network must be configured in [`hardhat.config.ts`](https://github.com/smartcontractkit/quickstarts-lootbox/blob/main/hardhat.config.ts).
 
 ```bash
-npx hardhat run scripts/deploy.js --network <network>
+npx hardhat run scripts/deploy.ts --network <network>
 ```
 
 The [deploy script](https://github.com/smartcontractkit/quickstarts-lootbox/blob/main/scripts/deploy.ts) also completes the following actions:


### PR DESCRIPTION
## Description
The command npx hardhat run scripts/deploy.js --network <network> does not work because the script is called deploy.ts. 

## Changes
Fix the issue by replacing deploy.js mention by deploy.ts instead.
