### PR TITLE
Update notation for URL and pipe chars

### DIFF
--- a/src/content/any-api/get-request/examples/large-responses.mdx
+++ b/src/content/any-api/get-request/examples/large-responses.mdx
@@ -79,7 +79,7 @@ To use this contract:
 
 1. Run the `requestBytes` function. This builds the `Chainlink.Request` using the correct parameters:
 
-   - The `req.add("get", "<url>")` request parameter provides the oracle node with the [url](https://ipfs.io/ipfs/QmZgsvrA1o1C8BGCrx6mHTqR1Ui1XqbCrtbMVrRLHtuPVD?filename=big-api-response.json) where to fetch the response.
+   - The `req.add("get", "URL")` request parameter provides the oracle node with the [url](https://ipfs.io/ipfs/QmZgsvrA1o1C8BGCrx6mHTqR1Ui1XqbCrtbMVrRLHtuPVD?filename=big-api-response.json) where to fetch the response.
    - The `req.add('path', 'image')` request parameter tells the oracle node how to parse the response.
 
 1. After few seconds, call the `data` and `image_url` functions. You should get non-empty responses.

--- a/src/content/chainlink-nodes/v1/configuration.mdx
+++ b/src/content/chainlink-nodes/v1/configuration.mdx
@@ -383,9 +383,11 @@ The `AUDIT_LOGGER_*` environment variables configure this optional audit log HTT
 - Default: _none_
 
 An optional list of HTTP headers to be added for every optional audit log event. If the above `AUDIT_LOGGER_FORWARD_TO_URL` is set, audit log events will be POSTed to that URL, and will include headers specified in this environment variable. One example use case is auth for example:
+
 `AUDIT_LOGGER_HEADERS="Authorization||{token}"`
 
-Header keys and values are delimited on `||`, and multiple headers can be added with a forward slash delimiter (`\`). An example of multiple key value pairs:
+Header keys and values are delimited on ||, and multiple headers can be added with a forward slash delimiter (`\`). An example of multiple key value pairs:
+
 `AUDIT_LOGGER_HEADERS="Authorization||{token}\Some-Other-Header||{token2}"`
 
 ### AUDIT_LOGGER_JSON_WRAPPER_KEY


### PR DESCRIPTION
## Description

Update URL placeholder notation to allcaps. Update pipe character notation to add breaks and allow translation.
