### PR TITLE
CCIP: SAS token

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -1344,6 +1344,20 @@
             }
           }
         },
+        "SAS": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SDT": {
           "rateLimiterConfig": {
             "in": {
@@ -1650,37 +1664,7 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": false,
-      "supportedTokens": {
-        "SolvBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "60000000000000000000",
-              "isEnabled": true,
-              "rate": "694440000000000"
-            },
-            "out": {
-              "capacity": "60000000000000000000",
-              "isEnabled": true,
-              "rate": "694440000000000"
-            }
-          }
-        },
-        "SolvBTC.BBN": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "60000000000000000000",
-              "isEnabled": true,
-              "rate": "694440000000000"
-            },
-            "out": {
-              "capacity": "60000000000000000000",
-              "isEnabled": true,
-              "rate": "694440000000000"
-            }
-          }
-        }
-      }
+      "rmnPermeable": false
     },
     "sonic-mainnet": {
       "offRamp": {
@@ -6179,9 +6163,9 @@
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             },
             "out": {
               "capacity": "2500000000000000000",
@@ -6193,9 +6177,9 @@
         "SolvBTC.BBN": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             },
             "out": {
               "capacity": "2500000000000000000",
@@ -6221,28 +6205,28 @@
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             },
             "out": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             }
           }
         },
         "SolvBTC.BBN": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             },
             "out": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             }
           }
         }
@@ -6263,28 +6247,28 @@
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             },
             "out": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             }
           }
         },
         "SolvBTC.BBN": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             },
             "out": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             }
           }
         }
@@ -6359,28 +6343,28 @@
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             },
             "out": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             }
           }
         },
         "SolvBTC.BBN": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             },
             "out": {
-              "capacity": "15000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694400000000000"
+              "rate": "115740000000000"
             }
           }
         }
@@ -7998,9 +7982,9 @@
               "rate": "1736100000000000"
             },
             "out": {
-              "capacity": "150000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "1736100000000000"
+              "rate": "115740000000000"
             }
           }
         },
@@ -8012,9 +7996,9 @@
               "rate": "1736100000000000"
             },
             "out": {
-              "capacity": "150000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "1736100000000000"
+              "rate": "115740000000000"
             }
           }
         },
@@ -8433,6 +8417,20 @@
               "capacity": "500000000000000000000",
               "isEnabled": true,
               "rate": "46000000000000000"
+            }
+          }
+        },
+        "SAS": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -11356,7 +11354,23 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": true
+      "rmnPermeable": true,
+      "supportedTokens": {
+        "SAS": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
+      }
     },
     "soneium-mainnet": {
       "offRamp": {
@@ -12634,7 +12648,23 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": false
+      "rmnPermeable": false,
+      "supportedTokens": {
+        "SAS": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
+      }
     }
   },
   "soneium-mainnet": {
@@ -12648,37 +12678,7 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": false,
-      "supportedTokens": {
-        "SolvBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "60000000000000000000",
-              "isEnabled": true,
-              "rate": "694440000000000"
-            },
-            "out": {
-              "capacity": "60000000000000000000",
-              "isEnabled": true,
-              "rate": "694440000000000"
-            }
-          }
-        },
-        "SolvBTC.BBN": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "60000000000000000000",
-              "isEnabled": true,
-              "rate": "694440000000000"
-            },
-            "out": {
-              "capacity": "60000000000000000000",
-              "isEnabled": true,
-              "rate": "694440000000000"
-            }
-          }
-        }
-      }
+      "rmnPermeable": false
     },
     "celo-mainnet": {
       "offRamp": {
@@ -12726,9 +12726,9 @@
               "rate": "694440000000000"
             },
             "out": {
-              "capacity": "60000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694440000000000"
+              "rate": "115740000000000"
             }
           }
         },
@@ -12740,9 +12740,9 @@
               "rate": "694440000000000"
             },
             "out": {
-              "capacity": "60000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "694440000000000"
+              "rate": "115740000000000"
             }
           }
         }
@@ -12966,9 +12966,9 @@
               "rate": "3472000000000000"
             },
             "out": {
-              "capacity": "300000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "3472000000000000"
+              "rate": "115740000000000"
             }
           }
         },
@@ -12980,9 +12980,9 @@
               "rate": "3472000000000000"
             },
             "out": {
-              "capacity": "300000000000000000000",
+              "capacity": "2500000000000000000",
               "isEnabled": true,
-              "rate": "3472000000000000"
+              "rate": "115740000000000"
             }
           }
         },

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -1613,6 +1613,35 @@
       "tokenAddress": "0x0AA1e96D2a46Ec6beB2923dE1E61Addf5F5f1dce"
     }
   },
+  "SAS": {
+    "bsc-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "ShibArmyStrong",
+      "poolAddress": "0xd13129ee86f6285d51F66196A02a929E2be977a4",
+      "poolType": "burnMint",
+      "symbol": "SAS",
+      "tokenAddress": "0x28BE7E8cD8125CB7A74D2002A5862E1bfd774cd9"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "ShibArmyStrong",
+      "poolAddress": "0x89F39cdbad48b6531DDBd38ea0D84E9c9CbCdA27",
+      "poolType": "lockRelease",
+      "symbol": "SAS",
+      "tokenAddress": "0x28BE7E8cD8125CB7A74D2002A5862E1bfd774cd9"
+    },
+    "shibarium-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "ShibArmyStrong",
+      "poolAddress": "0xab8B05d4d7d31b28d9973C5CD2965b9e48a2a35d",
+      "poolType": "burnMint",
+      "symbol": "SAS",
+      "tokenAddress": "0x7E315C269F7849F80824755A666DC6fb4Ba8BEe1"
+    }
+  },
   "SD": {
     "ethereum-mainnet-arbitrum-1": {
       "allowListEnabled": false,


### PR DESCRIPTION
This pull request includes several changes to the `src/config/data/ccip/v1_2_0/mainnet/lanes.json` and `src/config/data/ccip/v1_2_0/mainnet/tokens.json` files. The changes primarily involve the addition of a new token configuration for "SAS" and modifications to the rate limiter configurations for existing tokens.

### New Token Configuration:
* Added configuration for the "SAS" token in various networks, including `bsc-mainnet`, `mainnet`, and `shibarium-mainnet`.

### Rate Limiter Adjustments:
* Reduced the `capacity` and `rate` for `SolvBTC` and `SolvBTC.BBN` from `15000000000000000000` to `2500000000000000000` and from `694400000000000` to `115740000000000` respectively in multiple instances. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L6182-R6168) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L6196-R6182) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L6224-R6229) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L6266-R6271) [[5]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L6362-R6367)
* Reduced the `capacity` and `rate` for `SolvBTC` in `celo-mainnet` from `60000000000000000000` to `2500000000000000000` and from `694440000000000` to `115740000000000` respectively. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L12729-R12731) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L12743-R12745)
* Reduced the `capacity` and `rate` for `SolvBTC` in `sonic-mainnet` from `300000000000000000000` to `2500000000000000000` and from `3472000000000000` to `115740000000000` respectively. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L12969-R12971) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L12983-R12985)

### Removal of Unsupported Tokens:
* Removed the `supportedTokens` configuration for `SolvBTC` and `SolvBTC.BBN` from the bsc <-> soneium. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L1653-R1667) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L12651-R12681)

### Addition of Rate Limiter Configurations:
* Added rate limiter configurations for the "SAS" token with zero capacity and rate, and disabled status in multiple instances. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R1347-R1360) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R8423-R8436) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L11359-R11373) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L12637-R12667)