### PR TITLE
Refactor: move some feed metadata from docs to root level

### DIFF
--- a/src/features/feeds/components/Tables.tsx
+++ b/src/features/feeds/components/Tables.tsx
@@ -139,7 +139,7 @@ const DefaultTr = ({ network, proxy, showExtraDetails, isTestnet = false }) => (
   <tr>
     <td className={tableStyles.pairCol}>
       <div className={tableStyles.assetPair}>
-        {feedCategories[proxy.docs.feedCategory] || ""}
+        {feedCategories[proxy.feedCategory] || ""}
         {proxy.name}
       </div>
       {proxy.docs.shutdownDate && (
@@ -182,21 +182,21 @@ const DefaultTr = ({ network, proxy, showExtraDetails, isTestnet = false }) => (
       {!isTestnet && (
         <div>
           <dl className={tableStyles.listContainer}>
-            {proxy.docs.assetName && (
+            {proxy.assetName && (
               <div className={tableStyles.definitionGroup}>
                 <dt>
                   <span className="label">Asset name:</span>
                 </dt>
-                <dd>{proxy.docs.assetName}</dd>
+                <dd>{proxy.assetName}</dd>
               </div>
             )}
-            {proxy.docs.feedType && (
+            {proxy.feedType && (
               <div className={tableStyles.definitionGroup}>
                 <dt>
                   <span className="label">Asset type:</span>
                 </dt>
                 <dd>
-                  {proxy.docs.feedType}
+                  {proxy.feedType}
                   {proxy.docs.assetSubClass === "UK" ? " - " + proxy.docs.assetSubClass : ""}
                 </dd>
               </div>
@@ -906,11 +906,11 @@ export const MainnetTable = ({
       if (isDeprecating) return !!chain.docs.shutdownDate
 
       if (dataFeedType === "streamsCrypto") {
-        return chain.contractType === "verifier" && chain.docs.feedType === "Crypto"
+        return chain.contractType === "verifier" && chain.feedType === "Crypto"
       }
 
       if (dataFeedType === "streamsRwa") {
-        return chain.contractType === "verifier" && chain.docs.feedType === "Forex"
+        return chain.contractType === "verifier" && chain.feedType === "Forex"
       }
 
       if (isSmartData) {
@@ -1017,10 +1017,10 @@ export const TestnetTable = ({
     .filter((chain) => {
       if (isStreams) {
         if (dataFeedType === "streamsCrypto") {
-          return chain.contractType === "verifier" && chain.docs.feedType === "Crypto"
+          return chain.contractType === "verifier" && chain.feedType === "Crypto"
         }
         if (dataFeedType === "streamsRwa") {
-          return chain.contractType === "verifier" && chain.docs.feedType === "Forex"
+          return chain.contractType === "verifier" && chain.feedType === "Forex"
         }
       }
       if (isSmartData) return !!chain.docs.porType


### PR DESCRIPTION
This pull request includes changes to the `src/features/feeds/components/Tables.tsx` file to simplify the code by removing redundant `docs` references and directly accessing properties from the `proxy` and `chain` objects. 

The most important changes include:

Code simplification:
* [`src/features/feeds/components/Tables.tsx`](diffhunk://#diff-ef3526edcbc07ee07216ef3f69138a4fcf75429e5783f0a1ce8f4fb960c82904L142-R142): Modified the `DefaultTr` component to access `feedCategory`, `assetName`, and `feedType` directly from the `proxy` object instead of through `proxy.docs`. [[1]](diffhunk://#diff-ef3526edcbc07ee07216ef3f69138a4fcf75429e5783f0a1ce8f4fb960c82904L142-R142) [[2]](diffhunk://#diff-ef3526edcbc07ee07216ef3f69138a4fcf75429e5783f0a1ce8f4fb960c82904L185-R199)
* [`src/features/feeds/components/Tables.tsx`](diffhunk://#diff-ef3526edcbc07ee07216ef3f69138a4fcf75429e5783f0a1ce8f4fb960c82904L909-R913): Modified the `MainnetTable` and `TestnetTable` components to access `feedType` directly from the `chain` object instead of through `chain.docs`. [[1]](diffhunk://#diff-ef3526edcbc07ee07216ef3f69138a4fcf75429e5783f0a1ce8f4fb960c82904L909-R913) [[2]](diffhunk://#diff-ef3526edcbc07ee07216ef3f69138a4fcf75429e5783f0a1ce8f4fb960c82904L1020-R1023)