### PR TITLE
Update supported clients link to stable version

### DIFF
--- a/src/content/chainlink-nodes/resources/requirements.mdx
+++ b/src/content/chainlink-nodes/resources/requirements.mdx
@@ -28,7 +28,7 @@ Chainlink nodes have the following software dependencies:
 
 ## Blockchain connectivity
 
-Chainlink nodes require a fully-synced network client so that they can run onchain transactions and interact with deployed contracts. For Ethereum, see the list of [supported clients](https://github.com/smartcontractkit/chainlink/tree/v1.13.0-beta3#ethereum-execution-client-requirements). Other L1s, L2s, and side-chains use different clients. See your network's documentation to learn how to run a client for your specific network.
+Chainlink nodes require a fully-synced network client so that they can run onchain transactions and interact with deployed contracts. For Ethereum, see the list of [supported clients](https://github.com/smartcontractkit/chainlink#ethereum-execution-client-requirements). Other L1s, L2s, and side-chains use different clients. See your network's documentation to learn how to run a client for your specific network.
 
 The client must meet the following requirements:
 


### PR DESCRIPTION
## Description

The `Blockchain Connectivity` section  on our docs has a `supported clients` links that points to a `v1.13beta` branch. Fixing it to link to the current version.