### PR TITLE
Add line break to avoid image encroachment

### DIFF
--- a/src/content/chainlink-functions/getting-started.mdx
+++ b/src/content/chainlink-functions/getting-started.mdx
@@ -94,7 +94,9 @@ To run the example:
 1.  In Remix under the **Deploy & Run Transactions** tab, expand your contract in the **Deployed Contracts** section.
 1.  Expand the `sendRequest` function to display its parameters.
 1.  Fill in the `subscriptionId` with your subscription ID and `args` with `[1]`, then click **transact** button.
+
     <ClickToZoom src="/images/chainlink-functions/getting-started/send-request.jpg" />
+
 1.  Wait for the request to be fulfilled. You can monitor the status of your request on the Chainlink Functions Subscription Manager.
     <ClickToZoom src="/images/chainlink-functions/getting-started/request-fulfilled.jpg" />
 1.  Once the status is _Success_, check the character name: In Remix, under the **Deploy & Run Transactions** tab, click on the `character` function, and you'll get the name of your character.

--- a/src/content/chainlink-functions/getting-started.mdx
+++ b/src/content/chainlink-functions/getting-started.mdx
@@ -100,6 +100,7 @@ To run the example:
 1.  Wait for the request to be fulfilled. You can monitor the status of your request on the Chainlink Functions Subscription Manager.
     <ClickToZoom src="/images/chainlink-functions/getting-started/request-fulfilled.jpg" />
 1.  Once the status is _Success_, check the character name: In Remix, under the **Deploy & Run Transactions** tab, click on the `character` function, and you'll get the name of your character.
+
     <ClickToZoom src="/images/chainlink-functions/getting-started/character.jpg" />
 
 Chainlink Functions is capable of much more than just computation. Try one of the [Tutorials](/chainlink-functions/tutorials) to see examples that can GET and POST to public APIs, securely handle API secrets, handle custom responses, and query multiple APIs.


### PR DESCRIPTION
## Description

Bullet no. 3 in https://docs.chain.link/chainlink-functions/getting-started?lang=en#run-the-example, the image encroaches the line of text. Adding break to prevent.