### PR TITLE
Fix homepage sizing

### DIFF
--- a/src/features/landing/components/ProductCard.module.css
+++ b/src/features/landing/components/ProductCard.module.css
@@ -1,5 +1,4 @@
 .productCardWrapper {
-  width: 375px;
   display: flex;
   flex-grow: 1;
   flex-shrink: 0;

--- a/src/features/landing/components/Tabs.module.css
+++ b/src/features/landing/components/Tabs.module.css
@@ -1,6 +1,17 @@
 .tabContent {
-  display: flex;
-  flex-wrap: wrap;
-  width: 100%;
+  display: grid;
   gap: 32px;
+  grid-template-columns: 1fr;
+}
+
+@media screen and (min-width: 768px) {
+  .tabContent {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media screen and (min-width: 1300px) {
+  .tabContent {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
 }

--- a/src/features/landing/sections/HeroCTA.astro
+++ b/src/features/landing/sections/HeroCTA.astro
@@ -24,7 +24,7 @@ import button from "@chainlink/design-system/button.module.css"
     justify-content: space-between;
     align-items: center;
     flex-wrap: wrap;
-    margin: 15px 0;
+    margin: var(--space-8x) 0 var(--space-4x);
   }
   h2,
   h2 span {


### PR DESCRIPTION
## Closing Issue

Closes [FRONT-4421](https://smartcontract-it.atlassian.net/browse/FRONT-4421)

## Description

The `ProductCard` components were using a fixed width with flex wrap to break across lines, but this created overflow on smaller displays. This fixes the overflow by aligning them to a grid in `Tabs`. This also adds a top margin to `HeroCTA`, which is required on mobile to not be awkwardly close to the top of the page.

## Changes

- Aligns `ProductCard` components to grid in `Tabs`
- Adds margin to `HeroCTA`