### PR TITLE
Remove network name from URL params

### DIFF
--- a/src/features/feeds/components/FeedList.tsx
+++ b/src/features/feeds/components/FeedList.tsx
@@ -24,10 +24,11 @@ export const FeedList = ({
   initialCache?: Record<string, ChainMetadata>
 }) => {
   const chains = ecosystem === "deprecating" ? ALL_CHAINS : CHAINS
+  const isStreams = dataFeedType === "streamsCrypto" || dataFeedType === "streamsRwa"
 
   const [selectedChain, setSelectedChain] = useQueryString(
-    "network",
-    ecosystem === "deprecating" ? chains[0].page : initialNetwork
+    isStreams ? "" : "network",
+    isStreams ? "" : ecosystem === "deprecating" ? chains[0].page : initialNetwork
   )
   const [searchValue, setSearchValue] = useQueryString("search", "")
   const [selectedFeedCategories, setSelectedFeedCategories] = useQueryString("categories", [])
@@ -51,12 +52,16 @@ export const FeedList = ({
     { key: "NAVLink", name: "NAVLink" },
     { key: "SmartAUM", name: "SmartAUM" },
   ]
-  const chain = chains.filter((chain) => chain.page === selectedChain)[0]
+  const [streamsChain] = useState(initialNetwork)
+  const activeChain = isStreams ? streamsChain : selectedChain
+  const chain = chains.filter((chain) => chain.page === activeChain)[0]
   const chainMetadata = useGetChainMetadata(chain, initialCache && initialCache[chain.page])
   const wrapperRef = useRef(null)
 
   function handleNetworkSelect(chain: Chain) {
-    setSelectedChain(chain.page)
+    if (!isStreams) {
+      setSelectedChain(chain.page)
+    }
     setSearchValue("")
     setSelectedFeedCategories([])
     setCurrentPage("1")
@@ -104,7 +109,6 @@ export const FeedList = ({
   }
 
   useOutsideAlerter(wrapperRef)
-  const isStreams = dataFeedType === "streamsCrypto" || dataFeedType === "streamsRwa"
   const isSmartData = dataFeedType === "smartdata"
   const isRates = dataFeedType === "rates"
   const isDeprecating = ecosystem === "deprecating"


### PR DESCRIPTION
This pull request includes updates to the `FeedList` component in `src/features/feeds/components/FeedList.tsx` to enhance the handling of different data feed types, specifically for "streamsCrypto" and "streamsRwa". The most important changes include the introduction of a new state variable for streams, adjustments to the network selection logic, and the reorganization of the `isStreams` variable.

Enhancements to data feed type handling:

* Introduced a new constant `isStreams` to determine if the `dataFeedType` is "streamsCrypto" or "streamsRwa", and adjusted the initial value of `selectedChain` based on this condition.
* Added a new state variable `streamsChain` for handling the initial network when `dataFeedType` is a stream, and updated the `activeChain` and `chain` variables accordingly.
* Moved the declaration of the `isStreams` variable to a higher scope to ensure it is defined before its usage.