### PR TITLE
FIX: Imports for Functions are available on Mainnet

### DIFF
--- a/src/content/chainlink-functions/tutorials/simple-computation.mdx
+++ b/src/content/chainlink-functions/tutorials/simple-computation.mdx
@@ -94,7 +94,7 @@ To run the example:
 
 #### source.js
 
-The Decentralized Oracle Network will run the [JavaScript code](https://github.com/smartcontractkit/smart-contract-examples/blob/main/functions-examples/examples/1-simple-computation/source.js). The code is self-explanatory and has comments to help you understand all the steps. **Note**: Functions requests with custom source code can use vanilla [Deno](https://deno.land/) but cannot use any require statements. Import statements and imported modules are supported only on testnets.
+The Decentralized Oracle Network will run the [JavaScript code](https://github.com/smartcontractkit/smart-contract-examples/blob/main/functions-examples/examples/1-simple-computation/source.js). The code is self-explanatory and has comments to help you understand all the steps. **Note**: Functions requests with custom source code can use vanilla [Deno](https://deno.land/) but cannot use any require statements.
 
 The main steps are:
 

--- a/src/content/chainlink-functions/tutorials/simple-computation.mdx
+++ b/src/content/chainlink-functions/tutorials/simple-computation.mdx
@@ -94,7 +94,7 @@ To run the example:
 
 #### source.js
 
-The Decentralized Oracle Network will run the [JavaScript code](https://github.com/smartcontractkit/smart-contract-examples/blob/main/functions-examples/examples/1-simple-computation/source.js). The code is self-explanatory and has comments to help you understand all the steps. **Note**: Functions requests with custom source code can use vanilla [Deno](https://deno.land/) but cannot use any require statements.
+The Decentralized Oracle Network will run the [JavaScript code](https://github.com/smartcontractkit/smart-contract-examples/blob/main/functions-examples/examples/1-simple-computation/source.js). The code is self-explanatory and has comments to help you understand all the steps.
 
 The main steps are:
 

--- a/src/features/chainlink-functions/common/DenoImportNotes.mdx
+++ b/src/features/chainlink-functions/common/DenoImportNotes.mdx
@@ -1,8 +1,7 @@
 import { Aside } from "@components"
 
 <Aside type="note">
-  Functions requests with custom source code can use vanilla [Deno](https://deno.com/). Import statements and imported
-  modules are supported only on testnets. You cannot use any require statements.
+  Functions requests with custom source code can use vanilla [Deno](https://deno.com/). You cannot use any require statements.
   
   It is important to understand that importing an NPM package into Deno does not automatically ensure full compatibility. Deno and Node.js have distinct architectures and module systems. While some NPM packages might function without issues, others may need modifications or overrides, especially those relying on Node.js-specific APIs or features Deno does not support.
 

--- a/src/features/chainlink-functions/common/DenoImportNotes.mdx
+++ b/src/features/chainlink-functions/common/DenoImportNotes.mdx
@@ -1,7 +1,6 @@
 import { Aside } from "@components"
 
 <Aside type="note">
-  Functions requests with custom source code can use vanilla [Deno](https://deno.com/). You cannot use any require statements.
   
   It is important to understand that importing an NPM package into Deno does not automatically ensure full compatibility. Deno and Node.js have distinct architectures and module systems. While some NPM packages might function without issues, others may need modifications or overrides, especially those relying on Node.js-specific APIs or features Deno does not support.
 


### PR DESCRIPTION

## Description

Removed the warning that imports are only available on Testnet.
