### PR TITLE
Fix Sidebar caret jumping around

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -87,6 +87,7 @@ const currentPageMatch = removeSlashes(currentPage.slice(1))
 <style>
   nav {
     padding-bottom: calc(2 * var(--doc-padding));
+    width: 100%;
   }
 
   .nav-groups {


### PR DESCRIPTION
Fixes the width of the sidebar so that the caret doesn't jump left and right.

![CleanShot_Brave Browser_000421](https://github.com/smartcontractkit/documentation/assets/16008141/b1db324e-e469-42f0-be84-ba45049ed46c)
