### PR TITLE
External Links Quick Fixes (404 Errors)

### DIFF
--- a/public/samples/ChainlinkFunctions/GettingStartedFunctionsConsumer.sol
+++ b/public/samples/ChainlinkFunctions/GettingStartedFunctionsConsumer.sol
@@ -40,11 +40,11 @@ contract GettingStartedFunctionsConsumer is FunctionsClient, ConfirmedOwner {
 
     // JavaScript source code
     // Fetch character name from the Star Wars API.
-    // Documentation: https://swapi.dev/documentation#people
+    // Documentation: https://swapi.info/people
     string source =
         "const characterId = args[0];"
         "const apiResponse = await Functions.makeHttpRequest({"
-        "url: `https://swapi.dev/api/people/${characterId}/`"
+        "url: `https://swapi.info/api/people/${characterId}/`"
         "});"
         "if (apiResponse.error) {"
         "throw Error('Request failed');"

--- a/public/samples/ChainlinkFunctions/starwars-api.js
+++ b/public/samples/ChainlinkFunctions/starwars-api.js
@@ -1,6 +1,6 @@
 const characterId = args[0];
 const apiResponse = await Functions.makeHttpRequest({
-  url: `https://swapi.dev/api/people/${characterId}/`,
+  url: `https://swapi.info/api/people/${characterId}/`,
 });
 if (apiResponse.error) {
   throw Error("Request failed");

--- a/src/content/chainlink-functions/getting-started.mdx
+++ b/src/content/chainlink-functions/getting-started.mdx
@@ -21,7 +21,7 @@ Learn how to make requests to the Chainlink Functions Decentralized Oracle Netwo
 - Set up your web3 wallet and fund it with testnet tokens.
 - Simulate a Chainlink Functions on the [Chainlink Functions
   Playground](https://functions.chain.link/playground).
-- Send a Chainlink Functions request to the DON. The JavaScript source code makes an API call to the [Star Wars API](https://swapi.dev/) and fetches the name of a given character.
+- Send a Chainlink Functions request to the DON. The JavaScript source code makes an API call to the [Star Wars API](https://swapi.info) and fetches the name of a given character.
 - Receive the response from Chainlink Functions and parse the result.
 
 <YouTube id="https://www.youtube.com/watch?v=p3CxiGwytHM" />
@@ -310,17 +310,17 @@ Chainlink Functions is capable of much more than just retrieving data. Try one o
 
 <CodeSample lang="javascript" src="samples/ChainlinkFunctions/starwars-api.js" />
 
-This JavaScript source code uses [Functions.makeHttpRequest](/chainlink-functions/api-reference/javascript-source#http-requests) to make HTTP requests. The source code calls the `https://swapi.dev/` API to request a Star Wars character name. If you read the [Functions.makeHttpRequest](/chainlink-functions/api-reference/javascript-source#http-requests) documentation and the [Star Wars API documentation](https://swapi.dev/documentation#people), you notice that URL has the following format where `$characterId` is provided as parameter when making the HTTP request:
+This JavaScript source code uses [Functions.makeHttpRequest](/chainlink-functions/api-reference/javascript-source#http-requests) to make HTTP requests. The source code calls the `https://swapi.info/` API to request a Star Wars character name. If you read the [Functions.makeHttpRequest](/chainlink-functions/api-reference/javascript-source#http-requests) documentation and the [Star Wars API documentation](https://swapi.info/people), you notice that URL has the following format where `$characterId` is provided as parameter when making the HTTP request:
 
 ```
-url: `https://swapi.dev/api/people/${characterId}/`
+url: `https://swapi.info/api/people/${characterId}/`
 ```
 
-To check the expected API response for the first character, you can directly paste the following URL in your browser `https://swapi.dev/api/people/1/` or run the `curl` command in your terminal:
+To check the expected API response for the first character, you can directly paste the following URL in your browser `https://swapi.info/api/people/1/` or run the `curl` command in your terminal:
 
 ```bash
 curl -X 'GET' \
-  'https://swapi.dev/api/people/1/' \
+  'https://swapi.info/api/people/1/' \
   -H 'accept: application/json'
 ```
 
@@ -336,19 +336,19 @@ The response should be similar to the following example:
   "eye_color": "blue",
   "birth_year": "19BBY",
   "gender": "male",
-  "homeworld": "https://swapi.dev/api/planets/1/",
+  "homeworld": "https://swapi.info/api/planets/1/",
   "films": [
-    "https://swapi.dev/api/films/1/",
-    "https://swapi.dev/api/films/2/",
-    "https://swapi.dev/api/films/3/",
-    "https://swapi.dev/api/films/6/"
+    "https://swapi.info/api/films/1/",
+    "https://swapi.info/api/films/2/",
+    "https://swapi.info/api/films/3/",
+    "https://swapi.info/api/films/6/"
   ],
   "species": [],
-  "vehicles": ["https://swapi.dev/api/vehicles/14/", "https://swapi.dev/api/vehicles/30/"],
-  "starships": ["https://swapi.dev/api/starships/12/", "https://swapi.dev/api/starships/22/"],
+  "vehicles": ["https://swapi.info/api/vehicles/14/", "https://swapi.info/api/vehicles/30/"],
+  "starships": ["https://swapi.info/api/starships/12/", "https://swapi.info/api/starships/22/"],
   "created": "2014-12-09T13:50:51.644000Z",
   "edited": "2014-12-20T21:17:56.891000Z",
-  "url": "https://swapi.dev/api/people/1/"
+  "url": "https://swapi.info/api/people/1/"
 }
 ```
 


### PR DESCRIPTION
- swapi.dev: not available anymore
- swapi.info: to align with the API endpoints used in the playground