### PR TITLE
add new hyperevm testnet rpc guide to network specific ccip docs

### DIFF
--- a/src/config/sidebar.ts
+++ b/src/config/sidebar.ts
@@ -1775,6 +1775,10 @@ export const SIDEBAR: Partial<Record<Sections, SectionEntry[]>> = {
               title: "Hyperliquid Integration Guide",
               url: "ccip/tools-resources/network-specific/hyperliquid-integration-guide",
             },
+            {
+              title: "HyperEVM Testnet RPC Guide",
+              url: "/ccip/tools-resources/network-specific/hyperevm-testnet-rpc",
+            },
           ],
         },
         {

--- a/src/content/ccip/tools-resources/network-specific/hyperevm-testnet-rpc.mdx
+++ b/src/content/ccip/tools-resources/network-specific/hyperevm-testnet-rpc.mdx
@@ -1,0 +1,169 @@
+---
+title: "HyperEVM Testnet RPC Guide"
+section: "ccip"
+metadata:
+  description: "CCIP is fully compatible with Hyperliquid, allowing multichain tokens to be eligible for trading on the Hyperliquid decentralized exchange."
+  excerpt: "ccip hyperliquid hyperevm hypercore bridge cross-chain token"
+  datePublished: "2024-08-08T07:51:46Z"
+---
+
+import { CopyText } from "@components"
+import { Aside } from "@components"
+
+<Aside type="note" title="Disclaimer">
+  This RPC is provided “as is” without warranties of any kind. Use is at your own risk, Chainlink Labs and its
+  affiliates are not liable for any losses, damages, or interruptions arising from its use. The RPC may be modified or
+  unavailable at any time, and users are solely responsible for their interactions and compliance with applicable laws.
+</Aside>
+
+## Overview
+
+To enhance the HyperEVM developer experience we are providing free public access to our professionally hosted Testnet RPC endpoint. Developers can use this to build Hyperliquid applications and as a testnet RPC endpoint in the browser wallet. For mainnet deployments, see available mainnet RPC urls on the [Hyperliquid docs](https://hyperliquid.gitbook.io/hyperliquid-docs/builder-tools/hyperevm-tools).
+
+## RPC Endpoint Details
+
+- **Network Name**: HyperEVM Testnet
+- **RPC URL**: https://rpcs.chain.link/hyperevm/testnet
+- **Chain ID**: 998
+- **Currency Symbol**: HYPE
+- **Block Explorer URL (Optional)**: https://testnet.purrsec.com/
+
+IMPORTANT: We are seeking approval to host this at https://rpcs.chain.link/hyperevm/testnet
+
+## For Developers: Building with the RPC
+
+You can use this endpoint in your dApps, scripts, or backend services with any standard Web3 library.
+
+### Ethers.js (JavaScript/TypeScript)
+
+```javascript
+import { ethers } from "ethers"
+
+const rpcUrl = "https://rpcs.chain.link/hyperevm/testnet"
+const provider = new ethers.JsonRpcProvider(rpcUrl)
+
+async function getBlock() {
+  const blockNumber = await provider.getBlockNumber()
+  console.log("Current Block Number:", blockNumber)
+}
+
+getBlock()
+```
+
+### Web3.js (JavaScript/TypeScript)
+
+```javascript
+import Web3 from "web3"
+
+const rpcUrl = "https://rpcs.chain.link/hyperevm/testnet"
+const web3 = new Web3(new Web3.providers.HttpProvider(rpcUrl))
+
+async function getBlock() {
+  const blockNumber = await web3.eth.getBlockNumber()
+  console.log("Current Block Number:", blockNumber)
+}
+
+getBlock()
+```
+
+### Web3.py (Python)
+
+```python
+from web3 import Web3
+
+rpc_url =  "https://rpcs.chain.link/hyperevm/testnet"
+w3 = Web3(Web3.HTTPProvider(rpc_url))
+
+if w3.is_connected():
+    print("Connected to RPC!")
+    block_number = w3.eth.block_number
+    print("Current Block Number:", block_number)
+else:
+    print("Failed to connect.")
+```
+
+### cURL (Testing)
+
+```shell
+curl -X POST -H "Content-Type: application/json" \
+     --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+      https://rpcs.chain.link/hyperevm/testnet
+```
+
+**Expected Response**:
+
+```json
+{ "jsonrpc": "2.0", "id": 1, "result": "0x1f92031" }
+```
+
+## For Users: Adding to Your Wallet
+
+You can easily add this network to browser extension wallets like MetaMask or Rabby.
+
+### Using MetaMask
+
+1. Open your MetaMask wallet.
+2. Click the network selection dropdown at the top left.
+3. Click "Add network".
+4. At the bottom, select "Add a network manually".
+5. Fill in the form with the network details:
+   - Network Name: HyperEVM Testnet
+   - RPC URL: https://rpcs.chain.link/hyperevm/testnet
+   - Chain ID: 998
+   - Currency Symbol: HYPE
+   - Block Explorer URL (Optional): https://testnet.purrsec.com/
+6. Click "Save".
+
+### Using Rabby
+
+1. Click on the “More” button, find “Add Custom Network” .
+2. Press "Add Custom Network", or the edit button if editing an existing connection
+3. Fill in the network details:
+   - Network Name: HyperEVM Testnet
+   - RPC URL: https://rpcs.chain.link/hyperevm/testnet
+   - Chain ID: 998
+   - Currency Symbol: HYPE
+   - Block Explorer URL (Optional): https://testnet.purrsec.com/
+4. Click "Confirm."
+
+## Supported JSON-RPC Methods
+
+| Method                                  | Description                                                                                              |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| net_version                             | Returns the current network ID (as a decimal string).                                                    |
+| web3_clientVersion                      | Returns the client software version string.                                                              |
+| eth_blockNumber                         | Returns the number of the most recent block (hex quantity).                                              |
+| eth_call                                | Executes a read-only call (no state change) against a contract. Only the latest block is supported.      |
+| eth_chainId                             | Returns the chain ID used for EIP-155 transaction signing (hex quantity).                                |
+| eth_estimateGas                         | Estimates the gas required to execute a transaction/call. Only the latest block is supported.            |
+| eth_feeHistory                          | Returns historical base fees, priority fee rewards, and gas usage ratios for a range of recent blocks.   |
+| eth_gasPrice                            | Returns the node’s suggested gas price. Returns the base fee for the next small block.                   |
+| eth_getBalance                          | Returns the account balance for an address. Only the latest block is supported.                          |
+| eth_getBlockByHash                      | Returns block details by block hash; can include full transactions when requested.                       |
+| eth_getBlockByNumber                    | Returns block details by block number; can include full transactions when requested.                     |
+| eth_getBlockReceipts                    | Returns all transaction receipts for the specified block.                                                |
+| eth_getBlockTransactionCountByHash      | Returns the number of transactions in a block, by block hash.                                            |
+| eth_getBlockTransactionCountByNumber    | Returns the number of transactions in a block, by block number.                                          |
+| eth_getCode                             | Returns the EVM bytecode at an address. Only the latest block is supported.                              |
+| eth_getLogs                             | Returns log entries that match a filter object. Up to 4 topics and up to 50 blocks in query range.       |
+| eth_getStorageAt                        | Returns the value from a storage slot at an address. Only the latest block is supported.                 |
+| eth_getTransactionByBlockHashAndIndex   | Returns a transaction from a block, by block hash and transaction index.                                 |
+| eth_getTransactionByBlockNumberAndIndex | Returns a transaction from a block, by block number and transaction index.                               |
+| eth_getTransactionByHash                | Returns a transaction by its hash.                                                                       |
+| eth_getTransactionCount                 | Returns the number of transactions sent from an address (the nonce). Only the latest block is supported. |
+| eth_getTransactionReceipt               | Returns the receipt of a transaction by hash (includes status, gas used, logs).                          |
+| eth_maxPriorityFeePerGas                | Returns the current max priority fee per gas (tip). Always returns zero currently.                       |
+| eth_syncing                             | Reports node sync status. Always returns false.                                                          |
+
+The following HyperEVM specific endpoints are available:
+
+| Method                        | Description                                                                                                |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| eth_bigBlockGasPrice          | Returns the base fee for the next big block.                                                               |
+| eth_usingBigBlocks            | Returns whether the address is using big blocks.                                                           |
+| eth_getSystemTxsByBlockHash   | Similar to the "getTransaction" analogs but returns the system transactions that originate from HyperCore. |
+| eth_getSystemTxsByBlockNumber | Similar to the "getTransaction" analogs but returns the system transactions that originate from HyperCore. |
+
+## Rate Limits
+
+1,000 requests per IP 5 minute moving window.

--- a/src/content/ccip/tools-resources/network-specific/index.mdx
+++ b/src/content/ccip/tools-resources/network-specific/index.mdx
@@ -7,4 +7,7 @@ isIndex: true
 
 This section provides guidance on how to integrate with networks that require specific setup in order to successfully utilize CCIP.
 
+## Hyperliquid
+
 - [Hyperliquid Integration Guide](/ccip/tools-resources/network-specific/hyperliquid-integration-guide)
+- [HyperEVM Testnet RPC Guide](/ccip/tools-resources/network-specific/hyperevm-testnet-rpc)


### PR DESCRIPTION
This pull request adds comprehensive documentation for the HyperEVM Testnet RPC endpoint to the CCIP tools and resources section, making it easier for developers and users to integrate HyperEVM with their applications and wallets. The sidebar and index are updated to include this new guide, improving discoverability for anyone seeking Hyperliquid-related resources.

**Documentation Additions:**

* Added a new file `hyperevm-testnet-rpc.mdx` containing a detailed guide for using the HyperEVM Testnet RPC, including endpoint details, developer instructions, wallet integration steps, supported JSON-RPC methods (including HyperEVM-specific endpoints), and rate limits.

**Navigation Updates:**

* Updated the sidebar configuration in `sidebar.ts` to include the "HyperEVM Testnet RPC Guide" under the Hyperliquid section for easier access.
* Added a link to the new guide in the network-specific index page, ensuring users can find it alongside other Hyperliquid resources.