### PR TITLE
Fix typo: p2pv2Boostrappers -> p2pv2Bootstrappers

### DIFF
--- a/src/content/chainlink-nodes/oracle-jobs/all-jobs.mdx
+++ b/src/content/chainlink-nodes/oracle-jobs/all-jobs.mdx
@@ -307,9 +307,10 @@ See [shared fields](/chainlink-nodes/oracle-jobs/jobs/#shared-fields).
 
   `p2pBootstrapPeers = [ "/dns4/HOST_NAME_OR_IP/tcp/PORT/p2p/BOOTSTRAP_NODE'S_P2P_ID" ]`
 
-- `p2pv2Boostrappers`: A list of libp2p dial addresses of the other bootstrap nodes helping oracle nodes find one another on the network. It is used with P2P networking stack V2 as follows:
+- `p2pv2Bootstrappers`: A list of libp2p dial addresses of the other bootstrap nodes helping oracle nodes find one another on the network. It is used with P2P networking stack V2 as follows:
 
-  `p2pv2Boostrappers = [ "BOOTSTRAP_NODE'S_P2P_ID@HOST_NAME_OR_IP:PORT" ]`
+  `p2pv2Bootstrappers = [ "BOOTSTRAP_NODE'S_P2P_ID@HOST_NAME_OR_IP:PORT" ]`
+  
 
 - `isBootstrapPeer`: This must be set to `true`.
 
@@ -377,9 +378,9 @@ See [shared fields](/chainlink-nodes/oracle-jobs/jobs/#shared-fields).
 - `p2pBootstrapPeers`: A list of libp2p dial addresses of the other bootstrap nodes helping oracle nodes find one another on the network. It is used with P2P networking stack V1 as follows:
   `p2pBootstrapPeers = [ "/dns4/<host name or ip>/tcp/<port>/p2p/<bootstrap node's P2P ID>" ]`
 
-- `p2pv2Boostrappers`: A list of libp2p dial addresses of the other bootstrap nodes helping oracle nodes find one another on the network. It is used with P2P networking stack V2 as follows:
+- `p2pv2Bootstrappers`: A list of libp2p dial addresses of the other bootstrap nodes helping oracle nodes find one another on the network. It is used with P2P networking stack V2 as follows:
 
-  `p2pv2Boostrappers = [ "<bootstrap node's P2P ID>@<host name or ip>:<port>" ]`
+  `p2pv2Bootstrappers = [ "<bootstrap node's P2P ID>@<host name or ip>:<port>" ]`
 
 - `keyBundleID`: The hash of the OCR key bundle to be used by this node. The Chainlink node keystore manages these key bundles. Use the node **Key Management** UI or the `chainlink keys ocr` sub-commands in the CLI to create and manage key bundles.
 - `monitoringEndpoint`: The URL of the telemetry endpoint to send OCR metrics to.


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.Any change needs to be discussed before proceeding.**


## Description

Fixes a typo on https://docs.chain.link/chainlink-nodes/oracle-jobs/all-jobs#offchain-reporting-jobs

## Changes

Fix typo: `p2pv2Boostrappers` --> `p2pv2Bootstrappers`