### PR TITLE
fix dead link detect-new-tokens.ts

### DIFF
--- a/src/scripts/ccip/detect-new-tokens.ts
+++ b/src/scripts/ccip/detect-new-tokens.ts
@@ -195,7 +195,7 @@ const DEFAULT_LOG_LEVEL = "INFO"
 /** URL constants */
 const URL_CONSTANTS = {
   /** Template URL for token documentation */
-  DOC_URL_TEMPLATE: "https://docs.chain.link/ccip/directory/mainnet/token/",
+  DOC_URL_TEMPLATE: "https://docs.chain.link/ccip/directory/mainnet",
 }
 
 /** Paths for temporary and output files */


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL. 
https://docs.chain.link/ccip/directory/mainnet/token/ - old link
https://docs.chain.link/ccip/directory/mainnet - new link