### PR TITLE
update

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -1610,7 +1610,37 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": true
+      "rmnPermeable": true,
+      "supportedTokens": {
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
+            }
+          }
+        }
+      }
     },
     "mainnet": {
       "offRamp": {
@@ -2707,9 +2737,9 @@
         "stBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
               "capacity": "0",
@@ -3085,9 +3115,9 @@
         "stBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
               "capacity": "0",
@@ -3474,6 +3504,20 @@
             }
           }
         },
+        "SAS": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SDM": {
           "rateLimiterConfig": {
             "in": {
@@ -3575,14 +3619,14 @@
         "USDO": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "262500000000000000000000",
+              "capacity": "10500000000000000000000000",
               "isEnabled": true,
-              "rate": "300000000000000000"
+              "rate": "1160000000000000000000"
             },
             "out": {
-              "capacity": "2",
+              "capacity": "10000000000000000000000000",
               "isEnabled": true,
-              "rate": "1"
+              "rate": "1160000000000000000000"
             }
           }
         },
@@ -3625,6 +3669,20 @@
               "capacity": "490000000000",
               "isEnabled": true,
               "rate": "136111000"
+            }
+          }
+        },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -3892,6 +3950,20 @@
       },
       "rmnPermeable": true,
       "supportedTokens": {
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -3903,6 +3975,34 @@
               "capacity": "2500000000000000000",
               "isEnabled": true,
               "rate": "115740000000000"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
+            }
+          }
+        },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -4357,14 +4457,14 @@
         "USDO": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "262500000000000000000000",
+              "capacity": "10500000000000000000000000",
               "isEnabled": true,
-              "rate": "300000000000000000"
+              "rate": "1160000000000000000000"
             },
             "out": {
-              "capacity": "250000000000000000000000",
+              "capacity": "10000000000000000000000000",
               "isEnabled": true,
-              "rate": "300000000000000000"
+              "rate": "1160000000000000000000"
             }
           }
         },
@@ -4435,6 +4535,20 @@
               "capacity": "490000000000",
               "isEnabled": true,
               "rate": "136111000"
+            }
+          }
+        },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -4603,6 +4717,20 @@
               "capacity": "1000000000000",
               "isEnabled": true,
               "rate": "12000000"
+            }
+          }
+        },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -8894,6 +9022,20 @@
             }
           }
         },
+        "SAS": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SDM": {
           "rateLimiterConfig": {
             "in": {
@@ -8995,14 +9137,14 @@
         "USDO": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "262500000000000000000000",
+              "capacity": "10500000000000000000000000",
               "isEnabled": true,
-              "rate": "300000000000000000"
+              "rate": "1160000000000000000000"
             },
             "out": {
-              "capacity": "2",
+              "capacity": "10000000000000000000000000",
               "isEnabled": true,
-              "rate": "1"
+              "rate": "1160000000000000000000"
             }
           }
         },
@@ -9045,6 +9187,20 @@
               "capacity": "490000000000",
               "isEnabled": true,
               "rate": "136111000"
+            }
+          }
+        },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -10556,6 +10712,20 @@
             }
           }
         },
+        "SAS": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SHIB": {
           "rateLimiterConfig": {
             "in": {
@@ -10892,6 +11062,20 @@
             }
           }
         },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "xSolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -11158,6 +11342,20 @@
             }
           }
         },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "xSolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -11341,6 +11539,20 @@
           }
         },
         "NEKO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "SAS": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -15848,7 +16060,23 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": true
+      "rmnPermeable": true,
+      "supportedTokens": {
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
+      }
     }
   },
   "hemi-mainnet": {
@@ -15876,7 +16104,37 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": true
+      "rmnPermeable": true,
+      "supportedTokens": {
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
+            }
+          }
+        }
+      }
     },
     "bsc-mainnet": {
       "offRamp": {
@@ -15890,6 +16148,20 @@
       },
       "rmnPermeable": true,
       "supportedTokens": {
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -15901,6 +16173,34 @@
               "capacity": "2500000000000000000",
               "isEnabled": true,
               "rate": "115740000000000"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
+            }
+          }
+        },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -15946,6 +16246,20 @@
             }
           }
         },
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -15960,6 +16274,20 @@
             }
           }
         },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            }
+          }
+        },
         "VSN": {
           "rateLimiterConfig": {
             "in": {
@@ -15971,6 +16299,20 @@
               "capacity": "75000000000000000000000000",
               "isEnabled": true,
               "rate": "69000000000000000000"
+            }
+          }
+        },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -17161,14 +17503,14 @@
         "USDO": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "262500000000000000000000",
+              "capacity": "10500000000000000000000000",
               "isEnabled": true,
-              "rate": "300000000000000000"
+              "rate": "1160000000000000000000"
             },
             "out": {
-              "capacity": "250000000000000000000000",
+              "capacity": "10000000000000000000000000",
               "isEnabled": true,
-              "rate": "300000000000000000"
+              "rate": "1160000000000000000000"
             }
           }
         },
@@ -17239,6 +17581,20 @@
               "capacity": "490000000000",
               "isEnabled": true,
               "rate": "136111000"
+            }
+          }
+        },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -18818,6 +19174,20 @@
             }
           }
         },
+        "SAS": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SHIB": {
           "rateLimiterConfig": {
             "in": {
@@ -19151,6 +19521,20 @@
               "capacity": "490000000000",
               "isEnabled": true,
               "rate": "136111000"
+            }
+          }
+        },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -20448,7 +20832,23 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       },
-      "rmnPermeable": true
+      "rmnPermeable": true,
+      "supportedTokens": {
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
+      }
     },
     "hemi-mainnet": {
       "offRamp": {
@@ -20488,6 +20888,20 @@
             }
           }
         },
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -20502,6 +20916,20 @@
             }
           }
         },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            }
+          }
+        },
         "VSN": {
           "rateLimiterConfig": {
             "in": {
@@ -20513,6 +20941,20 @@
               "capacity": "75000000000000000000000000",
               "isEnabled": true,
               "rate": "69000000000000000000"
+            }
+          }
+        },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -20831,6 +21273,20 @@
               "capacity": "1000000000000",
               "isEnabled": true,
               "rate": "12000000"
+            }
+          }
+        },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -22348,6 +22804,20 @@
             }
           }
         },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "xSolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -22747,6 +23217,20 @@
               "capacity": "1000000000000000000000000",
               "isEnabled": true,
               "rate": "11600000000000000000"
+            }
+          }
+        },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -23293,6 +23777,20 @@
               "capacity": "1000000000000",
               "isEnabled": true,
               "rate": "12000000"
+            }
+          }
+        },
+        "xGold": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -24585,6 +25083,20 @@
           }
         },
         "NEKO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "SAS": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -573,6 +573,15 @@
       "symbol": "brBTC",
       "tokenAddress": "0x3376eBCa0A85Fc8D791B1001a571C41fdd61514a"
     },
+    "hyperliquid-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "brBTC",
+      "poolAddress": "0x330BF3C554ab94533069AF11313143eD3884cf15",
+      "poolType": "burnMint",
+      "symbol": "brBTC",
+      "tokenAddress": "0xDfc7D2d003A053b2E0490531e9317A59962b511E"
+    },
     "mainnet": {
       "allowListEnabled": false,
       "decimals": 8,
@@ -3003,6 +3012,15 @@
       "symbol": "SAS",
       "tokenAddress": "0x28BE7E8cD8125CB7A74D2002A5862E1bfd774cd9"
     },
+    "ethereum-mainnet-base-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "ShibArmyStrong",
+      "poolAddress": "0xd13129ee86f6285d51F66196A02a929E2be977a4",
+      "poolType": "burnMint",
+      "symbol": "SAS",
+      "tokenAddress": "0x28BE7E8cD8125CB7A74D2002A5862E1bfd774cd9"
+    },
     "mainnet": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -3846,7 +3864,7 @@
       "allowListEnabled": false,
       "decimals": 18,
       "name": "Lorenzo stBTC",
-      "poolAddress": "0xC4926CfE95Fb97D634CcFf2fa39C6f0e1c02773c",
+      "poolAddress": "0x4B8BdCAdbDbb20330a6f90C8c8B1BA2E363E9BE8",
       "poolType": "burnMint",
       "symbol": "stBTC",
       "tokenAddress": "0xf6718b2701D4a6498eF77D7c152b2137Ab28b8A3"
@@ -3855,7 +3873,7 @@
       "allowListEnabled": false,
       "decimals": 18,
       "name": "Lorenzo stBTC",
-      "poolAddress": "0x45EA4ADA535DC8b0Bb85D9ED505cd1C6ebdAb5F5",
+      "poolAddress": "0x20282C8e5d2d44BaC0E37A3C78a18b3f78EE1d86",
       "poolType": "burnMint",
       "symbol": "stBTC",
       "tokenAddress": "0xf6718b2701D4a6498eF77D7c152b2137Ab28b8A3"
@@ -4366,6 +4384,15 @@
       "poolType": "burnMint",
       "symbol": "uniBTC",
       "tokenAddress": "0x93919784C523f39CACaa98Ee0a9d96c3F32b593e"
+    },
+    "hyperliquid-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "uniBTC",
+      "poolAddress": "0xda57087632409A30876e978450De23A2f55ADA91",
+      "poolType": "burnMint",
+      "symbol": "uniBTC",
+      "tokenAddress": "0xF9775085d726E782E83585033B58606f7731AB18"
     },
     "mainnet": {
       "allowListEnabled": false,
@@ -5870,6 +5897,62 @@
       "poolType": "feeTokenOnly",
       "symbol": "wzkCRO",
       "tokenAddress": "0xC1bF55EE54E16229d9b369a5502Bfe5fC9F20b6d"
+    }
+  },
+  "xGold": {
+    "bsc-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "xGold",
+      "poolAddress": "0xe199E1C5201CCDd3792ed902aD3f610Ce5629B59",
+      "poolType": "burnMint",
+      "symbol": "xGold",
+      "tokenAddress": "0x281A83ee4819068C40937A066d801aAD7C6e0400"
+    },
+    "ethereum-mainnet-base-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "xGold",
+      "poolAddress": "0x055860f40533c4d9E7CD38105F4c0d1EB0593072",
+      "poolType": "burnMint",
+      "symbol": "xGold",
+      "tokenAddress": "0x5D84B92A34635e5C21b7885fB29D6a4B60287ab7"
+    },
+    "hedera-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "xGold",
+      "poolAddress": "0x2110679A2155534b7674349273741a537495C50C",
+      "poolType": "burnMint",
+      "symbol": "xGold",
+      "tokenAddress": "0x3FA41d2b29c69F8DA6E2D0bFc4f83C62D6582750"
+    },
+    "hyperliquid-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "xGold",
+      "poolAddress": "0x5B806bA13B8B66F83339A63496C2f914BDd4Eb13",
+      "poolType": "burnMint",
+      "symbol": "xGold",
+      "tokenAddress": "0x74FC58Ba6FE27771589Be4b405D88Ab1521CD143"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "xGold",
+      "poolAddress": "0x55585FFBd94471925252C13ade6A81604C781C5D",
+      "poolType": "burnMint",
+      "symbol": "xGold",
+      "tokenAddress": "0x5E75a1aD7b10523f7ed98C1C7CA0b4A79B1bBDee"
+    },
+    "matic-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "xGold",
+      "poolAddress": "0x9EC2F7DBEB9dC7fc72F8476D8a5770E89e13D385",
+      "poolType": "burnMint",
+      "symbol": "xGold",
+      "tokenAddress": "0xDCFdCa64194945a44F092F8eD000245146aFcDd6"
     }
   },
   "xrETH": {


### PR DESCRIPTION
This pull request updates the `src/config/data/ccip/v1_2_0/mainnet/tokens.json` file to add support for new tokens and networks, as well as update pool addresses for existing tokens. The main changes include adding full multi-network support for the `xGold` token, introducing new pools for `brBTC`, `uniBTC`, and `SAS` on additional networks, and updating pool addresses for the `Lorenzo stBTC` token.

**New token and network support:**

* Added full multi-network support for the `xGold` token, including entries for `bsc-mainnet`, `ethereum-mainnet-base-1`, `hedera-mainnet`, `hyperliquid-mainnet`, `mainnet`, and `matic-mainnet`.

**New pools for existing tokens:**

* Added a new `hyperliquid-mainnet` pool for the `brBTC` token.
* Added a new `hyperliquid-mainnet` pool for the `uniBTC` token.
* Added a new `ethereum-mainnet-base-1` pool for the `SAS` token.

**Pool address updates:**

* Updated the pool address for the `Lorenzo stBTC` token on two networks. [[1]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L3849-R3867) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L3858-R3876)