### PR TITLE
update metadata

### DIFF
--- a/src/components/HeadSEO.astro
+++ b/src/components/HeadSEO.astro
@@ -11,12 +11,15 @@ export interface Props {
   metadata?: Metadata
   canonicalURL: URL | string
   quickstartFrontmatter?: QuickstartsFrontmatter
+  pageTitle?: string // Add page title from frontmatter
 }
 
-const { metadata, canonicalURL, quickstartFrontmatter } = Astro.props
-const formattedContentTitle = metadata?.title
-  ? `${metadata.title} | ${SITE.title}`
-  : `${PAGE.titleFallback} | ${SITE.title}`
+const { metadata, canonicalURL, quickstartFrontmatter, pageTitle } = Astro.props
+const formattedContentTitle = pageTitle
+  ? `${pageTitle} | ${SITE.title}`
+  : metadata?.title
+    ? `${metadata.title} | ${SITE.title}`
+    : `${PAGE.titleFallback} | ${SITE.title}`
 const description = metadata?.description ?? SITE.description
 const excerpt = metadata?.excerpt ?? description
 
@@ -73,6 +76,11 @@ const structuredDataObjects = quickstartFrontmatter
 <!-- Primary Meta Tags -->
 <meta name="description" content={description} />
 <meta name="keywords" content={excerpt} />
+<meta name="author" content="Chainlink Labs" />
+<meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+{metadata?.datePublished && <meta name="article:published_time" content={metadata.datePublished} />}
+{metadata?.lastModified && <meta name="article:modified_time" content={metadata.lastModified} />}
+<meta name="format-detection" content="telephone=no" />
 
 <!-- OpenGraph Tags -->
 <meta property="og:title" content={formattedContentTitle} />
@@ -81,16 +89,26 @@ const structuredDataObjects = quickstartFrontmatter
 <meta property="og:locale" content={SITE.defaultLanguage} />
 <meta property="og:image" content={canonicalImageSrc} />
 <meta property="og:image:alt" content={OPEN_GRAPH.image.alt} />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:type" content="image/png" />
 <meta property="og:description" content={description} />
 <meta property="og:site_name" content={SITE.title} />
+{metadata?.datePublished && <meta property="article:published_time" content={metadata.datePublished} />}
+{metadata?.lastModified && <meta property="article:modified_time" content={metadata.lastModified} />}
+<meta property="article:author" content="Chainlink Labs" />
+<meta property="article:section" content="Documentation" />
 
 <!-- Twitter Tags -->
 <meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:site" content={OPEN_GRAPH.twitter} />
+<meta name="twitter:site" content={`@${OPEN_GRAPH.twitter}`} />
+<meta name="twitter:creator" content="@chainlink" />
 <meta name="twitter:title" content={formattedContentTitle} />
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={canonicalImageSrc} />
 <meta name="twitter:image:alt" content={OPEN_GRAPH.image.alt} />
+<meta name="twitter:domain" content="docs.chain.link" />
+<meta name="twitter:url" content={canonicalURL} />
 
 <!-- PWA Icons -->
 <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon" />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,8 +11,9 @@ interface Props {
   title: string
   metadata?: Metadata
   quickstartFrontmatter?: QuickstartsFrontmatter
+  pageTitle?: string
 }
-const { title, metadata, quickstartFrontmatter } = Astro.props
+const { title, metadata, quickstartFrontmatter, pageTitle } = Astro.props
 const canonicalURLStr = new URL(Astro.url.pathname, Astro.site).href.replace(/\/+$/, "")
 const canonicalURL = new URL(canonicalURLStr)
 ---
@@ -20,7 +21,7 @@ const canonicalURL = new URL(canonicalURLStr)
 <html dir="ltr" lang="en-us" class="initial" transition:animate="none">
   <head>
     <HeadCommon {title} />
-    <HeadSEO metadata={metadata} {canonicalURL} quickstartFrontmatter={quickstartFrontmatter} />
+    <HeadSEO metadata={metadata} {canonicalURL} quickstartFrontmatter={quickstartFrontmatter} {pageTitle} />
     <style>
       html {
         scroll-behavior: smooth;

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -48,7 +48,7 @@ const includeLinkToWalletScript = !!Astro.props.frontmatter.metadata?.linkToWall
 const { isApiReference, product, isVersioned } = detectApiReference(currentPage)
 ---
 
-<BaseLayout title={formattedContentTitle} metadata={frontmatter.metadata}>
+<BaseLayout title={formattedContentTitle} metadata={frontmatter.metadata} pageTitle={frontmatter.title}>
   <StickyHeader client:media="(max-width: 50em)" {initialHeadings} />
   <DocsNavigation client:load pathname={currentPage} />
   <main>


### PR DESCRIPTION
This pull request enhances SEO and social sharing capabilities by adding comprehensive meta tags and improving title handling in the documentation site. It introduces support for a `pageTitle` prop, ensuring that each page's title and metadata are accurately reflected in the HTML head, and adds a richer set of meta tags for better indexing and sharing across platforms.

**SEO and Social Meta Tag Enhancements:**

* Added multiple meta tags to `HeadSEO.astro` for improved SEO, including author, robots, article publication/modification times, and format-detection.
* Expanded OpenGraph meta tags with image dimensions, type, and additional article-specific properties for richer link previews.
* Enhanced Twitter meta tags with domain, URL, creator, and corrected the site handle format for better Twitter card support.

**Title and Metadata Handling Improvements:**

* Updated `HeadSEO.astro`, `BaseLayout.astro`, and `DocsLayout.astro` to support an optional `pageTitle` prop, allowing more flexible and accurate page titles in the head section. [[1]](diffhunk://#diff-ee38b7b5e308dac2b224e83edb2493553625e6b820e5be229d963bb38f9b2084R14-R20) [[2]](diffhunk://#diff-621c0d4e1d798274214c5a1d9218138167506a88dcdace8c2bb980d6fb10b08bR14-R24) [[3]](diffhunk://#diff-d1e961f78b59a57aaffb1171e0df6b53b97e64217f062f5e8cb3f38660f95274L51-R51)
* Modified the logic for constructing `formattedContentTitle` to prioritize `pageTitle` when available, falling back to metadata or a default.