### PR TITLE
Update Source Chain Name

### DIFF
--- a/src/content/ccip/tutorials/get-status-offchain.mdx
+++ b/src/content/ccip/tutorials/get-status-offchain.mdx
@@ -31,7 +31,7 @@ node src/get-status.js sourceChain destinationChain messageID
 
 **Example Usage:**
 
-If you initiated a transaction from the Ethereum Sepolia testnet to the Ethereum Sepolia testnet and received a message ID, you can check the status of this message with the following command:
+If you initiated a transaction from the Avalanche Fuji testnet to the Ethereum Sepolia testnet and received a message ID, you can check the status of this message with the following command:
 
 ```text
 $ node src/get-status.js avalancheFuji ethereumSepolia 0x25d18c6adfc1f99514b40f9931a14ca08228cdbabfc5226c1e6a43ce7441595d


### PR DESCRIPTION

## Description

<!-- Please provide enough information so that others can review your pull request: -->

This pull request updates the source chain name in the transaction status check command usage statement from "Ethereum Sepolia testnet" to "Avalanche Fuji testnet".