### PR TITLE
add three new search capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@astrojs/react": "^4.3.0",
     "@astrojs/sitemap": "^3.5.1",
     "@astrojs/vercel": "^8.2.7",
-    "@chainlink/cl-search-frontend": "^0.11.4",
+    "@chainlink/cl-search-frontend": "^0.12.0-3",
     "@chainlink/components": "^0.4.18",
     "@chainlink/contracts": "1.4.0",
     "@chainlink/contracts-ccip": "1.6.1",

--- a/src/components/Header/aiSearch/Search.tsx
+++ b/src/components/Header/aiSearch/Search.tsx
@@ -40,6 +40,9 @@ function AlgoliaSearch({ algoliaVars }) {
       categoryOrder={["Documentation"]}
       popularCards={popularCards}
       ariaLabel="Open AI search"
+      spotlight={["Documentation"]}
+      categoriesToShow={["Documentation", "CCIP Network"]}
+      hideSuggestions={true}
     />
   )
 }


### PR DESCRIPTION
// This will force the application to JUST show the following categories
categoryToShow={['Site','CCIP']} 

// This field will hide the suggested entries shown when the Search is first loaded
hideSuggestions={true} 

// This field marks a category as spotlight. This will add the blue dot in the category navbar, but also add the "localResource" in the search result
spotlight={["Site", 'CCIP']}