### PR TITLE
fix/AllowSimplePasswords: true disallowed for secure builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ PRs are welcome! We try to keep a clean commit history, so we'll follow a standa
   - Changes are often formatted like `add doc X`, `fix page Y`, `improve docs for Z`.
   - Example: "`update contract addresses for BNB Chain`".
 - If you touch any infrastructure, make sure it builds with `yarn build`
+  - If you haven't already, `npm -g install astro`
 - Trust the autoformatter (prettier)
 - Make sure images are optimized and compressed
 - Keep images < 20kb whenever possible to keep the site fast and the repo small (try [trimage](https://trimage.org/))

--- a/src/content/chainlink-nodes/v1/secrets-config.mdx
+++ b/src/content/chainlink-nodes/v1/secrets-config.mdx
@@ -59,7 +59,7 @@ Environment variable: `CL_DATABASE_BACKUP_URL`
 AllowSimplePasswords = false # Default
 ```
 
-AllowSimplePasswords skips the password complexity check normally enforced on URL & BackupURL.
+AllowSimplePasswords skips the password complexity check normally enforced on URL & BackupURL. A value of true is allowed only for dev builds.
 
 Environment variable: `CL_DATABASE_ALLOW_SIMPLE_PASSWORDS`
 


### PR DESCRIPTION


## Description

AllowSimplePasswords is now disallowed for secure builds. Updating secrets config documentation accordingly.



