### PR TITLE
Clarify smart contract function listing

### DIFF
--- a/src/content/ccip/tutorials/cross-chain-tokens.mdx
+++ b/src/content/ccip/tutorials/cross-chain-tokens.mdx
@@ -71,7 +71,7 @@ You will transfer _0.001 CCIP-BnM_. The CCIP fees for using CCIP will be paid in
 1.  Transfer CCIP-BnM from _Avalanche Fuji_:
 
     1. Open MetaMask and select the network _Avalanche Fuji_.
-    1. In Remix IDE, under _Deploy & Run Transactions_, open the list of your smart contract deployed on _Avalanche Fuji_.
+    1. In Remix IDE, under _Deploy & Run Transactions_, open the list of functions for your smart contract deployed on _Avalanche Fuji_.
 
     1. Fill in the arguments of the _**transferTokensPayLINK**_ function:
 


### PR DESCRIPTION
Clarifying a sentence regarding accessing smart contract functions on Avalanche Fuji. The phrase "open the list of your smart contract deployed on Avalanche Fuji" is changed to "open the list of functions for your smart contract deployed on Avalanche Fuji." This change aims to provide clearer instructions to users about the specific information they can access related to their deployed smart contracts on Avalanche Fuji.

The opened issue:  #1891
