### PR TITLE
liquid mainnet

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -300,6 +300,26 @@
   "data": [
     {
       "category": "integration",
+      "date": "2025-06-27",
+      "description": "Chainlink CCIP expands support to new blockchains:",
+      "newNetworks": [
+        {
+          "displayName": "Hyperliquid Mainnet",
+          "network": "hyperliquid",
+          "url": "https://docs.chain.link/ccip/directory/mainnet/chain/hyperliquid-mainnet"
+        },
+        {
+          "displayName": "Hyperliquid Testnet",
+          "network": "hyperliquid",
+          "url": "https://docs.chain.link/ccip/directory/testnet/chain/hyperliquid-testnet"
+        }
+      ],
+      "relatedNetworks": ["hyperliquid"],
+      "title": "CCIP on Hyperliquid Mainnet and Testnet",
+      "topic": "CCIP"
+    },
+    {
+      "category": "integration",
       "date": "2025-06-22",
       "description": "Newly supported tokens: EmCH, SDM, WLD, xSILO",
       "relatedTokens": [

--- a/src/components/QuickLinks/data/productChainLinks.ts
+++ b/src/components/QuickLinks/data/productChainLinks.ts
@@ -85,6 +85,7 @@ export const productChainLinks: ProductChainLinks = {
       neox: "/ccip/directory/testnet/chain/neox-testnet-t4",
       polygonkatana: "/ccip/directory/testnet/chain/polygon-testnet-tatara",
       "0g": "/ccip/directory/testnet/chain/0g-testnet-galileo",
+      hyperliquid: "/ccip/directory/mainnet/chain/hyperliquid-mainnet",
     },
   },
   "Data Feeds": {
@@ -283,6 +284,7 @@ export const productChainLinks: ProductChainLinks = {
     neox: "/resources/link-token-contracts#neo-x",
     polygonkatana: "/resources/link-token-contracts#polygon-katana",
     "0g": "/resources/link-token-contracts#0g",
+    hyperliquid: "/resources/link-token-contracts#hyperliquid",
   },
 }
 

--- a/src/config/data/ccip/v1_2_0/mainnet/chains.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/chains.json
@@ -879,6 +879,30 @@
       "version": "1.5.1"
     }
   },
+  "hyperliquid-mainnet": {
+    "armProxy": {
+      "address": "0x07f15e9813FBd007d38CF534133C0838f449ecFA",
+      "version": "1.5.0"
+    },
+    "chainSelector": "2442541497099098535",
+    "feeTokens": ["LINK", "WHYPE"],
+    "registryModule": {
+      "address": "0xbAb3aBB5F29275065F2814F1f4B10Ffc1284fFEf",
+      "version": "1.5.0"
+    },
+    "router": {
+      "address": "0x13b3332b66389B1467CA6eBd6fa79775CCeF65ec",
+      "version": "1.2.0"
+    },
+    "tokenAdminRegistry": {
+      "address": "0xcE44363496ABc3a9e53B3F404a740F992D977bDF",
+      "version": "1.5.0"
+    },
+    "tokenPoolFactory": {
+      "address": "0x1C2a560009253Bb5e7AF6e021Ea31E53ee8F2E90",
+      "version": "1.5.1"
+    }
+  },
   "lens-mainnet": {
     "armProxy": {
       "address": "0xE187a792bbf76232A307d8E44615973C849E25A0",

--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -2859,14 +2859,14 @@
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             },
             "out": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             }
           }
         },
@@ -3125,14 +3125,14 @@
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             },
             "out": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             }
           }
         },
@@ -5279,14 +5279,14 @@
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             },
             "out": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             }
           }
         },
@@ -5807,14 +5807,14 @@
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             },
             "out": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             }
           }
         },
@@ -8119,14 +8119,14 @@
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             },
             "out": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             }
           }
         },
@@ -8607,14 +8607,14 @@
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             },
             "out": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             }
           }
         },
@@ -9895,14 +9895,14 @@
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             },
             "out": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             }
           }
         },
@@ -14695,6 +14695,20 @@
       "rmnPermeable": true
     }
   },
+  "hyperliquid-mainnet": {
+    "mainnet": {
+      "offRamp": {
+        "address": "0xf69F5e554E6D3D90DC3a221121ffEf1ee8bf5B2A",
+        "version": "1.5.0"
+      },
+      "onRamp": {
+        "address": "0x375dDf245FB9951A1D1D4EF516Abd7D2B521238F",
+        "enforceOutOfOrder": false,
+        "version": "1.5.0"
+      },
+      "rmnPermeable": true
+    }
+  },
   "lens-mainnet": {
     "mainnet": {
       "offRamp": {
@@ -17609,14 +17623,14 @@
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             },
             "out": {
-              "capacity": "500000000000",
+              "capacity": "1000000000000",
               "isEnabled": true,
-              "rate": "138880000"
+              "rate": "277770000"
             }
           }
         },
@@ -18907,6 +18921,18 @@
       },
       "onRamp": {
         "address": "0x7d7C4933f17B414f50C97d1a8862A1ace82557B3",
+        "enforceOutOfOrder": false,
+        "version": "1.5.0"
+      },
+      "rmnPermeable": true
+    },
+    "hyperliquid-mainnet": {
+      "offRamp": {
+        "address": "0x69c3619326d5DF0d5abB752f2AE629413811ccD1",
+        "version": "1.5.0"
+      },
+      "onRamp": {
+        "address": "0xC4a125BDBeE19Ec8BE02502cff9310FF9395905B",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -1940,6 +1940,14 @@
       "symbol": "LINK",
       "tokenAddress": "0x63dbE12A6381D64adE47bc3D92aBF4393DFF4BC8"
     },
+    "hyperliquid-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "ChainLink Token",
+      "poolType": "feeTokenOnly",
+      "symbol": "LINK",
+      "tokenAddress": "0x1AC2EE68b8d038C982C1E1f73F596927dd70De59"
+    },
     "lens-mainnet": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -5122,6 +5130,16 @@
       "tokenAddress": "0x9eC02756A559700d8D9e79ECe56809f7bcC5dC27"
     }
   },
+  "WHYPE": {
+    "hyperliquid-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Wrapped HYPE",
+      "poolType": "feeTokenOnly",
+      "symbol": "WHYPE",
+      "tokenAddress": "0x5555555555555555555555555555555555555555"
+    }
+  },
   "WLD": {
     "ethereum-mainnet-worldchain-1": {
       "allowListEnabled": false,
@@ -5187,7 +5205,7 @@
       "allowListEnabled": false,
       "decimals": 6,
       "name": "WorldMobileToken",
-      "poolAddress": "0x54Fa21f0F88076A98f1b1e6757bc00c43F49AF28",
+      "poolAddress": "0x0C03636614fe25278786e363643Ee5D4260C9eFE",
       "poolType": "burnMint",
       "symbol": "WMTX",
       "tokenAddress": "0xDBB5Cf12408a3Ac17d668037Ce289f9eA75439D7"
@@ -5196,7 +5214,7 @@
       "allowListEnabled": false,
       "decimals": 6,
       "name": "WorldMobileToken",
-      "poolAddress": "0x5936748Dc69A095f95BE095a832393FDc9c8270D",
+      "poolAddress": "0xF32C2942Cb14Dc47DB8d0387A089948171Bb8F05",
       "poolType": "burnMint",
       "symbol": "WMTX",
       "tokenAddress": "0xDBB5Cf12408a3Ac17d668037Ce289f9eA75439D7"
@@ -5205,7 +5223,7 @@
       "allowListEnabled": false,
       "decimals": 6,
       "name": "WorldMobileToken",
-      "poolAddress": "0xB90079D2A2872122da0c8235110249127cAcd54D",
+      "poolAddress": "0x7adF83556CE7141BaB0eFdA46DB40C5d5840eBe7",
       "poolType": "burnMint",
       "symbol": "WMTX",
       "tokenAddress": "0x3e31966d4f81C72D2a55310A6365A56A4393E98D"
@@ -5214,7 +5232,7 @@
       "allowListEnabled": false,
       "decimals": 6,
       "name": "WorldMobileToken",
-      "poolAddress": "0x485858BA818aab8744f2932A4982bfB0E7Db0005",
+      "poolAddress": "0x229a1956929489870A31b01854a80EF9B0fd27c9",
       "poolType": "burnMint",
       "symbol": "WMTX",
       "tokenAddress": "0xDBB5Cf12408a3Ac17d668037Ce289f9eA75439D7"

--- a/src/config/data/ccip/v1_2_0/testnet/chains.json
+++ b/src/config/data/ccip/v1_2_0/testnet/chains.json
@@ -1020,6 +1020,30 @@
       "version": "1.5.0"
     }
   },
+  "hyperliquid-testnet": {
+    "armProxy": {
+      "address": "0x29BF4b8Ab30b7293bAbd5280999f1F055FF4420A",
+      "version": "1.5.0"
+    },
+    "chainSelector": "4286062357653186312",
+    "feeTokens": ["LINK", "WHYPE"],
+    "registryModule": {
+      "address": "0x335c0f663683DCDDE0Eea7cFEb00E4a402ee07b7",
+      "version": "1.5.0"
+    },
+    "router": {
+      "address": "0xC1bfda59F0D6dD9f7D0A24c5a7AAfED3945A8ed6",
+      "version": "1.2.0"
+    },
+    "tokenAdminRegistry": {
+      "address": "0xFeA0ADAd87BD3431521De21467781592cD2Bf209",
+      "version": "1.5.0"
+    },
+    "tokenPoolFactory": {
+      "address": "0x2AB798B96F46423d65c5586ECc2F24B8239E1dE6",
+      "version": "1.5.1"
+    }
+  },
   "ink-testnet-sepolia": {
     "armProxy": {
       "address": "0x84017cfddD12D319E5bBf090e0de6d55B78160Cb",

--- a/src/config/data/ccip/v1_2_0/testnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/testnet/lanes.json
@@ -2586,6 +2586,18 @@
       },
       "rmnPermeable": true
     },
+    "hyperliquid-testnet": {
+      "offRamp": {
+        "address": "0x47be0AB5B7Bc0F7d4e1ccB05639E4D8AB2EAF2f5",
+        "version": "1.5.0"
+      },
+      "onRamp": {
+        "address": "0x621965545A30C6c04D532CB3e7E4d0BCd33e47DC",
+        "enforceOutOfOrder": false,
+        "version": "1.5.0"
+      },
+      "rmnPermeable": true
+    },
     "ink-testnet-sepolia": {
       "offRamp": {
         "address": "0x6271096998d2aE68985687834f7aF0096D4C6C85",
@@ -5379,6 +5391,20 @@
       },
       "onRamp": {
         "address": "0x2b771F61faBea82C189F92ca934aB2a64a809735",
+        "enforceOutOfOrder": false,
+        "version": "1.5.0"
+      },
+      "rmnPermeable": true
+    }
+  },
+  "hyperliquid-testnet": {
+    "ethereum-testnet-sepolia": {
+      "offRamp": {
+        "address": "0x82cceB58b28B7a7BaFc7927171e782d4ACE92641",
+        "version": "1.5.0"
+      },
+      "onRamp": {
+        "address": "0xD83265064337811d55297f5e340d161F6feDc596",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },

--- a/src/config/data/ccip/v1_2_0/testnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/testnet/tokens.json
@@ -923,6 +923,14 @@
       "symbol": "LINK",
       "tokenAddress": "0x5246409a2e09134824c4E709602205B176491e57"
     },
+    "hyperliquid-testnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "ChainLink Token",
+      "poolType": "feeTokenOnly",
+      "symbol": "LINK",
+      "tokenAddress": "0xDD311DBec8A24EdFabf5F985845a75F42e8f9544"
+    },
     "ink-testnet-sepolia": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -1589,6 +1597,16 @@
       "poolType": "feeTokenOnly",
       "symbol": "WHSK",
       "tokenAddress": "0x2896e619Fa7c831A7E52b87EffF4d671bEc6B262"
+    }
+  },
+  "WHYPE": {
+    "hyperliquid-testnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Wrapped HYPE",
+      "poolType": "feeTokenOnly",
+      "symbol": "WHYPE",
+      "tokenAddress": "0x5555555555555555555555555555555555555555"
     }
   },
   "WMAGIC": {

--- a/src/content/resources/link-token-contracts.mdx
+++ b/src/content/resources/link-token-contracts.mdx
@@ -732,9 +732,19 @@ Testnet Native and LINK is available at [faucets.chain.link/hedera-testnet](http
 | :-------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Chain ID  | `999`                                                                                                                                                                                                |
 | Address   | <Address contractUrl="https://app.hyperliquid.xyz/explorer/address/0x1AC2EE68b8d038C982C1E1f73F596927dd70De59" urlId="999_0x1AC2EE68b8d038C982C1E1f73F596927dd70De59" urlClass="erc-token-address"/> |
-| Name      | Chainlink Token on Hemi Mainnet Testnet                                                                                                                                                              |
+| Name      | Chainlink Token                                                                                                                                                                                      |
 | Symbol    | LINK                                                                                                                                                                                                 |
 | Decimals  | 18                                                                                                                                                                                                   |
+
+### Hyperliquid Testnet
+
+| Parameter | Value                                                                                                                                                                                                        |
+| :-------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Chain ID  | `998`                                                                                                                                                                                                        |
+| Address   | <Address contractUrl="https://app.hyperliquid-testnet.xyz/explorer/address/0xDD311DBec8A24EdFabf5F985845a75F42e8f9544" urlId="998_0xDD311DBec8A24EdFabf5F985845a75F42e8f9544" urlClass="erc-token-address"/> |
+| Name      | Chainlink Token                                                                                                                                                                                              |
+| Symbol    | LINK                                                                                                                                                                                                         |
+| Decimals  | 18                                                                                                                                                                                                           |
 
 ## <img src="/assets/chains/ink.svg" style="height: 24px; width: auto; margin-right: 8px;" />Ink
 


### PR DESCRIPTION
This pull request introduces support for the Hyperliquid Mainnet and Testnet in the Chainlink CCIP system. It includes updates to configuration files, documentation, and quick links to integrate these new networks. Additionally, it modifies rate limiter configurations for WMTX tokens and updates certain token pool addresses.

### New Network Integrations:
* Added support for Hyperliquid Mainnet and Testnet in `public/changelog.json`, with detailed metadata and links to documentation.
* Updated `src/config/data/ccip/v1_2_0/mainnet/chains.json` and `src/config/data/ccip/v1_2_0/testnet/chains.json` to include configuration details for Hyperliquid Mainnet and Testnet, such as addresses, versions, and fee tokens. [[1]](diffhunk://#diff-597b8d0301be33df45a6b4645e26f73ac96109253548dace4afaf6831828656dR882-R905) [[2]](diffhunk://#diff-b401f7649971c54aa2b2ae67a377771d1ece35ae87e9aa8d448c6d442e1cc76eR1023-R1046)

### Quick Links Updates:
* Added quick links for Hyperliquid Mainnet and Testnet in `src/components/QuickLinks/data/productChainLinks.ts`. [[1]](diffhunk://#diff-2bfbbedefca65ada6cb373ac973a5803e1deb4c0e0cbd3d4fcec908823621b91R88) [[2]](diffhunk://#diff-2bfbbedefca65ada6cb373ac973a5803e1deb4c0e0cbd3d4fcec908823621b91R287)

### Rate Limiter Configuration Changes:
* Increased the capacity and rate for WMTX tokens across multiple entries in `src/config/data/ccip/v1_2_0/mainnet/lanes.json`. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L2862-R2869) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L17612-R17633)

### Token Configuration Updates:
* Added token configuration for Hyperliquid Mainnet and Testnet, including LINK and WHYPE tokens, in `src/config/data/ccip/v1_2_0/mainnet/tokens.json` and `src/config/data/ccip/v1_2_0/testnet/tokens.json`. [[1]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R1943-R1950) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R5133-R5142) [[3]](diffhunk://#diff-c075353384fe1bbb8775ec4d8a4dd025194207d0858b70d148034a20d11a8174R926-R933) [[4]](diffhunk://#diff-c075353384fe1bbb8775ec4d8a4dd025194207d0858b70d148034a20d11a8174R1602-R1611)
* Updated pool addresses for WMTX tokens in `src/config/data/ccip/v1_2_0/mainnet/tokens.json`. [[1]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L5190-R5208) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L5199-R5217) [[3]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L5208-R5226) [[4]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L5217-R5235)

### Documentation Updates:
* Added Hyperliquid Testnet details to `src/content/resources/link-token-contracts.mdx`, including chain ID, address, and token metadata.