### PR TITLE
update

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -1264,6 +1264,18 @@
       },
       "rmnPermeable": true
     },
+    "solana-mainnet": {
+      "offRamp": {
+        "address": "0xe72d25aDd538E8ef9CeF85622eA8912a6CB98Be6",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x02A4D69cFfeC00Fbf7F3B60c93e3529Dfc58894d",
+        "enforceOutOfOrder": true,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
+    },
     "sonic-mainnet": {
       "offRamp": {
         "address": "0xc8c3E45D29311a51D74D30Dd4019555D7ef59186",
@@ -4900,6 +4912,20 @@
       },
       "rmnPermeable": true,
       "supportedTokens": {
+        "BR": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "500000000000000",
+              "isEnabled": true,
+              "rate": "5800000000"
+            },
+            "out": {
+              "capacity": "5000000000000000000000000",
+              "isEnabled": true,
+              "rate": "58000000000000000000"
+            }
+          }
+        },
         "FHE": {
           "rateLimiterConfig": {
             "in": {
@@ -8492,6 +8518,20 @@
             }
           }
         },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
@@ -11776,6 +11816,20 @@
             }
           }
         },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
@@ -14932,7 +14986,23 @@
         "enforceOutOfOrder": true,
         "version": "1.6.0"
       },
-      "rmnPermeable": true
+      "rmnPermeable": true,
+      "supportedTokens": {
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
+      }
     },
     "sonic-mainnet": {
       "offRamp": {
@@ -16427,6 +16497,18 @@
           }
         }
       }
+    },
+    "solana-mainnet": {
+      "offRamp": {
+        "address": "0x70003d849A20e33997fea69bBc8a366D6ab0E131",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x72f6000D70B291C67bED898214156d01383274b1",
+        "enforceOutOfOrder": true,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
     }
   },
   "lens-mainnet": {
@@ -22024,6 +22106,20 @@
             }
           }
         },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
@@ -24468,6 +24564,18 @@
         }
       }
     },
+    "solana-mainnet": {
+      "offRamp": {
+        "address": "0x02A4D69cFfeC00Fbf7F3B60c93e3529Dfc58894d",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0xc23071a8AE83671f37bdA1DaDBC745a9780f632A",
+        "enforceOutOfOrder": true,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
+    },
     "sonic-mainnet": {
       "offRamp": {
         "address": "0xB081ce3581CE89e873F1F9d0a2EcD8bFc4b26BF5",
@@ -25345,9 +25453,33 @@
           }
         }
       }
+    },
+    "solana-mainnet": {
+      "offRamp": {
+        "address": "0x77FDbd20ED582794b1d9F1a8a94e4a60494D677e",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x530Ae314EC3fA038bd9A215095E37295ec76162a",
+        "enforceOutOfOrder": true,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
     }
   },
   "solana-mainnet": {
+    "avalanche-mainnet": {
+      "offRamp": {
+        "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
+        "version": "V1"
+      },
+      "onRamp": {
+        "address": "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C",
+        "enforceOutOfOrder": true,
+        "version": "V1"
+      },
+      "rmnPermeable": true
+    },
     "bsc-mainnet": {
       "offRamp": {
         "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
@@ -25360,6 +25492,20 @@
       },
       "rmnPermeable": true,
       "supportedTokens": {
+        "BR": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "500000000000000",
+              "isEnabled": true,
+              "rate": "5800000000"
+            },
+            "out": {
+              "capacity": "500000000000000",
+              "isEnabled": true,
+              "rate": "5800000000"
+            }
+          }
+        },
         "FHE": {
           "rateLimiterConfig": {
             "in": {
@@ -25489,14 +25635,28 @@
         "FLUID": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "2000000000000000",
+              "capacity": "500000000000000",
               "isEnabled": true,
               "rate": "23148100000"
             },
             "out": {
-              "capacity": "2000000000000000",
+              "capacity": "500000000000000",
               "isEnabled": true,
               "rate": "23148100000"
+            }
+          }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -25531,12 +25691,12 @@
         "FLUID": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "2000000000000000",
+              "capacity": "500000000000000",
               "isEnabled": true,
               "rate": "23148100000"
             },
             "out": {
-              "capacity": "2000000000000000",
+              "capacity": "500000000000000",
               "isEnabled": true,
               "rate": "23148100000"
             }
@@ -25584,6 +25744,20 @@
             }
           }
         },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
@@ -25624,6 +25798,34 @@
         "enforceOutOfOrder": true,
         "version": "V1"
       },
+      "rmnPermeable": true,
+      "supportedTokens": {
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
+      }
+    },
+    "hyperliquid-mainnet": {
+      "offRamp": {
+        "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
+        "version": "V1"
+      },
+      "onRamp": {
+        "address": "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C",
+        "enforceOutOfOrder": true,
+        "version": "V1"
+      },
       "rmnPermeable": true
     },
     "mainnet": {
@@ -25655,12 +25857,12 @@
         "FLUID": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "2000000000000000",
+              "capacity": "500000000000000",
               "isEnabled": true,
               "rate": "23148100000"
             },
             "out": {
-              "capacity": "2000000000000000",
+              "capacity": "500000000000000",
               "isEnabled": true,
               "rate": "23148100000"
             }
@@ -25722,6 +25924,20 @@
             }
           }
         },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
@@ -25765,6 +25981,30 @@
           }
         }
       }
+    },
+    "polygon-mainnet-katana": {
+      "offRamp": {
+        "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
+        "version": "V1"
+      },
+      "onRamp": {
+        "address": "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C",
+        "enforceOutOfOrder": true,
+        "version": "V1"
+      },
+      "rmnPermeable": true
+    },
+    "shibarium-mainnet": {
+      "offRamp": {
+        "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
+        "version": "V1"
+      },
+      "onRamp": {
+        "address": "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C",
+        "enforceOutOfOrder": true,
+        "version": "V1"
+      },
+      "rmnPermeable": true
     },
     "sonic-mainnet": {
       "offRamp": {

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -543,6 +543,15 @@
       "poolType": "burnMint",
       "symbol": "BR",
       "tokenAddress": "0x9B61879e91a0b1322F3d61c23Aaf936231882096"
+    },
+    "solana-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "Bedrock",
+      "poolAddress": "3m8zgkeD3WSEqqjkG8UehV9uwAunkZoiZK99ZjPsyZxH",
+      "poolType": "burnMint",
+      "symbol": "BR",
+      "tokenAddress": "BRryKTBVA4xYbgY6kkZtRWGEKz4aujNMeBkqNLRQbzp1"
     }
   },
   "brBTC": {
@@ -4619,7 +4628,7 @@
       "allowListEnabled": false,
       "decimals": 6,
       "name": "USD Coin",
-      "poolAddress": "0x9fCd83bC7F67ADa1fB51a4caBEa333c72B641bd1",
+      "poolAddress": "0x40530f5305d6Fd6912925C5ec2C36453B85d8F5f",
       "poolType": "usdc",
       "symbol": "USDC",
       "tokenAddress": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
@@ -4628,7 +4637,7 @@
       "allowListEnabled": false,
       "decimals": 6,
       "name": "USD Coin",
-      "poolAddress": "0x5931822f394baBC2AACF4588E98FC77a9f5aa8C9",
+      "poolAddress": "0x6378c36C44B28f4d1513e7a5510A8481a23eecda",
       "poolType": "usdc",
       "symbol": "USDC",
       "tokenAddress": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
@@ -4637,7 +4646,7 @@
       "allowListEnabled": false,
       "decimals": 6,
       "name": "USD Coin",
-      "poolAddress": "0x5931822f394baBC2AACF4588E98FC77a9f5aa8C9",
+      "poolAddress": "0xE67E30B1b4F80A35852488757C3efc093903651A",
       "poolType": "usdc",
       "symbol": "USDC",
       "tokenAddress": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85"
@@ -4655,7 +4664,7 @@
       "allowListEnabled": false,
       "decimals": 6,
       "name": "USD Coin",
-      "poolAddress": "0xc2e3A3C18ccb634622B57fF119a1C8C7f12e8C0c",
+      "poolAddress": "0x03D19033AdA17750D5BC2d8E325337D0748F9FEF",
       "poolType": "usdc",
       "symbol": "USDC",
       "tokenAddress": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
@@ -4677,6 +4686,15 @@
       "poolType": "burnMint",
       "symbol": "USDC",
       "tokenAddress": "0x0B7007c13325C48911F73A2daD5FA5dCBf808aDc"
+    },
+    "solana-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 6,
+      "name": "USD Coin",
+      "poolAddress": "Gog2wHG7KS8St26d1fPrgNFtta6HK8Xza7SSHzgbWPr5",
+      "poolType": "usdc",
+      "symbol": "USDC",
+      "tokenAddress": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
     },
     "wemix-mainnet": {
       "allowListEnabled": false,


### PR DESCRIPTION
This pull request updates the CCIP v1.2.0 mainnet configuration files to add support for Solana mainnet lanes and tokens, introduces new rate limiter configurations for several tokens, and updates pool addresses for USDC on multiple chains. These changes expand cross-chain support and improve token management and security.

**Solana mainnet support:**

* Added `solana-mainnet` lanes with onRamp and offRamp details to multiple chain sections in `lanes.json`, enabling Solana cross-chain connectivity. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R1267-R1278) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R16500-R16511) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R24567-R24578) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R25456-R25482)
* Added Solana-specific token entries for `BR` (Bedrock) and `USDC` in `tokens.json`, including pool addresses and token addresses. [[1]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R546-R554) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R4690-R4698)

**Rate limiter configuration updates:**

* Introduced new rate limiter configs for `BR`, `USDC`, and updated `FLUID` token limits across several chain lanes, enhancing security and throughput control. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R4915-R4928) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R8521-R8534) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R11819-R11832) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L14935-R15005) [[5]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R25495-R25508) [[6]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L25492-R25662) [[7]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L25534-R25699) [[8]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R25747-R25760) [[9]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L25658-R25865) [[10]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R25927-R25940)

**USDC pool address updates:**

* Updated the `poolAddress` for USDC tokens on multiple chains in `tokens.json` to reflect new contract addresses. [[1]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L4622-R4631) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L4631-R4640) [[3]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L4640-R4649) [[4]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L4658-R4667)

**New lanes for additional chains:**

* Added new lanes for `polygon-mainnet-katana`, `shibarium-mainnet`, and `ethereum-mainnet-optimism-1` with onRamp/offRamp and rate limiter configs, broadening supported networks. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R25985-R26008) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R25792-R25819)

**General improvements to configuration:**

* Ensured consistent support for `rmnPermeable` and `enforceOutOfOrder` flags across newly added lanes and tokens, improving reliability and message ordering. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L14935-R15005) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R1267-R1278) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R24567-R24578) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R16500-R16511) [[5]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R25456-R25482) [[6]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R25792-R25819) [[7]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R25985-R26008)