### PR TITLE
Correcting checkGasLimit to 10M

### DIFF
--- a/src/features/chainlink-automation/data/chainlink-automation-config.json
+++ b/src/features/chainlink-automation/data/chainlink-automation-config.json
@@ -103,7 +103,7 @@
     "paymentPremiumPPB": 700000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 10000000,
+    "checkGasLimit": 6500000,
     "gasCeilingMultiplier": 3,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -128,7 +128,7 @@
     "paymentPremiumPPB": 300000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 10000000,
+    "checkGasLimit": 6500000,
     "gasCeilingMultiplier": 3,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -278,7 +278,7 @@
     "paymentPremiumPPB": 500000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 10000000,
+    "checkGasLimit": 6500000,
     "gasCeilingMultiplier": 5,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -328,7 +328,7 @@
     "paymentPremiumPPB": 500000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 10000000,
+    "checkGasLimit": 6500000,
     "gasCeilingMultiplier": 5,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -353,7 +353,7 @@
     "paymentPremiumPPB": 500000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 10000000,
+    "checkGasLimit": 6500000,
     "gasCeilingMultiplier": 5,
     "minUpkeepSpend": {
       "type": "BigNumber",

--- a/src/features/chainlink-automation/data/chainlink-automation-config.json
+++ b/src/features/chainlink-automation/data/chainlink-automation-config.json
@@ -3,7 +3,7 @@
     "paymentPremiumPPB": 200000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 2,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -28,7 +28,7 @@
     "paymentPremiumPPB": 200000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 3,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -53,7 +53,7 @@
     "paymentPremiumPPB": 300000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 3,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -78,7 +78,7 @@
     "paymentPremiumPPB": 300000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 3,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -103,7 +103,7 @@
     "paymentPremiumPPB": 700000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 3,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -128,7 +128,7 @@
     "paymentPremiumPPB": 300000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 3,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -153,7 +153,7 @@
     "paymentPremiumPPB": 400000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 2,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -178,7 +178,7 @@
     "paymentPremiumPPB": 400000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 2,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -203,7 +203,7 @@
     "paymentPremiumPPB": 500000000,
     "blockCountPerTurn": 50,
     "maxCheckDataSize": "Not Applicable",
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 4,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -228,7 +228,7 @@
     "paymentPremiumPPB": 500000000,
     "blockCountPerTurn": 200,
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 2,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -253,7 +253,7 @@
     "paymentPremiumPPB": 500000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 5,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -278,7 +278,7 @@
     "paymentPremiumPPB": 500000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 5,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -303,7 +303,7 @@
     "paymentPremiumPPB": 500000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 5,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -328,7 +328,7 @@
     "paymentPremiumPPB": 500000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 5,
     "minUpkeepSpend": {
       "type": "BigNumber",
@@ -353,7 +353,7 @@
     "paymentPremiumPPB": 500000000,
     "blockCountPerTurn": "Not Applicable",
     "maxCheckDataSize": 5000,
-    "checkGasLimit": 6500000,
+    "checkGasLimit": 10000000,
     "gasCeilingMultiplier": 5,
     "minUpkeepSpend": {
       "type": "BigNumber",


### PR DESCRIPTION
Update CLA supported networks page to reflect 10M checkGasLimit across all networks (for v2.1)

https://documentation-git-thedriftofwords-cla-correction-chainlinklabs.vercel.app/chainlink-automation/overview/supported-networks