### PR TITLE
Functions: all networks use USD-denominated premium fees

### DIFF
--- a/src/content/chainlink-functions/resources/billing.mdx
+++ b/src/content/chainlink-functions/resources/billing.mdx
@@ -42,7 +42,7 @@ During the **request** step:
    total estimated cost in LINK = total estimated gas cost + premium fees
    ```
 
-   For networks with USD-denominated premium fees, the fixed premium fee is denominated in USD but no USD is ever used. The LINK equivalent of this fee is calculated at request time.
+   All networks have USD-denominated premium fees. This means that the fixed premium fee is denominated in USD, but no USD is ever used. The LINK equivalent of this fee is calculated at request time.
 
 1. The total estimated cost is then added to the subscription reservation.
 
@@ -58,7 +58,7 @@ When a DON's oracle reports the response, subscription accounts are charged base
    total cost in LINK = total gas cost + premium fees
    ```
 
-   For networks with USD-denominated premium fees, the LINK equivalent of the fixed premium fee was calculated at request time. At response time, this calculated value in LINK is charged to your subscription.
+   All networks have USD-denominated premium fees. This means that the fixed premium fee is denominated in USD, but no USD is ever used. The LINK equivalent of this fee is calculated at request time.
 
 1. The FunctionsRouter contract performs several accounting movements.
 
@@ -70,48 +70,11 @@ For networks with USD-denominated premium fees, the premium fees are set in USD,
 
 #### Cost Simulation (Reservation)
 
-{/* prettier-ignore */}
-<TabsContent sharedStore="feeType" client:visible>
-<Fragment slot="tab.1">LINK-denominated premium fee</Fragment>
-<Fragment slot="tab.2">USD-denominated premium fee</Fragment>
-<Fragment slot="panel.1">
-| Parameter               | Value    |
-| ----------------------- | -------- |
-| Overestimated gas price | 9 gwei   |
-| Callback gas limit      | 300000   |
-| Gas overhead            | 185000   |
-| Premium fee             | 0.2 LINK |
-
-1. Calculate the total estimated gas cost in LINK, using an overestimated gas price, the gas overhead, and the full callback gas limit:
-
-   | Gas cost calculation                                          | Total estimated gas cost    |
-   | ------------------------------------------------------------- | --------------------------- |
-   | Overestimated gas price x (Gas overhead + Callback gas limit) |                             |
-   | 9 gwei x (300000 + 185000)                                    | 4365000 gwei (0.004365 ETH) |
-
-1. Convert the gas cost to LINK using the [LINK/ETH feed](https://data.chain.link/ethereum/mainnet/crypto-eth/link-eth).
-   For this example, assume the feed returns a conversion value of Ξ0.007 ETH per 1 LINK.
-
-   | ETH to LINK cost conversion   | Total gas cost (LINK) |
-   | ----------------------------- | --------------------- |
-   | 0.004365 ETH / 0.007 ETH/LINK | 0.62 LINK             |
-
-1. Add the premium fee to get the estimated cost for a subscription reservation:
-
-   | Adding LINK premium                 | Maximum request cost (LINK) |
-   | ----------------------------------- | --------------------------- |
-   | Total gas cost (LINK) + Premium fee |                             |
-   | 0.62 LINK + 0.2 LINK                | 0.82 LINK                   |
-
-For this example request, 0.82 LINK is reserved from your subscription balance, but not yet deducted. When the request is fulfilled, the exact request cost is deducted. The estimated cost of a request is overestimated to allow for 99% of gas price fluctuation increases in between request and response time.
-
-</Fragment>
-<Fragment slot="panel.2">
-| Parameter               | Value    |
-| ----------------------- | -------- |
-| Overestimated gas price | 9 gwei   |
-| Callback gas limit      | 300000   |
-| Gas overhead            | 185000   |
+| Parameter               | Value         |
+| ----------------------- | ------------- |
+| Overestimated gas price | 9 gwei        |
+| Callback gas limit      | 300000        |
+| Gas overhead            | 185000        |
 | Premium fee             | 320 cents USD |
 
 1. Calculate the total estimated gas cost in LINK, using an overestimated gas price, the gas overhead, and the full callback gas limit:
@@ -144,54 +107,14 @@ For this example request, 0.82 LINK is reserved from your subscription balance, 
 
 For this example request, 0.78 LINK is reserved from your subscription balance, but not yet deducted. When the request is fulfilled, the exact request cost is deducted. The estimated cost of a request is overestimated to allow for 99% of gas price fluctuation increases in between request and response time.
 
-</Fragment>
-</TabsContent>
-
 #### Cost calculation (fulfillment)
 
-{/* prettier-ignore */}
-<TabsContent sharedStore="feeType" client:visible>
-<Fragment slot="tab.1">LINK-denominated premium fee</Fragment>
-<Fragment slot="tab.2">USD-denominated premium fee</Fragment>
-<Fragment slot="panel.1">
-| Parameter    | Value    |
-| ------------ | -------- |
-| Gas price    | 1.5 gwei |
-| Callback gas | 200000   |
-| Gas overhead | 185000   |
-| Premium fee  | 0.2 LINK |
-
-1. Calculate the total gas cost:
-
-   | Gas cost calculation                      | Total gas cost              |
-   | ----------------------------------------- | --------------------------- |
-   | Gas price x (Gas overhead + Callback gas) |                             |
-   | 1.5 gwei x (200000 + 185000)              | 577500 gwei (0.0005775 ETH) |
-
-1. Convert the gas cost to LINK using the [LINK/ETH feed](https://data.chain.link/ethereum/mainnet/crypto-eth/link-eth).
-   For this example, assume the feed returns a conversion value of Ξ0.007 ETH per 1 LINK.
-
-   | ETH to LINK cost conversion    | Total gas cost (LINK) |
-   | ------------------------------ | --------------------- |
-   | 0.0005775 ETH / 0.007 ETH/LINK | 0.0825 LINK           |
-
-1. Add the premium fee to get the total cost of a request:
-
-   | Adding premium fee                  | Total request cost (LINK) |
-   | ----------------------------------- | ------------------------- |
-   | Total gas cost (LINK) + premium fee |                           |
-   | 0.0825 LINK + 0.2 LINK              | 0.2825 LINK               |
-
-This example request would cost 0.2825 LINK when it is fulfilled. The subscription reservation for the 0.82 LINK is released, and the actual cost of 0.2825 LINK is deducted from your subscription balance.
-
-</Fragment>
-<Fragment slot="panel.2">
-| Parameter    | Value    |
-| ------------ | -------- |
-| Gas price    | 1.5 gwei |
-| Callback gas | 200000   |
-| Gas overhead | 185000   |
-| Premium fee converted to LINK  | 0.16 LINK |
+| Parameter                     | Value     |
+| ----------------------------- | --------- |
+| Gas price                     | 1.5 gwei  |
+| Callback gas                  | 200000    |
+| Gas overhead                  | 185000    |
+| Premium fee converted to LINK | 0.16 LINK |
 
 1. Calculate the total gas cost:
 
@@ -215,9 +138,6 @@ This example request would cost 0.2825 LINK when it is fulfilled. The subscripti
    | 0.0825 LINK + 0.16 LINK             | 0.2425 LINK               |
 
 This example request would cost 0.2425 LINK when it is fulfilled. The subscription reservation for the 0.78 LINK is released, and the actual cost of 0.2425 LINK is deducted from your subscription balance.
-
-</Fragment>
-</TabsContent>
 
 ## Minimum balance for uploading encrypted secrets
 

--- a/src/content/chainlink-functions/resources/release-notes.mdx
+++ b/src/content/chainlink-functions/resources/release-notes.mdx
@@ -6,6 +6,16 @@ title: "Chainlink Functions Release Notes"
 
 import { Aside } from "@components"
 
+## USD-denominated premium fees on all networks - 2024-07-31
+
+Chainlink Functions now uses USD-denominated fixed premium fees on all [supported networks](/chainlink-functions/supported-networks). This means that the premium fees are set in USD, but no USD is ever used. The LINK equivalent of the fee is calculated at request time, and then deducted from your subscription in LINK at response time. See the [example cost calculation](/chainlink-functions/resources/billing#cost-calculation-example) for more information.
+
+The networks that have just switched from LINK-denominated premium fees to USD-denominated premium fees are:
+
+- Ethereum mainnet and Sepolia testnet
+- Arbitrum mainnet
+- Avalanche mainnet
+
 ## Polygon Amoy support - 2024-04-26
 
 Chainlink Functions is available on [Polygon Amoy](/chainlink-functions/supported-networks#polygon-amoy-testnet).

--- a/src/content/chainlink-functions/supported-networks.mdx
+++ b/src/content/chainlink-functions/supported-networks.mdx
@@ -14,6 +14,12 @@ Read the [LINK Token Contracts](/resources/link-token-contracts) page to learn w
 
 ## Ethereum
 
+<Aside type="note" title="USD-denominated premium fees">
+  The fixed premium fee is denominated in USD but no USD is ever used. The LINK equivalent of the fee is calculated at
+  request time, and then deducted from your subscription in LINK at response time. See the [example cost
+  calculation](/chainlink-functions/resources/billing#cost-calculation-example) for more information.
+</Aside>
+
 ### Ethereum mainnet
 
 | Item                               | Value                                                                                                                                                                    |
@@ -22,12 +28,12 @@ Read the [LINK Token Contracts](/resources/link-token-contracts) page to learn w
 | <DonId client:load/>               | <CopyText text="fun-ethereum-mainnet-1" code /> / <CopyText text="0x66756e2d657468657265756d2d6d61696e6e65742d3100000000000000000000"code format formatType="bytes32" /> |
 | Encrypted secrets upload endpoints | <ul><li><CopyText text="https://01.functions-gateway.chain.link/" code /></li><li><CopyText text="https://02.functions-gateway.chain.link/" code /></li></ul>            |
 
-| Billing Item                                    | Value     |
-| ----------------------------------------------- | --------- |
-| Premium fees                                    | 0.25 LINK |
-| Request threshold (withdrawing funds)           | 1 request |
-| Cancellation fees (withdrawing funds)           | 1 LINK    |
-| Minimum balance for uploading encrypted secrets | 1 LINK    |
+| Billing Item                                    | Value         |
+| ----------------------------------------------- | ------------- |
+| Premium fees                                    | 400 cents USD |
+| Request threshold (withdrawing funds)           | 1 request     |
+| Cancellation fees (withdrawing funds)           | 1 LINK        |
+| Minimum balance for uploading encrypted secrets | 1 LINK        |
 
 ### Sepolia testnet
 
@@ -37,12 +43,12 @@ Read the [LINK Token Contracts](/resources/link-token-contracts) page to learn w
 | <DonId client:load/>               | <CopyText text="fun-ethereum-sepolia-1" code /> / <CopyText text="0x66756e2d657468657265756d2d7365706f6c69612d3100000000000000000000"code format formatType="bytes32" />      |
 | Encrypted secrets upload endpoints | <ul><li><CopyText text="https://01.functions-gateway.testnet.chain.link/" code /></li><li><CopyText text="https://02.functions-gateway.testnet.chain.link/" code /></li></ul> |
 
-| Billing Item                                    | Value       |
-| ----------------------------------------------- | ----------- |
-| Premium fees                                    | 0.2 LINK    |
-| Request threshold (withdrawing funds)           | 10 requests |
-| Cancellation fees (withdrawing funds)           | 2 LINK      |
-| Minimum balance for uploading encrypted secrets | 2 LINK      |
+| Billing Item                                    | Value         |
+| ----------------------------------------------- | ------------- |
+| Premium fees                                    | 320 cents USD |
+| Request threshold (withdrawing funds)           | 10 requests   |
+| Cancellation fees (withdrawing funds)           | 2 LINK        |
+| Minimum balance for uploading encrypted secrets | 2 LINK        |
 
 ## Polygon
 
@@ -84,6 +90,12 @@ Read the [LINK Token Contracts](/resources/link-token-contracts) page to learn w
 
 ## Avalanche
 
+<Aside type="note" title="USD-denominated premium fees">
+  The fixed premium fee is denominated in USD but no USD is ever used. The LINK equivalent of the fee is calculated at
+  request time, and then deducted from your subscription in LINK at response time. See the [example cost
+  calculation](/chainlink-functions/resources/billing#cost-calculation-example) for more information.
+</Aside>
+
 ### Avalanche Mainnet
 
 | Item                               | Value                                                                                                                                                                     |
@@ -92,12 +104,12 @@ Read the [LINK Token Contracts](/resources/link-token-contracts) page to learn w
 | <DonId client:load/>               | <CopyText text="fun-avalanche-mainnet-1" code /> / <CopyText text="0x66756e2d6176616c616e6368652d6d61696e6e65742d31000000000000000000"code format formatType="bytes32" /> |
 | Encrypted secrets upload endpoints | <ul><li><CopyText text="https://01.functions-gateway.chain.link/" code /></li><li><CopyText text="https://02.functions-gateway.chain.link/" code /></li></ul>             |
 
-| Billing Item                                    | Value      |
-| ----------------------------------------------- | ---------- |
-| Premium fees                                    | 0.004 LINK |
-| Request threshold (withdrawing funds)           | 1 request  |
-| Cancellation fees (withdrawing funds)           | 1 LINK     |
-| Minimum balance for uploading encrypted secrets | 1 LINK     |
+| Billing Item                                    | Value       |
+| ----------------------------------------------- | ----------- |
+| Premium fees                                    | 3 cents USD |
+| Request threshold (withdrawing funds)           | 1 request   |
+| Cancellation fees (withdrawing funds)           | 1 LINK      |
+| Minimum balance for uploading encrypted secrets | 1 LINK      |
 
 ### Avalanche Fuji testnet
 
@@ -107,14 +119,20 @@ Read the [LINK Token Contracts](/resources/link-token-contracts) page to learn w
 | <DonId client:load/>               | <CopyText text="fun-avalanche-fuji-1" code /> / <CopyText text="0x66756e2d6176616c616e6368652d66756a692d31000000000000000000000000"code format formatType="bytes32" />        |
 | Encrypted secrets upload endpoints | <ul><li><CopyText text="https://01.functions-gateway.testnet.chain.link/" code /></li><li><CopyText text="https://02.functions-gateway.testnet.chain.link/" code /></li></ul> |
 
-| Billing Item                                    | Value       |
-| ----------------------------------------------- | ----------- |
-| Premium fees                                    | 0.2 LINK    |
-| Request threshold (withdrawing funds)           | 10 requests |
-| Cancellation fees (withdrawing funds)           | 2 LINK      |
-| Minimum balance for uploading encrypted secrets | 2 LINK      |
+| Billing Item                                    | Value         |
+| ----------------------------------------------- | ------------- |
+| Premium fees                                    | 320 cents USD |
+| Request threshold (withdrawing funds)           | 10 requests   |
+| Cancellation fees (withdrawing funds)           | 2 LINK        |
+| Minimum balance for uploading encrypted secrets | 2 LINK        |
 
 ## Arbitrum
+
+<Aside type="note" title="USD-denominated premium fees">
+  The fixed premium fee is denominated in USD but no USD is ever used. The LINK equivalent of the fee is calculated at
+  request time, and then deducted from your subscription in LINK at response time. See the [example cost
+  calculation](/chainlink-functions/resources/billing#cost-calculation-example) for more information.
+</Aside>
 
 ### Arbitrum Mainnet
 
@@ -126,18 +144,12 @@ Read the [LINK Token Contracts](/resources/link-token-contracts) page to learn w
 
 | Billing Item                                    | Value       |
 | ----------------------------------------------- | ----------- |
-| Premium fees                                    | 0.004 LINK  |
+| Premium fees                                    | 3 cents USD |
 | Request threshold (withdrawing funds)           | 10 requests |
 | Cancellation fees (withdrawing funds)           | 0.1 LINK    |
 | Minimum balance for uploading encrypted secrets | 0.1 LINK    |
 
 ### Arbitrum Sepolia testnet
-
-<Aside type="note" title="USD-denominated premium fees">
-  The fixed premium fee is denominated in USD but no USD is ever used. The LINK equivalent of the fee is calculated at
-  request time, and then deducted from your subscription in LINK at response time. See the [example cost
-  calculation](/chainlink-functions/resources/billing#cost-calculation-example) for more information.
-</Aside>
 
 | Item                               | Value                                                                                                                                                                         |
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
https://documentation-git-fork-thedriftofwords-073-0278bd-chainlinklabs.vercel.app/chainlink-functions/supported-networks - ETH, Sepolia, Arbitrum and Avalanche mainnets

Also updated
- [Release notes](https://documentation-git-fork-thedriftofwords-073-0278bd-chainlinklabs.vercel.app/chainlink-functions/resources/release-notes#usd-denominated-premium-fees-on-all-networks---2024-07-31)
- [Cost calculation example](https://documentation-git-fork-thedriftofwords-073-0278bd-chainlinklabs.vercel.app/chainlink-functions/resources/billing#cost-calculation-example) has had the tabs with the LINK-denominated premium examples removed