### PR TITLE
update explorer base URL for mainnet and testnet

### DIFF
--- a/src/config/data/chains.json
+++ b/src/config/data/chains.json
@@ -535,7 +535,7 @@
         "chainId": 1111,
         "title": "Wemix",
         "explorer": {
-          "baseUrl": "https://wemixscan.com"
+          "baseUrl": "https://scan.wemix.com"
         },
         "nativeCurrency": {
           "name": "Wemix",
@@ -547,7 +547,7 @@
         "chainId": 1112,
         "title": "Wemix Testnet",
         "explorer": {
-          "baseUrl": "https://testnet.wemixscan.com"
+          "baseUrl": "https://scan.wemix.com/wemixTestnet"
         },
         "nativeCurrency": {
           "name": "Testnet Wemix",


### PR DESCRIPTION
update Wemix explorer base URLs for mainnet and testnet:

For ex.:
https://wemixscan.com/address/
becomes
https://scan.wemix.com/address/
and for testnet it's this pattern :
http://scan.wemix.com/wemixTestnet/address/
