### PR TITLE
directory listing 20251010

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -173,12 +173,12 @@
             "in": {
               "capacity": "200000000",
               "isEnabled": true,
-              "rate": "23148"
+              "rate": "2315"
             },
             "out": {
               "capacity": "200000000",
               "isEnabled": true,
-              "rate": "23148"
+              "rate": "2315"
             }
           }
         },
@@ -187,12 +187,26 @@
             "in": {
               "capacity": "200000000",
               "isEnabled": true,
-              "rate": "23148"
+              "rate": "2315"
             },
             "out": {
               "capacity": "200000000",
               "isEnabled": true,
-              "rate": "23148"
+              "rate": "2315"
+            }
+          }
+        },
+        "USD1": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -225,14 +239,14 @@
         "LINK": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "5000000000000",
+              "isEnabled": true,
+              "rate": "1388000000"
             },
             "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "5000000000000",
+              "isEnabled": true,
+              "rate": "1388000000"
             }
           }
         }
@@ -267,26 +281,26 @@
             "in": {
               "capacity": "200000000",
               "isEnabled": true,
-              "rate": "23148"
+              "rate": "2315"
             },
             "out": {
               "capacity": "200000000",
               "isEnabled": true,
-              "rate": "23148"
+              "rate": "2315"
             }
           }
         },
         "LINK": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "5000000000000",
+              "isEnabled": true,
+              "rate": "1388000000"
             },
             "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "5000000000000",
+              "isEnabled": true,
+              "rate": "1388000000"
             }
           }
         },
@@ -295,12 +309,26 @@
             "in": {
               "capacity": "200000000",
               "isEnabled": true,
-              "rate": "23148"
+              "rate": "2315"
             },
             "out": {
               "capacity": "200000000",
               "isEnabled": true,
-              "rate": "23148"
+              "rate": "2315"
+            }
+          }
+        },
+        "USD1": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -321,14 +349,14 @@
         "LINK": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "5000000000000",
+              "isEnabled": true,
+              "rate": "1388000000"
             },
             "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "5000000000000",
+              "isEnabled": true,
+              "rate": "1388000000"
             }
           }
         }
@@ -431,6 +459,20 @@
       "rmnPermeable": false,
       "supportedTokens": {
         "BETS": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "LEND": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -582,6 +624,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SDY": {
           "rateLimiterConfig": {
             "in": {
@@ -667,6 +723,20 @@
           }
         },
         "VRTX": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "wstLINK": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -775,6 +845,20 @@
               "capacity": "1500000000000000000000000",
               "isEnabled": true,
               "rate": "300000000000000000000"
+            }
+          }
+        },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -964,15 +1048,15 @@
     },
     "ethereum-mainnet-linea-1": {
       "offRamp": {
-        "address": "0x6A3CEf8e5CA7135C574f69d0b58dd0ac9DB2D892",
-        "version": "1.5.0"
+        "address": "0xe72d25aDd538E8ef9CeF85622eA8912a6CB98Be6",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0xc432b86153Eb64D46ecea00591EE7CBc27538c4b",
-        "enforceOutOfOrder": true,
-        "version": "1.5.0"
+        "address": "0x02A4D69cFfeC00Fbf7F3B60c93e3529Dfc58894d",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
       },
-      "rmnPermeable": false,
+      "rmnPermeable": true,
       "supportedTokens": {
         "SolvBTC": {
           "rateLimiterConfig": {
@@ -1296,6 +1380,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "Memento": {
           "rateLimiterConfig": {
             "in": {
@@ -1464,6 +1562,34 @@
             }
           }
         },
+        "wstLINK": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "wstPOL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "xSILO": {
           "rateLimiterConfig": {
             "in": {
@@ -1534,6 +1660,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "Memento": {
           "rateLimiterConfig": {
             "in": {
@@ -1590,6 +1730,34 @@
             }
           }
         },
+        "wstLINK": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "wstPOL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "xSolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -1616,7 +1784,23 @@
         "enforceOutOfOrder": false,
         "version": "1.6.0"
       },
-      "rmnPermeable": true
+      "rmnPermeable": true,
+      "supportedTokens": {
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
+      }
     },
     "sei-mainnet": {
       "offRamp": {
@@ -3375,6 +3559,20 @@
               "rate": "2315"
             }
           }
+        },
+        "USD1": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -3391,6 +3589,20 @@
       "rmnPermeable": false,
       "supportedTokens": {
         "BETS": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "LEND": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -3808,6 +4020,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "mBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -3881,9 +4107,9 @@
         "STBU": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
             },
             "out": {
               "capacity": "0",
@@ -4113,6 +4339,20 @@
               "capacity": "5000000000",
               "isEnabled": true,
               "rate": "462963"
+            }
+          }
+        },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -4896,6 +5136,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "mBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -5383,6 +5637,20 @@
               "capacity": "20000000000000000000000",
               "isEnabled": true,
               "rate": "5550000000000000000"
+            }
+          }
+        },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -6516,6 +6784,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SDY": {
           "rateLimiterConfig": {
             "in": {
@@ -6611,6 +6893,20 @@
               "capacity": "10000000000000000000000000",
               "isEnabled": true,
               "rate": "1000000000000000000000000"
+            }
+          }
+        },
+        "wstLINK": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -6810,6 +7106,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "mBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -6888,9 +7198,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
             }
           }
         },
@@ -7251,6 +7561,20 @@
               "capacity": "3000000000000000000000000",
               "isEnabled": true,
               "rate": "34720000000000000000"
+            }
+          }
+        },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -7692,15 +8016,15 @@
     },
     "ethereum-mainnet-linea-1": {
       "offRamp": {
-        "address": "0xCb1DBBb4Be5aEc889C65ff34882f1eAb2Cd5785B",
-        "version": "1.5.0"
+        "address": "0xee85aEfb15b9489563A6a29891ebe0750AA1A7Ae",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0xCeAB512ed28727EeAB94698281F38A2c04b0ce78",
-        "enforceOutOfOrder": true,
-        "version": "1.5.0"
+        "address": "0x76a443768A5e3B8d1AED0105FC250877841Deb40",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
       },
-      "rmnPermeable": false,
+      "rmnPermeable": true,
       "supportedTokens": {
         "SolvBTC": {
           "rateLimiterConfig": {
@@ -8444,6 +8768,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "mBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -8718,9 +9056,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
             }
           }
         },
@@ -9186,6 +9524,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SDM": {
           "rateLimiterConfig": {
             "in": {
@@ -9222,9 +9574,9 @@
               "rate": "0"
             },
             "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
             }
           }
         },
@@ -9284,6 +9636,20 @@
             }
           }
         },
+        "wstLINK": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "xSolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -9327,14 +9693,14 @@
         "FLUID": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "100000000000000000000",
+              "capacity": "500000000000000000000000",
               "isEnabled": true,
-              "rate": "1157407407407407"
+              "rate": "5787000000000000000"
             },
             "out": {
-              "capacity": "100000000000000000000",
+              "capacity": "500000000000000000000000",
               "isEnabled": true,
-              "rate": "1157407407407407"
+              "rate": "5787000000000000000"
             }
           }
         }
@@ -9738,6 +10104,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "Memento": {
           "rateLimiterConfig": {
             "in": {
@@ -10113,6 +10493,20 @@
               "capacity": "5000000000",
               "isEnabled": true,
               "rate": "462963"
+            }
+          }
+        },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -10559,6 +10953,20 @@
               "capacity": "3000000000000000000000000",
               "isEnabled": true,
               "rate": "34720000000000000000"
+            }
+          }
+        },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -11042,15 +11450,15 @@
     },
     "ethereum-mainnet-linea-1": {
       "offRamp": {
-        "address": "0x335581943Ef47030e52E4Fe921d4b72d15a20aB3",
-        "version": "1.5.0"
+        "address": "0xf09AFe78d3c7d359b334d7cB88995751F7eC5E13",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0xB1ddDDe9C1e88DF7751f8f2cf18569B13C8AF670",
-        "enforceOutOfOrder": true,
-        "version": "1.5.0"
+        "address": "0xee85aEfb15b9489563A6a29891ebe0750AA1A7Ae",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
       },
-      "rmnPermeable": false,
+      "rmnPermeable": true,
       "supportedTokens": {
         "AISTR": {
           "rateLimiterConfig": {
@@ -11848,6 +12256,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "LINK": {
           "rateLimiterConfig": {
             "in": {
@@ -12576,6 +12998,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "LYP": {
           "rateLimiterConfig": {
             "in": {
@@ -12731,14 +13167,14 @@
         "FLUID": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "100000000000000000000",
+              "capacity": "500000000000000000000000",
               "isEnabled": true,
-              "rate": "1157407407407407"
+              "rate": "5787000000000000000"
             },
             "out": {
-              "capacity": "100000000000000000000",
+              "capacity": "500000000000000000000000",
               "isEnabled": true,
-              "rate": "1157407407407407"
+              "rate": "5787000000000000000"
             }
           }
         }
@@ -14246,15 +14682,15 @@
   "ethereum-mainnet-linea-1": {
     "avalanche-mainnet": {
       "offRamp": {
-        "address": "0xd2f4330dc0f587770f0fCb61F8D96409f4BD23Fe",
-        "version": "1.5.0"
+        "address": "0x61b7492A40AE4c403629703a38d24851CAA1e7E4",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x03dD4319019435D8FD5aE5920B96f37989EA410e",
+        "address": "0x1bADBe95bEe68D3a74EC08621256ddDBe6eAd3F9",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
-      "rmnPermeable": false,
+      "rmnPermeable": true,
       "supportedTokens": {
         "SolvBTC": {
           "rateLimiterConfig": {
@@ -14386,15 +14822,15 @@
     },
     "ethereum-mainnet-arbitrum-1": {
       "offRamp": {
-        "address": "0x90388147f034A60Adc4FbE9dc93084bab639D047",
-        "version": "1.5.0"
+        "address": "0x61b7492A40AE4c403629703a38d24851CAA1e7E4",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x6d297Db3471057D7d014D7100A073de2e2656b8F",
+        "address": "0x1bADBe95bEe68D3a74EC08621256ddDBe6eAd3F9",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
-      "rmnPermeable": false,
+      "rmnPermeable": true,
       "supportedTokens": {
         "SolvBTC": {
           "rateLimiterConfig": {
@@ -14456,15 +14892,15 @@
     },
     "ethereum-mainnet-base-1": {
       "offRamp": {
-        "address": "0x502eAaF47ECC410ed5f7b39Dd476d0d05Ae55864",
-        "version": "1.5.0"
+        "address": "0x61b7492A40AE4c403629703a38d24851CAA1e7E4",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x39ee3A92a5E836eD5a3CceB6B6F00481B5093b3e",
+        "address": "0x1bADBe95bEe68D3a74EC08621256ddDBe6eAd3F9",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
-      "rmnPermeable": false,
+      "rmnPermeable": true,
       "supportedTokens": {
         "AISTR": {
           "rateLimiterConfig": {
@@ -14816,7 +15252,31 @@
         }
       }
     },
+    "plasma-mainnet": {
+      "offRamp": {
+        "address": "0x61b7492A40AE4c403629703a38d24851CAA1e7E4",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x1bADBe95bEe68D3a74EC08621256ddDBe6eAd3F9",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
+    },
     "sonic-mainnet": {
+      "offRamp": {
+        "address": "0x61b7492A40AE4c403629703a38d24851CAA1e7E4",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x1bADBe95bEe68D3a74EC08621256ddDBe6eAd3F9",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
+    },
+    "xdai-mainnet": {
       "offRamp": {
         "address": "0x61b7492A40AE4c403629703a38d24851CAA1e7E4",
         "version": "1.6.0"
@@ -15161,6 +15621,20 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
             }
           }
         },
@@ -18239,6 +18713,20 @@
               "rate": "2315"
             }
           }
+        },
+        "USD1": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -18381,6 +18869,20 @@
           }
         },
         "LEASH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "LEND": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -18559,6 +19061,34 @@
               "capacity": "1000000000000000000000000",
               "isEnabled": true,
               "rate": "11600000000000000000"
+            }
+          }
+        },
+        "wstLINK": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "wstPOL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -19245,6 +19775,20 @@
           }
         },
         "LEASH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "LEND": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -20218,6 +20762,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "mBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -20487,9 +21045,9 @@
         "STBU": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
             },
             "out": {
               "capacity": "0",
@@ -21227,6 +21785,20 @@
           }
         },
         "LEASH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "LEND": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -22360,6 +22932,20 @@
             }
           }
         },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            }
+          }
+        },
         "wUSDx": {
           "rateLimiterConfig": {
             "in": {
@@ -23478,6 +24064,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "Memento": {
           "rateLimiterConfig": {
             "in": {
@@ -23646,6 +24246,20 @@
             }
           }
         },
+        "wstLINK": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "wstPOL": {
           "rateLimiterConfig": {
             "in": {
@@ -23769,14 +24383,14 @@
         "FLUID": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "100000000000000000000",
+              "capacity": "500000000000000000000000",
               "isEnabled": true,
-              "rate": "1157407407407407"
+              "rate": "5787000000000000000"
             },
             "out": {
-              "capacity": "100000000000000000000",
+              "capacity": "500000000000000000000000",
               "isEnabled": true,
-              "rate": "1157407407407407"
+              "rate": "5787000000000000000"
             }
           }
         },
@@ -25132,6 +25746,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "Memento": {
           "rateLimiterConfig": {
             "in": {
@@ -25185,6 +25813,34 @@
               "capacity": "1000000000000000000000000",
               "isEnabled": true,
               "rate": "11600000000000000000"
+            }
+          }
+        },
+        "wstLINK": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "wstPOL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -25323,6 +25979,20 @@
               "capacity": "20000000000000000000000",
               "isEnabled": true,
               "rate": "5550000000000000000"
+            }
+          }
+        },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -25546,6 +26216,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SDM": {
           "rateLimiterConfig": {
             "in": {
@@ -25577,9 +26261,9 @@
         "STBU": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
             },
             "out": {
               "capacity": "0",
@@ -25641,6 +26325,20 @@
               "capacity": "1000000000000",
               "isEnabled": true,
               "rate": "12000000"
+            }
+          }
+        },
+        "wstLINK": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -25729,6 +26427,20 @@
           }
         },
         "IXT": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "LEND": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -26246,6 +26958,20 @@
             }
           }
         },
+        "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "Memento": {
           "rateLimiterConfig": {
             "in": {
@@ -26411,6 +27137,20 @@
               "capacity": "1000000000000",
               "isEnabled": true,
               "rate": "12000000"
+            }
+          }
+        },
+        "wstLINK": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -26671,6 +27411,18 @@
         "version": "1.6.0"
       },
       "rmnPermeable": true
+    },
+    "solana-mainnet": {
+      "offRamp": {
+        "address": "0x26d3681DfC9E4c8C79cfbf461adec8A21d5d73C5",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x913814782144864e523C3FdB78E3ca25D2c2aeCa",
+        "enforceOutOfOrder": true,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
     }
   },
   "metal-mainnet": {
@@ -26782,7 +27534,23 @@
         "enforceOutOfOrder": false,
         "version": "1.6.0"
       },
-      "rmnPermeable": true
+      "rmnPermeable": true,
+      "supportedTokens": {
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
+      }
     },
     "ethereum-mainnet-arbitrum-1": {
       "offRamp": {
@@ -26839,6 +27607,18 @@
           }
         }
       }
+    },
+    "ethereum-mainnet-linea-1": {
+      "offRamp": {
+        "address": "0xc2BE2F77562A6676098e8D363B9d8A33Ea009D4e",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x8FE3B17E6B0863aeEA3D38DF063AEa39D4Ab1602",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
     },
     "mainnet": {
       "offRamp": {
@@ -28830,6 +29610,18 @@
       },
       "rmnPermeable": true
     },
+    "memento-mainnet": {
+      "offRamp": {
+        "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
+        "version": "V1"
+      },
+      "onRamp": {
+        "address": "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C",
+        "enforceOutOfOrder": true,
+        "version": "V1"
+      },
+      "rmnPermeable": true
+    },
     "plasma-mainnet": {
       "offRamp": {
         "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
@@ -30703,6 +31495,18 @@
           }
         }
       }
+    },
+    "ethereum-mainnet-linea-1": {
+      "offRamp": {
+        "address": "0x6525923279256B8a86c1C01cF5955eB00C39B048",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x5fA6f142EAC511DF12325776386AB92B0F4D1eba",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
     },
     "ethereum-mainnet-optimism-1": {
       "offRamp": {

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -2078,6 +2078,62 @@
       "tokenAddress": "0xBb1ea2697b13Cc06e03D875D2d39c06AC6dd5a93"
     }
   },
+  "LEND": {
+    "avalanche-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Lendefi DAO",
+      "poolAddress": "0x934635de453A1161D02Ce395F2F59E775597fE13",
+      "poolType": "burnMint",
+      "symbol": "LEND",
+      "tokenAddress": "0x5e53AeBE377eFC92213514eC07f8EF3Af426DD1d"
+    },
+    "bsc-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Lendefi DAO",
+      "poolAddress": "0x934635de453A1161D02Ce395F2F59E775597fE13",
+      "poolType": "burnMint",
+      "symbol": "LEND",
+      "tokenAddress": "0x5e53AeBE377eFC92213514eC07f8EF3Af426DD1d"
+    },
+    "ethereum-mainnet-arbitrum-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Lendefi DAO",
+      "poolAddress": "0x934635de453A1161D02Ce395F2F59E775597fE13",
+      "poolType": "burnMint",
+      "symbol": "LEND",
+      "tokenAddress": "0x5e53AeBE377eFC92213514eC07f8EF3Af426DD1d"
+    },
+    "ethereum-mainnet-base-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Lendefi DAO",
+      "poolAddress": "0x934635de453A1161D02Ce395F2F59E775597fE13",
+      "poolType": "burnMint",
+      "symbol": "LEND",
+      "tokenAddress": "0x5e53AeBE377eFC92213514eC07f8EF3Af426DD1d"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Lendefi DAO",
+      "poolAddress": "0x934635de453A1161D02Ce395F2F59E775597fE13",
+      "poolType": "burnMint",
+      "symbol": "LEND",
+      "tokenAddress": "0x5e53AeBE377eFC92213514eC07f8EF3Af426DD1d"
+    },
+    "matic-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Lendefi DAO",
+      "poolAddress": "0x934635de453A1161D02Ce395F2F59E775597fE13",
+      "poolType": "burnMint",
+      "symbol": "LEND",
+      "tokenAddress": "0x5e53AeBE377eFC92213514eC07f8EF3Af426DD1d"
+    }
+  },
   "LINK": {
     "0g-mainnet": {
       "allowListEnabled": false,
@@ -3687,6 +3743,26 @@
       "tokenAddress": "0xDA06eE2dACF9245Aa80072a4407deBDea0D7e341"
     }
   },
+  "savUSD": {
+    "avalanche-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Staked avUSD",
+      "poolAddress": "0x8FcC42c414E29e8e3dBFa1628CF45E8ed80C999D",
+      "poolType": "lockRelease",
+      "symbol": "savUSD",
+      "tokenAddress": "0x06d47F3fb376649c3A9Dafe069B3D6E35572219E"
+    },
+    "plasma-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Staked avUSD",
+      "poolAddress": "0xFCCfA86d9AEdD2fF8dF60600110d6D1649679Fef",
+      "poolType": "burnMint",
+      "symbol": "savUSD",
+      "tokenAddress": "0xA29420057F3e3B9512D4786df135Da1674BD74D4"
+    }
+  },
   "SD": {
     "ethereum-mainnet-arbitrum-1": {
       "allowListEnabled": false,
@@ -5119,6 +5195,15 @@
       "symbol": "uniBTC",
       "tokenAddress": "0x93919784C523f39CACaa98Ee0a9d96c3F32b593e"
     },
+    "ethereum-mainnet-mode-1": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "uniBTC",
+      "poolAddress": "0x5A1764254dE62FC55a08E907c712565545615dDb",
+      "poolType": "burnMint",
+      "symbol": "uniBTC",
+      "tokenAddress": "0x6B2a01A5f79dEb4c2f3c0eDa7b01DF456FbD726a"
+    },
     "ethereum-mainnet-optimism-1": {
       "allowListEnabled": false,
       "decimals": 8,
@@ -5282,6 +5367,15 @@
     }
   },
   "USD1": {
+    "aptos-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 6,
+      "name": "World Liberty Financial USD",
+      "poolAddress": "0x1eb155d08acc900954b6ccee01659b390399ae81ad4c582b73d41374c475caf6",
+      "poolType": "burnMint",
+      "symbol": "USD1",
+      "tokenAddress": "0x05fabd1b12e39967a3c24e91b7b8f67719a6dacee74f3c8b9fb7d93e855437d2"
+    },
     "bsc-mainnet": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -6699,6 +6793,15 @@
     }
   },
   "wstLINK": {
+    "avalanche-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Wrapped stLINK",
+      "poolAddress": "0x04be180c1c3468c86EB68939aB53dbDC7306aDc7",
+      "poolType": "burnMint",
+      "symbol": "wstLINK",
+      "tokenAddress": "0x601486C8Fdc3aD22745b01c920037d6c036A38B9"
+    },
     "ethereum-mainnet-arbitrum-1": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -6716,9 +6819,27 @@
       "poolType": "lockRelease",
       "symbol": "wstLINK",
       "tokenAddress": "0x911D86C72155c33993d594B0Ec7E6206B4C803da"
+    },
+    "matic-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Wrapped stLINK",
+      "poolAddress": "0x97f40E42e4aE3BA12b5856F685136f6747Fa49a5",
+      "poolType": "burnMint",
+      "symbol": "wstLINK",
+      "tokenAddress": "0xc271A17DB5cE6F53745A3F466077Ec816bC20a9C"
     }
   },
   "wstPOL": {
+    "avalanche-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Wrapped stPOL",
+      "poolAddress": "0x481242B7846FA88fA76f2Ee73157aAa3AE2B280b",
+      "poolType": "burnMint",
+      "symbol": "wstPOL",
+      "tokenAddress": "0x9178baB5362282a861922Ce641F4f3b7D4Bb9EF3"
+    },
     "mainnet": {
       "allowListEnabled": false,
       "decimals": 18,

--- a/src/config/data/ccip/v1_2_0/testnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/testnet/lanes.json
@@ -5813,6 +5813,18 @@
         "version": "1.6.0"
       },
       "rmnPermeable": true
+    },
+    "solana-devnet": {
+      "offRamp": {
+        "address": "0xad4c7a1430D140Fc5121C0697B2f7Efc655c0070",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x934c1B8f6913070528CC24081E0b78d57D3A97A3",
+        "enforceOutOfOrder": true,
+        "version": "1.6.0"
+      },
+      "rmnPermeable": true
     }
   },
   "metal-testnet": {
@@ -6855,6 +6867,18 @@
           }
         }
       }
+    },
+    "memento-testnet": {
+      "offRamp": {
+        "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
+        "version": "V1"
+      },
+      "onRamp": {
+        "address": "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C",
+        "enforceOutOfOrder": true,
+        "version": "V1"
+      },
+      "rmnPermeable": true
     },
     "plasma-testnet": {
       "offRamp": {


### PR DESCRIPTION
This pull request adds support for several new tokens and blockchain lanes to the CCIP configuration files for both mainnet and testnet environments. The changes enhance cross-chain compatibility by introducing new token definitions on various networks and enabling new lanes for testnet environments.

**Mainnet Token Additions:**

* Added full configuration for the `LEND` token (`Lendefi DAO`) across six networks: `avalanche-mainnet`, `bsc-mainnet`, `ethereum-mainnet-arbitrum-1`, `ethereum-mainnet-base-1`, `mainnet`, and `matic-mainnet`.
* Added the `savUSD` token (`Staked avUSD`) for `avalanche-mainnet` and `plasma-mainnet`.
* Added the `uniBTC` token to `ethereum-mainnet-mode-1`.
* Added the `USD1` token (`World Liberty Financial USD`) to `aptos-mainnet`.

**Mainnet Token Pool Expansions:**

* Added new pools for `wstLINK` (`Wrapped stLINK`) on `avalanche-mainnet` and `matic-mainnet`. [[1]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R6796-R6804) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R6822-R6842)
* Added a new pool for `wstPOL` (`Wrapped stPOL`) on `avalanche-mainnet`.

**Testnet Lane Additions:**

* Added a new lane for `solana-devnet` with both `onRamp` and `offRamp` configuration.
* Added a new lane for `memento-testnet` with corresponding `onRamp` and `offRamp` configuration.