### PR TITLE
Link fix

### DIFF
--- a/src/content/vrf/v2-5/subscription/create-manage.mdx
+++ b/src/content/vrf/v2-5/subscription/create-manage.mdx
@@ -53,7 +53,7 @@ If you prefer to create, fund and manage your subscriptions programmatically, yo
     <Fragment slot="tab.1">Subscription contract</Fragment>
     <Fragment slot="tab.2">Using a block explorer</Fragment>
     <Fragment slot="panel.1">
-    Deploy the [`SubscriptionManager` contract](/samples/VRF/v2-5/SubscriptionManager.sol). On deployment, the contract creates a new subscription and adds itself as a consumer to the new subscription.
+    Deploy the [`SubscriptionManager` contract](https://remix.ethereum.org/#url=https://docs.chain.link/samples/VRF/v2-5/SubscriptionManager.sol). On deployment, the contract creates a new subscription and adds itself as a consumer to the new subscription.
     </Fragment>
     <Fragment slot="panel.2">
     1. Navigate to the VRF coordinator contract on the block explorer for the network you want to use (for example, Etherscan or Polygonscan). You can find the coordinator addresses with links to the block explorers on the [Supported Networks](/vrf/v2-5/supported-networks) page.


### PR DESCRIPTION
Replaced `/samples/VRF/v2-5/SubscriptionManager.sol` with `https://remix.ethereum.org/#url=https://docs.chain.link/samples/VRF/v2-5/SubscriptionManager.sol` to open the file in Remix IDE instead of downloading it locally.