### PR TITLE
 Documentation Updates

### DIFF
--- a/src/content/data-feeds/index.mdx
+++ b/src/content/data-feeds/index.mdx
@@ -25,7 +25,7 @@ import button from "@chainlink/design-system/button.module.css"
   Data Feeds with your applications.
 </Aside>
 
-Chainlink Data Feeds are the quickest way to connect your smart contracts to the real-world data such as asset prices, reserve balances, and L2 sequencer health.
+Chainlink Data Feeds are the quickest way to connect your smart contracts to real-world data such as asset prices, reserve balances, and L2 sequencer health.
 
 If you already started a project and need to integrate Chainlink, you can [add Chainlink to your existing project](/resources/create-a-chainlinked-project?parent=dataFeeds#installing-into-existing-projects) with the [`@chainlink/contracts` NPM package](https://www.npmjs.com/package/@chainlink/contracts).
 
@@ -70,7 +70,7 @@ See the [Rate and Volatility Contract Addresses](/data-feeds/rates-feeds/address
 
 L2 sequencer feeds track the last known status of the sequencer on an L2 network at a given point in time. This helps you prevent mass liquidations by providing a grace period to allow customers to react to these events.
 
-To learn how to use L2 sequencer uptime feeds feeds, see the [L2 Sequencer Uptime Feeds](/data-feeds/l2-sequencer-feeds) documentation.
+To learn how to use L2 sequencer uptime feeds, see the [L2 Sequencer Uptime Feeds](/data-feeds/l2-sequencer-feeds) documentation.
 
 ## Components of a data feed
 

--- a/src/content/data-feeds/rates-feeds/index.mdx
+++ b/src/content/data-feeds/rates-feeds/index.mdx
@@ -47,7 +47,7 @@ Realized volatility measures asset price movement over a specific time interval.
 
 Each data feed reflects the volatility of an asset over a specific rolling window of time. For example, some data feeds provide volatility data for the last 24 hours, 7 days, and 30 days of time. You can compare the data across these windows to infer whether the volatility of an asset is trending up or down. For example, if realized volatility for the 24-hour window is higher than the 7-day window, volatility might increase.
 
-The same high-quality data providers used in Chailink’s price feeds sample price data every 10 minutes to refresh volatility estimates. onchain values are updated when the feed heartbeat or deviation threshold is met.
+The same high-quality data providers used in Chainlink’s price feeds sample price data every 10 minutes to refresh volatility estimates. onchain values are updated when the feed heartbeat or deviation threshold is met.
 
 <ClickToZoom
   src="/images/data-feed/realised-volatility-feed-V3.webp"


### PR DESCRIPTION

## Changes Made

### File: src/content/data-feeds/rates-feeds/index.mdx
- "Chailink's" -> "Chainlink's"
Reason: Fixed company name typo

### General Text Improvements
- Removed redundant "the" before "real-world data"
- Removed duplicate word "feeds" in "L2 sequencer uptime feeds feeds"

## Testing
- Verified links functionality
- Confirmed proper formatting
- Checked terminology consistency
