### PR TITLE
Add VRF v2.5 notice to V2 migration page

### DIFF
--- a/src/content/vrf/v2-5/migration-from-v2.mdx
+++ b/src/content/vrf/v2-5/migration-from-v2.mdx
@@ -10,6 +10,8 @@ import { Tabs, TabsContent } from "@components/Tabs"
 
 <Vrf2_5Common callout="security" />
 
+VRF V2.5 replaces both VRF V1 and VRF V2 on November 29, 2024. [Learn more about VRF V2.5](https://blog.chain.link/introducing-vrf-v2-5/).
+
 ## Benefits of VRF v2.5
 
 Chainlink VRF v2.5 includes [all the same key benefits as VRF v2](https://blog.chain.link/vrf-v2-mainnet-launch/), along with the following additional benefits and changes:


### PR DESCRIPTION
https://documentation-git-docs-vrf-notice-updates-chainlinklabs.vercel.app/vrf/v2-5/migration-from-v2