### PR TITLE
update

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/chains.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/chains.json
@@ -45,11 +45,12 @@
       "version": "1.0.0"
     },
     "chainSelector": "6433500567565415381",
-    "feeTokens": ["LINK", "WAVAX"],
+    "feeTokens": ["GHO", "LINK", "WAVAX"],
     "registryModule": {
       "address": "0x76Aa17dCda9E8529149E76e9ffaE4aD1C4AD701B",
       "version": "1.6.0"
     },
+    "rmnPermeable": false,
     "router": {
       "address": "0xF4c7E640EdA248ef95972845a62bdC74237805dB",
       "version": "1.2.0"

--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -215,6 +215,20 @@
               "rate": "115740000000000"
             }
           }
+        },
+        "YBTC.B": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -998,20 +1012,6 @@
             }
           }
         },
-        "syrupUSDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            }
-          }
-        },
         "USDC": {
           "rateLimiterConfig": {
             "in": {
@@ -1065,6 +1065,20 @@
               "capacity": "2500000000000000000",
               "isEnabled": true,
               "rate": "115740000000000"
+            }
+          }
+        },
+        "YBTC.B": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -1316,7 +1330,23 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": false
+      "rmnPermeable": false,
+      "supportedTokens": {
+        "GHO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            },
+            "out": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            }
+          }
+        }
+      }
     }
   },
   "berachain-mainnet": {
@@ -2677,9 +2707,9 @@
         "stBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
             },
             "out": {
               "capacity": "0",
@@ -2825,6 +2855,20 @@
               "capacity": "2500000000000000000",
               "isEnabled": true,
               "rate": "115740000000000"
+            }
+          }
+        },
+        "YBTC.B": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -3041,9 +3085,9 @@
         "stBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
             },
             "out": {
               "capacity": "0",
@@ -8442,7 +8486,23 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": false
+      "rmnPermeable": false,
+      "supportedTokens": {
+        "GHO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            },
+            "out": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            }
+          }
+        }
+      }
     }
   },
   "ethereum-mainnet-base-1": {
@@ -11598,7 +11658,23 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": false
+      "rmnPermeable": false,
+      "supportedTokens": {
+        "GHO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            },
+            "out": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            }
+          }
+        }
+      }
     }
   },
   "ethereum-mainnet-blast-1": {
@@ -15884,6 +15960,20 @@
             }
           }
         },
+        "VSN": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "82500000000000000000000000",
+              "isEnabled": true,
+              "rate": "69000000000000000000"
+            },
+            "out": {
+              "capacity": "75000000000000000000000000",
+              "isEnabled": true,
+              "rate": "69000000000000000000"
+            }
+          }
+        },
         "xSolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -16162,20 +16252,6 @@
             }
           }
         },
-        "syrupUSDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            }
-          }
-        },
         "USDC": {
           "rateLimiterConfig": {
             "in": {
@@ -16229,6 +16305,20 @@
               "capacity": "2500000000000000000",
               "isEnabled": true,
               "rate": "115740000000000"
+            }
+          }
+        },
+        "YBTC.B": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -20412,6 +20502,20 @@
             }
           }
         },
+        "VSN": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "82500000000000000000000000",
+              "isEnabled": true,
+              "rate": "69000000000000000000"
+            },
+            "out": {
+              "capacity": "75000000000000000000000000",
+              "isEnabled": true,
+              "rate": "69000000000000000000"
+            }
+          }
+        },
         "xSolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -21853,6 +21957,20 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
+            }
+          }
+        },
+        "GHO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            },
+            "out": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
             }
           }
         },
@@ -26526,7 +26644,23 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": false
+      "rmnPermeable": false,
+      "supportedTokens": {
+        "GHO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            },
+            "out": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            }
+          }
+        }
+      }
     },
     "bsc-mainnet": {
       "offRamp": {
@@ -26550,7 +26684,23 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": false
+      "rmnPermeable": false,
+      "supportedTokens": {
+        "GHO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            },
+            "out": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            }
+          }
+        }
+      }
     },
     "ethereum-mainnet-base-1": {
       "offRamp": {
@@ -26562,7 +26712,23 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": false
+      "rmnPermeable": false,
+      "supportedTokens": {
+        "GHO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            },
+            "out": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            }
+          }
+        }
+      }
     },
     "ethereum-mainnet-ink-1": {
       "offRamp": {
@@ -26611,6 +26777,20 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
+            }
+          }
+        },
+        "GHO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            },
+            "out": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
             }
           }
         },

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -597,10 +597,10 @@
       "allowListEnabled": false,
       "decimals": 18,
       "name": "BTR token",
-      "poolAddress": "0x5a715bb6e88B5BdefBBA0C5b70343Ca2Fbc437Af",
+      "poolAddress": "0x86248bE697645cfE0fdeB37FBa0102604f355eFA",
       "poolType": "burnMint",
       "symbol": "BTR",
-      "tokenAddress": "0x6C76dE483F1752Ac8473e2B4983A873991e70dA7"
+      "tokenAddress": "0xfed13D0c40790220fbdE712987079Eda1Ed75C51"
     },
     "mainnet": {
       "allowListEnabled": false,
@@ -1261,6 +1261,15 @@
       "poolType": "lockRelease",
       "symbol": "GHO",
       "tokenAddress": "0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f"
+    },
+    "xdai-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Gho Token",
+      "poolAddress": "0xDe6539018B095353A40753Dc54C91C68c9487D4E",
+      "poolType": "burnMint",
+      "symbol": "GHO",
+      "tokenAddress": "0xfc421aD3C883Bf9E7C4f42dE845C4e4405799e73"
     }
   },
   "hyETH": {
@@ -4036,15 +4045,6 @@
     }
   },
   "syrupUSDC": {
-    "avalanche-mainnet": {
-      "allowListEnabled": false,
-      "decimals": 6,
-      "name": "Syrup USDC",
-      "poolAddress": "0xC109F0AA8e307bFa23952dB09100c0aa43e922F9",
-      "poolType": "burnMint",
-      "symbol": "syrupUSDC",
-      "tokenAddress": "0x085BE2297c1A1A2C2a119b731AF887DD0119D035"
-    },
     "ethereum-mainnet-arbitrum-1": {
       "allowListEnabled": false,
       "decimals": 6,
@@ -4943,6 +4943,15 @@
       "poolType": "burnMint",
       "symbol": "VSN",
       "tokenAddress": "0x6fBBbD8bFB1cd3986B1D05e7861a0f62F87DB74b"
+    },
+    "hyperliquid-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Vision",
+      "poolAddress": "0x1bb58BA8B6fc5a779EDB2D6421c330d464183c08",
+      "poolType": "burnMint",
+      "symbol": "VSN",
+      "tokenAddress": "0x31185950db028eCFc70DF6a35a4B552462A35773"
     },
     "mainnet": {
       "allowListEnabled": false,


### PR DESCRIPTION
This pull request updates the CCIP mainnet configuration files to add support for new tokens and update token and rate limiter configurations across several chains. The most significant changes include adding GHO and VSN tokens, updating rate limiter settings for supported tokens, and removing references to syrupUSDC on Avalanche. The changes impact both the `chains.json` and `lanes.json` configuration files, as well as the `tokens.json` registry.

**Token Support and Configuration Updates**

* Added GHO as a supported fee token on Avalanche and configured its rate limiter across multiple chains and lanes. (`chains.json`, `lanes.json`, `tokens.json`) [[1]](diffhunk://#diff-597b8d0301be33df45a6b4645e26f73ac96109253548dace4afaf6831828656dL48-R53) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L1319-R1349) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L8445-R8505) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L11601-R11677) [[5]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L26529-R26663) [[6]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L26553-R26703) [[7]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L26565-R26731) [[8]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R26783-R26796) [[9]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R1264-R1272) [[10]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R21963-R21976)
* Added VSN token support and rate limiter configuration for the hyperliquid-mainnet chain and in relevant lanes. (`tokens.json`, `lanes.json`) [[1]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R4947-R4955) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R15963-R15976) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R20505-R20518)

**Token Removal and Address Updates**

* Removed syrupUSDC token configuration from Avalanche and its associated rate limiter entries. (`tokens.json`, `lanes.json`) [[1]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L4039-L4047) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L1001-L1014) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L16165-L16178)
* Updated pool and token addresses for BTR token on Avalanche. (`tokens.json`)

**Rate Limiter and Token Lane Adjustments**

* Added YBTC.B token entries with disabled rate limiters in multiple lanes. (`lanes.json`) [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R218-R231) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R1070-R1083) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R2860-R2873) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R16310-R16323)
* Enabled and updated rate limiter for stBTC in certain lanes. (`lanes.json`) [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L2680-R2712) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L3044-R3090)

These changes ensure more comprehensive token support, up-to-date rate limiting, and improved accuracy of token address information across the CCIP mainnet configuration.