### PR TITLE
fixes typo: replaces incorrect function name

### DIFF
--- a/src/content/ccip/tutorials/cross-chain-tokens.mdx
+++ b/src/content/ccip/tutorials/cross-chain-tokens.mdx
@@ -204,7 +204,7 @@ The `transferTokensPayLINK` function undertakes six primary operations:
 
    - The `_receiver` address is encoded in bytes to accommodate non-EVM destination blockchains with distinct address formats. The encoding is achieved through [abi.encode](https://docs.soliditylang.org/en/develop/abi-spec.html).
    - The `data` is empty because you only transfer tokens.
-   - The `tokenAmounts` is an array, with each element comprising a [`EVMTokenAmount` struct](/ccip/api-reference/client#evmtokenamount) that contains the token address and amount. The array contains one element where the `_token` (token address) and `_amount` (token amount) are passed by the user when calling the `transferTokensPayNative` function.
+   - The `tokenAmounts` is an array, with each element comprising a [`EVMTokenAmount` struct](/ccip/api-reference/client#evmtokenamount) that contains the token address and amount. The array contains one element where the `_token` (token address) and `_amount` (token amount) are passed by the user when calling the `transferTokensPayLINK` function.
    - The `extraArgs` specifies the `gasLimit` for relaying the message to the recipient contract on the destination blockchain. In this example, the `gasLimit` is set to `0` because the contract only transfers tokens and does not expect function calls on the destination blockchain.
    - The `_feeTokenAddress` designates the token address used for CCIP fees. Here, `address(linkToken)` signifies payment in LINK.
 


### PR DESCRIPTION
Replaces incorrect function name from `transferTokensPayNative` to `transferTokensPayLINK`

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

None

## Description

There was a typo under the `Explanation` header for `transferTokensPayLINK`. 

[Reference](https://docs.chain.link/ccip/tutorials/cross-chain-tokens#transferring-tokens-and-pay-in-link)

The tokenAmounts is an array, with each element comprising a [EVMTokenAmount struct](https://docs.chain.link/ccip/api-reference/client#evmtokenamount) that contains the token address and amount. The array contains one element where the _token (token address) and _amount (token amount) are passed by the user when calling the **transferTokensPayNative** function.

## Changes

Instead of `transferTokensPayLINK` the mention was that of `transferTokensPayNative`.
This PR fixes the above mentioned typo and makes the documentation consistent.
