### PR TITLE
Fix LeftSidebar sections from appearing misaligned

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -175,6 +175,8 @@ const currentPageMatch = removeSlashes(currentPage.slice(1))
 
 <style is:inline>
   .nav-link svg {
+    min-height: 12px;
+    min-width: 12px;
     opacity: 0;
   }
 


### PR DESCRIPTION
## Description

`LeftSidebar` section entries were appearing misaligned. This was due to the svg elements (hex logo) on selected sections being resized if the section text spanned multiple lines. This change adds `min-width` and `min-height` properties to prevent the svgs from resizing.