### PR TITLE
VRF: Migration from V1 guide

### DIFF
--- a/src/config/sidebar.ts
+++ b/src/config/sidebar.ts
@@ -767,6 +767,10 @@ export const SIDEBAR: Partial<Record<Sections, SectionEntry[]>> = {
           url: "vrf/v2-5/migration-from-v2",
         },
         {
+          title: "Migrating from V1",
+          url: "vrf/v2-5/migration-from-v1",
+        },
+        {
           title: "Supported Networks",
           url: "vrf/v2-5/supported-networks",
         },

--- a/src/content/vrf/v2-5/migration-from-v1.mdx
+++ b/src/content/vrf/v2-5/migration-from-v1.mdx
@@ -21,7 +21,7 @@ Chainlink VRF v2.5 includes several improvements and changes to the way you fund
 
 ### New billing options
 
-- **Native billing:** You have the option to use either native tokens or LINK to pay for VRF requests. Instead of a flat LINK fee per request, there is percentage-based premium fee applied to each request. Refer to the [Billing](/vrf/v2-5/billing) page for more details. To find out the premium percentages for the networks you use, see the [Supported Networks](/vrf/v2-5/supported-networks) page.
+- **Native billing:** You have the option to use either native tokens or LINK to pay for VRF requests. Instead of a flat LINK fee per request, there is percentage-based premium fee applied to each request. See the [Billing](/vrf/v2-5/billing) page for more details. To find out the premium percentages for the networks you use, see the [Supported Networks](/vrf/v2-5/supported-networks) page.
 
 - **Subscription management:** Chainlink VRF v2.5 has a [Subscription Manager](https://vrf.chain.link) application that allows smart contract applications to pre-fund multiple requests for randomness using one subscription account. This reduces the gas fees for VRF requests by eliminating the need to transfer funds for each individual request. You transfer funds to the subscription balance only when it requires additional funding.
 
@@ -36,7 +36,7 @@ Chainlink VRF v2.5 includes several improvements and changes to the way you fund
 For direct funding, the configurations for overhead gas have changed:
 
 - The amount of wrapper overhead gas is reduced compared to V2.
-- The amount of coordinator overhead gas used varies depending on the network used for your request, whether you're paying in LINK or native tokens, and how many random values you want in each VRF request. Refer to the [Billing](/vrf/v2-5/billing) page for more details and examples, and see the new configurations on the [Supported Networks](/vrf/v2-5/supported-networks) page.
+- The amount of coordinator overhead gas used varies depending on the network used for your request, whether you're paying in LINK or native tokens, and how many random values you want in each VRF request. See the [Billing](/vrf/v2-5/billing) page for more details and examples. The new configurations are listed in the [Supported Networks](/vrf/v2-5/supported-networks) page.
 
 ### Updating your applications to use VRF v2.5
 

--- a/src/content/vrf/v2-5/migration-from-v1.mdx
+++ b/src/content/vrf/v2-5/migration-from-v1.mdx
@@ -67,9 +67,9 @@ To modify your existing smart contract code to work with VRF v2.5, complete the 
    import { VRFV2PlusClient } from "@chainlink/contracts/src/v0.8/vrf/dev/libraries/VRFV2PlusClient.sol";
    ```
 
-1. Add a `VRFConsumerBaseV2Plus` constructor, passing in the LINK token address for the network you're using. as shown in the [Get a Random Number](/vrf/v2-5/subscription/get-a-random-number) example.
+1. Add a `VRFConsumerBaseV2Plus` constructor, passing in the LINK token address for the network you're using, as shown in the [Get a Random Number](/vrf/v2-5/subscription/get-a-random-number) example.
 
-1. Change `requestRandomness` function calls to `requestRandomWords`. The `requestRandomWords` function requires several additional parameters. You must include a value for the new `extraArgs` key, which allows you to add extra arguments related to new VRF features. Use the `nativePayment` argument to enable or disable payment in native tokens.
+1. Change `requestRandomness` function calls to `requestRandomWords`. The `requestRandomWords` function requires several additional parameters. The `extraArgs` key allows you to add extra arguments related to new VRF features. Use the `nativePayment` argument to enable or disable payment in native tokens.
 
    {/* prettier-ignore */}
    ```solidity
@@ -92,17 +92,17 @@ To modify your existing smart contract code to work with VRF v2.5, complete the 
 
 To modify your existing smart contract code to work with VRF v2.5, complete the following changes. See the [Get a Random Number](/vrf/v2-5/direct-funding/get-a-random-number) guide for an example.
 
-1. Import and inherit the new [`VRFV2WrapperConsumerBase.sol` contract](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/VRFV2WrapperConsumerBase.sol) and remove the v1 `VRFConsumerBase.sol` import. This contract includes the `fulfillRandomWords` function.
+1.  Import and inherit the [`VRFV2PlusWrapperConsumerBase`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/VRFV2PlusWrapperConsumerBase.sol) contract and remove the v1 `VRFConsumerBase.sol` import. This contract includes the `fulfillRandomWords` function.
 
-1. Add a `VRFV2WrapperConsumerBase` constructor as shown in the [Get a Random Number](/vrf/v2/direct-funding/examples/get-a-random-number) example and use the correct VRF v2 Direct funding configuration.
+1.  Add a `VRFV2PlusWrapperConsumerBase` constructor, passing in the VRF wrapper address for the network you're using, as shown in the [Get a Random Number](/vrf/v2-5/direct-funding/get-a-random-number) example.
 
-1. You can still call the `requestRandomness` function. However, the v2 `requestRandomness` function requires several different parameters. See the [Supported networks](/vrf/v2-5/supported-networks) page to adjust them for your own needs.
+1.  You can still call the `requestRandomness` function. However, the v2 `requestRandomness` function requires several different parameters. See the [Supported networks](/vrf/v2-5/supported-networks) page to adjust them for your own needs.
 
-   - The `requestRandomness` function in the wrapper contract requires a new `extraArgs` argument that allows you to add extra arguments related to new VRF features. Use the `nativePayment` argument to enable or disable payment in native tokens.
-   - Additionally, the `requestRandomness` function now returns two arguments instead of one: the request ID and the request price.
+    - The `requestRandomness` function in the wrapper contract requires a new `extraArgs` argument that allows you to add extra arguments related to new VRF features. Use the `nativePayment` argument to enable or disable payment in native tokens.
+    - Additionally, the `requestRandomness` function now returns two arguments instead of one: the request ID and the request price.
 
-   {/* prettier-ignore */}
-   ```solidity
+    {/* prettier-ignore */}
+    ```solidity
     bytes memory extraArgs = VRFV2PlusClient._argsToBytes(
         VRFV2PlusClient.ExtraArgsV1({nativePayment: false})
     );
@@ -114,7 +114,47 @@ To modify your existing smart contract code to work with VRF v2.5, complete the 
     );
     ```
 
-1. Change `fulfillRandomness` function calls to `fulfillRandomWords`. Update the call to handle the returned `uint256[]` array instead of the single `uint256` variable.
+1.  If you're paying for requests with LINK, you can still call the `requestRandomness` function. However, if you're paying with native tokens, call the `requestRandomnessPayInNative` function instead.
+
+    - Both functions return two arguments instead of one: the request ID and the request price.
+    - Both functions require one additional parameter, `extraArgs`. Use `nativePayment` to specify whether or not you want to pay for VRF requests using native tokens:
+
+          {/* prettier-ignore */}
+          <Tabs sharedStore="feePaymentType" client:visible>
+          <Fragment slot="tab.1">LINK</Fragment>
+          <Fragment slot="tab.2">Native tokens</Fragment>
+          <Fragment slot="panel.1">
+          {/* prettier-ignore */}
+          ```solidity
+          bytes memory extraArgs = VRFV2PlusClient._argsToBytes(
+              VRFV2PlusClient.ExtraArgsV1({nativePayment: false})
+          );
+          (uint256 reqId, uint256 reqPrice) = requestRandomness(
+              callbackGasLimit,
+              requestConfirmations,
+              numWords,
+              extraArgs
+          );
+          ```
+          </Fragment>
+          <Fragment slot="panel.2">
+          {/* prettier-ignore */}
+          ```solidity
+          bytes memory extraArgs = VRFV2PlusClient._argsToBytes(
+              VRFV2PlusClient.ExtraArgsV1({nativePayment: true})
+          );
+          (uint256 reqId, uint256 reqPrice) = requestRandomnessPayInNative(
+              callbackGasLimit,
+              requestConfirmations,
+              numWords,
+              extraArgs
+          );
+          ```
+          </Fragment>
+
+      </Tabs>
+
+1.  Change `fulfillRandomness` function calls to `fulfillRandomWords`. Update the call to handle the returned `uint256[]` array instead of the single `uint256` variable.
 
 </Fragment>
 </TabsContent>
@@ -250,7 +290,19 @@ To modify your existing smart contract code to work with VRF v2.5, complete the 
 
 1.  The V2.5 `requestRandomness` and `requestRandomnessPayInNative` functions both return a tuple: `(uint256 requestId, uint256 requestPrice)`. Adjust your `requestRandomWords` function or any other functions in your code where you call the V2.5 wrapper's `requestRandomness` or `requestRandomnessPayInNative` functions.
 
-1.  Make sure your contract has a withdraw function for both native tokens and LINK. Both are included in the [direct funding example code](#direct-funding-example-code) and the [`VRFV2PlusWrapperConsumerExample`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/testhelpers/VRFV2PlusWrapperConsumerExample.sol) contract.
+1.  Make sure your contract has a withdraw function for both native tokens and LINK. Both are included in the [direct funding example code](#view-example-code) and the [`VRFV2PlusWrapperConsumerExample`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/testhelpers/VRFV2PlusWrapperConsumerExample.sol) contract.
 
 </Fragment>
 </TabsContent>
+
+## View example code
+
+View example code for both VRF 2.5 subscription and direct funding:
+
+Open the full example `SubscriptionConsumer` contract:
+
+<CodeSample src="samples/VRF/v2-5/SubscriptionConsumer.sol" showButtonOnly />
+
+Open the full example `DirectFundingConsumer` contract:
+
+<CodeSample src="samples/VRF/v2-5/DirectFundingConsumer.sol" showButtonOnly />

--- a/src/content/vrf/v2-5/migration-from-v1.mdx
+++ b/src/content/vrf/v2-5/migration-from-v1.mdx
@@ -21,22 +21,22 @@ Chainlink VRF v2.5 includes several improvements and changes to the way you fund
 
 ### New billing options
 
-- **Native billing:** You have the option to use either native tokens or LINK to pay for VRF requests. To accommodate this, the premium fee has changed from a flat LINK premium amount per request, to a percentage-based premium per request. Refer to the [Billing](/vrf/v2-5/billing) page for more details. To find out the new premium percentages for the networks you use, see the [Supported Networks](/vrf/v2-5/supported-networks) page.
+- **Native billing:** You have the option to use either native tokens or LINK to pay for VRF requests. Instead of a flat LINK fee per request, there is percentage-based premium fee applied to each request. Refer to the [Billing](/vrf/v2-5/billing) page for more details. To find out the premium percentages for the networks you use, see the [Supported Networks](/vrf/v2-5/supported-networks) page.
 
 - **Subscription management:** Chainlink VRF v2.5 has a [Subscription Manager](https://vrf.chain.link) application that allows smart contract applications to pre-fund multiple requests for randomness using one subscription account. This reduces the gas fees for VRF requests by eliminating the need to transfer funds for each individual request. You transfer funds to the subscription balance only when it requires additional funding.
 
 - **Unified Billing - Delegate Subscription Balance to Multiple Addresses:** Chainlink VRF v2.5 allows up to 100 smart contract addresses to fund their requests for verifiable randomness from a single subscription account, which is managed by the subscription owner.
-
-For direct funding, the configurations for overhead gas have changed:
-
-- The amount of wrapper overhead gas is reduced compared to V2.
-- The amount of coordinator overhead gas used varies depending on the network used for your request, whether you're paying in LINK or native tokens, and how many random values you want in each VRF request. Refer to the [Billing](/vrf/v2-5/billing) page for more details and examples, and see the new configurations on the [Supported Networks](/vrf/v2-5/supported-networks) page.
 
 - **Variable Callback Gas Limit:** Chainlink VRF v2.5 lets you adjust the callback gas limit when your smart contract application receives verifiable randomness. Consuming contracts can execute more complex logic in the callback request function that receives the random values. Tasks involving the delivered randomness are handled during the response process. The new gas limits are higher than the VRF V1 limit, and vary depending on the underlying blockchain you use. See the gas limits on the [VRF Supported Networks](/vrf/v2-5/supported-networks) page.
 
 - **More configuration capability:** You can define how many block confirmations must pass before verifiable randomness is generated and delivered onchain when your application makes a request transaction. The range is from 3 to 200 blocks. VRF V1 always waited 10 blocks on Ethereum before delivering onchain randomness. Select a value that protects your application from block re-organizations while still providing sufficiently low latency from request to response. See the [Security Considerations](/vrf/v2-5/security) page to learn more.
 
 - **Multiple Random Outputs in a Single Request:** In VRF v2.5, you can request multiple random numbers (multi-word) in a single onchain transaction, which reduces gas costs. The fulfillment is also a single transaction, which reduces the latency of responses.
+
+For direct funding, the configurations for overhead gas have changed:
+
+- The amount of wrapper overhead gas is reduced compared to V2.
+- The amount of coordinator overhead gas used varies depending on the network used for your request, whether you're paying in LINK or native tokens, and how many random values you want in each VRF request. Refer to the [Billing](/vrf/v2-5/billing) page for more details and examples, and see the new configurations on the [Supported Networks](/vrf/v2-5/supported-networks) page.
 
 ### Updating your applications to use VRF v2.5
 
@@ -57,11 +57,17 @@ To modify your existing smart contract code to work with VRF v2.5, complete the 
      <a href="https://vrf.chain.link">Open the Subscription Manager</a>
    </div>
 
-1. Import the new [`VRFConsumerBaseV2.sol` contract](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/VRFConsumerBaseV2.sol) and remove the v1 `VRFConsumerBase.sol` import. This contract includes the `fulfillRandomWords` function.
+1. Add the following imports to your contract:
 
-1. Import the [`VRFCoordinatorV2Interface.sol` interface](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/interfaces/VRFCoordinatorV2Interface.sol). This interface includes the new `requestRandomWords` function.
+   - [`VRFConsumerBaseV2Plus`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2Plus.sol). Remove the v1 `VRFConsumerBase.sol` import. `VRFConsumerBaseV2Plus` includes the `fulfillRandomWords` function. The `VRFConsumerBaseV2Plus` contract imports the `IVRFCoordinatorV2Plus` interface, which includes the `requestRandomWords` function.
+   - [`VRFV2PlusClient`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev//libraries/VRFV2PlusClient.sol) is a library used to format your VRF requests.
 
-1. Add a `VRFConsumerBaseV2` constructor as shown in the [Get a Random Number](/vrf/v2/subscription/examples/get-a-random-number) example.
+   ```solidity
+   import { VRFConsumerBaseV2Plus } from "@chainlink/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2Plus.sol";
+   import { VRFV2PlusClient } from "@chainlink/contracts/src/v0.8/vrf/dev/libraries/VRFV2PlusClient.sol";
+   ```
+
+1. Add a `VRFConsumerBaseV2Plus` constructor, passing in the LINK token address for the network you're using. as shown in the [Get a Random Number](/vrf/v2-5/subscription/get-a-random-number) example.
 
 1. Change `requestRandomness` function calls to `requestRandomWords`. The `requestRandomWords` function requires several additional parameters. You must include a value for the new `extraArgs` key, which allows you to add extra arguments related to new VRF features. Use the `nativePayment` argument to enable or disable payment in native tokens.
 

--- a/src/content/vrf/v2-5/migration-from-v1.mdx
+++ b/src/content/vrf/v2-5/migration-from-v1.mdx
@@ -1,7 +1,7 @@
 ---
 section: vrf
 date: Last Modified
-title: "Migrating from VRF v2"
+title: "Migrating from VRF v1"
 ---
 
 import Vrf2_5Common from "@features/vrf/v2-5/Vrf2_5Common.astro"
@@ -10,51 +10,37 @@ import { Tabs, TabsContent } from "@components/Tabs"
 
 <Vrf2_5Common callout="security" />
 
-## Benefits of VRF v2.5
+VRF V2.5 replaces both VRF V1 and VRF V2 on November 29, 2024. [Learn more about VRF V2.5](https://blog.chain.link/introducing-vrf-v2-5/).
 
-Chainlink VRF v2.5 includes all the same key benefits as VRF v2 and introduces the following additional benefits and changes:
+## Comparing VRF v1 to VRF v2.5
 
-- The option to pay for requests in either LINK or native tokens
-- Easier upgrades to future versions by using the new `setCoordinator` function
-- New, flexible request format to make any future upgrades easier
+Chainlink VRF v2.5 includes several improvements and changes to the way you fund and request randomness for your smart contracts:
 
-(Learn more about VRF V2.5)[https://blog.chain.link/introducing-vrf-v2-5/].
+- You have the option to manage payment for your VRF requests by pre-funding a subscription account, or to directly fund your consuming contracts as you do with VRF V1. [Compare subscription and direct funding](/vrf/#choosing-the-correct-method).
+- VRF v2.5 introduces the option to pay for requests in either LINK or native tokens. This choice is available for both subscription and direct funding.
 
-### Comparing VRF v1 to VRF v2.5
+### New billing options
 
-{/* prettier-ignore */}
-<TabsContent sharedStore="vrfMethod" client:visible>
-<Fragment slot="tab.1">Subscription</Fragment>
-<Fragment slot="tab.2">Direct funding</Fragment>
-<Fragment slot="panel.1">
+- **Native billing:** You have the option to use either native tokens or LINK to pay for VRF requests. To accommodate this, the premium fee has changed from a flat LINK premium amount per request, to a percentage-based premium per request. Refer to the [Billing](/vrf/v2-5/billing) page for more details. To find out the new premium percentages for the networks you use, see the [Supported Networks](/vrf/v2-5/supported-networks) page.
 
-Chainlink VRF v2 includes several improvements and changes to the way you fund and request randomness for your smart contracts.
+- **Subscription management:** Chainlink VRF v2.5 has a [Subscription Manager](https://vrf.chain.link) application that allows smart contract applications to pre-fund multiple requests for randomness using one subscription account. This reduces the gas fees for VRF requests by eliminating the need to transfer funds for each individual request. You transfer funds to the subscription balance only when it requires additional funding.
 
-- **Subscription management:** Chainlink VRF v2 introduces a [Subscription Manager](https://vrf.chain.link) application that allows smart contract applications to pre-fund multiple requests for randomness using a single LINK token balance. This reduces the gas fees for VRF requests by eliminating the need to transfer LINK tokens for each individual request. You transfer LINK tokens to the subscription balance only when it requires additional funding.
+- **Unified Billing - Delegate Subscription Balance to Multiple Addresses:** Chainlink VRF v2.5 allows up to 100 smart contract addresses to fund their requests for verifiable randomness from a single subscription account, which is managed by the subscription owner.
 
-- **Variable Callback Gas Limit:** Chainlink VRF v2 lets you adjust the callback gas limit when your smart contract application receives verifiable randomness. Consuming contracts can execute more complex logic in the callback request function that receives the random values. Tasks involving the delivered randomness are handled during the response process. The new gas limits are higher than the VRF V1 limit, and vary depending on the underlying blockchain you use. See the gas limits on the [VRF Supported Networks](/vrf/v2/subscription/supported-networks) page.
+For direct funding, the configurations for overhead gas have changed:
 
-- **More configuration capability:** You can define how many block confirmations must pass before verifiable randomness is generated and delivered onchain when your application makes a request transaction. The range is from 3 to 200 blocks. VRF V1 always waited 10 blocks on Ethereum before delivering onchain randomness. Select a value that protects your application from block re-organizations while still providing sufficiently low latency from request to response. See the [Security Considerations](/vrf/v2/security) page to learn more.
+- The amount of wrapper overhead gas is reduced compared to V2.
+- The amount of coordinator overhead gas used varies depending on the network used for your request, whether you're paying in LINK or native tokens, and how many random values you want in each VRF request. Refer to the [Billing](/vrf/v2-5/billing) page for more details and examples, and see the new configurations on the [Supported Networks](/vrf/v2-5/supported-networks) page.
 
-- **Multiple Random Outputs in a Single Request:** The [VRF Coordinator contracts](/vrf/v2/subscription/supported-networks) in VRF v2 allow you to request multiple random numbers (multi-word) in a single onchain transaction, which reduces gas costs. The fulfillment is also a single transaction, which reduces the latency of responses.
+- **Variable Callback Gas Limit:** Chainlink VRF v2.5 lets you adjust the callback gas limit when your smart contract application receives verifiable randomness. Consuming contracts can execute more complex logic in the callback request function that receives the random values. Tasks involving the delivered randomness are handled during the response process. The new gas limits are higher than the VRF V1 limit, and vary depending on the underlying blockchain you use. See the gas limits on the [VRF Supported Networks](/vrf/v2-5/supported-networks) page.
 
-- **Unified Billing - Delegate Subscription Balance to Multiple Addresses:** Chainlink VRF v2 allows up to 100 smart contract addresses to fund their requests for verifiable randomness from a single LINK subscription balance, which is managed by the subscription owner.
+- **More configuration capability:** You can define how many block confirmations must pass before verifiable randomness is generated and delivered onchain when your application makes a request transaction. The range is from 3 to 200 blocks. VRF V1 always waited 10 blocks on Ethereum before delivering onchain randomness. Select a value that protects your application from block re-organizations while still providing sufficiently low latency from request to response. See the [Security Considerations](/vrf/v2-5/security) page to learn more.
 
-</Fragment>
-<Fragment slot="panel.2">
+- **Multiple Random Outputs in a Single Request:** In VRF v2.5, you can request multiple random numbers (multi-word) in a single onchain transaction, which reduces gas costs. The fulfillment is also a single transaction, which reduces the latency of responses.
 
-The main similarity between VRF v1 and VRF v2 Direct funding method is that consuming contracts must be funded with LINK to pay for requests. However, Chainlink VRF v2 includes several improvements.
+### Updating your applications to use VRF v2.5
 
-- **Variable Callback Gas Limit:** Chainlink VRF v2 lets you adjust the callback gas limit when your smart contract application receives verifiable randomness. Consuming contracts can execute more complex logic in the callback request function that receives the random values. Tasks involving the delivered randomness are handled during the response process. The new gas limits are higher than the VRF V1 limit, and vary depending on the underlying blockchain that you use. See the gas limits on the [Supported networks](/vrf/v2/direct-funding/supported-networks) page.
-
-- **More configuration capability:** You can define how many block confirmations must pass before verifiable randomness is generated and delivered onchain when your application makes a request transaction. The range is from 3 to 200 blocks. VRF V1 always waited 10 blocks on Ethereum before delivering onchain randomness. Select a value that protects your application from block re-organizations while still providing sufficiently low latency from request to response. See the [Security Considerations](/vrf/v2/security) page to learn more.
-
-- **Multiple Random Outputs in a Single Request:** The [VRF Wrapper contracts](/vrf/v2/direct-funding/supported-networks) in VRF v2 allow you to request multiple random numbers (multi-word) in a single onchain transaction, which reduces gas costs. The fulfillment is also a single transaction, which reduces the latency of responses.
-
-</Fragment>
-</TabsContent>
-
-### Updating your applications to use VRF v2
+You have the option to manage payment for your VRF requests with a subscription account, or to directly fund your consuming contracts as you do with VRF V1. [Compare subscription and direct funding](/vrf/#choosing-the-correct-method).
 
 {/* prettier-ignore */}
 <TabsContent sharedStore="vrfMethod" client:visible>
@@ -62,7 +48,7 @@ The main similarity between VRF v1 and VRF v2 Direct funding method is that cons
 <Fragment slot="tab.2">Direct funding</Fragment>
 <Fragment slot="panel.1">
 
-To modify your existing smart contract code to work with VRF v2, complete the following changes. See the [Get a Random Number](/vrf/v2/subscription/examples/get-a-random-number) guide for an example.
+To modify your existing smart contract code to work with VRF v2.5, complete the following changes. See the [Get a Random Number](/vrf/v2-5/subscription/get-a-random-number) guide for an example.
 
 1. Set up and fund a subscription in the Subscription Manager at [vrf.chain.link](https://vrf.chain.link).
    {/* prettier-ignore */}
@@ -77,95 +63,59 @@ To modify your existing smart contract code to work with VRF v2, complete the fo
 
 1. Add a `VRFConsumerBaseV2` constructor as shown in the [Get a Random Number](/vrf/v2/subscription/examples/get-a-random-number) example.
 
-1. Change `requestRandomness` function calls to `requestRandomWords`. The `requestRandomWords` function requires several additional parameters.
+1. Change `requestRandomness` function calls to `requestRandomWords`. The `requestRandomWords` function requires several additional parameters. You must include a value for the new `extraArgs` key, which allows you to add extra arguments related to new VRF features. Use the `nativePayment` argument to enable or disable payment in native tokens.
+
+   {/* prettier-ignore */}
+   ```solidity
+    uint256 requestId = s_vrfCoordinator.requestRandomWords(
+        VRFV2PlusClient.RandomWordsRequest({
+            keyHash: keyHash,
+            subId: s_vrfSubscriptionId,
+            requestConfirmations: requestConfirmations,
+            callbackGasLimit: callbackGasLimit,
+            numWords: numWords,
+            extraArgs: VRFV2PlusClient._argsToBytes(VRFV2PlusClient.ExtraArgsV1({nativePayment: true}))
+        })
+    );
+    ```
 
 1. Change `fulfillRandomness` function calls to `fulfillRandomWords`. Update the call to handle the returned `uint256[]` array instead of the single `uint256` variable.
 
 </Fragment>
 <Fragment slot="panel.2">
 
-To modify your existing smart contract code to work with VRF v2, complete the following changes. See the [Get a Random Number](/vrf/v2/direct-funding/examples/get-a-random-number) guide for an example.
+To modify your existing smart contract code to work with VRF v2.5, complete the following changes. See the [Get a Random Number](/vrf/v2-5/direct-funding/get-a-random-number) guide for an example.
 
 1. Import and inherit the new [`VRFV2WrapperConsumerBase.sol` contract](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/VRFV2WrapperConsumerBase.sol) and remove the v1 `VRFConsumerBase.sol` import. This contract includes the `fulfillRandomWords` function.
 
 1. Add a `VRFV2WrapperConsumerBase` constructor as shown in the [Get a Random Number](/vrf/v2/direct-funding/examples/get-a-random-number) example and use the correct VRF v2 Direct funding configuration.
 
-1. You can still call the `requestRandomness` function. However, the v2 `requestRandomness` function requires several different parameters (`callbackGasLimit` , `requestConfirmations` , `numWords`). See the [Supported networks](/vrf/v2/direct-funding/supported-networks) page to adjust them for your own needs.
+1. You can still call the `requestRandomness` function. However, the v2 `requestRandomness` function requires several different parameters. See the [Supported networks](/vrf/v2-5/supported-networks) page to adjust them for your own needs.
+
+   - The `requestRandomness` function in the wrapper contract requires a new `extraArgs` argument that allows you to add extra arguments related to new VRF features. Use the `nativePayment` argument to enable or disable payment in native tokens.
+   - Additionally, the `requestRandomness` function now returns two arguments instead of one: the request ID and the request price.
+
+   {/* prettier-ignore */}
+   ```solidity
+    bytes memory extraArgs = VRFV2PlusClient._argsToBytes(
+        VRFV2PlusClient.ExtraArgsV1({nativePayment: false})
+    );
+    (uint256 reqId, uint256 reqPrice) = requestRandomness(
+        callbackGasLimit,
+        requestConfirmations,
+        numWords,
+        extraArgs
+    );
+    ```
 
 1. Change `fulfillRandomness` function calls to `fulfillRandomWords`. Update the call to handle the returned `uint256[]` array instead of the single `uint256` variable.
-
-</Fragment>
-</TabsContent>
-
-## Code changes
-
-VRF v2.5 introduces a new request format and the `setCoordinator` function. See the [full migration walkthrough](#migration-walkthrough) or the code example for more details.
-
-### New request format
-
-The request format for VRF v2.5 has changed:
-
-{/* prettier-ignore */}
-<TabsContent sharedStore="vrfMethod" client:visible>
-<Fragment slot="tab.1">Subscription</Fragment>
-<Fragment slot="tab.2">Direct funding</Fragment>
-<Fragment slot="panel.1">
-The `requestRandomWords` function now uses `VRFV2PlusClient.RandomWordsRequest` with an object labeling each part of the request:
-
-{/* prettier-ignore */}
-```solidity
-uint256 requestId = s_vrfCoordinator.requestRandomWords(
-    VRFV2PlusClient.RandomWordsRequest({
-        keyHash: keyHash,
-        subId: s_vrfSubscriptionId,
-        requestConfirmations: requestConfirmations,
-        callbackGasLimit: callbackGasLimit,
-        numWords: numWords,
-        extraArgs: VRFV2PlusClient._argsToBytes(VRFV2PlusClient.ExtraArgsV1({nativePayment: true}))
-    })
-);
-```
-
-You must include a value for the new `extraArgs` key, which allows you to add extra arguments related to new VRF features. Use the `nativePayment` argument to enable or disable payment in native tokens.
-
-</Fragment>
-<Fragment slot="panel.2">
-The `requestRandomness` function in the wrapper contract requires a new `extraArgs` argument that allows you to add extra arguments related to new VRF features. Use the `nativePayment` argument to enable or disable payment in native tokens.
-
-Additionally, the `requestRandomness` function now returns two arguments instead of one: the request ID and the request price.
-
-{/* prettier-ignore */}
-```solidity
-bytes memory extraArgs = VRFV2PlusClient._argsToBytes(
-    VRFV2PlusClient.ExtraArgsV1({nativePayment: false})
-);
-(uint256 reqId, uint256 reqPrice) = requestRandomness(
-    callbackGasLimit,
-    requestConfirmations,
-    numWords,
-    extraArgs
-);
-```
 
 </Fragment>
 </TabsContent>
 
 ### setCoordinator function
 
-Add the `setCoordinator` function to your contract so that you can easily update the VRF coordinator for future VRF releases.
-
-### Subscription ID type change
-
-Note that the subscription ID has changed types from `uint64` in VRF V2 to `uint256` in VRF V2.5.
-
-## Billing changes
-
-You have the option to use either native tokens or LINK to pay for VRF requests. To accommodate this, the premium fee has changed from a flat LINK premium amount per request, to a percentage-based premium per request. Refer to the [Billing](/vrf/v2-5/billing) page for more details. To find out the new premium percentages for the networks you use, see the [Supported Networks](/vrf/v2-5/supported-networks) page.
-
-For direct funding, the configurations for overhead gas have changed:
-
-- The amount of wrapper overhead gas is reduced compared to V2.
-- The amount of coordinator overhead gas used varies depending on the network used for your request, whether you're paying in LINK or native tokens, and how many random values you want in each VRF request. Refer to the [Billing](/vrf/v2-5/billing) page for more details and examples, and see the new configurations on the [Supported Networks](/vrf/v2-5/supported-networks) page.
+If you're using subscriptions, use the `setCoordinator` function in your contract so that you can easily update the VRF coordinator for future VRF releases. This function is inherited from the [`IVRFCoordinatorV2Plus`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/interfaces/IVRFCoordinatorV2Plus.sol) interface.
 
 ## Migration walkthrough
 
@@ -295,309 +245,6 @@ To modify your existing smart contract code to work with VRF v2.5, complete the 
 1.  The V2.5 `requestRandomness` and `requestRandomnessPayInNative` functions both return a tuple: `(uint256 requestId, uint256 requestPrice)`. Adjust your `requestRandomWords` function or any other functions in your code where you call the V2.5 wrapper's `requestRandomness` or `requestRandomnessPayInNative` functions.
 
 1.  Make sure your contract has a withdraw function for both native tokens and LINK. Both are included in the [direct funding example code](#direct-funding-example-code) and the [`VRFV2PlusWrapperConsumerExample`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/testhelpers/VRFV2PlusWrapperConsumerExample.sol) contract.
-
-</Fragment>
-</TabsContent>
-
-### Compare example code
-
-#### Subscription example code
-
-The example `SubscriptionConsumer` contract shows the migration steps above, applied to the example code from [this VRF V2 tutorial](/vrf/v2/subscription/examples/get-a-random-number#analyzing-the-contract). Both of these examples use the subscription method.
-
-Open the full example `SubscriptionConsumer` contract:
-
-<CodeSample src="samples/VRF/v2-5/SubscriptionConsumer.sol" showButtonOnly />
-
-Compare the major changes between V2.5 and V2:
-
-{/* prettier-ignore */}
-<TabsContent sharedStore="vrfVersion" client:visible>
-<Fragment slot="tab.1">VRF V2.5 example code</Fragment>
-<Fragment slot="tab.2">VRF V2 example code</Fragment>
-<Fragment slot="panel.1">
-
-{/* prettier-ignore */}
-```solidity
-// SPDX-License-Identifier: MIT
-// An example of a consumer contract that relies on a subscription for funding.
-pragma solidity 0.8.19;
-
-///// UPDATE IMPORTS TO V2.5 /////
-import {VRFConsumerBaseV2Plus} from "@chainlink/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2Plus.sol";
-import {VRFV2PlusClient} from "@chainlink/contracts/src/v0.8/vrf/dev/libraries/VRFV2PlusClient.sol";
-
-...
-
-/\*\*
-
-- THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
-- THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
-- DO NOT USE THIS CODE IN PRODUCTION.
-  \*/
-
-///// INHERIT NEW CONSUMER BASE CONTRACT /////
-contract SubscriptionConsumer is VRFConsumerBaseV2Plus {
-...
-    ///// No need to declare a coordinator variable /////
-    ///// Use the `s_vrfCoordinator` from VRFConsumerBaseV2Plus.sol /////
-
-    ///// SUBSCRIPTION ID IS NOW UINT256 /////
-    uint256 s_subscriptionId;
-
-    ...
-
-    ///// USE NEW KEYHASH FOR VRF 2.5 GAS LANE /////
-    // For a list of available gas lanes on each network,
-    // see https://docs.chain.link/docs/vrf/v2-5/supported-networks
-    bytes32 keyHash =
-        0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae;
-
-    ...
-
-    ///// USE NEW CONSUMER BASE CONSTRUCTOR /////
-    constructor(
-        ///// UPDATE TO UINT256 /////
-        uint256 subscriptionId
-    )
-        VRFConsumerBaseV2Plus(0x9DdfaCa8183c41ad55329BdeeD9F6A8d53168B1B)
-    {
-        s_subscriptionId = subscriptionId;
-    }
-
-    function requestRandomWords()
-        external
-        onlyOwner
-        returns (uint256 requestId)
-    {
-        ///// UPDATE TO NEW V2.5 REQUEST FORMAT /////
-        // To enable payment in native tokens, set nativePayment to true.
-        // Use the `s_vrfCoordinator` from VRFConsumerBaseV2Plus.sol
-        requestId = s_vrfCoordinator.requestRandomWords(
-            VRFV2PlusClient.RandomWordsRequest({
-                keyHash: keyHash,
-                subId: s_subscriptionId,
-                requestConfirmations: requestConfirmations,
-                callbackGasLimit: callbackGasLimit,
-                numWords: numWords,
-                extraArgs: VRFV2PlusClient._argsToBytes(
-                    VRFV2PlusClient.ExtraArgsV1({nativePayment: false})
-                )
-            })
-        );
-        ...
-    }
-    ...
-
-}
-```
-
-</Fragment>
-<Fragment slot="panel.2">
-
-{/* prettier-ignore */}
-```solidity
-// SPDX-License-Identifier: MIT
-// An example of a consumer contract that relies on a subscription for funding.
-pragma solidity ^0.8.7;
-
-///// USES V2 IMPORTS /////
-import {VRFCoordinatorV2Interface} from "@chainlink/contracts/src/v0.8/vrf/interfaces/VRFCoordinatorV2Interface.sol";
-import {VRFConsumerBaseV2} from "@chainlink/contracts/src/v0.8/vrf/VRFConsumerBaseV2.sol";
-import {ConfirmedOwner} from "@chainlink/contracts/src/v0.8/shared/access/ConfirmedOwner.sol";
-
-/\*\*
-
-- THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
-- THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
-- DO NOT USE THIS CODE IN PRODUCTION.
-  \*/
-
-///// USES V2 CONSUMER BASE CONTRACT /////
-contract VRFv2Consumer is VRFConsumerBaseV2, ConfirmedOwner {
-...
-
-    ///// OLD TYPE FOR SUBSCRIPTION ID /////
-    uint64 s_subscriptionId;
-
-    ...
-
-    ///// KEYHASH FOR VRF V2 GAS LANE /////
-    // The gas lane to use, which specifies the maximum gas price to bump to.
-    // For a list of available gas lanes on each network,
-    // see https://docs.chain.link/docs/vrf/v2/subscription/supported-networks/#configurations
-    bytes32 keyHash =
-        0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c;
-
-    ...
-
-     ///// USES V2 CONSUMER BASE AND COORDINATOR CONSTRUCTORS /////
-    constructor(
-        uint64 subscriptionId
-    )
-        VRFConsumerBaseV2(0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625)
-        ConfirmedOwner(msg.sender)
-    {
-        COORDINATOR = VRFCoordinatorV2Interface(
-            0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625
-        );
-        s_subscriptionId = subscriptionId;
-    }
-
-    ...
-
-    function requestRandomWords()
-        external
-        onlyOwner
-        returns (uint256 requestId)
-    {   ///// USES V2 REQUEST FORMAT /////
-        requestId = COORDINATOR.requestRandomWords(
-            keyHash,
-            s_subscriptionId,
-            requestConfirmations,
-            callbackGasLimit,
-            numWords
-        );
-        ...
-    }
-
-...
-}
-```
-
-</Fragment>
-</TabsContent>
-
-#### Direct funding example code
-
-The example `DirectFundingConsumer` contract shows the migration steps above, applied to the example code from [this VRF V2 tutorial](/vrf/v2/direct-funding/examples/get-a-random-number#analyzing-the-contract). Both of these examples use the direct funding method.
-
-Open the full example `DirectFundingConsumer` contract:
-
-<CodeSample src="samples/VRF/v2-5/DirectFundingConsumer.sol" showButtonOnly />
-
-Compare the major changes between V2.5 and V2:
-
-{/* prettier-ignore */}
-<TabsContent sharedStore="vrfVersion" client:visible>
-<Fragment slot="tab.1">VRF V2.5 example code</Fragment>
-<Fragment slot="tab.2">VRF V2 example code</Fragment>
-<Fragment slot="panel.1">
-
-{/* prettier-ignore */}
-```solidity
-// SPDX-License-Identifier: MIT
-// An example of a consumer contract that directly pays for each request.
-pragma solidity 0.8.20;
-
-///// UPDATE IMPORTS TO V2.5 /////
-import {ConfirmedOwner} from "@chainlink/contracts/src/v0.8/shared/access/ConfirmedOwner.sol";
-import {VRFV2PlusWrapperConsumerBase} from "@chainlink/contracts/src/v0.8/vrf/dev/VRFV2PlusWrapperConsumerBase.sol";
-import {LinkTokenInterface} from "@chainlink/contracts/src/v0.8/shared/interfaces/LinkTokenInterface.sol";
-import {VRFV2PlusClient} from "@chainlink/contracts/src/v0.8/vrf/dev/libraries/VRFV2PlusClient.sol";
-
-/**
- * THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
- * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
- * DO NOT USE THIS CODE IN PRODUCTION.
- */
-
- ///// INHERIT NEW WRAPPER CONSUMER BASE CONTRACT /////
-contract DirectFundingConsumer is VRFV2PlusWrapperConsumerBase, ConfirmedOwner {
-
-    ...
-    ///// USE NEW WRAPPER CONSUMER BASE CONSTRUCTOR /////
-    constructor()
-        ConfirmedOwner(msg.sender)
-        VRFV2PlusWrapperConsumerBase(wrapperAddress) ///// ONLY PASS IN WRAPPER ADDRESS /////
-    {}
-
-    function requestRandomWords(
-        bool enableNativePayment
-    ) external onlyOwner returns (uint256) {
-        ///// UPDATE TO NEW V2.5 REQUEST FORMAT: ADD EXTRA ARGS /////
-        bytes memory extraArgs = VRFV2PlusClient._argsToBytes(
-            VRFV2PlusClient.ExtraArgsV1({nativePayment: enableNativePayment})
-        );
-        uint256 requestId;
-        uint256 reqPrice;
-        if (enableNativePayment) { 
-            ///// USE THIS FUNCTION TO PAY IN NATIVE TOKENS /////
-            (requestId, reqPrice) = requestRandomnessPayInNative(
-                callbackGasLimit,
-                requestConfirmations,
-                numWords,
-                extraArgs ///// PASS IN EXTRA ARGS /////
-            );
-        } else {
-            ///// USE THIS FUNCTION TO PAY IN LINK /////
-            (requestId, reqPrice) = requestRandomness(
-                callbackGasLimit,
-                requestConfirmations,
-                numWords,
-                extraArgs ///// PASS IN EXTRA ARGS /////
-            );
-        }
-        ...
-        return requestId;
-    }
-   ...
-}
-```
-
-</Fragment>
-<Fragment slot="panel.2">
-
-{/* prettier-ignore */}
-```solidity
-// SPDX-License-Identifier: MIT
-// An example of a consumer contract that directly pays for each request.
-pragma solidity ^0.8.7;
-
-///// USES V2 IMPORTS /////
-import {ConfirmedOwner} from "@chainlink/contracts/src/v0.8/shared/access/ConfirmedOwner.sol";
-import {VRFV2WrapperConsumerBase} from "@chainlink/contracts/src/v0.8/vrf/VRFV2WrapperConsumerBase.sol";
-import {LinkTokenInterface} from "@chainlink/contracts/src/v0.8/shared/interfaces/LinkTokenInterface.sol";
-
-/\*\*
-
-- THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
-- THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
-- DO NOT USE THIS CODE IN PRODUCTION.
-  \*/
-
-///// USES V2 WRAPPER CONSUMER BASE CONTRACT /////
-contract VRFv2DirectFundingConsumer is
-VRFV2WrapperConsumerBase,
-ConfirmedOwner
-{
-...
-
-    ///// USES V2 WRAPPER CONSUMER BASE CONSTRUCTOR /////
-    constructor()
-        ConfirmedOwner(msg.sender)
-        VRFV2WrapperConsumerBase(linkAddress, wrapperAddress) ///// TWO PARAMETERS /////
-    {}
-
-    function requestRandomWords()
-        external
-        onlyOwner
-        returns (uint256 requestId)
-    {
-        ///// USES V2 REQUEST FORMAT /////
-        requestId = requestRandomness(
-            callbackGasLimit,
-            requestConfirmations,
-            numWords
-        );
-        ...
-        return requestId;
-    }
-
-...
-
-}
-```
 
 </Fragment>
 </TabsContent>

--- a/src/content/vrf/v2-5/migration-from-v1.mdx
+++ b/src/content/vrf/v2-5/migration-from-v1.mdx
@@ -1,0 +1,583 @@
+---
+section: vrf
+date: Last Modified
+title: "Migrating from VRF v2"
+---
+
+import Vrf2_5Common from "@features/vrf/v2-5/Vrf2_5Common.astro"
+import { Aside, CodeSample } from "@components"
+import { Tabs, TabsContent } from "@components/Tabs"
+
+<Vrf2_5Common callout="security" />
+
+## Benefits of VRF v2.5
+
+Chainlink VRF v2.5 includes [all the same key benefits as VRF v2](https://blog.chain.link/vrf-v2-mainnet-launch/), along with the following additional benefits and changes:
+
+- Easier upgrades to future versions by using the new `setCoordinator` function
+- The option to pay for requests in either LINK or native tokens
+- New, flexible request format in `requestRandomWords` to make any future upgrades easier
+
+### Comparing VRF v1 to the VRF v2 subscription method
+
+Chainlink VRF v2 includes several improvements and changes to the way you fund and request randomness for your smart contracts.
+
+- **Subscription management:** Chainlink VRF v2 introduces a [Subscription Manager](/vrf/v2/subscription/ui) application that allows smart contract applications to pre-fund multiple requests for randomness using a single LINK token balance. This reduces the gas fees for VRF requests by eliminating the need to transfer LINK tokens for each individual request. You transfer LINK tokens to the subscription balance only when it requires additional funding. Read the [Subscription Manager](/vrf/v2/subscription/ui) page to learn more.
+
+- **Variable Callback Gas Limit:** Chainlink VRF v2 lets you adjust the callback gas limit when your smart contract application receives verifiable randomness. Consuming contracts can execute more complex logic in the callback request function that receives the random values. Tasks involving the delivered randomness are handled during the response process. The new gas limits are higher than the VRF V1 limit, and vary depending on the underlying blockchain you use. See the gas limits on the [VRF Supported Networks](/vrf/v2/subscription/supported-networks) page.
+
+- **More configuration capability:** You can define how many block confirmations must pass before verifiable randomness is generated and delivered onchain when your application makes a request transaction. The range is from 3 to 200 blocks. VRF V1 always waited 10 blocks on Ethereum before delivering onchain randomness. Select a value that protects your application from block re-organizations while still providing sufficiently low latency from request to response. See the [Security Considerations](/vrf/v2/security) page to learn more.
+
+- **Multiple Random Outputs in a Single Request:** The [VRF Coordinator contracts](/vrf/v2/subscription/supported-networks) in VRF v2 allow you to request multiple random numbers (multi-word) in a single onchain transaction, which reduces gas costs. The fulfillment is also a single transaction, which reduces the latency of responses.
+
+- **Unified Billing - Delegate Subscription Balance to Multiple Addresses:** Chainlink VRF v2 allows up to 100 smart contract addresses to fund their requests for verifiable randomness from a single LINK subscription balance, which is managed by the subscription owner.
+
+Read the [Chainlink VRF v2 blog post](https://blog.chain.link/vrf-v2-mainnet-launch/) for a detailed explanation about the benefits and use cases for VRF v2.
+
+### Comparison between VRF v1 and VRF v2 (Direct funding method)
+
+The main similarity between VRF v1 and VRF v2 Direct funding method is that consuming contracts must be funded with LINK to pay for requests. However, Chainlink VRF v2 includes several improvements.
+
+- **Variable Callback Gas Limit:** Chainlink VRF v2 lets you adjust the callback gas limit when your smart contract application receives verifiable randomness. Consuming contracts can execute more complex logic in the callback request function that receives the random values. Tasks involving the delivered randomness are handled during the response process. The new gas limits are higher than the VRF V1 limit, and vary depending on the underlying blockchain that you use. See the gas limits on the [Supported networks](/vrf/v2/direct-funding/supported-networks) page.
+
+- **More configuration capability:** You can define how many block confirmations must pass before verifiable randomness is generated and delivered onchain when your application makes a request transaction. The range is from 3 to 200 blocks. VRF V1 always waited 10 blocks on Ethereum before delivering onchain randomness. Select a value that protects your application from block re-organizations while still providing sufficiently low latency from request to response. See the [Security Considerations](/vrf/v2/security) page to learn more.
+
+- **Multiple Random Outputs in a Single Request:** The [VRF Wrapper contracts](/vrf/v2/direct-funding/supported-networks) in VRF v2 allow you to request multiple random numbers (multi-word) in a single onchain transaction, which reduces gas costs. The fulfillment is also a single transaction, which reduces the latency of responses.
+
+### Updating your applications to use VRF v2 subscription
+
+To modify your existing smart contract code to work with VRF v2, complete the following changes. See the [Get a Random Number](/vrf/v2/subscription/examples/get-a-random-number) guide for an example.
+
+1. Set up and fund a subscription in the Subscription Manager at [vrf.chain.link](https://vrf.chain.link).
+   {/* prettier-ignore */}
+
+   <div class="remix-callout">
+     <a href="https://vrf.chain.link">Open the Subscription Manager</a>
+   </div>
+
+1. Import the new [`VRFConsumerBaseV2.sol` contract](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/VRFConsumerBaseV2.sol) and remove the v1 `VRFConsumerBase.sol` import. This contract includes the `fulfillRandomWords` function.
+
+1. Import the [`VRFCoordinatorV2Interface.sol` interface](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/interfaces/VRFCoordinatorV2Interface.sol). This interface includes the new `requestRandomWords` function.
+
+1. Add a `VRFConsumerBaseV2` constructor as shown in the [Get a Random Number](/vrf/v2/subscription/examples/get-a-random-number) example.
+
+1. Change `requestRandomness` function calls to `requestRandomWords`. The `requestRandomWords` function requires several additional parameters.
+
+1. Change `fulfillRandomness` function calls to `fulfillRandomWords`. Update the call to handle the returned `uint256[]` array instead of the single `uint256` variable.
+
+## Updating your applications to use VRF v2 direct funding
+
+To modify your existing smart contract code to work with VRF v2, complete the following changes. See the [Get a Random Number](/vrf/v2/direct-funding/examples/get-a-random-number) guide for an example.
+
+1. Import and inherit the new [`VRFV2WrapperConsumerBase.sol` contract](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/VRFV2WrapperConsumerBase.sol) and remove the v1 `VRFConsumerBase.sol` import. This contract includes the `fulfillRandomWords` function.
+
+1. Add a `VRFV2WrapperConsumerBase` constructor as shown in the [Get a Random Number](/vrf/v2/direct-funding/examples/get-a-random-number) example and use the correct VRF v2 Direct funding configuration.
+
+1. You can still call the `requestRandomness` function. However, the v2 `requestRandomness` function requires several different parameters (`callbackGasLimit` , `requestConfirmations` , `numWords`). See the [Supported networks](/vrf/v2/direct-funding/supported-networks) page to adjust them for your own needs.
+
+1. Change `fulfillRandomness` function calls to `fulfillRandomWords`. Update the call to handle the returned `uint256[]` array instead of the single `uint256` variable.
+
+## Code changes
+
+VRF v2.5 introduces a new request format and the `setCoordinator` function. See the [full migration walkthrough](#migration-walkthrough) or the code example for more details.
+
+### New request format
+
+The request format for VRF v2.5 has changed:
+
+{/* prettier-ignore */}
+<TabsContent sharedStore="vrfMethod" client:visible>
+<Fragment slot="tab.1">Subscription</Fragment>
+<Fragment slot="tab.2">Direct funding</Fragment>
+<Fragment slot="panel.1">
+The `requestRandomWords` function now uses `VRFV2PlusClient.RandomWordsRequest` with an object labeling each part of the request:
+
+{/* prettier-ignore */}
+```solidity
+uint256 requestId = s_vrfCoordinator.requestRandomWords(
+    VRFV2PlusClient.RandomWordsRequest({
+        keyHash: keyHash,
+        subId: s_vrfSubscriptionId,
+        requestConfirmations: requestConfirmations,
+        callbackGasLimit: callbackGasLimit,
+        numWords: numWords,
+        extraArgs: VRFV2PlusClient._argsToBytes(VRFV2PlusClient.ExtraArgsV1({nativePayment: true}))
+    })
+);
+```
+
+You must include a value for the new `extraArgs` key, which allows you to add extra arguments related to new VRF features. Use the `nativePayment` argument to enable or disable payment in native tokens.
+
+</Fragment>
+<Fragment slot="panel.2">
+The `requestRandomness` function in the wrapper contract requires a new `extraArgs` argument that allows you to add extra arguments related to new VRF features. Use the `nativePayment` argument to enable or disable payment in native tokens.
+
+Additionally, the `requestRandomness` function now returns two arguments instead of one: the request ID and the request price.
+
+{/* prettier-ignore */}
+```solidity
+bytes memory extraArgs = VRFV2PlusClient._argsToBytes(
+    VRFV2PlusClient.ExtraArgsV1({nativePayment: false})
+);
+(uint256 reqId, uint256 reqPrice) = requestRandomness(
+    callbackGasLimit,
+    requestConfirmations,
+    numWords,
+    extraArgs
+);
+```
+
+</Fragment>
+</TabsContent>
+
+### setCoordinator function
+
+Add the `setCoordinator` function to your contract so that you can easily update the VRF coordinator for future VRF releases.
+
+### Subscription ID type change
+
+Note that the subscription ID has changed types from `uint64` in VRF V2 to `uint256` in VRF V2.5.
+
+## Billing changes
+
+You have the option to use either native tokens or LINK to pay for VRF requests. To accommodate this, the premium fee has changed from a flat LINK premium amount per request, to a percentage-based premium per request. Refer to the [Billing](/vrf/v2-5/billing) page for more details. To find out the new premium percentages for the networks you use, see the [Supported Networks](/vrf/v2-5/supported-networks) page.
+
+For direct funding, the configurations for overhead gas have changed:
+
+- The amount of wrapper overhead gas is reduced compared to V2.
+- The amount of coordinator overhead gas used varies depending on the network used for your request, whether you're paying in LINK or native tokens, and how many random values you want in each VRF request. Refer to the [Billing](/vrf/v2-5/billing) page for more details and examples, and see the new configurations on the [Supported Networks](/vrf/v2-5/supported-networks) page.
+
+## Migration walkthrough
+
+VRF v2.5 currently supports subscriptions and direct funding on all [supported networks](/vrf/v2-5/supported-networks). To migrate, you need to [update your existing smart contract code](#update-your-code) and redeploy your contracts.
+
+If using subscriptions, [create and fund a new VRF v2.5 subscription](/vrf/v2-5/subscription/create-manage).
+
+For direct funding, deploy the [`DirectFundingConsumer`](/samples/VRF/v2-5/DirectFundingConsumer.sol) example:
+
+<CodeSample src="samples/VRF/v2-5/DirectFundingConsumer.sol" showButtonOnly />
+
+### Update your code
+
+To modify your existing smart contract code to work with VRF v2.5, complete the following changes:
+
+{/* prettier-ignore */}
+<TabsContent sharedStore="vrfMethod" client:visible>
+<Fragment slot="tab.1">Subscription</Fragment>
+<Fragment slot="tab.2">Direct funding</Fragment>
+<Fragment slot="panel.1">
+1. Import the [`VRFConsumerBaseV2Plus`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2Plus.sol) contract and remove the v2 `VRFConsumerBaseV2` import.
+
+1.  Import the VRF v2.5 coordinator, [`VRFCoordinatorV2_5`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/VRFCoordinatorV2_5.sol), and update any old references to the VRF V2 coordinator in your contract.
+
+1.  Add a `VRFConsumerBaseV2Plus` constructor, passing in the LINK token address for the network you're using.
+
+1.  Update your `requestRandomWords` function calls to reflect the new request structure for VRF v2.5. Make sure to include the new `extraArgs` part of the `VRFV2PlusClient.RandomWordsRequest` object, and specify whether or not you want to pay for VRF requests using native tokens:
+
+        {/* prettier-ignore */}
+        <Tabs sharedStore="feePaymentType" client:visible>
+        <Fragment slot="tab.1">LINK</Fragment>
+        <Fragment slot="tab.2">Native tokens</Fragment>
+        <Fragment slot="panel.1">
+
+        {/* prettier-ignore */}
+        ```solidity
+        uint256 requestId = s_vrfCoordinator.requestRandomWords(
+            VRFV2PlusClient.RandomWordsRequest({
+                keyHash: keyHash,
+                subId: s_vrfSubscriptionId,
+                requestConfirmations: requestConfirmations,
+                callbackGasLimit: callbackGasLimit,
+                numWords: numWords,
+                extraArgs: VRFV2PlusClient._argsToBytes(VRFV2PlusClient.ExtraArgsV1({nativePayment: false}))
+            })
+        );
+        ```
+
+        </Fragment>
+        <Fragment slot="panel.2">
+
+        {/* prettier-ignore */}
+        ```solidity
+        uint256 requestId = s_vrfCoordinator.requestRandomWords(
+            VRFV2PlusClient.RandomWordsRequest({
+                keyHash: keyHash,
+                subId: s_vrfSubscriptionId,
+                requestConfirmations: requestConfirmations,
+                callbackGasLimit: callbackGasLimit,
+                numWords: numWords,
+                extraArgs: VRFV2PlusClient._argsToBytes(VRFV2PlusClient.ExtraArgsV1({nativePayment: true}))
+            })
+        );
+        ```
+        </Fragment>
+        </Tabs>
+
+1.  When using the [`@chainlink/contracts`](https://www.npmjs.com/package/@chainlink/contracts/v/1.1.1) package version 1.1.1 and later, update your `fulfillRandomWords` function signature to match the `VRFConsumerBaseV2Plus` contract, which has changed to:
+
+        ```
+        function fulfillRandomWords(uint256 requestId, uint256[] calldata randomWords)
+        ```
+
+        In the `@chainlink/contracts` package version 1.1.0 and earlier, the `randomWords` parameter has a `memory` storage location.
+
+</Fragment>
+<Fragment slot="panel.2">
+
+1.  Import the [`VRFV2PlusWrapperConsumerBase`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/VRFV2PlusWrapperConsumerBase.sol) contract and remove the v2 `VRFV2WrapperConsumerBase` import.
+
+1.  Add a `VRFV2PlusWrapperConsumerBase` constructor, passing in the VRF wrapper address for the network you're using. Unlike in V2, you don't have to pass the LINK token address to the constructor.
+
+1.  If you're paying for requests with LINK, you can still call the `requestRandomness` function. However, if you're paying with native tokens, call the `requestRandomnessPayInNative` function instead.
+
+    Both functions require one additional parameter, `extraArgs`. Use `nativePayment` to specify whether or not you want to pay for VRF requests using native tokens:
+
+        {/* prettier-ignore */}
+        <Tabs sharedStore="feePaymentType" client:visible>
+        <Fragment slot="tab.1">LINK</Fragment>
+        <Fragment slot="tab.2">Native tokens</Fragment>
+        <Fragment slot="panel.1">
+
+        {/* prettier-ignore */}
+        ```solidity
+        bytes memory extraArgs = VRFV2PlusClient._argsToBytes(
+            VRFV2PlusClient.ExtraArgsV1({nativePayment: false})
+        );
+        (uint256 reqId, uint256 reqPrice) = requestRandomness(
+            callbackGasLimit,
+            requestConfirmations,
+            numWords,
+            extraArgs
+        );
+        ```
+
+        </Fragment>
+
+    <Fragment slot="panel.2">
+
+        {/* prettier-ignore */}
+        ```solidity
+        bytes memory extraArgs = VRFV2PlusClient._argsToBytes(
+            VRFV2PlusClient.ExtraArgsV1({nativePayment: true})
+        );
+        (uint256 reqId, uint256 reqPrice) = requestRandomnessPayInNative(
+            callbackGasLimit,
+            requestConfirmations,
+            numWords,
+            extraArgs
+        );
+        ```
+
+        </Fragment>
+
+    </Tabs>
+
+1.  The V2.5 `requestRandomness` and `requestRandomnessPayInNative` functions both return a tuple: `(uint256 requestId, uint256 requestPrice)`. Adjust your `requestRandomWords` function or any other functions in your code where you call the V2.5 wrapper's `requestRandomness` or `requestRandomnessPayInNative` functions.
+
+1.  Make sure your contract has a withdraw function for both native tokens and LINK. Both are included in the [direct funding example code](#direct-funding-example-code) and the [`VRFV2PlusWrapperConsumerExample`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/testhelpers/VRFV2PlusWrapperConsumerExample.sol) contract.
+
+</Fragment>
+</TabsContent>
+
+### Compare example code
+
+#### Subscription example code
+
+The example `SubscriptionConsumer` contract shows the migration steps above, applied to the example code from [this VRF V2 tutorial](/vrf/v2/subscription/examples/get-a-random-number#analyzing-the-contract). Both of these examples use the subscription method.
+
+Open the full example `SubscriptionConsumer` contract:
+
+<CodeSample src="samples/VRF/v2-5/SubscriptionConsumer.sol" showButtonOnly />
+
+Compare the major changes between V2.5 and V2:
+
+{/* prettier-ignore */}
+<TabsContent sharedStore="vrfVersion" client:visible>
+<Fragment slot="tab.1">VRF V2.5 example code</Fragment>
+<Fragment slot="tab.2">VRF V2 example code</Fragment>
+<Fragment slot="panel.1">
+
+{/* prettier-ignore */}
+```solidity
+// SPDX-License-Identifier: MIT
+// An example of a consumer contract that relies on a subscription for funding.
+pragma solidity 0.8.19;
+
+///// UPDATE IMPORTS TO V2.5 /////
+import {VRFConsumerBaseV2Plus} from "@chainlink/contracts/src/v0.8/vrf/dev/VRFConsumerBaseV2Plus.sol";
+import {VRFV2PlusClient} from "@chainlink/contracts/src/v0.8/vrf/dev/libraries/VRFV2PlusClient.sol";
+
+...
+
+/\*\*
+
+- THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
+- THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+- DO NOT USE THIS CODE IN PRODUCTION.
+  \*/
+
+///// INHERIT NEW CONSUMER BASE CONTRACT /////
+contract SubscriptionConsumer is VRFConsumerBaseV2Plus {
+...
+    ///// No need to declare a coordinator variable /////
+    ///// Use the `s_vrfCoordinator` from VRFConsumerBaseV2Plus.sol /////
+
+    ///// SUBSCRIPTION ID IS NOW UINT256 /////
+    uint256 s_subscriptionId;
+
+    ...
+
+    ///// USE NEW KEYHASH FOR VRF 2.5 GAS LANE /////
+    // For a list of available gas lanes on each network,
+    // see https://docs.chain.link/docs/vrf/v2-5/supported-networks
+    bytes32 keyHash =
+        0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae;
+
+    ...
+
+    ///// USE NEW CONSUMER BASE CONSTRUCTOR /////
+    constructor(
+        ///// UPDATE TO UINT256 /////
+        uint256 subscriptionId
+    )
+        VRFConsumerBaseV2Plus(0x9DdfaCa8183c41ad55329BdeeD9F6A8d53168B1B)
+    {
+        s_subscriptionId = subscriptionId;
+    }
+
+    function requestRandomWords()
+        external
+        onlyOwner
+        returns (uint256 requestId)
+    {
+        ///// UPDATE TO NEW V2.5 REQUEST FORMAT /////
+        // To enable payment in native tokens, set nativePayment to true.
+        // Use the `s_vrfCoordinator` from VRFConsumerBaseV2Plus.sol
+        requestId = s_vrfCoordinator.requestRandomWords(
+            VRFV2PlusClient.RandomWordsRequest({
+                keyHash: keyHash,
+                subId: s_subscriptionId,
+                requestConfirmations: requestConfirmations,
+                callbackGasLimit: callbackGasLimit,
+                numWords: numWords,
+                extraArgs: VRFV2PlusClient._argsToBytes(
+                    VRFV2PlusClient.ExtraArgsV1({nativePayment: false})
+                )
+            })
+        );
+        ...
+    }
+    ...
+
+}
+```
+
+</Fragment>
+<Fragment slot="panel.2">
+
+{/* prettier-ignore */}
+```solidity
+// SPDX-License-Identifier: MIT
+// An example of a consumer contract that relies on a subscription for funding.
+pragma solidity ^0.8.7;
+
+///// USES V2 IMPORTS /////
+import {VRFCoordinatorV2Interface} from "@chainlink/contracts/src/v0.8/vrf/interfaces/VRFCoordinatorV2Interface.sol";
+import {VRFConsumerBaseV2} from "@chainlink/contracts/src/v0.8/vrf/VRFConsumerBaseV2.sol";
+import {ConfirmedOwner} from "@chainlink/contracts/src/v0.8/shared/access/ConfirmedOwner.sol";
+
+/\*\*
+
+- THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
+- THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+- DO NOT USE THIS CODE IN PRODUCTION.
+  \*/
+
+///// USES V2 CONSUMER BASE CONTRACT /////
+contract VRFv2Consumer is VRFConsumerBaseV2, ConfirmedOwner {
+...
+
+    ///// OLD TYPE FOR SUBSCRIPTION ID /////
+    uint64 s_subscriptionId;
+
+    ...
+
+    ///// KEYHASH FOR VRF V2 GAS LANE /////
+    // The gas lane to use, which specifies the maximum gas price to bump to.
+    // For a list of available gas lanes on each network,
+    // see https://docs.chain.link/docs/vrf/v2/subscription/supported-networks/#configurations
+    bytes32 keyHash =
+        0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c;
+
+    ...
+
+     ///// USES V2 CONSUMER BASE AND COORDINATOR CONSTRUCTORS /////
+    constructor(
+        uint64 subscriptionId
+    )
+        VRFConsumerBaseV2(0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625)
+        ConfirmedOwner(msg.sender)
+    {
+        COORDINATOR = VRFCoordinatorV2Interface(
+            0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625
+        );
+        s_subscriptionId = subscriptionId;
+    }
+
+    ...
+
+    function requestRandomWords()
+        external
+        onlyOwner
+        returns (uint256 requestId)
+    {   ///// USES V2 REQUEST FORMAT /////
+        requestId = COORDINATOR.requestRandomWords(
+            keyHash,
+            s_subscriptionId,
+            requestConfirmations,
+            callbackGasLimit,
+            numWords
+        );
+        ...
+    }
+
+...
+}
+```
+
+</Fragment>
+</TabsContent>
+
+#### Direct funding example code
+
+The example `DirectFundingConsumer` contract shows the migration steps above, applied to the example code from [this VRF V2 tutorial](/vrf/v2/direct-funding/examples/get-a-random-number#analyzing-the-contract). Both of these examples use the direct funding method.
+
+Open the full example `DirectFundingConsumer` contract:
+
+<CodeSample src="samples/VRF/v2-5/DirectFundingConsumer.sol" showButtonOnly />
+
+Compare the major changes between V2.5 and V2:
+
+{/* prettier-ignore */}
+<TabsContent sharedStore="vrfVersion" client:visible>
+<Fragment slot="tab.1">VRF V2.5 example code</Fragment>
+<Fragment slot="tab.2">VRF V2 example code</Fragment>
+<Fragment slot="panel.1">
+
+{/* prettier-ignore */}
+```solidity
+// SPDX-License-Identifier: MIT
+// An example of a consumer contract that directly pays for each request.
+pragma solidity 0.8.20;
+
+///// UPDATE IMPORTS TO V2.5 /////
+import {ConfirmedOwner} from "@chainlink/contracts/src/v0.8/shared/access/ConfirmedOwner.sol";
+import {VRFV2PlusWrapperConsumerBase} from "@chainlink/contracts/src/v0.8/vrf/dev/VRFV2PlusWrapperConsumerBase.sol";
+import {LinkTokenInterface} from "@chainlink/contracts/src/v0.8/shared/interfaces/LinkTokenInterface.sol";
+import {VRFV2PlusClient} from "@chainlink/contracts/src/v0.8/vrf/dev/libraries/VRFV2PlusClient.sol";
+
+/**
+ * THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
+ * THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+ * DO NOT USE THIS CODE IN PRODUCTION.
+ */
+
+ ///// INHERIT NEW WRAPPER CONSUMER BASE CONTRACT /////
+contract DirectFundingConsumer is VRFV2PlusWrapperConsumerBase, ConfirmedOwner {
+
+    ...
+    ///// USE NEW WRAPPER CONSUMER BASE CONSTRUCTOR /////
+    constructor()
+        ConfirmedOwner(msg.sender)
+        VRFV2PlusWrapperConsumerBase(wrapperAddress) ///// ONLY PASS IN WRAPPER ADDRESS /////
+    {}
+
+    function requestRandomWords(
+        bool enableNativePayment
+    ) external onlyOwner returns (uint256) {
+        ///// UPDATE TO NEW V2.5 REQUEST FORMAT: ADD EXTRA ARGS /////
+        bytes memory extraArgs = VRFV2PlusClient._argsToBytes(
+            VRFV2PlusClient.ExtraArgsV1({nativePayment: enableNativePayment})
+        );
+        uint256 requestId;
+        uint256 reqPrice;
+        if (enableNativePayment) { 
+            ///// USE THIS FUNCTION TO PAY IN NATIVE TOKENS /////
+            (requestId, reqPrice) = requestRandomnessPayInNative(
+                callbackGasLimit,
+                requestConfirmations,
+                numWords,
+                extraArgs ///// PASS IN EXTRA ARGS /////
+            );
+        } else {
+            ///// USE THIS FUNCTION TO PAY IN LINK /////
+            (requestId, reqPrice) = requestRandomness(
+                callbackGasLimit,
+                requestConfirmations,
+                numWords,
+                extraArgs ///// PASS IN EXTRA ARGS /////
+            );
+        }
+        ...
+        return requestId;
+    }
+   ...
+}
+```
+
+</Fragment>
+<Fragment slot="panel.2">
+
+{/* prettier-ignore */}
+```solidity
+// SPDX-License-Identifier: MIT
+// An example of a consumer contract that directly pays for each request.
+pragma solidity ^0.8.7;
+
+///// USES V2 IMPORTS /////
+import {ConfirmedOwner} from "@chainlink/contracts/src/v0.8/shared/access/ConfirmedOwner.sol";
+import {VRFV2WrapperConsumerBase} from "@chainlink/contracts/src/v0.8/vrf/VRFV2WrapperConsumerBase.sol";
+import {LinkTokenInterface} from "@chainlink/contracts/src/v0.8/shared/interfaces/LinkTokenInterface.sol";
+
+/\*\*
+
+- THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
+- THIS IS AN EXAMPLE CONTRACT THAT USES UN-AUDITED CODE.
+- DO NOT USE THIS CODE IN PRODUCTION.
+  \*/
+
+///// USES V2 WRAPPER CONSUMER BASE CONTRACT /////
+contract VRFv2DirectFundingConsumer is
+VRFV2WrapperConsumerBase,
+ConfirmedOwner
+{
+...
+
+    ///// USES V2 WRAPPER CONSUMER BASE CONSTRUCTOR /////
+    constructor()
+        ConfirmedOwner(msg.sender)
+        VRFV2WrapperConsumerBase(linkAddress, wrapperAddress) ///// TWO PARAMETERS /////
+    {}
+
+    function requestRandomWords()
+        external
+        onlyOwner
+        returns (uint256 requestId)
+    {
+        ///// USES V2 REQUEST FORMAT /////
+        requestId = requestRandomness(
+            callbackGasLimit,
+            requestConfirmations,
+            numWords
+        );
+        ...
+        return requestId;
+    }
+
+...
+
+}
+```
+
+</Fragment>
+</TabsContent>

--- a/src/content/vrf/v2-5/migration-from-v1.mdx
+++ b/src/content/vrf/v2-5/migration-from-v1.mdx
@@ -87,6 +87,8 @@ To modify your existing smart contract code to work with VRF v2.5, complete the 
 
 1. Change `fulfillRandomness` function calls to `fulfillRandomWords`. Update the call to handle the returned `uint256[]` array instead of the single `uint256` variable.
 
+1. Use the `setCoordinator` function in your contract so that you can easily update the VRF coordinator for future VRF releases. This function is inherited from the [`IVRFCoordinatorV2Plus`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/interfaces/IVRFCoordinatorV2Plus.sol) interface.
+
 </Fragment>
 <Fragment slot="panel.2">
 
@@ -158,10 +160,6 @@ To modify your existing smart contract code to work with VRF v2.5, complete the 
 
 </Fragment>
 </TabsContent>
-
-### setCoordinator function
-
-If you're using subscriptions, use the `setCoordinator` function in your contract so that you can easily update the VRF coordinator for future VRF releases. This function is inherited from the [`IVRFCoordinatorV2Plus`](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/vrf/dev/interfaces/IVRFCoordinatorV2Plus.sol) interface.
 
 ## Migration walkthrough
 

--- a/src/content/vrf/v2-5/migration-from-v1.mdx
+++ b/src/content/vrf/v2-5/migration-from-v1.mdx
@@ -12,17 +12,25 @@ import { Tabs, TabsContent } from "@components/Tabs"
 
 ## Benefits of VRF v2.5
 
-Chainlink VRF v2.5 includes [all the same key benefits as VRF v2](https://blog.chain.link/vrf-v2-mainnet-launch/), along with the following additional benefits and changes:
+Chainlink VRF v2.5 includes all the same key benefits as VRF v2 and introduces the following additional benefits and changes:
 
-- Easier upgrades to future versions by using the new `setCoordinator` function
 - The option to pay for requests in either LINK or native tokens
-- New, flexible request format in `requestRandomWords` to make any future upgrades easier
+- Easier upgrades to future versions by using the new `setCoordinator` function
+- New, flexible request format to make any future upgrades easier
 
-### Comparing VRF v1 to the VRF v2 subscription method
+(Learn more about VRF V2.5)[https://blog.chain.link/introducing-vrf-v2-5/].
+
+### Comparing VRF v1 to VRF v2.5
+
+{/* prettier-ignore */}
+<TabsContent sharedStore="vrfMethod" client:visible>
+<Fragment slot="tab.1">Subscription</Fragment>
+<Fragment slot="tab.2">Direct funding</Fragment>
+<Fragment slot="panel.1">
 
 Chainlink VRF v2 includes several improvements and changes to the way you fund and request randomness for your smart contracts.
 
-- **Subscription management:** Chainlink VRF v2 introduces a [Subscription Manager](/vrf/v2/subscription/ui) application that allows smart contract applications to pre-fund multiple requests for randomness using a single LINK token balance. This reduces the gas fees for VRF requests by eliminating the need to transfer LINK tokens for each individual request. You transfer LINK tokens to the subscription balance only when it requires additional funding. Read the [Subscription Manager](/vrf/v2/subscription/ui) page to learn more.
+- **Subscription management:** Chainlink VRF v2 introduces a [Subscription Manager](https://vrf.chain.link) application that allows smart contract applications to pre-fund multiple requests for randomness using a single LINK token balance. This reduces the gas fees for VRF requests by eliminating the need to transfer LINK tokens for each individual request. You transfer LINK tokens to the subscription balance only when it requires additional funding.
 
 - **Variable Callback Gas Limit:** Chainlink VRF v2 lets you adjust the callback gas limit when your smart contract application receives verifiable randomness. Consuming contracts can execute more complex logic in the callback request function that receives the random values. Tasks involving the delivered randomness are handled during the response process. The new gas limits are higher than the VRF V1 limit, and vary depending on the underlying blockchain you use. See the gas limits on the [VRF Supported Networks](/vrf/v2/subscription/supported-networks) page.
 
@@ -32,9 +40,8 @@ Chainlink VRF v2 includes several improvements and changes to the way you fund a
 
 - **Unified Billing - Delegate Subscription Balance to Multiple Addresses:** Chainlink VRF v2 allows up to 100 smart contract addresses to fund their requests for verifiable randomness from a single LINK subscription balance, which is managed by the subscription owner.
 
-Read the [Chainlink VRF v2 blog post](https://blog.chain.link/vrf-v2-mainnet-launch/) for a detailed explanation about the benefits and use cases for VRF v2.
-
-### Comparison between VRF v1 and VRF v2 (Direct funding method)
+</Fragment>
+<Fragment slot="panel.2">
 
 The main similarity between VRF v1 and VRF v2 Direct funding method is that consuming contracts must be funded with LINK to pay for requests. However, Chainlink VRF v2 includes several improvements.
 
@@ -44,7 +51,16 @@ The main similarity between VRF v1 and VRF v2 Direct funding method is that cons
 
 - **Multiple Random Outputs in a Single Request:** The [VRF Wrapper contracts](/vrf/v2/direct-funding/supported-networks) in VRF v2 allow you to request multiple random numbers (multi-word) in a single onchain transaction, which reduces gas costs. The fulfillment is also a single transaction, which reduces the latency of responses.
 
-### Updating your applications to use VRF v2 subscription
+</Fragment>
+</TabsContent>
+
+### Updating your applications to use VRF v2
+
+{/* prettier-ignore */}
+<TabsContent sharedStore="vrfMethod" client:visible>
+<Fragment slot="tab.1">Subscription</Fragment>
+<Fragment slot="tab.2">Direct funding</Fragment>
+<Fragment slot="panel.1">
 
 To modify your existing smart contract code to work with VRF v2, complete the following changes. See the [Get a Random Number](/vrf/v2/subscription/examples/get-a-random-number) guide for an example.
 
@@ -65,7 +81,8 @@ To modify your existing smart contract code to work with VRF v2, complete the fo
 
 1. Change `fulfillRandomness` function calls to `fulfillRandomWords`. Update the call to handle the returned `uint256[]` array instead of the single `uint256` variable.
 
-## Updating your applications to use VRF v2 direct funding
+</Fragment>
+<Fragment slot="panel.2">
 
 To modify your existing smart contract code to work with VRF v2, complete the following changes. See the [Get a Random Number](/vrf/v2/direct-funding/examples/get-a-random-number) guide for an example.
 
@@ -76,6 +93,9 @@ To modify your existing smart contract code to work with VRF v2, complete the fo
 1. You can still call the `requestRandomness` function. However, the v2 `requestRandomness` function requires several different parameters (`callbackGasLimit` , `requestConfirmations` , `numWords`). See the [Supported networks](/vrf/v2/direct-funding/supported-networks) page to adjust them for your own needs.
 
 1. Change `fulfillRandomness` function calls to `fulfillRandomWords`. Update the call to handle the returned `uint256[]` array instead of the single `uint256` variable.
+
+</Fragment>
+</TabsContent>
 
 ## Code changes
 


### PR DESCRIPTION
https://documentation-git-fork-thedriftofwords-vrf-a6feb1-chainlinklabs.vercel.app/vrf/v2-5/migration-from-v1