### PR TITLE
Typos fix

### DIFF
--- a/src/content/ccip/tutorials/cross-chain-tokens/update-rate-limiters-hardhat.mdx
+++ b/src/content/ccip/tutorials/cross-chain-tokens/update-rate-limiters-hardhat.mdx
@@ -244,7 +244,7 @@ npx hardhat updateRateLimiters \
 
 Suppose you want to enable inbound and outbound rate limits for your token pool on Avalanche Fuji to control the number of tokens received or sent from/to Arbitrum Sepolia. We will use an existing token pool that interacts with an ERC20 token with 18 decimals:
 
-- **Token Pool on Avalance Fuji**:
+- **Token Pool on Avalanche Fuji**:
 
   - **Outbound Rate Limiter**:
 

--- a/src/content/ccip/tutorials/transfer-tokens-from-eoa.mdx
+++ b/src/content/ccip/tutorials/transfer-tokens-from-eoa.mdx
@@ -75,7 +75,7 @@ In this tutorial, you will use Chainlink CCIP to transfer tokens directly from y
 
 ### Transfer tokens and pay in LINK
 
-In this example, you will transfer CCIP-BnM tokens from your EOA on _Avalanche Fuji_ to an account on _Ethereum Sepolia_. The destination account could be an [EOA (Externally Owned Account)](https://ethereum.org/en/developers/docs/accounts/#types-of-account) or a smart contract. The example shows how to transfer CCIP-BnM tokens, but you can re-use the same example to transfer other tokens as long as they are supported for your [lane](/ccip/concepts#lane).
+In this example, you will transfer CCIP-BnM tokens from your EOA on _Avalanche Fuji_ to an account on _Ethereum Sepolia_. The destination account could be an [EOA (Externally Owned Account)](https://ethereum.org/en/developers/docs/accounts/#types-of-account) or a smart contract. The example shows how to transfer CCIP-BnM tokens, but you can reuse the same example to transfer other tokens as long as they are supported for your [lane](/ccip/concepts#lane).
 
 For this example, CCIP fees are paid in LINK tokens. To learn how to pay CCIP fees in native AVAX, read the [Pay in native](#transfer-tokens-and-pay-in-native) section. To see a detailed description of the example code, read the [code explanation](#code-explanation) section.
 
@@ -158,7 +158,7 @@ Complete the following steps in your terminal:
 
 ### Transfer tokens and pay in native
 
-In this example, you will transfer CCIP-BnM tokens from your EOA on _Avalanche Fuji_ to an account on _Ethereum Sepolia_. The destination account could be an [EOA (Externally Owned Account)](https://ethereum.org/en/developers/docs/accounts/#types-of-account) or a smart contract. The example shows how to transfer LINK tokens, but you can re-use the same example to transfer other tokens as long as they are supported for your [lane](/ccip/concepts#lane).
+In this example, you will transfer CCIP-BnM tokens from your EOA on _Avalanche Fuji_ to an account on _Ethereum Sepolia_. The destination account could be an [EOA (Externally Owned Account)](https://ethereum.org/en/developers/docs/accounts/#types-of-account) or a smart contract. The example shows how to transfer LINK tokens, but you can reuse the same example to transfer other tokens as long as they are supported for your [lane](/ccip/concepts#lane).
 
 For this example, CCIP fees are paid in Sepolia's native ETH. To learn how to pay CCIP fees in LINK, read the [Pay in LINK](#transfer-tokens-and-pay-in-link) section. To see a detailed description of the example code, read the [code explanation](#code-explanation) section.
 

--- a/src/content/chainlink-nodes/v1/node-config.mdx
+++ b/src/content/chainlink-nodes/v1/node-config.mdx
@@ -14279,7 +14279,7 @@ In EIP-1559 mode, the following changes occur to how configuration works:
 - All new transactions will be sent as type 0x2 transactions specifying a TipCap and FeeCap. Be aware that existing pending legacy transactions will continue to be gas bumped in legacy mode.
 - `BlockHistoryEstimator` will apply its calculations (gas percentile etc) to the TipCap and this value will be used for new transactions (GasPrice will be ignored)
 - `FixedPriceEstimator` will use `GasTipCapDefault` instead of `GasPriceDefault` for the tip cap
-- `FixedPriceEstimator` will use `GasFeeCapDefault` instaed of `GasPriceDefault` for the fee cap
+- `FixedPriceEstimator` will use `GasFeeCapDefault` instead of `GasPriceDefault` for the fee cap
 - `PriceMin` is ignored for new transactions and `GasTipCapMinimum` is used instead (default 0)
 - `PriceMax` still represents that absolute upper limit that Chainlink will ever spend (total) on a single tx
 - `Keeper.GasTipCapBufferPercent` is ignored in EIP-1559 mode and `Keeper.GasTipCapBufferPercent` is used instead

--- a/templates/getting-started.mdx
+++ b/templates/getting-started.mdx
@@ -13,7 +13,7 @@ Fill out the fields in the frontmatter above.
 
 - Section: What section of the top-nav this page appears in dataFeeds, vrf, automation, chainlinkFunctions, nodeOperator
 - Title: The title appearing at the top of the page
-- Whats Next: A list of pages to include in the What's Next section. Preferably imperative sentences describing the goal of the next page.
+- What's Next: A list of pages to include in the What's Next section. Preferably imperative sentences describing the goal of the next page.
   \*/}
 
 {/* Import components when necessary */}


### PR DESCRIPTION
### Changes

1. **File:** `/templates/getting-started.mdx`
    - Fixed `Whats` to `What's` (Line 16)
1. **File:** `/src/content/ccip/tutorials/transfer-tokens-from-eoa.mdx`
    - Fixed `re-use` to `reuse` (Line 78)
1. **File:** `/src/content/ccip/tutorials/cross-chain-tokens/update-rate-limiters-hardhat.mdx`
    - Fixed `Avalance` to `Avalanche` (Line 247)
1. **File:** `/src/content/chainlink-nodes/v1/node-config.mdx`
    - Fixed `instaed` to `instead` (Line 14282)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.