### PR TITLE
update

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/chains.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/chains.json
@@ -518,30 +518,6 @@
       "version": "1.5.1"
     }
   },
-  "ethereum-mainnet-kroma-1": {
-    "armProxy": {
-      "address": "0x6E4d2dBBF8a1A943412aD451422FE11A25C781DE",
-      "version": "1.0.0"
-    },
-    "chainSelector": "3719320017875267166",
-    "feeTokens": ["LINK", "WETH"],
-    "registryModule": {
-      "address": "0xF549af21578Cfe2385FFD3488B3039fd9e52f006",
-      "version": "1.6.0"
-    },
-    "router": {
-      "address": "0xE93E8B0d1b1CEB44350C8758ed1E2799CCee31aB",
-      "version": "1.2.0"
-    },
-    "tokenAdminRegistry": {
-      "address": "0x447066676A5413682a881c63aed0F03f8ACf7E45",
-      "version": "1.5.0"
-    },
-    "tokenPoolFactory": {
-      "address": "0x5931822f394baBC2AACF4588E98FC77a9f5aa8C9",
-      "version": "1.5.1"
-    }
-  },
   "ethereum-mainnet-linea-1": {
     "armProxy": {
       "address": "0x1F8fbCf559f08FE7c4076f0d68DB861e1E27f95b",

--- a/src/config/data/ccip/v1_2_0/mainnet/decom.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/decom.json
@@ -1,5 +1,8 @@
 {
   "treasure-mainnet": {
     "chainSelector": "5214452172935136222"
+  },
+  "ethereum-mainnet-kroma-1": {
+    "chainSelector": "3719320017875267166"
   }
 }

--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -3390,6 +3390,20 @@
             }
           }
         },
+        "RIZE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SDM": {
           "rateLimiterConfig": {
             "in": {
@@ -8650,6 +8664,20 @@
             }
           }
         },
+        "RIZE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SDM": {
           "rateLimiterConfig": {
             "in": {
@@ -10272,6 +10300,20 @@
             }
           }
         },
+        "RIZE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SHIB": {
           "rateLimiterConfig": {
             "in": {
@@ -10773,6 +10815,20 @@
               "capacity": "50000000000000000000000",
               "isEnabled": true,
               "rate": "83333333333300000000"
+            }
+          }
+        },
+        "RIZE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -18266,6 +18322,20 @@
             }
           }
         },
+        "RIZE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SHIB": {
           "rateLimiterConfig": {
             "in": {
@@ -22011,6 +22081,20 @@
               "capacity": "50000000000000000000000",
               "isEnabled": true,
               "rate": "83333333333300000000"
+            }
+          }
+        },
+        "RIZE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },

--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -1346,6 +1346,20 @@
             }
           }
         },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            }
+          }
+        },
         "xSolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -1988,6 +2002,20 @@
             }
           }
         },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            }
+          }
+        },
         "xSolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -2358,9 +2386,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "2",
+              "capacity": "200000000",
               "isEnabled": true,
-              "rate": "1"
+              "rate": "2315"
             }
           }
         },
@@ -3738,6 +3766,18 @@
         }
       }
     },
+    "hyperliquid-mainnet": {
+      "offRamp": {
+        "address": "0x50ceF176C2F39080b15Aa4E7f97f6BE6Fa28c5d1",
+        "version": "1.5.0"
+      },
+      "onRamp": {
+        "address": "0xfF327Ef3b73346f2AacD6ec02c70440D31fd8319",
+        "enforceOutOfOrder": false,
+        "version": "1.5.0"
+      },
+      "rmnPermeable": true
+    },
     "mainnet": {
       "offRamp": {
         "address": "0xF616733641D420207b8F30db9C4cE39684768991",
@@ -3932,6 +3972,20 @@
             }
           }
         },
+        "RIZE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SAS": {
           "rateLimiterConfig": {
             "in": {
@@ -4030,6 +4084,20 @@
             }
           }
         },
+        "TREE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "TURBO": {
           "rateLimiterConfig": {
             "in": {
@@ -4069,6 +4137,20 @@
               "capacity": "15000000000000000000000000",
               "isEnabled": true,
               "rate": "520000000000000000000"
+            }
+          }
+        },
+        "USD0": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "3000000000000000000000000",
+              "isEnabled": true,
+              "rate": "35000000000000000000"
+            },
+            "out": {
+              "capacity": "3000000000000000000000000",
+              "isEnabled": true,
+              "rate": "35000000000000000000"
             }
           }
         },
@@ -4279,6 +4361,20 @@
               "capacity": "76923077000000000000000000",
               "isEnabled": true,
               "rate": "21367520000000000000000"
+            }
+          }
+        },
+        "RIZE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -4557,6 +4653,20 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
+            }
+          }
+        },
+        "WMTX": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
+            },
+            "out": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
             }
           }
         },
@@ -8010,7 +8120,23 @@
         "enforceOutOfOrder": true,
         "version": "1.6.0"
       },
-      "rmnPermeable": true
+      "rmnPermeable": true,
+      "supportedTokens": {
+        "WMTX": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
+            },
+            "out": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
+            }
+          }
+        }
+      }
     },
     "soneium-mainnet": {
       "offRamp": {
@@ -10202,6 +10328,20 @@
             }
           }
         },
+        "STABUL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "stTAO": {
           "rateLimiterConfig": {
             "in": {
@@ -10325,6 +10465,20 @@
               "capacity": "200000000000",
               "isEnabled": true,
               "rate": "55000000"
+            }
+          }
+        },
+        "USD0": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "3000000000000000000000000",
+              "isEnabled": true,
+              "rate": "35000000000000000000"
+            },
+            "out": {
+              "capacity": "3000000000000000000000000",
+              "isEnabled": true,
+              "rate": "35000000000000000000"
             }
           }
         },
@@ -10650,6 +10804,20 @@
             }
           }
         },
+        "STABUL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "USDC": {
           "rateLimiterConfig": {
             "in": {
@@ -10969,6 +11137,34 @@
               "capacity": "5000000000000",
               "isEnabled": true,
               "rate": "1388888888"
+            }
+          }
+        },
+        "MICHI": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "10000000000000",
+              "isEnabled": true,
+              "rate": "78722220"
+            },
+            "out": {
+              "capacity": "10000000000000",
+              "isEnabled": true,
+              "rate": "78722220"
+            }
+          }
+        },
+        "WMTX": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
+            },
+            "out": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
             }
           }
         },
@@ -11973,50 +12169,6 @@
               "capacity": "50000000",
               "isEnabled": true,
               "rate": "579"
-            }
-          }
-        }
-      }
-    }
-  },
-  "ethereum-mainnet-kroma-1": {
-    "wemix-mainnet": {
-      "offRamp": {
-        "address": "0xcB154Bb4ed63FC30C416Dd16A2d1C64D8DE8DfD5",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0xf3baf38136b55F656CC5fdd4417EB6C160877104",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      },
-      "rmnPermeable": true,
-      "supportedTokens": {
-        "LINK": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "50000000000000000000000",
-              "isEnabled": true,
-              "rate": "4630000000000000000"
-            },
-            "out": {
-              "capacity": "50000000000000000000000",
-              "isEnabled": true,
-              "rate": "4630000000000000000"
-            }
-          }
-        },
-        "una.WEMIX": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "200000000000000000000000",
-              "isEnabled": true,
-              "rate": "55550000000000000000"
-            },
-            "out": {
-              "capacity": "200000000000000000000000",
-              "isEnabled": true,
-              "rate": "55550000000000000000"
             }
           }
         }
@@ -15332,6 +15484,18 @@
     }
   },
   "hyperliquid-mainnet": {
+    "bsc-mainnet": {
+      "offRamp": {
+        "address": "0x50ceF176C2F39080b15Aa4E7f97f6BE6Fa28c5d1",
+        "version": "1.5.0"
+      },
+      "onRamp": {
+        "address": "0xfF327Ef3b73346f2AacD6ec02c70440D31fd8319",
+        "enforceOutOfOrder": false,
+        "version": "1.5.0"
+      },
+      "rmnPermeable": true
+    },
     "mainnet": {
       "offRamp": {
         "address": "0xf69F5e554E6D3D90DC3a221121ffEf1ee8bf5B2A",
@@ -15962,9 +16126,9 @@
               "rate": "2315"
             },
             "out": {
-              "capacity": "2",
+              "capacity": "200000000",
               "isEnabled": true,
-              "rate": "1"
+              "rate": "2315"
             }
           }
         },
@@ -16274,6 +16438,20 @@
             }
           }
         },
+        "RIZE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SAS": {
           "rateLimiterConfig": {
             "in": {
@@ -16372,6 +16550,20 @@
             }
           }
         },
+        "TREE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "TURBO": {
           "rateLimiterConfig": {
             "in": {
@@ -16411,6 +16603,20 @@
               "capacity": "15000000000000000000000000",
               "isEnabled": true,
               "rate": "520000000000000000000"
+            }
+          }
+        },
+        "USD0": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "3000000000000000000000000",
+              "isEnabled": true,
+              "rate": "35000000000000000000"
+            },
+            "out": {
+              "capacity": "3000000000000000000000000",
+              "isEnabled": true,
+              "rate": "35000000000000000000"
             }
           }
         },
@@ -18116,6 +18322,20 @@
             }
           }
         },
+        "STABUL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "stTAO": {
           "rateLimiterConfig": {
             "in": {
@@ -18239,6 +18459,20 @@
               "capacity": "200000000000",
               "isEnabled": true,
               "rate": "55000000"
+            }
+          }
+        },
+        "USD0": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "3000000000000000000000000",
+              "isEnabled": true,
+              "rate": "35000000000000000000"
+            },
+            "out": {
+              "capacity": "3000000000000000000000000",
+              "isEnabled": true,
+              "rate": "35000000000000000000"
             }
           }
         },
@@ -19864,6 +20098,20 @@
             }
           }
         },
+        "RIZE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SHIB": {
           "rateLimiterConfig": {
             "in": {
@@ -20159,12 +20407,12 @@
             "in": {
               "capacity": "3000000000",
               "isEnabled": true,
-              "rate": "92593"
+              "rate": "277778"
             },
             "out": {
-              "capacity": "3000000000",
+              "capacity": "40000000000",
               "isEnabled": true,
-              "rate": "92593"
+              "rate": "3703703"
             }
           }
         }
@@ -20569,6 +20817,20 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
+            }
+          }
+        },
+        "WMTX": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
+            },
+            "out": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
             }
           }
         },
@@ -21364,6 +21626,20 @@
             }
           }
         },
+        "RIZE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -21763,6 +22039,20 @@
               "capacity": "2500000000000000000",
               "isEnabled": true,
               "rate": "115740000000000"
+            }
+          }
+        },
+        "STABUL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -22225,6 +22515,20 @@
               "capacity": "50000000000000000000000",
               "isEnabled": true,
               "rate": "14000000000000000000"
+            }
+          }
+        },
+        "RIZE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -22863,14 +23167,14 @@
         "LBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "3000000000",
+              "capacity": "40000000000",
               "isEnabled": true,
-              "rate": "92593"
+              "rate": "3703703"
             },
             "out": {
               "capacity": "3000000000",
               "isEnabled": true,
-              "rate": "92593"
+              "rate": "277778"
             }
           }
         }
@@ -23824,6 +24128,20 @@
             }
           }
         },
+        "WMTX": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
+            },
+            "out": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
+            }
+          }
+        },
         "xSolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -23850,7 +24168,23 @@
         "enforceOutOfOrder": true,
         "version": "V1"
       },
-      "rmnPermeable": true
+      "rmnPermeable": true,
+      "supportedTokens": {
+        "WMTX": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
+            },
+            "out": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
+            }
+          }
+        }
+      }
     },
     "ethereum-mainnet-base-1": {
       "offRamp": {
@@ -23889,6 +24223,34 @@
               "capacity": "5000000000000",
               "isEnabled": true,
               "rate": "1388888888"
+            }
+          }
+        },
+        "MICHI": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "10000000000000",
+              "isEnabled": true,
+              "rate": "78722220"
+            },
+            "out": {
+              "capacity": "10000000000000",
+              "isEnabled": true,
+              "rate": "78722220"
+            }
+          }
+        },
+        "WMTX": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
+            },
+            "out": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
             }
           }
         },
@@ -23999,6 +24361,20 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
+            }
+          }
+        },
+        "WMTX": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
+            },
+            "out": {
+              "capacity": "1000000000000",
+              "isEnabled": true,
+              "rate": "277770000"
             }
           }
         },
@@ -25353,48 +25729,6 @@
         "version": "1.5.0"
       },
       "rmnPermeable": false
-    },
-    "ethereum-mainnet-kroma-1": {
-      "offRamp": {
-        "address": "0x64F833f1347fd8Ac6b07a08adCc844FFeB8dF928",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x19e7aD9B0cb28E4604f91376eE2f7dFF0E66318a",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      },
-      "rmnPermeable": true,
-      "supportedTokens": {
-        "LINK": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "50000000000000000000000",
-              "isEnabled": true,
-              "rate": "4630000000000000000"
-            },
-            "out": {
-              "capacity": "50000000000000000000000",
-              "isEnabled": true,
-              "rate": "4630000000000000000"
-            }
-          }
-        },
-        "una.WEMIX": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "200000000000000000000000",
-              "isEnabled": true,
-              "rate": "55550000000000000000"
-            },
-            "out": {
-              "capacity": "200000000000000000000000",
-              "isEnabled": true,
-              "rate": "55550000000000000000"
-            }
-          }
-        }
-      }
     },
     "ethereum-mainnet-optimism-1": {
       "offRamp": {

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -2880,6 +2880,15 @@
       "symbol": "RIZE",
       "tokenAddress": "0xAEDAff046601BEb063b647845Dfb21841f32d6A4"
     },
+    "ethereum-mainnet-base-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "RIZE",
+      "poolAddress": "0xd4D129Df31bF9d9eF7fF030aDF984f3d028E16a0",
+      "poolType": "burnMint",
+      "symbol": "RIZE",
+      "tokenAddress": "0x9818B6c09f5ECc843060927E8587c427C7C93583"
+    },
     "mainnet": {
       "allowListEnabled": false,
       "decimals": 18,

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -389,15 +389,6 @@
       "symbol": "BONE",
       "tokenAddress": "0xe1886337D2ecBdB48A9dE8a68e8dEa2Ba9C5dFd2"
     },
-    "ethereum-mainnet-kroma-1": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "BONE SHIBASWAP",
-      "poolAddress": "0x2a7C22c4B0f763B7E7fc179ab716d62E31d2312E",
-      "poolType": "burnMint",
-      "symbol": "BONE",
-      "tokenAddress": "0x9dab00EC33b5550dF8a4DdA3Da954bB79d00023d"
-    },
     "ethereum-mainnet-linea-1": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -1546,15 +1537,6 @@
       "symbol": "LEASH",
       "tokenAddress": "0xBc53643F2D736743ed29B6dC36E30F5Fb8941090"
     },
-    "ethereum-mainnet-kroma-1": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "DOGE KILLER",
-      "poolAddress": "0xA1d0b6d2E8f7c20c1FbA1Ca3A72107474216a60C",
-      "poolType": "burnMint",
-      "symbol": "LEASH",
-      "tokenAddress": "0xb7C2D1548C66d946f3024e3e5B35634fF91E2846"
-    },
     "ethereum-mainnet-linea-1": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -1844,15 +1826,6 @@
       "poolType": "feeTokenOnly",
       "symbol": "LINK",
       "tokenAddress": "0x71052BAe71C25C78E37fD12E5ff1101A71d9018F"
-    },
-    "ethereum-mainnet-kroma-1": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "ChainLink Token",
-      "poolAddress": "0xff170aD8f1d86eFAC90CA7a2E1204bA64aC5e0f9",
-      "poolType": "burnMint",
-      "symbol": "LINK",
-      "tokenAddress": "0xC1F6f7622ad37C3f46cDF6F8AA0344ADE80BF450"
     },
     "ethereum-mainnet-linea-1": {
       "allowListEnabled": false,
@@ -2415,6 +2388,26 @@
       "tokenAddress": "0xE49FB237974E29AE8022347Ed14084669D70875B"
     }
   },
+  "MICHI": {
+    "ethereum-mainnet-base-1": {
+      "allowListEnabled": false,
+      "decimals": 6,
+      "name": "michi",
+      "poolAddress": "0x65615642056b48BCB8120C109f7e7c0c3623A8BF",
+      "poolType": "burnMint",
+      "symbol": "michi",
+      "tokenAddress": "0x18a4d375323DFAB49862aCeb1A4c6E65F8e53F67"
+    },
+    "solana-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 6,
+      "name": "michi",
+      "poolAddress": "ATyY7SaiayLnp3teH3c4jRBGiPinSSZyt2gHNNN9C6BV",
+      "poolType": "lockRelease",
+      "symbol": "$michi",
+      "tokenAddress": "5mbK36SZ7J19An8jFochhQS4of8g6BwUjbeCSxBSoWdp"
+    }
+  },
   "MILO": {
     "ethereum-mainnet-arbitrum-1": {
       "allowListEnabled": false,
@@ -2877,6 +2870,35 @@
       "tokenAddress": "0x29c46e6F2A67872Ad6b1Dc04e1591934a96Af62E"
     }
   },
+  "RIZE": {
+    "bsc-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "RIZE",
+      "poolAddress": "0xf234609b2e2704b48745A819C89774Fe21E4a722",
+      "poolType": "burnMint",
+      "symbol": "RIZE",
+      "tokenAddress": "0xAEDAff046601BEb063b647845Dfb21841f32d6A4"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "RIZE",
+      "poolAddress": "0x17Be5d735D49c84919d3cFDfF9eABbdB12D6Ac20",
+      "poolType": "burnMint",
+      "symbol": "RIZE",
+      "tokenAddress": "0x9F1E8F87c6321b84baD7DDa7DfB86D5115A47605"
+    },
+    "matic-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "RIZE",
+      "poolAddress": "0xAEDAff046601BEb063b647845Dfb21841f32d6A4",
+      "poolType": "burnMint",
+      "symbol": "RIZE",
+      "tokenAddress": "0x9F1E8F87c6321b84baD7DDa7DfB86D5115A47605"
+    }
+  },
   "rsETH": {
     "ethereum-mainnet-linea-1": {
       "allowListEnabled": false,
@@ -3181,15 +3203,6 @@
       "poolType": "burnMint",
       "symbol": "SHIB",
       "tokenAddress": "0x3b4F8E846437c7CacE31080E6c9DFC455C1DBE77"
-    },
-    "ethereum-mainnet-kroma-1": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "SHIBA INU",
-      "poolAddress": "0x3E63F9dD7Ee4bc3462B5c5C65935E1CD20358A1c",
-      "poolType": "burnMint",
-      "symbol": "SHIB",
-      "tokenAddress": "0x30c810A84387900dD51A312b06Be309E9A8C1797"
     },
     "ethereum-mainnet-linea-1": {
       "allowListEnabled": false,
@@ -3735,6 +3748,15 @@
     }
   },
   "STABUL": {
+    "ethereum-mainnet-base-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Stabull Finance",
+      "poolAddress": "0x500F6D4948Aac25074690a1c42Ae267b41a73326",
+      "poolType": "burnMint",
+      "symbol": "STABUL",
+      "tokenAddress": "0x6722F882cc3A1B1034893eFA9764397C88897892"
+    },
     "mainnet": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -4046,6 +4068,26 @@
       "tokenAddress": "0x6e5970DBd6fc7eb1f29C6D2eDF2bC4c36124C0C1"
     }
   },
+  "TREE": {
+    "bsc-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Treehouse Token",
+      "poolAddress": "0x229AE3eC539865444404c666f504Be68CeB81E02",
+      "poolType": "burnMint",
+      "symbol": "TREE",
+      "tokenAddress": "0x77146784315Ba81904d654466968e3a7c196d1f3"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Treehouse Token",
+      "poolAddress": "0x407dBD0170A79Bb62a016d4555C656205BbA8a68",
+      "poolType": "lockRelease",
+      "symbol": "TREE",
+      "tokenAddress": "0x77146784315Ba81904d654466968e3a7c196d1f3"
+    }
+  },
   "TURBO": {
     "bsc-mainnet": {
       "allowListEnabled": false,
@@ -4113,15 +4155,6 @@
       "poolType": "burnMint",
       "symbol": "una.WEMIX",
       "tokenAddress": "0x89F590D8f9c1a306AEB4E939Dc923C80144998Cd"
-    },
-    "ethereum-mainnet-kroma-1": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "una WEMIX",
-      "poolAddress": "0xd4f2cB8d20c1D81273e216c4F9C01ceC2d633308",
-      "poolType": "burnMint",
-      "symbol": "una.WEMIX",
-      "tokenAddress": "0xc319a4855162E51599bF80387A615105Fe6BEdF3"
     },
     "ethereum-mainnet-optimism-1": {
       "allowListEnabled": false,
@@ -4346,6 +4379,35 @@
       "poolType": "burnMint",
       "symbol": "USD+",
       "tokenAddress": "0x98C6616F1CC0D3E938A16200830DD55663dd7DD3"
+    }
+  },
+  "USD0": {
+    "bsc-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Usual USD",
+      "poolAddress": "0x8d20F295518B12E63F65aB7cf930AD88e8d17cbA",
+      "poolType": "burnMint",
+      "symbol": "USD0",
+      "tokenAddress": "0x758a3e0b1F842C9306B783f8A4078C6C8C03a270"
+    },
+    "ethereum-mainnet-base-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Usual USD",
+      "poolAddress": "0x8d20F295518B12E63F65aB7cf930AD88e8d17cbA",
+      "poolType": "burnMint",
+      "symbol": "USD0",
+      "tokenAddress": "0x758a3e0b1F842C9306B783f8A4078C6C8C03a270"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Usual USD",
+      "poolAddress": "0xC3d39B77032114c8884276Dae0F02cdF75162782",
+      "poolType": "lockRelease",
+      "symbol": "USD0",
+      "tokenAddress": "0x73A15FeD60Bf67631dC6cd7Bc5B6e8da8190aCF5"
     }
   },
   "USD1": {
@@ -5029,14 +5091,6 @@
       "symbol": "WETH",
       "tokenAddress": "0x4200000000000000000000000000000000000006"
     },
-    "ethereum-mainnet-kroma-1": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "Wrapped Ether",
-      "poolType": "feeTokenOnly",
-      "symbol": "WETH",
-      "tokenAddress": "0x4200000000000000000000000000000000000001"
-    },
     "ethereum-mainnet-linea-1": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -5394,6 +5448,15 @@
       "poolType": "burnMint",
       "symbol": "WMTX",
       "tokenAddress": "0xDBB5Cf12408a3Ac17d668037Ce289f9eA75439D7"
+    },
+    "solana-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 6,
+      "name": "World Mobile Token",
+      "poolAddress": "4B9Yvea3RNJ7pJQfdDxz18yzPV5sKSpvQBxoMYgLnzuK",
+      "poolType": "burnMint",
+      "symbol": "WMTX",
+      "tokenAddress": "WMTXyYKUMTG3VuZA5beXuHVRLpyTwwaoP7h2i8YpuRH"
     }
   },
   "wOETH": {


### PR DESCRIPTION
This pull request primarily involves updates to the configuration files for the `ccip` project on the `mainnet`. The changes include the removal of configurations related to the `ethereum-mainnet-kroma-1` chain and the addition of new tokens across various chains. Below is a breakdown of the most important changes:

### Removal of `ethereum-mainnet-kroma-1` Configurations:
* Removed the `ethereum-mainnet-kroma-1` chain configuration, including its `armProxy`, `registryModule`, `router`, and associated token configurations from `chains.json` and `tokens.json`. [[1]](diffhunk://#diff-597b8d0301be33df45a6b4645e26f73ac96109253548dace4afaf6831828656dL521-L544) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L392-L400) [[3]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L1549-L1557) [[4]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L1848-L1856) [[5]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L3185-L3193) [[6]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L4117-L4125) [[7]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L5032-L5039)

### Addition of New Tokens:
* Added configurations for the `MICHI` token on `ethereum-mainnet-base-1` and `solana-mainnet`.
* Added configurations for the `RIZE` token on `bsc-mainnet`, `mainnet`, and `matic-mainnet`.
* Added configurations for the `STABUL` token on `ethereum-mainnet-base-1`.
* Added configurations for the `TREE` token on `bsc-mainnet` and `mainnet`.
* Added configurations for the `USD0` token on `bsc-mainnet`, `ethereum-mainnet-base-1`, and `mainnet`.

### Miscellaneous Changes:
* Added the `WMTX` token configuration for `solana-mainnet`.
* Updated `decom.json` to include the `ethereum-mainnet-kroma-1` chain selector.