### PR TITLE
Add redirects for old CCIP v1.2 supported networks urls

### DIFF
--- a/src/features/redirects/redirects.json
+++ b/src/features/redirects/redirects.json
@@ -1871,6 +1871,16 @@
       "statuscode": 301
     },
     {
+      "source": "ccip/supported-networks/v1_2_0/mainnet",
+      "destination": "ccip/directory/mainnet",
+      "statuscode": 301
+    },
+    {
+      "source": "ccip/supported-networks/v1_2_0/testnet",
+      "destination": "ccip/directory/testnet",
+      "statuscode": 301
+    },
+    {
       "source": "chainlink-functions/resources/playground",
       "destination": "chainlink-functions/resources/simulation",
       "statuscode": 301


### PR DESCRIPTION
To test try

https://documentation-git-fork-thedriftofwords-redirects-chainlinklabs.vercel.app/ccip/supported-networks/v1_2_0/mainnet#arbitrum-mainnet