### PR TITLE
add lanes

### DIFF
--- a/public/api/ccip/v1/openapi.json
+++ b/public/api/ccip/v1/openapi.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "CCIP Chains API",
-    "description": "API for retrieving CCIP chain information.\n\nTo get started quickly, you can download our [Postman Collection](/api/ccip/v1/postman-collection.json) which includes all endpoints and example requests.",
-    "version": "1.3.0",
+    "title": "CCIP Docs config API",
+    "description": "API for retrieving CCIP chain, token, and lane information.\n\nTo get started quickly, you can download our [Postman Collection](/api/ccip/v1/postman-collection.json) which includes all endpoints and example requests.",
+    "version": "1.4.0",
     "contact": {
       "name": "File issues",
       "url": "https://github.com/smartcontractkit/documentation/issues/new/choose"
@@ -31,6 +31,10 @@
     {
       "name": "tokens",
       "description": "Token information endpoints"
+    },
+    {
+      "name": "lanes",
+      "description": "Cross-chain lane information endpoints"
     }
   ],
   "paths": {
@@ -291,6 +295,190 @@
           }
         }
       }
+    },
+    "/lanes": {
+      "get": {
+        "tags": ["lanes"],
+        "summary": "Retrieve CCIP lane information",
+        "description": "Returns information about Cross-Chain Interoperability Protocol (CCIP) lanes between supported chains. Each lane represents a unidirectional connection from a source chain to a destination chain, with associated onRamp and offRamp contracts and supported tokens.",
+        "operationId": "getLanes",
+        "parameters": [
+          {
+            "name": "environment",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["mainnet", "testnet"]
+            },
+            "description": "The network environment to query"
+          },
+          {
+            "name": "sourceChainId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by source chain ID. Multiple chain IDs can be specified using comma-separated values",
+            "example": "1,56"
+          },
+          {
+            "name": "destinationChainId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by destination chain ID. Multiple chain IDs can be specified using comma-separated values",
+            "example": "137,42161"
+          },
+          {
+            "name": "sourceSelector",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by source chain CCIP selector. Multiple selectors can be specified using comma-separated values",
+            "example": "5009297550715157269"
+          },
+          {
+            "name": "destinationSelector",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by destination chain CCIP selector. Multiple selectors can be specified using comma-separated values",
+            "example": "4949039107694359620"
+          },
+          {
+            "name": "sourceInternalId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by source chain internal identifier. Multiple IDs can be specified using comma-separated values",
+            "example": "ethereum-mainnet"
+          },
+          {
+            "name": "destinationInternalId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by destination chain internal identifier. Multiple IDs can be specified using comma-separated values",
+            "example": "polygon-mainnet"
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by lane version. Only lanes where both onRamp and offRamp match the specified version will be returned",
+            "example": "1.6.0"
+          },
+          {
+            "name": "outputKey",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": ["chainId", "selector", "internalId"],
+              "default": "chainId"
+            },
+            "description": "Key format to use for organizing the lane keys in the response"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with lane data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaneApiResponse"
+                },
+                "example": {
+                  "metadata": {
+                    "environment": "mainnet",
+                    "timestamp": "2024-01-15T10:30:00Z",
+                    "requestId": "123e4567-e89b-12d3-a456-426614174000",
+                    "ignoredLaneCount": 0,
+                    "validLaneCount": 2
+                  },
+                  "data": {
+                    "1_to_56": {
+                      "sourceChain": {
+                        "chainId": 1,
+                        "displayName": "Ethereum Mainnet",
+                        "selector": "5009297550715157269",
+                        "internalId": "ethereum-mainnet"
+                      },
+                      "destinationChain": {
+                        "chainId": 56,
+                        "displayName": "BNB Smart Chain",
+                        "selector": "13264668187771770619",
+                        "internalId": "bsc-mainnet"
+                      },
+                      "onRamp": {
+                        "address": "0x925228D7B82d883Dde340A55Fe8e6dA56244A22C",
+                        "version": "1.6.0",
+                        "enforceOutOfOrder": false
+                      },
+                      "offRamp": {
+                        "address": "0xdf85c8381954694E74abD07488f452b374A4B4cC",
+                        "version": "1.6.0"
+                      },
+                      "supportedTokens": ["LINK", "CCIP-BnM", "USDC"]
+                    },
+                    "1_to_137": {
+                      "sourceChain": {
+                        "chainId": 1,
+                        "displayName": "Ethereum Mainnet",
+                        "selector": "5009297550715157269",
+                        "internalId": "ethereum-mainnet"
+                      },
+                      "destinationChain": {
+                        "chainId": 137,
+                        "displayName": "Polygon Mainnet",
+                        "selector": "4051577828743386545",
+                        "internalId": "polygon-mainnet"
+                      },
+                      "onRamp": {
+                        "address": "0x3df8dAe2d123081c4D5E946E655F7c109B9Dd630",
+                        "version": "1.5.0"
+                      },
+                      "offRamp": {
+                        "address": "0x0af338C8545eb6265FedC01BEca4cAe0d94DA9Da",
+                        "version": "1.5.0"
+                      },
+                      "supportedTokens": ["LINK", "USDC"]
+                    }
+                  },
+                  "ignored": []
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -464,6 +652,170 @@
               "$ref": "#/components/schemas/ChainConfigError"
             },
             "description": "List of chains that could not be configured"
+          }
+        }
+      },
+      "LaneMetadata": {
+        "type": "object",
+        "required": ["environment", "timestamp", "requestId", "ignoredLaneCount", "validLaneCount"],
+        "properties": {
+          "environment": {
+            "type": "string",
+            "enum": ["mainnet", "testnet"],
+            "description": "The network environment"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO timestamp of the response"
+          },
+          "requestId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier for the request"
+          },
+          "ignoredLaneCount": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of lanes ignored due to configuration issues"
+          },
+          "validLaneCount": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of valid lanes in the response"
+          }
+        }
+      },
+      "ChainInfo": {
+        "type": "object",
+        "required": ["chainId", "displayName", "selector", "internalId", "chainType", "chainFamily"],
+        "properties": {
+          "chainId": {
+            "oneOf": [{ "type": "integer" }, { "type": "string" }],
+            "description": "Identifier of the chain (numeric for EVM chains, string for Solana/Aptos chains)"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Human-readable name of the chain"
+          },
+          "selector": {
+            "type": "string",
+            "description": "CCIP chain selector as a string"
+          },
+          "internalId": {
+            "type": "string",
+            "description": "Internal identifier used in configuration"
+          },
+          "chainType": {
+            "type": "string",
+            "enum": ["evm", "solana", "aptos", "sui"],
+            "description": "Type of blockchain"
+          },
+          "chainFamily": {
+            "type": "string",
+            "enum": ["evm", "mvm", "svm"],
+            "description": "Family of blockchain virtual machine"
+          }
+        }
+      },
+      "LaneDetails": {
+        "type": "object",
+        "required": ["sourceChain", "destinationChain", "onRamp", "offRamp", "supportedTokens"],
+        "properties": {
+          "sourceChain": {
+            "$ref": "#/components/schemas/ChainInfo"
+          },
+          "destinationChain": {
+            "$ref": "#/components/schemas/ChainInfo"
+          },
+          "onRamp": {
+            "type": "object",
+            "required": ["address", "version"],
+            "properties": {
+              "address": {
+                "type": "string",
+                "description": "OnRamp contract address"
+              },
+              "version": {
+                "type": "string",
+                "pattern": "^\\d+\\.\\d+\\.\\d+$",
+                "description": "Normalized semantic version of the OnRamp contract"
+              },
+              "enforceOutOfOrder": {
+                "type": "boolean",
+                "description": "Whether the OnRamp enforces out-of-order execution"
+              }
+            }
+          },
+          "offRamp": {
+            "type": "object",
+            "required": ["address", "version"],
+            "properties": {
+              "address": {
+                "type": "string",
+                "description": "OffRamp contract address"
+              },
+              "version": {
+                "type": "string",
+                "pattern": "^\\d+\\.\\d+\\.\\d+$",
+                "description": "Normalized semantic version of the OffRamp contract"
+              }
+            }
+          },
+          "supportedTokens": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of supported token keys (e.g., LINK, CCIP-BnM, USDC)"
+          }
+        }
+      },
+      "LaneConfigError": {
+        "type": "object",
+        "required": ["sourceChain", "destinationChain", "reason", "missingFields"],
+        "properties": {
+          "sourceChain": {
+            "type": "string",
+            "description": "Source chain identifier that failed configuration"
+          },
+          "destinationChain": {
+            "type": "string",
+            "description": "Destination chain identifier that failed configuration"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Human-readable reason for the configuration failure"
+          },
+          "missingFields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of missing or invalid configuration fields"
+          }
+        }
+      },
+      "LaneApiResponse": {
+        "type": "object",
+        "required": ["metadata", "data", "ignored"],
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/LaneMetadata"
+          },
+          "data": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/LaneDetails"
+            },
+            "description": "Lane data organized by dynamic lane keys (e.g., '1_to_56', 'ethereum-mainnet_to_polygon-mainnet')"
+          },
+          "ignored": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LaneConfigError"
+            },
+            "description": "List of lanes that could not be configured"
           }
         }
       },

--- a/public/api/ccip/v1/postman-collection.json
+++ b/public/api/ccip/v1/postman-collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
-    "name": "CCIP Chains API",
-    "description": "Collection for testing the Cross-Chain Interoperability Protocol (CCIP) Chains API. Includes examples for EVM, Solana, and Aptos chains.",
+    "name": "CCIP API",
+    "description": "Collection for testing the Cross-Chain Interoperability Protocol (CCIP) API. Includes examples for chains, tokens, and lanes across EVM, Solana, and Aptos networks.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -325,6 +325,330 @@
       ]
     },
     {
+      "name": "Lanes",
+      "item": [
+        {
+          "name": "Get All Lanes (Mainnet)",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet",
+                  "description": "Network environment (mainnet/testnet)"
+                }
+              ]
+            },
+            "description": "Retrieve all available CCIP lanes for mainnet environment"
+          }
+        },
+        {
+          "name": "Get All Lanes (Testnet)",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=testnet",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "testnet",
+                  "description": "Network environment (mainnet/testnet)"
+                }
+              ]
+            },
+            "description": "Retrieve all available CCIP lanes for testnet environment"
+          }
+        },
+        {
+          "name": "Get Lanes by Source Chain ID",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet&sourceChainId=1",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet"
+                },
+                {
+                  "key": "sourceChainId",
+                  "value": "1",
+                  "description": "Source chain ID (e.g., 1 for Ethereum)"
+                }
+              ]
+            },
+            "description": "Retrieve lanes where the source chain matches the specified chain ID"
+          }
+        },
+        {
+          "name": "Get Lanes by Destination Chain ID",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet&destinationChainId=56",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet"
+                },
+                {
+                  "key": "destinationChainId",
+                  "value": "56",
+                  "description": "Destination chain ID (e.g., 56 for BSC)"
+                }
+              ]
+            },
+            "description": "Retrieve lanes where the destination chain matches the specified chain ID"
+          }
+        },
+        {
+          "name": "Get Lanes by Source and Destination Chain IDs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet&sourceChainId=1&destinationChainId=56",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet"
+                },
+                {
+                  "key": "sourceChainId",
+                  "value": "1",
+                  "description": "Source chain ID (Ethereum)"
+                },
+                {
+                  "key": "destinationChainId",
+                  "value": "56",
+                  "description": "Destination chain ID (BSC)"
+                }
+              ]
+            },
+            "description": "Retrieve specific lane between Ethereum and BSC"
+          }
+        },
+        {
+          "name": "Get Lanes by Source Selector",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet&sourceSelector=5009297550715157269",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet"
+                },
+                {
+                  "key": "sourceSelector",
+                  "value": "5009297550715157269",
+                  "description": "CCIP source chain selector"
+                }
+              ]
+            },
+            "description": "Retrieve lanes by source chain CCIP selector"
+          }
+        },
+        {
+          "name": "Get Lanes by Destination Selector",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet&destinationSelector=13264668187771770619",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet"
+                },
+                {
+                  "key": "destinationSelector",
+                  "value": "13264668187771770619",
+                  "description": "CCIP destination chain selector"
+                }
+              ]
+            },
+            "description": "Retrieve lanes by destination chain CCIP selector"
+          }
+        },
+        {
+          "name": "Get Lanes by Source Internal ID",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet&sourceInternalId=ethereum-mainnet",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet"
+                },
+                {
+                  "key": "sourceInternalId",
+                  "value": "ethereum-mainnet",
+                  "description": "Source chain internal identifier"
+                }
+              ]
+            },
+            "description": "Retrieve lanes by source chain internal ID"
+          }
+        },
+        {
+          "name": "Get Lanes by Destination Internal ID",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet&destinationInternalId=bsc-mainnet",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet"
+                },
+                {
+                  "key": "destinationInternalId",
+                  "value": "bsc-mainnet",
+                  "description": "Destination chain internal identifier"
+                }
+              ]
+            },
+            "description": "Retrieve lanes by destination chain internal ID"
+          }
+        },
+        {
+          "name": "Get Multiple Source Chains",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet&sourceChainId=1,56",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet"
+                },
+                {
+                  "key": "sourceChainId",
+                  "value": "1,56",
+                  "description": "Multiple source chain IDs (Ethereum and BSC)"
+                }
+              ]
+            },
+            "description": "Retrieve lanes from multiple source chains using comma-separated chain IDs"
+          }
+        },
+        {
+          "name": "Get Solana Lanes (Testnet)",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=testnet&sourceChainId=solana-devnet",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "testnet"
+                },
+                {
+                  "key": "sourceChainId",
+                  "value": "solana-devnet",
+                  "description": "Solana Devnet chain ID"
+                }
+              ]
+            },
+            "description": "Retrieve lanes originating from Solana Devnet"
+          }
+        },
+        {
+          "name": "Get Lanes with Selector Output Key",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet&outputKey=selector",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet"
+                },
+                {
+                  "key": "outputKey",
+                  "value": "selector",
+                  "description": "Organize response by selector (format: sourceSelector_to_destinationSelector)"
+                }
+              ]
+            },
+            "description": "Retrieve lanes with response organized by CCIP selectors"
+          }
+        },
+        {
+          "name": "Get Lanes by Version",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet&version=1.6.0",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet"
+                },
+                {
+                  "key": "version",
+                  "value": "1.6.0",
+                  "description": "Filter by lane version (both onRamp and offRamp must match)"
+                }
+              ]
+            },
+            "description": "Retrieve lanes filtered by specific version. Only returns lanes where both onRamp and offRamp versions match the specified value."
+          }
+        },
+        {
+          "name": "Get Lanes with Internal ID Output Key",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet&outputKey=internalId",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet"
+                },
+                {
+                  "key": "outputKey",
+                  "value": "internalId",
+                  "description": "Organize response by internal ID (format: sourceInternalId_to_destinationInternalId)"
+                }
+              ]
+            },
+            "description": "Retrieve lanes with response organized by internal IDs"
+          }
+        }
+      ]
+    },
+    {
       "name": "Chain Type Examples",
       "item": [
         {
@@ -435,6 +759,71 @@
               ]
             },
             "description": "Test error handling for invalid output key"
+          }
+        },
+        {
+          "name": "Lanes - Invalid Environment",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=invalid",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "invalid",
+                  "description": "Invalid environment value"
+                }
+              ]
+            },
+            "description": "Test lanes error handling for invalid environment"
+          }
+        },
+        {
+          "name": "Lanes - Invalid Filter Value",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet&sourceChainId=",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet"
+                },
+                {
+                  "key": "sourceChainId",
+                  "value": "",
+                  "description": "Empty filter value should cause validation error"
+                }
+              ]
+            },
+            "description": "Test lanes error handling for empty filter values"
+          }
+        },
+        {
+          "name": "Lanes - Invalid Output Key",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/ccip/v1/lanes?environment=mainnet&outputKey=invalid",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "ccip", "v1", "lanes"],
+              "query": [
+                {
+                  "key": "environment",
+                  "value": "mainnet"
+                },
+                {
+                  "key": "outputKey",
+                  "value": "invalid",
+                  "description": "Invalid output key value"
+                }
+              ]
+            },
+            "description": "Test lanes error handling for invalid output key"
           }
         }
       ]

--- a/src/config/data/ccip/v1_2_0/mainnet/chains.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/chains.json
@@ -1005,11 +1005,12 @@
       "version": "1.0.0"
     },
     "chainSelector": "4051577828743386545",
-    "feeTokens": ["LINK", "WMATIC"],
+    "feeTokens": ["LINK", "WPOL"],
     "registryModule": {
       "address": "0xc751E86208F0F8aF2d5CD0e29716cA7AD98B5eF5",
       "version": "1.6.0"
     },
+    "rmnPermeable": false,
     "router": {
       "address": "0x849c5ED5a80F5B408Dd4969b78c2C8fdf0565Bfe",
       "version": "1.2.0"
@@ -1364,6 +1365,7 @@
       "address": "0xF549af21578Cfe2385FFD3488B3039fd9e52f006",
       "version": "1.6.0"
     },
+    "rmnPermeable": false,
     "router": {
       "address": "0x7798b795Fde864f4Cd1b124a38Ba9619B7F8A442",
       "version": "1.2.0"
@@ -1388,6 +1390,7 @@
       "address": "0x1f524a11d89D68a4E4b1c8A195E91Fb1d8f0B56a",
       "version": "1.6.0"
     },
+    "rmnPermeable": false,
     "router": {
       "address": "0x4aAD6071085df840abD9Baf1697d5D5992bDadce",
       "version": "1.2.0"

--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -2020,6 +2020,18 @@
     }
   },
   "binance-smart-chain-mainnet-opbnb-1": {
+    "bsc-mainnet": {
+      "offRamp": {
+        "address": "0x97D090497861ab69fE637781232BCcf302497D17",
+        "version": "1.5.0"
+      },
+      "onRamp": {
+        "address": "0xbDD7a56aeF09C3E8a2Be3C20Bb8c8C054Ea87120",
+        "enforceOutOfOrder": false,
+        "version": "1.5.0"
+      },
+      "rmnPermeable": true
+    },
     "mainnet": {
       "offRamp": {
         "address": "0xe89eF171B45c318ee786941c96944CD162187E2A",
@@ -3226,6 +3238,18 @@
         }
       }
     },
+    "binance-smart-chain-mainnet-opbnb-1": {
+      "offRamp": {
+        "address": "0xA94106fd5c5be306c14Ccb8Ec9f2422bA24E4ea6",
+        "version": "1.5.0"
+      },
+      "onRamp": {
+        "address": "0x2e75695a0a580E120B387CCcADAf7FfdC217a427",
+        "enforceOutOfOrder": false,
+        "version": "1.5.0"
+      },
+      "rmnPermeable": true
+    },
     "bitcoin-mainnet-bitlayer-1": {
       "offRamp": {
         "address": "0xD7B436696b869e0C0241DC44d047F257504F7616",
@@ -4175,6 +4199,18 @@
           }
         }
       }
+    },
+    "ethereum-mainnet-zksync-1": {
+      "offRamp": {
+        "address": "0x67b973aBfd440e33f421b6b157706534295572E7",
+        "version": "1.5.0"
+      },
+      "onRamp": {
+        "address": "0x9D01e82068a9157976D8c794fbd74cAF395F5A37",
+        "enforceOutOfOrder": false,
+        "version": "1.5.0"
+      },
+      "rmnPermeable": true
     },
     "hyperliquid-mainnet": {
       "offRamp": {
@@ -16396,6 +16432,18 @@
         }
       }
     },
+    "bsc-mainnet": {
+      "offRamp": {
+        "address": "0xacE8A9a195d70834e39BD14b4b6973716f545f3a",
+        "version": "1.5.0"
+      },
+      "onRamp": {
+        "address": "0x0cEb5972a6BA5Ed57caB94d71179b741b7D69c74",
+        "enforceOutOfOrder": false,
+        "version": "1.5.0"
+      },
+      "rmnPermeable": true
+    },
     "celo-mainnet": {
       "offRamp": {
         "address": "0x9ff0f85AF7BE9526dC99b6ee91f5BCe5b391808A",
@@ -22829,14 +22877,14 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "50000000000",
+              "capacity": "20000000",
               "isEnabled": true,
-              "rate": "578700"
+              "rate": "2315"
             },
             "out": {
-              "capacity": "50000000000",
+              "capacity": "20000000",
               "isEnabled": true,
-              "rate": "578700"
+              "rate": "2315"
             }
           }
         },
@@ -24848,6 +24896,18 @@
         }
       }
     },
+    "solana-mainnet": {
+      "offRamp": {
+        "address": "0x77FDbd20ED582794b1d9F1a8a94e4a60494D677e",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x530Ae314EC3fA038bd9A215095E37295ec76162a",
+        "enforceOutOfOrder": true,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
+    },
     "soneium-mainnet": {
       "offRamp": {
         "address": "0x1bE40B0e51cC5C353842b94e2E3d2D99c7760865",
@@ -26853,6 +26913,18 @@
           }
         }
       }
+    },
+    "matic-mainnet": {
+      "offRamp": {
+        "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
+        "version": "V1"
+      },
+      "onRamp": {
+        "address": "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C",
+        "enforceOutOfOrder": true,
+        "version": "V1"
+      },
+      "rmnPermeable": true
     },
     "polygon-mainnet-katana": {
       "offRamp": {

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -5907,16 +5907,6 @@
       "tokenAddress": "WLFinEv6ypjkczcS83FZqFpgFZYwQXutRbxGe7oC16g"
     }
   },
-  "WMATIC": {
-    "matic-mainnet": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "Wrapped Polygon Ecosystem Token",
-      "poolType": "feeTokenOnly",
-      "symbol": "WPOL",
-      "tokenAddress": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270"
-    }
-  },
   "WMETIS": {
     "ethereum-mainnet-andromeda-1": {
       "allowListEnabled": false,
@@ -6051,6 +6041,16 @@
       "poolType": "feeTokenOnly",
       "symbol": "WPLUME",
       "tokenAddress": "0xEa237441c92CAe6FC17Caaf9a7acB3f953be4bd1"
+    }
+  },
+  "WPOL": {
+    "matic-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Wrapped Polygon Ecosystem Token",
+      "poolType": "feeTokenOnly",
+      "symbol": "WPOL",
+      "tokenAddress": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270"
     }
   },
   "WRBTC": {

--- a/src/pages/api/ccip/types/index.ts
+++ b/src/pages/api/ccip/types/index.ts
@@ -130,6 +130,83 @@ export interface TokenFilterType {
   chain_id?: string
 }
 
+// Lane Data API Types
+
+export type LaneConfigError = {
+  sourceChain: string
+  destinationChain: string
+  reason: string
+  missingFields: string[]
+}
+
+export type LaneMetadata = {
+  environment: Environment
+  timestamp: string
+  requestId: string
+  ignoredLaneCount: number
+  validLaneCount: number
+}
+
+// Internal interface with chainType and chainFamily for processing
+export interface ChainInfoInternal {
+  chainId: number | string
+  displayName: string
+  selector: string
+  internalId: string
+  chainType: ChainType
+  chainFamily: ChainFamily
+}
+
+// Public interface for API responses without chainType and chainFamily
+export interface ChainInfo {
+  chainId: number | string
+  displayName: string
+  selector: string
+  internalId: string
+}
+
+export interface LaneDetails {
+  sourceChain: ChainInfo
+  destinationChain: ChainInfo
+  onRamp: {
+    address: string
+    version: string
+    enforceOutOfOrder?: boolean
+  }
+  offRamp: {
+    address: string
+    version: string
+  }
+  supportedTokens: string[]
+}
+
+export type LaneDataResponse = Record<string, LaneDetails>
+
+export type LaneServiceResponse = {
+  data: LaneDataResponse
+  errors: LaneConfigError[]
+  metadata: {
+    validLaneCount: number
+    ignoredLaneCount: number
+  }
+}
+
+export type LaneApiResponse = {
+  metadata: LaneMetadata
+  data: LaneDataResponse
+  ignored: LaneConfigError[]
+}
+
+export interface LaneFilterType {
+  sourceChainId?: string
+  destinationChainId?: string
+  sourceSelector?: string
+  destinationSelector?: string
+  sourceInternalId?: string
+  destinationInternalId?: string
+  version?: string
+}
+
 // Faucet API Types
 export type {
   FaucetChainConfig,

--- a/src/pages/api/ccip/utils.ts
+++ b/src/pages/api/ccip/utils.ts
@@ -275,6 +275,34 @@ export const generateChainKey = (chainId: number | string, chainType: ChainType,
 }
 
 /**
+ * Normalizes version strings to consistent semantic versioning format
+ * @param version - Version string to normalize
+ * @returns Normalized version in x.y.z format
+ */
+export const normalizeVersion = (version: string): string => {
+  // Handle "OnRamp 1.6.0" or "OffRamp 1.6.0" formats
+  const contractVersionMatch = version.match(/(?:OnRamp|OffRamp)\s+(\d+\.\d+\.\d+)/i)
+  if (contractVersionMatch) {
+    return contractVersionMatch[1] // Extract "1.6.0"
+  }
+
+  // Handle "V1" format (typically for Solana)
+  if (version.toUpperCase() === "V1") {
+    return "1.6.0" // Map V1 to 1.6.0 for Solana
+  }
+
+  // Handle already correct semver format
+  const semverMatch = version.match(/^(\d+\.\d+\.\d+)$/)
+  if (semverMatch) {
+    return semverMatch[1]
+  }
+
+  // Fallback for unknown formats
+  console.warn(`Unknown version format: ${version}`)
+  return "1.0.0"
+}
+
+/**
  * Handles API errors and converts them to standardized responses
  * @param error - Error to handle
  * @returns Standardized error response

--- a/src/pages/api/ccip/v1/lanes.ts
+++ b/src/pages/api/ccip/v1/lanes.ts
@@ -1,0 +1,148 @@
+import type { APIRoute } from "astro"
+import {
+  validateEnvironment,
+  validateOutputKey,
+  handleApiError,
+  successHeaders,
+  commonHeaders,
+  APIErrorType,
+  createErrorResponse,
+  CCIPError,
+} from "../utils.ts"
+import { logger } from "@lib/logging/index.js"
+
+import type { LaneFilterType, LaneApiResponse, LaneMetadata } from "../types/index.ts"
+import { LaneDataService } from "../../services/lane-data.ts"
+
+export const prerender = false
+
+export const GET: APIRoute = async ({ request }) => {
+  const requestId = crypto.randomUUID()
+
+  try {
+    logger.info({
+      message: "Processing CCIP lanes request",
+      requestId,
+      url: request.url,
+    })
+
+    const url = new URL(request.url)
+    const params = url.searchParams
+
+    // Validate environment
+    const environment = validateEnvironment(params.get("environment") || undefined)
+    logger.debug({
+      message: "Environment validated",
+      requestId,
+      environment,
+    })
+
+    // Get filters for lanes
+    const filters: LaneFilterType = {
+      sourceChainId: params.get("sourceChainId") || undefined,
+      destinationChainId: params.get("destinationChainId") || undefined,
+      sourceSelector: params.get("sourceSelector") || undefined,
+      destinationSelector: params.get("destinationSelector") || undefined,
+      sourceInternalId: params.get("sourceInternalId") || undefined,
+      destinationInternalId: params.get("destinationInternalId") || undefined,
+      version: params.get("version") || undefined,
+    }
+
+    logger.debug({
+      message: "Filter parameters parsed",
+      requestId,
+      filters,
+    })
+
+    // Validate output key
+    const outputKey = validateOutputKey(params.get("outputKey") || undefined)
+    logger.debug({
+      message: "Output key validated",
+      requestId,
+      outputKey,
+    })
+
+    // Validate that at least one valid filter parameter is provided when filters are used
+    const hasFilters = Object.values(filters).some((value) => value !== undefined)
+    if (hasFilters) {
+      // Validate filter format (basic validation for comma-separated values)
+      for (const [key, value] of Object.entries(filters)) {
+        if (value && typeof value === "string") {
+          // Basic validation - ensure no empty values after split
+          const values = value
+            .split(",")
+            .map((v) => v.trim())
+            .filter((v) => v.length > 0)
+          if (values.length === 0) {
+            throw new CCIPError(400, `Invalid filter value for ${key}: cannot be empty`)
+          }
+        }
+      }
+    }
+
+    const laneDataService = new LaneDataService()
+    const {
+      data,
+      errors,
+      metadata: serviceMetadata,
+    } = await laneDataService.getFilteredLanes(environment, filters, outputKey)
+
+    logger.info({
+      message: "Lane data retrieved successfully",
+      requestId,
+      validLaneCount: Object.keys(data).length,
+      errorCount: errors.length,
+      filters,
+    })
+
+    // Create lane-specific metadata
+    const metadata: LaneMetadata = {
+      environment,
+      timestamp: new Date().toISOString(),
+      requestId,
+      ignoredLaneCount: serviceMetadata.ignoredLaneCount,
+      validLaneCount: serviceMetadata.validLaneCount,
+    }
+
+    const response: LaneApiResponse = {
+      metadata,
+      data,
+      ignored: errors,
+    }
+
+    logger.info({
+      message: "Sending successful response",
+      requestId,
+      metadata,
+    })
+
+    return new Response(JSON.stringify(response), {
+      headers: { ...commonHeaders, ...successHeaders },
+    })
+  } catch (error) {
+    logger.error({
+      message: "Error processing lanes request",
+      requestId,
+      error: error instanceof Error ? error.message : "Unknown error",
+      stack: error instanceof Error ? error.stack : undefined,
+    })
+
+    // Handle CCIPError specifically, preserving its status code
+    if (error instanceof CCIPError) {
+      return createErrorResponse(
+        error.statusCode === 400 ? APIErrorType.VALIDATION_ERROR : APIErrorType.SERVER_ERROR,
+        error.message,
+        error.statusCode,
+        {}
+      )
+    }
+
+    // Handle other errors
+    if (error instanceof Error) {
+      return createErrorResponse(APIErrorType.SERVER_ERROR, "Failed to process lanes request", 500, {
+        message: error.message,
+      })
+    }
+    return handleApiError(error)
+  }
+}

--- a/src/pages/api/services/chain-data.ts
+++ b/src/pages/api/services/chain-data.ts
@@ -362,7 +362,7 @@ class AptosChainStrategy extends BaseChainStrategy {
 
   private validateAptosRequirements(chainConfig: ChainsConfig[string]): string[] {
     return Object.entries(AptosChainStrategy.REQUIRED_FIELDS)
-      .filter(([_, validator]) => validator(chainConfig))
+      .filter(([, validator]) => validator(chainConfig))
       .map(([field]) => field)
   }
 }

--- a/src/pages/api/services/lane-data.ts
+++ b/src/pages/api/services/lane-data.ts
@@ -1,0 +1,392 @@
+import {
+  Environment,
+  LaneDetails,
+  LaneFilterType,
+  LaneConfigError,
+  LaneServiceResponse,
+  ChainInfo,
+  ChainInfoInternal,
+  OutputKeyType,
+  ChainType,
+  ChainFamily,
+} from "../ccip/types/index.ts"
+import { loadReferenceData, Version } from "@config/data/ccip/index.ts"
+import type { LaneConfig, ChainConfig } from "@config/data/ccip/types.ts"
+import { generateChainKey, normalizeVersion } from "@api/ccip/utils.ts"
+import { logger } from "@lib/logging/index.js"
+import {
+  getChainId,
+  getTitle,
+  getChainTypeAndFamily,
+  directoryToSupportedChain,
+} from "../../../features/utils/index.ts"
+
+export const prerender = false
+
+/**
+ * Service class for handling CCIP lane data operations
+ * Provides functionality to validate and filter lane configurations
+ */
+export class LaneDataService {
+  private errors: LaneConfigError[] = []
+  private readonly requestId: string
+  private skippedLanesCount = 0
+
+  /**
+   * Creates a new instance of LaneDataService
+   */
+  constructor() {
+    this.requestId = crypto.randomUUID()
+
+    logger.debug({
+      message: "LaneDataService initialized",
+      requestId: this.requestId,
+    })
+  }
+
+  /**
+   * Retrieves and filters lane data based on environment and filters
+   *
+   * @param environment - Network environment (mainnet/testnet)
+   * @param filters - Filter parameters for lanes
+   * @param outputKey - Format to use for displaying lane keys
+   * @returns Filtered lane data with metadata
+   */
+  async getFilteredLanes(
+    environment: Environment,
+    filters: LaneFilterType,
+    outputKey: OutputKeyType
+  ): Promise<LaneServiceResponse> {
+    logger.debug({
+      message: "Processing lane data",
+      requestId: this.requestId,
+      environment,
+      filters,
+      outputKey,
+    })
+
+    try {
+      // Load reference data
+      const { lanesReferenceData, chainsReferenceData } = loadReferenceData({
+        environment,
+        version: Version.V1_2_0,
+      })
+
+      const result: Record<string, LaneDetails> = {}
+      this.errors = []
+      this.skippedLanesCount = 0
+
+      // Process all lanes
+      for (const [sourceChainKey, destinations] of Object.entries(lanesReferenceData)) {
+        for (const [destChainKey, laneConfig] of Object.entries(destinations)) {
+          try {
+            // Get chain information
+            const sourceChain = this.resolveChainInfo(sourceChainKey, chainsReferenceData)
+            const destChain = this.resolveChainInfo(destChainKey, chainsReferenceData)
+
+            if (!sourceChain || !destChain) {
+              this.addError(sourceChainKey, destChainKey, "Failed to resolve chain information", [
+                "sourceChain",
+                "destinationChain",
+              ])
+              continue
+            }
+
+            // Apply filters
+            if (!this.passesFilters(sourceChain, destChain, filters)) {
+              this.skippedLanesCount++
+              continue
+            }
+
+            // Generate lane key
+            const laneKey = this.generateLaneKey(sourceChain, destChain, outputKey)
+
+            // Build lane details
+            const laneDetails = this.buildLaneDetails(sourceChain, destChain, laneConfig)
+
+            // Check for version mismatch
+            if (laneDetails.onRamp.version !== laneDetails.offRamp.version) {
+              this.addError(
+                sourceChainKey,
+                destChainKey,
+                `Version mismatch: onRamp v${laneDetails.onRamp.version} != offRamp v${laneDetails.offRamp.version}`,
+                ["version"]
+              )
+              continue
+            }
+
+            // Apply version filter if provided
+            if (filters.version) {
+              // Both onRamp and offRamp must match the specified version
+              if (laneDetails.onRamp.version !== filters.version || laneDetails.offRamp.version !== filters.version) {
+                this.skippedLanesCount++
+                continue
+              }
+            }
+
+            result[laneKey] = laneDetails
+
+            logger.debug({
+              message: "Lane processed successfully",
+              requestId: this.requestId,
+              laneKey,
+              sourceChain: sourceChainKey,
+              destinationChain: destChainKey,
+            })
+          } catch (error) {
+            this.addError(
+              sourceChainKey,
+              destChainKey,
+              `Lane processing failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+              ["laneConfig"]
+            )
+          }
+        }
+      }
+
+      const validLaneCount = Object.keys(result).length
+      const ignoredLaneCount = this.errors.length
+
+      logger.info({
+        message: "Lane data processing completed",
+        requestId: this.requestId,
+        validLaneCount,
+        ignoredLaneCount,
+        skippedLanesCount: this.skippedLanesCount,
+      })
+
+      return {
+        data: result,
+        errors: this.errors,
+        metadata: {
+          validLaneCount,
+          ignoredLaneCount,
+        },
+      }
+    } catch (error) {
+      logger.error({
+        message: "Failed to process lane data",
+        requestId: this.requestId,
+        error: error instanceof Error ? error.message : "Unknown error",
+      })
+
+      throw error
+    }
+  }
+
+  /**
+   * Resolves chain information from chain key
+   */
+  private resolveChainInfo(chainKey: string, chainsReferenceData: Record<string, unknown>): ChainInfoInternal | null {
+    try {
+      const chainConfig = chainsReferenceData[chainKey]
+
+      if (!chainConfig) {
+        return null
+      }
+
+      // Try to get supported chain for additional info, but don't fail if not found
+      let chainId: string | number = chainKey // fallback to chainKey
+      let displayName: string = chainKey // fallback to chainKey
+      let chainType: ChainType = "evm" // default to evm
+      let chainFamily: ChainFamily = "evm" // default to evm
+
+      try {
+        const supportedChain = directoryToSupportedChain(chainKey)
+        const resolvedChainId = getChainId(supportedChain)
+        const resolvedDisplayName = getTitle(supportedChain)
+        const { chainType: resolvedChainType, chainFamily: resolvedChainFamily } = getChainTypeAndFamily(supportedChain)
+
+        if (resolvedChainId) chainId = resolvedChainId
+        if (resolvedDisplayName) displayName = resolvedDisplayName
+        chainType = resolvedChainType
+        chainFamily = resolvedChainFamily
+      } catch {
+        // If directoryToSupportedChain fails, continue with fallback values
+        // This allows processing of chains not yet in the mapping
+      }
+
+      // Get selector from chain configuration
+      const configData = chainConfig as ChainConfig
+      const selector = configData.chainSelector
+
+      if (!selector) {
+        return null
+      }
+
+      return {
+        chainId,
+        displayName,
+        selector,
+        internalId: chainKey,
+        chainType,
+        chainFamily,
+      }
+    } catch (error) {
+      logger.warn({
+        message: "Failed to resolve chain info",
+        requestId: this.requestId,
+        chainKey,
+        error: error instanceof Error ? error.message : "Unknown error",
+      })
+      return null
+    }
+  }
+
+  /**
+   * Checks if a lane passes the given filters
+   */
+  private passesFilters(
+    sourceChain: ChainInfoInternal,
+    destChain: ChainInfoInternal,
+    filters: LaneFilterType
+  ): boolean {
+    // Check source chain filters
+    if (filters.sourceChainId && !this.matchesChainFilter(sourceChain, filters.sourceChainId, "chainId")) {
+      return false
+    }
+    if (filters.sourceSelector && !this.matchesChainFilter(sourceChain, filters.sourceSelector, "selector")) {
+      return false
+    }
+    if (filters.sourceInternalId && !this.matchesChainFilter(sourceChain, filters.sourceInternalId, "internalId")) {
+      return false
+    }
+
+    // Check destination chain filters
+    if (filters.destinationChainId && !this.matchesChainFilter(destChain, filters.destinationChainId, "chainId")) {
+      return false
+    }
+    if (filters.destinationSelector && !this.matchesChainFilter(destChain, filters.destinationSelector, "selector")) {
+      return false
+    }
+    if (
+      filters.destinationInternalId &&
+      !this.matchesChainFilter(destChain, filters.destinationInternalId, "internalId")
+    ) {
+      return false
+    }
+
+    return true
+  }
+
+  /**
+   * Checks if a chain matches a specific filter value
+   */
+  private matchesChainFilter(
+    chain: ChainInfoInternal,
+    filterValue: string,
+    filterType: "chainId" | "selector" | "internalId"
+  ): boolean {
+    const filterValues = filterValue.split(",").map((v) => v.trim())
+    const chainValue = chain[filterType].toString()
+
+    // For chainId, also check generated chain key format
+    if (filterType === "chainId") {
+      const generatedKey = generateChainKey(chain.chainId, chain.chainType, "chainId")
+      return filterValues.includes(chainValue) || filterValues.includes(generatedKey)
+    }
+
+    return filterValues.includes(chainValue)
+  }
+
+  /**
+   * Generates a lane key based on source and destination chains
+   */
+  private generateLaneKey(
+    sourceChain: ChainInfoInternal,
+    destChain: ChainInfoInternal,
+    outputKey: OutputKeyType
+  ): string {
+    const sourceKey =
+      outputKey === "chainId"
+        ? generateChainKey(sourceChain.chainId, sourceChain.chainType, outputKey)
+        : sourceChain[outputKey].toString()
+
+    const destKey =
+      outputKey === "chainId"
+        ? generateChainKey(destChain.chainId, destChain.chainType, outputKey)
+        : destChain[outputKey].toString()
+
+    return `${sourceKey}_to_${destKey}`
+  }
+
+  /**
+   * Builds lane details from chain info and lane config
+   */
+  private buildLaneDetails(
+    sourceChain: ChainInfoInternal,
+    destChain: ChainInfoInternal,
+    laneConfig: LaneConfig
+  ): LaneDetails {
+    // Convert internal chain info to public interface (remove chainType and chainFamily)
+    const publicSourceChain: ChainInfo = {
+      chainId: sourceChain.chainId,
+      displayName: sourceChain.displayName,
+      selector: sourceChain.selector,
+      internalId: sourceChain.internalId,
+    }
+
+    const publicDestChain: ChainInfo = {
+      chainId: destChain.chainId,
+      displayName: destChain.displayName,
+      selector: destChain.selector,
+      internalId: destChain.internalId,
+    }
+
+    return {
+      sourceChain: publicSourceChain,
+      destinationChain: publicDestChain,
+      onRamp: {
+        address: laneConfig.onRamp.address,
+        version: normalizeVersion(laneConfig.onRamp.version),
+        enforceOutOfOrder: laneConfig.onRamp.enforceOutOfOrder,
+      },
+      offRamp: {
+        address: laneConfig.offRamp.address,
+        version: normalizeVersion(laneConfig.offRamp.version),
+      },
+      supportedTokens: this.extractSupportedTokens(laneConfig),
+    }
+  }
+
+  /**
+   * Extracts supported token keys from lane configuration
+   */
+  private extractSupportedTokens(laneConfig: LaneConfig): string[] {
+    if (!laneConfig.supportedTokens) {
+      return []
+    }
+
+    // Extract token keys from supportedTokens object
+    // lanes.json structure: "supportedTokens": { "LINK": {...}, "CCIP-BnM": {...} }
+    return Object.keys(laneConfig.supportedTokens)
+  }
+
+  /**
+   * Adds an error to the error collection
+   */
+  private addError(sourceChain: string, destinationChain: string, reason: string, missingFields: string[]): void {
+    this.errors.push({
+      sourceChain,
+      destinationChain,
+      reason,
+      missingFields,
+    })
+
+    logger.warn({
+      message: "Lane validation error",
+      requestId: this.requestId,
+      sourceChain,
+      destinationChain,
+      reason,
+      missingFields,
+    })
+  }
+
+  /**
+   * Gets the request ID for this service instance
+   */
+  getRequestId(): string {
+    return this.requestId
+  }
+}

--- a/src/tests/openapi.test.ts
+++ b/src/tests/openapi.test.ts
@@ -19,7 +19,7 @@ describe("OpenAPI Specification", () => {
 
   it("should have required info fields", () => {
     expect(openApiDoc.info).toBeDefined()
-    expect(openApiDoc.info.title).toBe("CCIP Chains API")
+    expect(openApiDoc.info.title).toBe("CCIP Docs config API")
     expect(openApiDoc.info.version).toBeDefined()
     expect(openApiDoc.info.description).toBeDefined()
   })


### PR DESCRIPTION
This pull request updates the CCIP API documentation and Postman collection to introduce support for querying cross-chain lane information, in addition to existing chain and token endpoints. The changes expand the API specification to include new endpoints and response schemas for lanes, providing detailed metadata and error reporting for lane configurations.

### API Specification Enhancements

* Added a new `/lanes` endpoint to the OpenAPI specification, enabling retrieval of CCIP lane information with extensive query parameters for filtering by chain, selector, internal ID, and version. The endpoint includes detailed example responses and error handling.
* Introduced new OpenAPI components: `LaneMetadata`, `ChainInfo`, `LaneDetails`, `LaneConfigError`, and `LaneApiResponse` to describe lane data, metadata, and error reporting in responses.

### Documentation and Metadata Updates

* Updated the OpenAPI `info` section to reflect the broader scope of the API, now titled "CCIP Docs config API" and versioned as 1.4.0, with an expanded description covering chains, tokens, and lanes.
* Added a new `lanes` tag to the OpenAPI specification for organizing lane-related endpoints.
* Updated the Postman collection metadata to match the expanded API scope, renaming it to "CCIP API" and updating the description to include chains, tokens, and lanes.