### PR TITLE
update

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -8835,14 +8835,14 @@
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "15000000000000000000",
+              "isEnabled": true,
+              "rate": "694400000000000"
             },
             "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "15000000000000000000",
+              "isEnabled": true,
+              "rate": "694400000000000"
             }
           }
         },

--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -225,14 +225,14 @@
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "2500000000000000000",
+              "isEnabled": true,
+              "rate": "115740000000000"
             },
             "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "2500000000000000000",
+              "isEnabled": true,
+              "rate": "115740000000000"
             }
           }
         },
@@ -1046,6 +1046,20 @@
       },
       "rmnPermeable": false,
       "supportedTokens": {
+        "ALU": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "BETS": {
           "rateLimiterConfig": {
             "in": {
@@ -1197,6 +1211,20 @@
               "capacity": "7000000000000000000000",
               "isEnabled": true,
               "rate": "81000000000000000"
+            }
+          }
+        },
+        "TURBO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "7000000000000000000000000",
+              "isEnabled": true,
+              "rate": "1944444400000000000000"
+            },
+            "out": {
+              "capacity": "7000000000000000000000000",
+              "isEnabled": true,
+              "rate": "1944444400000000000000"
             }
           }
         },
@@ -4189,14 +4217,14 @@
         "SolvBTC.BBN": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "15000000000000000000",
+              "isEnabled": true,
+              "rate": "694400000000000"
             },
             "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "15000000000000000000",
+              "isEnabled": true,
+              "rate": "694400000000000"
             }
           }
         }
@@ -4436,6 +4464,20 @@
       },
       "rmnPermeable": false,
       "supportedTokens": {
+        "ALU": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "BETS": {
           "rateLimiterConfig": {
             "in": {
@@ -4615,6 +4657,20 @@
               "capacity": "1111000000000000000000",
               "isEnabled": true,
               "rate": "80000000000000000"
+            }
+          }
+        },
+        "NEIRO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -6998,6 +7054,20 @@
       },
       "rmnPermeable": false,
       "supportedTokens": {
+        "ALU": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "BETS": {
           "rateLimiterConfig": {
             "in": {
@@ -7149,6 +7219,20 @@
               "capacity": "7000000000000000000000",
               "isEnabled": true,
               "rate": "81000000000000000"
+            }
+          }
+        },
+        "TURBO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "7000000000000000000000000",
+              "isEnabled": true,
+              "rate": "1944444400000000000000"
+            },
+            "out": {
+              "capacity": "7000000000000000000000000",
+              "isEnabled": true,
+              "rate": "1944444400000000000000"
             }
           }
         },
@@ -8118,6 +8202,20 @@
       },
       "rmnPermeable": false,
       "supportedTokens": {
+        "ALU": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "BETS": {
           "rateLimiterConfig": {
             "in": {
@@ -8297,6 +8395,20 @@
               "capacity": "1111000000000000000000",
               "isEnabled": true,
               "rate": "80000000000000000"
+            }
+          }
+        },
+        "NEIRO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -9657,6 +9769,20 @@
               "rate": "4630000000000000000"
             }
           }
+        },
+        "ZENT": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -10623,6 +10749,20 @@
               "capacity": "50000000000000000000000",
               "isEnabled": true,
               "rate": "4630000000000000000"
+            }
+          }
+        },
+        "ZENT": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -17,6 +17,15 @@
       "poolType": "burnMint",
       "symbol": "ALU",
       "tokenAddress": "0x91Ad1b44913cD1B8241A4Ff1e2EAa198DA6Bf4c9"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Altura",
+      "poolAddress": "0x7Ee2788AecB35Be3F13FA1389c4f578a38d11332",
+      "poolType": "burnMint",
+      "symbol": "ALU",
+      "tokenAddress": "0x786A6743efe9500011C92c7D8540608a62382b6f"
     }
   },
   "BETS": {
@@ -1313,6 +1322,26 @@
       "tokenAddress": "0xE46a5E19B19711332e33F33c2DB3eA143e86Bc10"
     }
   },
+  "NEIRO": {
+    "ethereum-mainnet-base-1": {
+      "allowListEnabled": false,
+      "decimals": 9,
+      "name": "Neiro",
+      "poolAddress": "0x8f43e6A0E48c860946bbDeea28F1eE710FdCf6d4",
+      "poolType": "burnMint",
+      "symbol": "NEIRO",
+      "tokenAddress": "0x1d192a2f367DaF23540fFEAbF8dBe9B17803F00A"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 9,
+      "name": "Neiro",
+      "poolAddress": "0x47158771e67e4bDdaFd0FBD36f26Db929420B26C",
+      "poolType": "lockRelease",
+      "symbol": "NEIRO",
+      "tokenAddress": "0xEE2a03Aa6Dacf51C18679C516ad5283d8E7C2637"
+    }
+  },
   "NUON": {
     "ethereum-mainnet-arbitrum-1": {
       "allowListEnabled": false,
@@ -2120,6 +2149,26 @@
       "tokenAddress": "0x27DfD2D7b85e0010542da35C6EBcD59E45fc949D"
     }
   },
+  "TURBO": {
+    "bsc-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Turbo",
+      "poolAddress": "0xeA771EB68CcfE489cdA2713F4248CD512c880453",
+      "poolType": "burnMint",
+      "symbol": "TURBO",
+      "tokenAddress": "0x620a8b7Bd26b21d0d053ee9a05A593f35Bf37d8e"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Turbo",
+      "poolAddress": "0x348540aa7b129b0F3c931FEDE811d009E0e18E60",
+      "poolType": "lockRelease",
+      "symbol": "TURBO",
+      "tokenAddress": "0xA35923162C49cF95e6BF26623385eb431ad920D3"
+    }
+  },
   "una.USDC": {
     "mainnet": {
       "allowListEnabled": false,
@@ -2443,16 +2492,6 @@
     }
   },
   "WASTR": {
-    "polkadot-mainnet-astar": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "Wrapped Astar",
-      "poolType": "feeTokenOnly",
-      "symbol": "WASTR",
-      "tokenAddress": "0xAeaaf0e2c81Af264101B9129C00F4440cCF0F720"
-    }
-  },
-  "WASTR_new": {
     "polkadot-mainnet-astar": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -2914,6 +2953,26 @@
       "poolType": "burnMint",
       "symbol": "XSWAP",
       "tokenAddress": "0x8Fe815417913a93Ea99049FC0718ee1647A2a07c"
+    }
+  },
+  "ZENT": {
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Zentry",
+      "poolAddress": "0x55c47DE8bCfA02B3989f2B6F9542900E3A2EC6c3",
+      "poolType": "lockRelease",
+      "symbol": "ZENT",
+      "tokenAddress": "0xdBB7a34Bf10169d6d2D0d02A6cbb436cF4381BFa"
+    },
+    "ronin-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Zentry",
+      "poolAddress": "0x52fEd5115D8B7397C09eb4ce2f0a99739891D6B8",
+      "poolType": "burnMint",
+      "symbol": "ZENT",
+      "tokenAddress": "0x9f28c9C2dA4A833cbFaAacbf7eB62267334d7149"
     }
   },
   "ZUN": {


### PR DESCRIPTION
This pull request includes several updates to the `src/config/data/ccip/v1_2_0/mainnet/lanes.json` and `src/config/data/ccip/v1_2_0/mainnet/tokens.json` files. The changes mainly involve adding new tokens and updating rate limiter configurations for existing tokens.

### Updates to rate limiter configurations:

* Updated the rate limiter configuration for `SolvBTC` to enable it and set specific capacities and rates.
* Added a new token `TURBO` with specific rate limiter configurations. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R1217-R1230) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R7225-R7238)
* Updated the rate limiter configuration for `SolvBTC.BBN` to enable it and set specific capacities and rates.

### Addition of new tokens:

* Added the `ALU` token with its respective configurations. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R1049-R1062) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R4467-R4480) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R7057-R7070) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R8205-R8218) [[5]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R20-R28)
* Added the `NEIRO` token with its respective configurations. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R4663-R4676) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R8401-R8414) [[3]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R1325-R1344)
* Added the `TURBO` token with its respective configurations.
* Added the `ZENT` token with its respective configurations. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R9772-R9785) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R2958-R2977)