### PR TITLE
Node 2.26 Release -- Typos

### DIFF
--- a/src/content/chainlink-nodes/v1/node-config.mdx
+++ b/src/content/chainlink-nodes/v1/node-config.mdx
@@ -1136,7 +1136,7 @@ MaxSuccessfulRuns = 10000 # Default
 ```
 
 MaxSuccessfulRuns caps the number of completed successful runs per pipeline
-spec in the database. You can set it to zero as a performance optimisation;
+spec in the database. You can set it to zero as a performance optimization;
 this will avoid saving any successful run.
 
 Note this is not a hard cap, it can drift slightly larger than this but not
@@ -1283,7 +1283,7 @@ out during every poll interval, which would amount to the capability to
 censor any transaction.
 
 Note that 1 confirmation implies that the transaction/event has been mined in one block.
-0 confirmations would imply that the event would be recognised before it has even been mined, which is not currently supported.
+0 confirmations would imply that the event would be recognized before it has even been mined, which is not currently supported.
 e.g.
 Current block height: 42
 Changed in block height: 43
@@ -1356,7 +1356,7 @@ KeyBundleID is a sha256 hexadecimal hash identifier.
 CaptureEATelemetry = false # Default
 ```
 
-CaptureEATelemetry toggles collecting extra information from External Adaptares
+CaptureEATelemetry toggles collecting extra information from External Adapters
 
 ### CaptureAutomationCustomTelemetry
 
@@ -1506,7 +1506,7 @@ TransmitterAddress is the default sending address to use for OCR. If you have an
 CaptureEATelemetry = false # Default
 ```
 
-CaptureEATelemetry toggles collecting extra information from External Adaptares
+CaptureEATelemetry toggles collecting extra information from External Adapters
 
 ### TraceLogging
 
@@ -1534,7 +1534,7 @@ PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw' # Example
 TraceLogging = false # Default
 ```
 
-P2P has a versioned networking stack. Currenly only `[P2P.V2]` is supported.
+P2P has a versioned networking stack. Currently only `[P2P.V2]` is supported.
 All nodes in the OCR network should share the same networking stack.
 
 ### IncomingMessageBufferSize
@@ -16801,7 +16801,7 @@ MinAttempts = 3 # Example
 Enabled = false # Default
 ```
 
-Enabled enables or disables automatically purging transactions that have been idenitified as terminally stuck (will never be included on-chain). This feature is only expected to be used by ZK chains.
+Enabled enables or disables automatically purging transactions that have been identified as terminally stuck (will never be included on-chain). This feature is only expected to be used by ZK chains.
 
 ### DetectionApiUrl
 
@@ -17110,7 +17110,7 @@ In EIP-1559 mode, the following changes occur to how configuration works:
 - All new transactions will be sent as type 0x2 transactions specifying a TipCap and FeeCap. Be aware that existing pending legacy transactions will continue to be gas bumped in legacy mode.
 - `BlockHistoryEstimator` will apply its calculations (gas percentile etc) to the TipCap and this value will be used for new transactions (GasPrice will be ignored)
 - `FixedPriceEstimator` will use `GasTipCapDefault` instead of `GasPriceDefault` for the tip cap
-- `FixedPriceEstimator` will use `GasFeeCapDefault` instaed of `GasPriceDefault` for the fee cap
+- `FixedPriceEstimator` will use `GasFeeCapDefault` instead of `GasPriceDefault` for the fee cap
 - `PriceMin` is ignored for new transactions and `GasTipCapMinimum` is used instead (default 0)
 - `PriceMax` still represents that absolute upper limit that Chainlink will ever spend (total) on a single tx
 - `Keeper.GasTipCapBufferPercent` is ignored in EIP-1559 mode and `Keeper.GasTipCapBufferPercent` is used instead
@@ -17385,7 +17385,7 @@ for the head tracker before we start dropping heads to keep up.
 SamplingInterval = '1s' # Default
 ```
 
-SamplingInterval means that head tracker callbacks will at maximum be made once in every window of this duration. This is a performance optimisation for fast chains. Set to 0 to disable sampling entirely.
+SamplingInterval means that head tracker callbacks will at maximum be made once in every window of this duration. This is a performance optimization for fast chains. Set to 0 to disable sampling entirely.
 
 ### FinalityTagBypass
 
@@ -18319,7 +18319,7 @@ Ensure the value is greater than the number of blocks that would be produced bet
 ComputeUnitLimitDefault = 200_000 # Default
 ```
 
-ComputeUnitLimitDefault is the compute units limit applied to transactions unless overriden during the txm enqueue
+ComputeUnitLimitDefault is the compute units limit applied to transactions unless overridden during the txm enqueue
 
 ### EstimateComputeUnitLimit
 


### PR DESCRIPTION
Restores fixes from [2801](https://github.com/smartcontractkit/documentation/pull/2801) and [2766](https://github.com/smartcontractkit/documentation/pull/2766)