### PR TITLE
CLA supported networks bugfix

### DIFF
--- a/src/features/chainlink-automation/data/chainlink-automation-config.json
+++ b/src/features/chainlink-automation/data/chainlink-automation-config.json
@@ -93,8 +93,8 @@
       "type": "BigNumber",
       "hex": "0x02c68af0bb140000"
     },
+    "maxPerformDataSize": 5000,
     "flatFeeMicroLink": 0,
-    "maxPerformDataSize": 0,
     "stalenessSeconds": 90000,
     "registrar": "0x0631ea498c2Cd8371B020b9eC03f5F779174562B",
     "transcoder": "0x0000000000000000000000000000000000000000"


### PR DESCRIPTION
Fix blank "max perform data size" for BNB testnet in docs
<img width="629" alt="Screenshot 2024-08-20 at 2 56 20 PM" src="https://github.com/user-attachments/assets/f55baca1-1ec3-41c8-ad90-e5bcce5b97c8">

preview: https://documentation-git-08202024-cla-fix-chainlinklabs.vercel.app/chainlink-automation/overview/supported-networks#bnb-chain-testnet