### PR TITLE
Update a chain selector

### DIFF
--- a/src/content/ccip/tutorials/send-arbitrary-data.mdx
+++ b/src/content/ccip/tutorials/send-arbitrary-data.mdx
@@ -139,7 +139,7 @@ You will use CCIP to send a text. The CCIP fees for using CCIP will be paid in n
 
         | Argument                   | Description                                                                                                                                             | Value (_Ethereum Sepolia_)                   |
         | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-        | \_destinationChainSelector | CCIP Chain identifier of the target blockchain. You can find each network's chain selector on the [ supported networks page ](/ccip/supported-networks) | <CopyText text="14767482510784806043" code/> |
+        | \_destinationChainSelector | CCIP Chain identifier of the target blockchain. You can find each network's chain selector on the [ supported networks page ](/ccip/supported-networks) | <CopyText text="16015286601757825753" code/> |
         | \_receiver                 | The destination smart contract address                                                                                                                  | Your deployed receiver contract address      |
         | \_text                     | any `string`                                                                                                                                            | <CopyText text="Hello World!" code/>         |
 


### PR DESCRIPTION
Fixes an issue in this section - https://docs.chain.link/ccip/tutorials/send-arbitrary-data#send-data-and-pay-in-native

Has the Fuji chain selector:
![Screenshot 2024-04-18 at 8 49 33 PM](https://github.com/smartcontractkit/documentation/assets/5498502/1c6fdbe3-c5df-48a6-8dc8-49ddff8730d0)
