### PR TITLE
Fix broken link

### DIFF
--- a/src/content/data-feeds/l2-sequencer-feeds.mdx
+++ b/src/content/data-feeds/l2-sequencer-feeds.mdx
@@ -7,7 +7,7 @@ title: "L2 Sequencer Uptime Feeds"
 import { ClickToZoom, CodeSample } from "@components"
 import { Aside } from "@components"
 
-Optimistic rollup protocols move all execution off the layer 1 (L1) Ethereum chain, complete execution on a layer 2 (L2) chain, and return the results of the L2 execution back to the L1. These protocols have a [sequencer](https://community.optimism.io/docs/protocol/2-rollup-protocol/) that executes and rolls up the L2 transactions by batching multiple transactions into a single transaction.
+Optimistic rollup protocols move all execution off the layer 1 (L1) Ethereum chain, complete execution on a layer 2 (L2) chain, and return the results of the L2 execution back to the L1. These protocols have a [sequencer](https://docs.optimism.io/stack/rollup/overview) that executes and rolls up the L2 transactions by batching multiple transactions into a single transaction.
 
 If a sequencer becomes unavailable, it is impossible to access read/write APIs that consumers are using and applications on the L2 network will be down for most users without interacting directly through the L1 optimistic rollup contracts. The L2 has not stopped, but it would be unfair to continue providing service on your applications when only a few users can use them.
 


### PR DESCRIPTION
I found a broken link in the documentation. In the official Discord, I was advised to replace it with this: [https://docs.optimism.io/stack/rollup/overview]. If you have any other suggestions or disagree with this change, please share your version, and I will update it accordingly.