### PR TITLE
refresh directory

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -1040,6 +1040,20 @@
             }
           }
         },
+        "TREE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "USDC": {
           "rateLimiterConfig": {
             "in": {
@@ -1452,9 +1466,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -1486,6 +1500,20 @@
       },
       "rmnPermeable": true,
       "supportedTokens": {
+        "beraBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "BR": {
           "rateLimiterConfig": {
             "in": {
@@ -1508,9 +1536,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -1648,9 +1676,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -1702,9 +1730,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -1851,14 +1879,14 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "400000000",
-              "isEnabled": true,
-              "rate": "4629"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "400000000",
+              "capacity": "200000000",
               "isEnabled": true,
-              "rate": "4629"
+              "rate": "2315"
             }
           }
         },
@@ -2017,9 +2045,9 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
-              "isEnabled": true,
-              "rate": "2315"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
               "capacity": "200000000",
@@ -2861,9 +2889,9 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
-              "isEnabled": true,
-              "rate": "11574"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
               "capacity": "200000000",
@@ -3012,6 +3040,20 @@
       },
       "rmnPermeable": true,
       "supportedTokens": {
+        "beraBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "BR": {
           "rateLimiterConfig": {
             "in": {
@@ -3034,9 +3076,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "400000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "4630"
+              "rate": "1"
             }
           }
         },
@@ -3393,14 +3435,14 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
-              "isEnabled": true,
-              "rate": "2315"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -3552,9 +3594,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -4054,9 +4096,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -4469,9 +4511,9 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
-              "isEnabled": true,
-              "rate": "2315"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
               "capacity": "200000000",
@@ -5080,6 +5122,20 @@
             }
           }
         },
+        "WLFI": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
@@ -5603,9 +5659,9 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
-              "isEnabled": true,
-              "rate": "2315"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
               "capacity": "200000000",
@@ -5681,20 +5737,6 @@
               "capacity": "750000000000000000000000",
               "isEnabled": true,
               "rate": "207500000000000000000"
-            }
-          }
-        },
-        "wstLINK": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "15000000000000000000000",
-              "isEnabled": true,
-              "rate": "4000000000000000000"
-            },
-            "out": {
-              "capacity": "15000000000000000000000",
-              "isEnabled": true,
-              "rate": "4000000000000000000"
             }
           }
         }
@@ -5779,20 +5821,6 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
-            }
-          }
-        },
-        "wstLINK": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "15000000000000000000000",
-              "isEnabled": true,
-              "rate": "4000000000000000000"
-            },
-            "out": {
-              "capacity": "15000000000000000000000",
-              "isEnabled": true,
-              "rate": "4000000000000000000"
             }
           }
         }
@@ -6247,14 +6275,14 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
-              "isEnabled": true,
-              "rate": "2315"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -6391,20 +6419,6 @@
               "capacity": "750000000000000000000000",
               "isEnabled": true,
               "rate": "207500000000000000000"
-            }
-          }
-        },
-        "wstLINK": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "15000000000000000000000",
-              "isEnabled": true,
-              "rate": "4000000000000000000"
-            },
-            "out": {
-              "capacity": "15000000000000000000000",
-              "isEnabled": true,
-              "rate": "4000000000000000000"
             }
           }
         }
@@ -8063,9 +8077,9 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
-              "isEnabled": true,
-              "rate": "2315"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
               "capacity": "200000000",
@@ -9056,9 +9070,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -9196,9 +9210,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -11970,6 +11984,20 @@
             }
           }
         },
+        "YNE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "zBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -13665,9 +13693,9 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
-              "isEnabled": true,
-              "rate": "11574"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
               "capacity": "200000000",
@@ -14897,9 +14925,9 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
-              "isEnabled": true,
-              "rate": "11574"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
               "capacity": "200000000",
@@ -16434,9 +16462,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -16476,9 +16504,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -16926,6 +16954,20 @@
             }
           }
         },
+        "TREE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "USDC": {
           "rateLimiterConfig": {
             "in": {
@@ -17125,14 +17167,14 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "400000000",
+              "capacity": "200000000",
               "isEnabled": true,
-              "rate": "4629"
+              "rate": "2315"
             },
             "out": {
-              "capacity": "400000000",
+              "capacity": "200000000",
               "isEnabled": true,
-              "rate": "4629"
+              "rate": "2315"
             }
           }
         },
@@ -18201,20 +18243,6 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
-            }
-          }
-        },
-        "wstLINK": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "15000000000000000000000",
-              "isEnabled": true,
-              "rate": "4000000000000000000"
-            },
-            "out": {
-              "capacity": "15000000000000000000000",
-              "isEnabled": true,
-              "rate": "4000000000000000000"
             }
           }
         }
@@ -22288,6 +22316,20 @@
             }
           }
         },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            }
+          }
+        },
         "USDC": {
           "rateLimiterConfig": {
             "in": {
@@ -25814,6 +25856,20 @@
             }
           }
         },
+        "WLFI": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
@@ -26010,6 +26066,20 @@
             }
           }
         },
+        "YNE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "zBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -26159,6 +26229,20 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
             }
           }
         },

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -166,6 +166,26 @@
       "tokenAddress": "0x1a89ecd466a23e98f07111b0510a2D6c1cd5E400"
     }
   },
+  "beraBTC": {
+    "berachain-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "Bera Bitcoin",
+      "poolAddress": "0xE354FA112CD7aA0DE5C4Bedce19965c9f549e689",
+      "poolType": "lockRelease",
+      "symbol": "beraBTC",
+      "tokenAddress": "0xE368a6BBb2c285A557800FF676D85Dd7E9C6299B"
+    },
+    "bsc-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "Bera Bitcoin",
+      "poolAddress": "0x1eCFe2220f18a5e4cDBc08563572d413B46fA8Ea",
+      "poolType": "burnMint",
+      "symbol": "beraBTC",
+      "tokenAddress": "0x68C7A170bd9Ea9fb283a50d041531678111FBF31"
+    }
+  },
   "BETS": {
     "avalanche-mainnet": {
       "allowListEnabled": false,
@@ -4235,6 +4255,15 @@
     }
   },
   "TREE": {
+    "avalanche-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Treehouse Token",
+      "poolAddress": "0x229AE3eC539865444404c666f504Be68CeB81E02",
+      "poolType": "burnMint",
+      "symbol": "TREE",
+      "tokenAddress": "0x77146784315Ba81904d654466968e3a7c196d1f3"
+    },
     "bsc-mainnet": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -4467,6 +4496,15 @@
       "poolType": "burnMint",
       "symbol": "uniBTC",
       "tokenAddress": "0x004E9C3EF86bc1ca1f0bB5C7662861Ee93350568"
+    },
+    "solana-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "uniBTC",
+      "poolAddress": "A8qxRKqAftbqatfegeiq3yTVmVTPS9DimGWHtgzjC417",
+      "poolType": "burnMint",
+      "symbol": "uniBTC",
+      "tokenAddress": "uniBKsEV37qLRFZD7v3Z9drX6voyiCM8WcaePqeSSLc"
     },
     "sonic-mainnet": {
       "allowListEnabled": false,
@@ -5899,20 +5937,11 @@
     }
   },
   "wstLINK": {
-    "ethereum-mainnet-andromeda-1": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "Wrapped stLINK",
-      "poolAddress": "0x6040d2Ce5C3779b45eD4232F4f46689797b4b9e2",
-      "poolType": "burnMint",
-      "symbol": "wstLINK",
-      "tokenAddress": "0xD6999c1dCb675Ae5568931BB0CFca0c4f4Fe21Ca"
-    },
     "ethereum-mainnet-arbitrum-1": {
       "allowListEnabled": false,
       "decimals": 18,
       "name": "Wrapped stLINK",
-      "poolAddress": "0xf3988bA2e3C96B3E79763211A015A23f9AE3Fa9c",
+      "poolAddress": "0x5406e9d1CEF8f54eb675bd41139A5E3D83bFf80c",
       "poolType": "burnMint",
       "symbol": "wstLINK",
       "tokenAddress": "0x3106E2e148525b3DB36795b04691D444c24972fB"
@@ -5921,7 +5950,7 @@
       "allowListEnabled": false,
       "decimals": 18,
       "name": "Wrapped stLINK",
-      "poolAddress": "0x0D736853812A12F085DE867aDF4eA4ABA9521Fc0",
+      "poolAddress": "0xF6403CF6E954a43699097322e0867C63d653C2D0",
       "poolType": "lockRelease",
       "symbol": "wstLINK",
       "tokenAddress": "0x911D86C72155c33993d594B0Ec7E6206B4C803da"
@@ -6434,6 +6463,26 @@
       "poolType": "burnMint",
       "symbol": "YGG",
       "tokenAddress": "0x1c306872bC82525d72Bf3562E8F0aA3f8F26e857"
+    }
+  },
+  "YNE": {
+    "ethereum-mainnet-base-1": {
+      "allowListEnabled": false,
+      "decimals": 6,
+      "name": "yesnoerror",
+      "poolAddress": "0xd8F5e7FAc317c638d2Fe4d07ab3f436ca6b5e5c7",
+      "poolType": "burnMint",
+      "symbol": "YNE",
+      "tokenAddress": "0xE2f9db0186b13668AeC9fe0e15dbD13004ed8d6f"
+    },
+    "solana-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 6,
+      "name": "yesnoerror",
+      "poolAddress": "AyxbrQHM1sPx17HKWP1x13E8PBFxpvMQiMERvoG4ub53",
+      "poolType": "lockRelease",
+      "symbol": "YNE",
+      "tokenAddress": "7D1iYWfhw2cr9yBZBFE6nZaaSUvXHqG5FizFFEZwpump"
     }
   },
   "zBTC": {

--- a/src/config/data/ccip/v1_2_0/testnet/chains.json
+++ b/src/config/data/ccip/v1_2_0/testnet/chains.json
@@ -78,6 +78,7 @@
       "address": "0x97300785aF1edE1343DB6d90706A35CF14aA3d81",
       "version": "1.5.0"
     },
+    "rmnPermeable": false,
     "router": {
       "address": "0xF694E193200268f9a4868e4Aa017A0118C9a8177",
       "version": "1.2.0"
@@ -674,6 +675,7 @@
       "address": "0x8e3c251D4eAa31652c81bBa33A9Ee599B69fFEC2",
       "version": "1.5.0"
     },
+    "rmnPermeable": false,
     "router": {
       "address": "0xB4431A6c63F72916151fEA2864DBB13b8ce80E8a",
       "version": "1.2.0"
@@ -1039,6 +1041,10 @@
     "tokenAdminRegistry": {
       "address": "0x5c8a206f4800A61fF4430a2b75381A0033172860",
       "version": "1.5.0"
+    },
+    "tokenPoolFactory": {
+      "address": "0x150869eac5C58d3655f860C4316107fB626244d0",
+      "version": "1.5.1"
     }
   },
   "ink-testnet-sepolia": {
@@ -1195,6 +1201,10 @@
     "tokenAdminRegistry": {
       "address": "0x9f4fa39d257cBe5A69F4E4A22a3E8bf62CAF5218",
       "version": "1.5.0"
+    },
+    "tokenPoolFactory": {
+      "address": "0xa4E0E5e36399307F942a56B2D55496035511b696",
+      "version": "1.5.1"
     }
   },
   "neox-testnet-t4": {
@@ -1275,11 +1285,12 @@
       "version": "1.0.0"
     },
     "chainSelector": "16281711391670634445",
-    "feeTokens": ["LINK", "WMATIC"],
+    "feeTokens": ["LINK", "WPOL"],
     "registryModule": {
       "address": "0x84ad5890A63957C960e0F19b0448A038a574936B",
       "version": "1.5.0"
     },
+    "rmnPermeable": false,
     "router": {
       "address": "0x9C32fCB86BF0f4a1A8921a9Fe46de3198bb884B2",
       "version": "1.2.0"
@@ -1359,12 +1370,16 @@
     "tokenAdminRegistry": {
       "address": "0xDF27EE0050C2D3831089B14aCC465aBF9fD12C64",
       "version": "1.5.0"
+    },
+    "tokenPoolFactory": {
+      "address": "0xCa445E4F7ac651Ca6A70A8d3B5c42b3CA5876290",
+      "version": "1.5.1"
     }
   },
   "shibarium-testnet-puppynet": {
     "armProxy": {
       "address": "0x8d677784DA3707e57aC0306464552560E05dBCD7",
-      "version": "1.5.0"
+      "version": "1.0.0"
     },
     "chainSelector": "17833296867764334567",
     "feeTokens": ["LINK", "WBONE"],
@@ -1372,6 +1387,7 @@
       "address": "0xf6B25A05333C4B8Eb108758d306f28B99324A1bf",
       "version": "1.5.0"
     },
+    "rmnPermeable": false,
     "router": {
       "address": "0x449E234FEDF3F907b9E9Dd6BAf1ddc36664097E5",
       "version": "1.2.0"

--- a/src/config/data/ccip/v1_2_0/testnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/testnet/lanes.json
@@ -167,20 +167,6 @@
               "rate": "167000000000000000000"
             }
           }
-        },
-        "USDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            },
-            "out": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            }
-          }
         }
       }
     },
@@ -459,6 +445,18 @@
           }
         }
       }
+    },
+    "solana-devnet": {
+      "offRamp": {
+        "address": "0x3F1f176e347235858DD6Db905DDBA09Eaf25478a",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0xA5D5B0B844c8f11B61F28AC98BBA84dEA9b80953",
+        "enforceOutOfOrder": true,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
     },
     "wemix-testnet": {
       "offRamp": {
@@ -1539,20 +1537,6 @@
               "rate": "167000000000000000000"
             }
           }
-        },
-        "USDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            },
-            "out": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            }
-          }
         }
       }
     },
@@ -1973,20 +1957,6 @@
               "rate": "167000000000000000000"
             }
           }
-        },
-        "USDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            },
-            "out": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            }
-          }
         }
       }
     },
@@ -2027,20 +1997,6 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
-            }
-          }
-        },
-        "USDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            },
-            "out": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
             }
           }
         }
@@ -2317,20 +2273,6 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
-            }
-          }
-        },
-        "USDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            },
-            "out": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
             }
           }
         }
@@ -2863,20 +2805,6 @@
               "rate": "167000000000000000000"
             }
           }
-        },
-        "USDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            },
-            "out": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            }
-          }
         }
       }
     },
@@ -2929,20 +2857,6 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
-            }
-          }
-        },
-        "USDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
             }
           }
         }
@@ -3027,6 +2941,20 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
+            }
+          }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -3355,20 +3283,6 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
-            }
-          }
-        },
-        "USDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            },
-            "out": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
             }
           }
         }
@@ -3847,20 +3761,6 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
-            }
-          }
-        },
-        "USDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            },
-            "out": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
             }
           }
         }
@@ -4435,6 +4335,18 @@
         "version": "1.5.0"
       },
       "rmnPermeable": true
+    },
+    "sonic-testnet-blaze": {
+      "offRamp": {
+        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x289639CB51704043213d2E8806d19979eD8533e4",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
     }
   },
   "ethereum-testnet-sepolia-lisk-1": {
@@ -4715,20 +4627,6 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
-            }
-          }
-        },
-        "USDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            },
-            "out": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
             }
           }
         }
@@ -5891,20 +5789,6 @@
               "rate": "167000000000000000000"
             }
           }
-        },
-        "USDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            },
-            "out": {
-              "capacity": "100000000000",
-              "isEnabled": true,
-              "rate": "167000000"
-            }
-          }
         }
       }
     },
@@ -5987,6 +5871,18 @@
           }
         }
       }
+    },
+    "solana-devnet": {
+      "offRamp": {
+        "address": "0x056A1FAb28562750a54063E37DDc66d506e320d2",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
+        "enforceOutOfOrder": true,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
     },
     "wemix-testnet": {
       "offRamp": {
@@ -6153,20 +6049,6 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
-            }
-          }
-        },
-        "USDC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
             }
           }
         }
@@ -6367,9 +6249,33 @@
           }
         }
       }
+    },
+    "solana-devnet": {
+      "offRamp": {
+        "address": "0x384C8843411f725e800E625d5d1B659256D629dF",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0xe5e3a4fF1773d043a387b16Ceb3c91cC49bAFD54",
+        "enforceOutOfOrder": true,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
     }
   },
   "solana-devnet": {
+    "avalanche-fuji-testnet": {
+      "offRamp": {
+        "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
+        "version": "V1"
+      },
+      "onRamp": {
+        "address": "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C",
+        "enforceOutOfOrder": true,
+        "version": "V1"
+      },
+      "rmnPermeable": true
+    },
     "bsc-testnet": {
       "offRamp": {
         "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
@@ -6421,6 +6327,20 @@
               "capacity": "100000000000000",
               "isEnabled": true,
               "rate": "167000000000"
+            }
+          }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -6509,6 +6429,30 @@
           }
         }
       }
+    },
+    "polygon-testnet-amoy": {
+      "offRamp": {
+        "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
+        "version": "V1"
+      },
+      "onRamp": {
+        "address": "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C",
+        "enforceOutOfOrder": true,
+        "version": "V1"
+      },
+      "rmnPermeable": true
+    },
+    "shibarium-testnet-puppynet": {
+      "offRamp": {
+        "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
+        "version": "V1"
+      },
+      "onRamp": {
+        "address": "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C",
+        "enforceOutOfOrder": true,
+        "version": "V1"
+      },
+      "rmnPermeable": true
     },
     "sonic-testnet-blaze": {
       "offRamp": {
@@ -6601,6 +6545,18 @@
         "address": "0x900f41141a84F611Bd79F4Fe7029bC35d79dD950",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
+      },
+      "rmnPermeable": true
+    },
+    "ethereum-testnet-sepolia-linea-1": {
+      "offRamp": {
+        "address": "0xF094E1dB26Ce8C76C9fF0bD0566Bb8EEfF1b76dd",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x384C8843411f725e800E625d5d1B659256D629dF",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
       },
       "rmnPermeable": true
     },

--- a/src/config/data/ccip/v1_2_0/testnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/testnet/tokens.json
@@ -1122,7 +1122,7 @@
     "avalanche-fuji-testnet": {
       "allowListEnabled": false,
       "decimals": 6,
-      "name": "USD Coin",
+      "name": "USDC",
       "poolAddress": "0x5931822f394baBC2AACF4588E98FC77a9f5aa8C9",
       "poolType": "usdc",
       "symbol": "USDC",
@@ -1132,7 +1132,7 @@
       "allowListEnabled": false,
       "decimals": 6,
       "name": "USDC",
-      "poolAddress": "0xAff3fE524ea94118EF09DaDBE3c77ba6AA0005EC",
+      "poolAddress": "0x02eef4b366225362180d704C917c50f6c46af9e0",
       "poolType": "usdc",
       "symbol": "USDC",
       "tokenAddress": "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"
@@ -1173,14 +1173,14 @@
       "symbol": "USDC",
       "tokenAddress": "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582"
     },
-    "ronin-testnet-saigon": {
+    "solana-devnet": {
       "allowListEnabled": false,
       "decimals": 6,
       "name": "USD Coin",
-      "poolAddress": "0xd7CE1E7262ce471CC3Db3Bcd8c3EdeEe6d114115",
-      "poolType": "burnMint",
+      "poolAddress": "7hCNZAWQNSq49CCA1KtjLuZbK5cWguRSVVsJcMa3C5zL",
+      "poolType": "usdc",
       "symbol": "USDC",
-      "tokenAddress": "0x7e72e240572311F558A98C2D782079Fba704b74c"
+      "tokenAddress": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
     }
   },
   "WAPE": {
@@ -1609,16 +1609,6 @@
       "tokenAddress": "0x095ded714d42cBD5fb2E84A0FfbFb140E38dC9E1"
     }
   },
-  "WMATIC": {
-    "polygon-testnet-amoy": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "Wrapped Polygon Ecosystem Token",
-      "poolType": "feeTokenOnly",
-      "symbol": "WPOL",
-      "tokenAddress": "0x360ad4f9a9A8EFe9A8DCB5f461c4Cc1047E1Dcf9"
-    }
-  },
   "WMETIS": {
     "ethereum-testnet-sepolia-andromeda-1": {
       "allowListEnabled": false,
@@ -1667,6 +1657,16 @@
       "poolType": "feeTokenOnly",
       "symbol": "WPLUME",
       "tokenAddress": "0xC1FD14775c8665B31c7154074f537338774351EB"
+    }
+  },
+  "WPOL": {
+    "polygon-testnet-amoy": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Wrapped Polygon Ecosystem Token",
+      "poolType": "feeTokenOnly",
+      "symbol": "WPOL",
+      "tokenAddress": "0x360ad4f9a9A8EFe9A8DCB5f461c4Cc1047E1Dcf9"
     }
   },
   "WRBTC": {


### PR DESCRIPTION
This pull request makes significant updates to the rate limiter configurations for supported tokens within the `src/config/data/ccip/v1_2_0/mainnet/lanes.json` file. The main changes include adding new tokens with disabled rate limiters, adjusting the rate limiter settings for existing tokens (notably `uniBTC` and several others), and removing the `wstLINK` token from multiple lane configurations.

**Token additions and removals:**

* Added new tokens (`TREE`, `beraBTC`, `WLFI`, `YNE`) to various lanes, each with rate limiter configurations set to disabled (capacity and rate set to zero, isEnabled: false). [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R1043-R1056) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R1503-R1516) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R3043-R3056) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R5125-R5138) [[5]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R11987-R12000) [[6]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R16957-R16970)
* Removed the `wstLINK` token and its rate limiter configuration from several lanes. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L5686-L5699) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L5784-L5797) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L6396-L6409) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L18206-L18219)

**Rate limiter configuration changes:**

* For many tokens (especially `uniBTC`), the `in` rate limiter is now disabled (capacity and rate set to zero, isEnabled: false), while the `out` rate limiter has been drastically reduced (capacity set to 2, rate set to 1, isEnabled: true) in most lanes. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L1455-R1471) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L1511-R1541) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L1651-R1681) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L1705-R1735) [[5]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L3037-R3081) [[6]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L3396-R3445) [[7]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L3555-R3599) [[8]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L4057-R4101) [[9]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L6250-R6285) [[10]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L9059-R9075) [[11]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L9199-R9215) [[12]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L16437-R16467) [[13]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L16479-R16509)
* In some lanes, the `uniBTC` token's rate limiter configuration has been changed from high capacity and rate to disabled for `in` and reduced for `out`. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L1854-R1889) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L2020-R2050) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L2864-R2894) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L4472-R4516) [[5]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L5606-R5664) [[6]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L8066-R8082) [[7]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L13668-R13698) [[8]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L14900-R14930)
* In one lane, the `uniBTC` token's rate limiter configuration was restored to higher values (capacity: 200000000, rate: 2315, isEnabled: true) for both `in` and `out`. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L17128-R17177) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R22319-R22332)

These changes likely reflect a substantial update to how rate limiting is managed for tokens on mainnet lanes, possibly for testing, migration, or new token support purposes.