### PR TITLE
Updates docs link for SubscriptionConsumer.sol

### DIFF
--- a/public/samples/VRF/v2-5/SubscriptionConsumer.sol
+++ b/public/samples/VRF/v2-5/SubscriptionConsumer.sol
@@ -37,7 +37,7 @@ contract SubscriptionConsumer is VRFConsumerBaseV2Plus {
 
     // The gas lane to use, which specifies the maximum gas price to bump to.
     // For a list of available gas lanes on each network,
-    // see https://docs.chain.link/docs/vrf/v2-5/supported-networks
+    // see https://docs.chain.link/vrf/v2-5/supported-networks
     bytes32 public keyHash =
         0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae;
 


### PR DESCRIPTION
## Closing issues


closes #2136 

...

## Description

Updates the file with the correct link

...

## Changes

Comments for Supported Networks went to a 404 Page not found

Previous link goes to a 404 Page not found:
https://docs.chain.link/docs/vrf/v2-5/supported-networks 

Updated to the correct page:
https://docs.chain.link/vrf/v2-5/supported-networks 
