### PR TITLE
ptt:fix typos

### DIFF
--- a/src/content/ccip/llms-full.txt
+++ b/src/content/ccip/llms-full.txt
@@ -2156,7 +2156,7 @@ Message Types:
 
 - **Token Transfers:** Send tokens across chains without program execution
 - **Arbitrary Messaging:** Send data to trigger program execution on the destination chain
-- **Programmatic Token Transfers:** Send both tokens and data in a single message to trigger program execution with token transfers
+- **Programmable Token Transfers:** Send both tokens and data in a single message to trigger program execution with token transfers
 
 ## Get the latest Chainlink content straight to your inbox.
 
@@ -4986,7 +4986,7 @@ CCIP receivers that handle tokens need to understand how tokens are delivered an
 When tokens are sent via CCIP to a Solana program:
 
 1. The tokens are initially delivered to a token account specified as the `tokenReceiver` in the CCIP message
-2. For programmatic token transfers, this `tokenReceiver` must be a PDA that your program has authority over
+2. For programmable token transfers, this `tokenReceiver` must be a PDA that your program has authority over
 3. Your program must implement the logic to handle the received tokens
 
 ### [Token Admin PDA](https://docs.chain.link/ccip/tutorials/svm/receivers\#token-admin-pda)

--- a/src/content/ccip/tutorials/svm/destination/build-messages.mdx
+++ b/src/content/ccip/tutorials/svm/destination/build-messages.mdx
@@ -4,8 +4,8 @@ date: Last Modified
 title: "Building CCIP Messages from EVM to SVM"
 isIndex: false
 metadata:
-  description: "Implement CCIP messages from EVM chains to Solana. Guide covers message structure, parameters, and implementation for token transfers, arbitrary data, and programmatic token transfers (data+tokens)."
-  excerpt: "ccip messages evm to solana cross-chain messaging token transfers solana integration blockchain interoperability programmatic token transfers"
+  description: "Implement CCIP messages from EVM chains to Solana. Guide covers message structure, parameters, and implementation for token transfers, arbitrary data, and programmable token transfers (data+tokens)."
+  excerpt: "ccip messages evm to solana cross-chain messaging token transfers solana integration blockchain interoperability programmable token transfers"
 ---
 
 import { Aside, ClickToZoom } from "@components"
@@ -14,7 +14,7 @@ import CcipCommon from "@features/ccip/CcipCommon.astro"
 
 ## Introduction
 
-This guide explains how to construct CCIP Messages from Ethereum Virtual Machine (EVM) chains (e.g. Ethereum) to SVM chains (e.g. Solana). We'll cover the message structure, required parameters, and implementation details for different message types including token transfers, arbitrary data messaging, and programmatic token transfers (data and tokens).
+This guide explains how to construct CCIP Messages from Ethereum Virtual Machine (EVM) chains (e.g. Ethereum) to SVM chains (e.g. Solana). We'll cover the message structure, required parameters, and implementation details for different message types including token transfers, arbitrary data messaging, and programmable token transfers (data and tokens).
 
 ## CCIP Message Structure
 
@@ -36,7 +36,7 @@ struct EVM2AnyMessage {
 - **Token-only transfers**:
   - **Use**: `0x0000000000000000000000000000000000000000000000000000000000000000` (32-byte zero address)
   - **Why**: No program execution needed for token-only transfers.
-- **Arbitrary Messaging** or **Programmatic Token Transfers**:
+- **Arbitrary Messaging** or **Programmable Token Transfers**:
   - **Use**: The program ID of the SVM program that implements the `ccip_receive` instruction, converted to a 32-byte hex format.
   - **Why**: The program will process the incoming CCIP message and execute the `ccip_receive` instruction.
 
@@ -61,7 +61,7 @@ struct EVM2AnyMessage {
 
 - **Definition**: Contains the payload that will be passed to the receiving program
 - **For token-only transfers**: Empty (`0x`)
-- **For arbitrary messaging** or **programmatic token transfers**: Contains the data the receiver program will process
+- **For arbitrary messaging** or **programmable token transfers**: Contains the data the receiver program will process
 - **Encoding requirement**: Must be encoded as a hex string with `0x`· prefix
 
 <Aside type="tip" title="Data Encoding">
@@ -80,7 +80,7 @@ const messageData = `0x${Buffer.from("Hello World").toString("hex")}`
 
 - **Definition**: An array of token addresses and amounts to transfer
 - **For data-only messages**: Must be an empty array
-- **For token transfers** or **programmatic token transfers**: Each entry specifies a token address and amount. **Note**: Check the [CCIP Directory](/ccip/directory) for the list of supported tokens on each lane
+- **For token transfers** or **programmable token transfers**: Each entry specifies a token address and amount. **Note**: Check the [CCIP Directory](/ccip/directory) for the list of supported tokens on each lane
 
 ### feeToken
 
@@ -115,7 +115,7 @@ Specifies the amount of compute units allowed for calling the `ccip_receive` ins
 
 - **For token transfers only**: **MUST** be set to 0
 
-- **For arbitrary messaging** or **programmatic token transfers**: Must be
+- **For arbitrary messaging** or **programmable token transfers**: Must be
   determined through comprehensive testing of the receiver program under different conditions
 
 </Aside>
@@ -390,7 +390,7 @@ Use this configuration when sending only data messages to SVM:
 
 </Aside>
 
-### Programmatic Token Transfer (Data and Tokens)
+### Programmable Token Transfer (Data and Tokens)
 
 Use this configuration when sending both tokens and data in a single message:
 

--- a/src/content/ccip/tutorials/svm/destination/index.mdx
+++ b/src/content/ccip/tutorials/svm/destination/index.mdx
@@ -4,8 +4,8 @@ date: Last Modified
 title: "CCIP Tutorials: EVM to SVM"
 isIndex: true
 metadata:
-  description: "Learn how to implement cross-chain communication from Ethereum to Solana using Chainlink CCIP. Tutorials cover token transfers, arbitrary messaging, and programmatic token transfers with detailed implementation guides."
-  excerpt: "ccip messages evm to solana cross-chain messaging token transfers solana integration blockchain interoperability programmatic token transfers"
+  description: "Learn how to implement cross-chain communication from Ethereum to Solana using Chainlink CCIP. Tutorials cover token transfers, arbitrary messaging, and programmable token transfers with detailed implementation guides."
+  excerpt: "ccip messages evm to solana cross-chain messaging token transfers solana integration blockchain interoperability programmable token transfers"
 ---
 
 import { Aside } from "@components"

--- a/src/content/ccip/tutorials/svm/index.mdx
+++ b/src/content/ccip/tutorials/svm/index.mdx
@@ -46,7 +46,7 @@ Message Types:
 
 - **Token Transfers:** Send tokens across chains without program execution
 - **Arbitrary Messaging:** Send data to trigger program execution on the destination chain
-- **Programmatic Token Transfers:** Send both tokens and data in a single message to trigger program execution with token transfers
+- **Programmable Token Transfers:** Send both tokens and data in a single message to trigger program execution with token transfers
 
 <Aside type="note">
   These tutorials use the Solana Devnet and Ethereum Sepolia testnet for demonstration purposes. When deploying to

--- a/src/content/ccip/tutorials/svm/receivers.mdx
+++ b/src/content/ccip/tutorials/svm/receivers.mdx
@@ -347,7 +347,7 @@ CCIP receivers that handle tokens need to understand how tokens are delivered an
 When tokens are sent via CCIP to a Solana program:
 
 1. The tokens are initially delivered to a token account specified as the `tokenReceiver` in the CCIP message
-1. For programmatic token transfers, this `tokenReceiver` must be a PDA that your program has authority over
+1. For programmable token transfers, this `tokenReceiver` must be a PDA that your program has authority over
 1. Your program must implement the logic to handle the received tokens
 
 <Aside type="caution" title="Token Ownership">

--- a/src/content/ccip/tutorials/svm/source/build-messages.mdx
+++ b/src/content/ccip/tutorials/svm/source/build-messages.mdx
@@ -4,8 +4,8 @@ date: Last Modified
 title: "Building CCIP Messages from SVM to EVM"
 isIndex: false
 metadata:
-  description: "Comprehensive guide for implementing Cross-Chain Interoperability Protocol (CCIP) messages from SVM  to EVM chains. Learn how to structure messages, manage account requirements, and implement token transfers, arbitrary data messaging, and programmatic token transfers."
-  excerpt: "ccip messages solana to evm cross-chain messaging token transfers solana integration blockchain interoperability programmatic token transfers"
+  description: "Comprehensive guide for implementing Cross-Chain Interoperability Protocol (CCIP) messages from SVM  to EVM chains. Learn how to structure messages, manage account requirements, and implement token transfers, arbitrary data messaging, and programmable token transfers."
+  excerpt: "ccip messages solana to evm cross-chain messaging token transfers solana integration blockchain interoperability programmable token transfers"
 ---
 
 import { Aside, ClickToZoom } from "@components"
@@ -14,7 +14,7 @@ import CcipCommon from "@features/ccip/CcipCommon.astro"
 
 ## Introduction
 
-This guide explains how to construct CCIP Messages from SVM chains (e.g. Solana) to EVM chains (e.g. Ethereum, Arbitrum, Avalanche, etc.). We'll cover the message structure, required parameters, account management, and implementation details for different message types including token transfers, arbitrary data messaging, and programmatic token transfers (data and tokens).
+This guide explains how to construct CCIP Messages from SVM chains (e.g. Solana) to EVM chains (e.g. Ethereum, Arbitrum, Avalanche, etc.). We'll cover the message structure, required parameters, account management, and implementation details for different message types including token transfers, arbitrary data messaging, and programmable token transfers (data and tokens).
 
 ## CCIP Message Structure
 
@@ -68,7 +68,7 @@ pub struct SVM2AnyMessage {
 
 - **Definition**: Contains the payload that will be passed to the receiving contract on the destination chain
 - **For token-only transfers**: Must be empty
-- **For arbitrary messaging** or **programmatic token transfers**: Contains the data the receiver contract will process
+- **For arbitrary messaging** or **programmable token transfers**: Contains the data the receiver contract will process
 - **Encoding consideration**: The receiver on the destination chain must be able to correctly decode this data.
 
 <Aside title="Data Encoding for Cross-Chain Messages">
@@ -150,7 +150,7 @@ struct GenericExtraArgsV2 {
 
 - **Gas limit**:
   - For token transfers only: Gas limit must be set to 0
-  - For arbitrary messaging or programmatic token transfers: gas limit must be set based on the receiving contract's complexity.
+  - For arbitrary messaging or programmable token transfers: gas limit must be set based on the receiving contract's complexity.
 - **Allow out of order execution**:
   - Must always be set to true.
 
@@ -257,7 +257,7 @@ Use this configuration when sending only data to EVM chains:
 
 </Aside>
 
-### Programmatic Token Transfer (Data and Tokens)
+### Programmable Token Transfer (Data and Tokens)
 
 Use this configuration when sending both tokens and data in a single message:
 

--- a/src/content/ccip/tutorials/svm/source/index.mdx
+++ b/src/content/ccip/tutorials/svm/source/index.mdx
@@ -5,7 +5,7 @@ title: "CCIP Tutorials: SVM to EVM"
 isIndex: true
 metadata:
   description: "Learn how to implement cross-chain communication from Solana to Ethereum using Chainlink CCIP. Tutorials cover environment setup, token transfers, and message building with detailed implementation guides."
-  excerpt: "ccip messages solana to evm cross-chain messaging token transfers solana integration blockchain interoperability programmatic token transfers"
+  excerpt: "ccip messages solana to evm cross-chain messaging token transfers solana integration blockchain interoperability programmable token transfers"
 ---
 
 import { Aside } from "@components"


### PR DESCRIPTION
This pull request standardizes terminology across multiple documentation files by replacing "Programmatic Token Transfers" with "Programmable Token Transfers" for consistency and clarity. The changes span various sections, including descriptions, examples, and metadata.

### Terminology Update: "Programmable Token Transfers"
* Updated the term "Programmatic Token Transfers" to "Programmable Token Transfers" in the `Message Types` section across multiple files for consistency (`src/content/ccip/llms-full.txt`, `src/content/ccip/tutorials/svm/index.mdx`, `src/content/ccip/tutorials/svm/receivers.mdx`). [[1]](diffhunk://#diff-ed4d106f89c9df8a4a70d275aa87d33904784c5107b3018519abd34086e3b101L2159-R2159) [[2]](diffhunk://#diff-e5051439adcb0fd8e8d9e91729507aabe5bc116deba9179b4a01fcc52a2fb05bL49-R49) [[3]](diffhunk://#diff-75ff3eaa969b72fc6d614bc814e11a555ac0651f7d2267cea7a4eaa71bd371f9L350-R350)
* Modified descriptions and metadata in tutorial files to reflect the terminology change (`src/content/ccip/tutorials/svm/destination/build-messages.mdx`, `src/content/ccip/tutorials/svm/source/build-messages.mdx`, `src/content/ccip/tutorials/svm/destination/index.mdx`, `src/content/ccip/tutorials/svm/source/index.mdx`). [[1]](diffhunk://#diff-5cf265da2796e47532f77ed2c7e250c4db14b4763da62af38ca3f5e6309742ceL7-R8) [[2]](diffhunk://#diff-49b4713a7554388b491f00ebfecbd9be02b05638a945e94b0ca8407770fef4a1L7-R8) [[3]](diffhunk://#diff-f933eca1720c8bfb4440f4b2483a9ff2d0c6dee21cac24ca3022be9333cba910L7-R8) [[4]](diffhunk://#diff-769f17285a8a183ab7b61d401c875e1fb8aa531599a727f71807e64e25e8016fL8-R8)

### Documentation and Examples
* Adjusted examples and explanations to use "Programmable Token Transfers" in contexts like Solana program requirements, data encoding, and gas limit settings (`src/content/ccip/tutorials/svm/destination/build-messages.mdx`, `src/content/ccip/tutorials/svm/source/build-messages.mdx`). [[1]](diffhunk://#diff-ed4d106f89c9df8a4a70d275aa87d33904784c5107b3018519abd34086e3b101L4989-R4989) [[2]](diffhunk://#diff-5cf265da2796e47532f77ed2c7e250c4db14b4763da62af38ca3f5e6309742ceL39-R39) [[3]](diffhunk://#diff-49b4713a7554388b491f00ebfecbd9be02b05638a945e94b0ca8407770fef4a1L71-R71) [[4]](diffhunk://#diff-49b4713a7554388b491f00ebfecbd9be02b05638a945e94b0ca8407770fef4a1L153-R153)

These changes ensure consistent terminology and improve the documentation's clarity for developers working on cross-chain messaging with Chainlink CCIP.