### PR TITLE
Fix path handling in glob pattern for cross-platform compatibility

### DIFF
--- a/src/scripts/helper/find-nonchecksummed-addresses.ts
+++ b/src/scripts/helper/find-nonchecksummed-addresses.ts
@@ -54,7 +54,7 @@ const checkFile = async (filePath: string) => {
 const processDirectories = async () => {
   try {
     for (const directoryPath of directoryPaths) {
-      const paths = await glob(directoryPath + "/**/*")
+      const paths = await glob(path.join(directoryPath, "**/*"))
 
       // Process each file
       for (const filepath of paths) {


### PR DESCRIPTION
 Replace string concatenation with path.join() when creating glob patterns to ensure correct path separators across different operating systems, especially on Windows where backslashes are used instead of forward slashes.