### PR TITLE
add announcement banner for aptos launch

### DIFF
--- a/src/features/notifications/data/index.ts
+++ b/src/features/notifications/data/index.ts
@@ -1,9 +1,9 @@
 import { BannerContent } from "../components/HeaderBanner.tsx"
 
 export const NotificationData: BannerContent = {
-  description: "Chainlink CCIP is now officially live on Solana.",
+  description: "Chainlink CCIP is now officially live on Aptos.",
   type: "info",
   linkText: "View lanes and tokens.",
   linkUrl:
-    "https://docs.chain.link/ccip/directory/mainnet/chain/solana-mainnet?utm_medium=referral&utm_source=chainlink-docs&utm_campaign=solana-ccip",
+    "https://docs.chain.link/ccip/directory/mainnet/chain/aptos-mainnet?utm_medium=referral&utm_source=chainlink-docs&utm_campaign=aptos-ccip",
 }


### PR DESCRIPTION
Chainlink CCIP is now officially live on Aptos. [View lanes and tokens.](https://docs.chain.link/ccip/directory/mainnet/chain/aptos-mainnet?utm_medium=referral&utm_source=chainlink-docs&utm_campaign=aptos-ccip)
