### PR TITLE
Add warning text and icon when gas price is higher than selected gas lane to VRF calculator

### DIFF
--- a/src/features/vrf/v2/components/CostTable.tsx
+++ b/src/features/vrf/v2/components/CostTable.tsx
@@ -8,7 +8,7 @@ import button from "@chainlink/design-system/button.module.css"
 interface Props {
   method: "vrfSubscription" | "vrfDirectFunding"
   network: string
-  icon: HTMLElement | undefined
+  aside: HTMLElement | undefined
 }
 
 interface directFundingResponse {
@@ -177,7 +177,7 @@ export const getGasCalculatorUrl = ({
   }&method=${method === "vrfSubscription" ? "subscription" : "directFunding"}`
 }
 
-export const CostTable = ({ method, network, icon }: Props) => {
+export const CostTable = ({ method, network, aside }: Props) => {
   const [state, dispatch] = useReducer(reducer, initialState)
   const getDataResponse = useCallback(
     async (mainChainName: string, networkName: string, chainNetwork: ChainNetwork): Promise<dataResponse> => {
@@ -702,13 +702,7 @@ export const CostTable = ({ method, network, icon }: Props) => {
           (state.currentGasPrice === state.gasPrice
             ? BigNumber.from(state.currentGasPrice).gt(utils.parseUnits(state.currentGasLane.toString(), "gwei"))
             : parseFloat(state.currentGasPrice) > state.currentGasLane) && (
-            <>
-              <p>
-                {icon} Warning: your chosen gas price is higher than the selected gas lane, which means that the request
-                will not be fulfilled until the network gas price goes down to the maximum price for the selected gas
-                lane. The estimated cost shown is for informational purposes only.
-              </p>
-            </>
+            <div className="warning-container">{aside}</div>
           )}
         <h6>Estimated cost per request: {formatTotal()} LINK</h6>
 

--- a/src/features/vrf/v2/components/Dropdown.astro
+++ b/src/features/vrf/v2/components/Dropdown.astro
@@ -1,11 +1,17 @@
 ---
-import { Icon } from "~/components"
+import { Aside } from "~/components"
 import { MethodCheckbox } from "./MethodCheckbox"
 import { Props } from "astro"
 ---
 
 <div>
   <MethodCheckbox client:load>
-    <Icon type="caution" slot="icon" />
+    <Aside type="caution" slot="aside">
+      <p>
+        Your chosen gas price is higher than the selected gas lane, which means that the request will not be fulfilled
+        until the network gas price goes down to the maximum price for the selected gas lane. The estimated cost shown
+        is for informational purposes only.
+      </p>
+    </Aside>
   </MethodCheckbox>
 </div>

--- a/src/features/vrf/v2/components/MethodCheckbox.tsx
+++ b/src/features/vrf/v2/components/MethodCheckbox.tsx
@@ -7,10 +7,10 @@ import { Dropdown } from "./Dropdown"
 import useQueryString from "~/hooks/useQueryString"
 
 interface Props {
-  icon?: HTMLElement | undefined
+  aside?: HTMLElement | undefined
 }
 
-export const MethodCheckbox = ({ icon }: Props) => {
+export const MethodCheckbox = ({ aside }: Props) => {
   const [vrfMethodUsed, setVrfMethodUsed] = useState<"vrfSubscription" | "vrfDirectFunding">("vrfSubscription")
   const [network] = useQueryString("network", "")
   const handleChange = (event) => {
@@ -47,7 +47,7 @@ export const MethodCheckbox = ({ icon }: Props) => {
         </div>
       </div>
       <Dropdown options={options} />
-      {network && <CostTable method={vrfMethodUsed} network={network.toString()} icon={icon} />}
+      {network && <CostTable method={vrfMethodUsed} network={network.toString()} aside={aside} />}
     </div>
   )
 }

--- a/src/features/vrf/v2/components/costTable.css
+++ b/src/features/vrf/v2/components/costTable.css
@@ -33,6 +33,10 @@ th {
   padding: 1.5rem;
 }
 
+.warning-container {
+  padding-bottom: 1.5rem;
+}
+
 @media screen and (min-width: 768px) {
   .keyhash-radio-container {
     flex-direction: row;


### PR DESCRIPTION
## Description

During a gas spike for a specific network, estimated cost in the VRF calculator is no longer valid because the gas price is higher than the current gas lane.

## Changes
Added a warning text when this case happens.
