### PR TITLE
consistency explorer url directory

### DIFF
--- a/src/components/CCIP/Tables/TokenChainsTable.tsx
+++ b/src/components/CCIP/Tables/TokenChainsTable.tsx
@@ -123,7 +123,7 @@ function TokenChainsTable({ networks, token, lanes, environment }: TableProps) {
                     <td>{network.tokenDecimals}</td>
                     <td data-clipboard-type="token">
                       <Address
-                        contractUrl={getExplorerAddressUrl(network.explorer)(network.tokenAddress)}
+                        contractUrl={getExplorerAddressUrl(network.explorer, network.chainType)(network.tokenAddress)}
                         address={network.tokenAddress}
                         endLength={6}
                       />
@@ -131,7 +131,10 @@ function TokenChainsTable({ networks, token, lanes, environment }: TableProps) {
                     <td>{tokenPoolDisplay(network.tokenPoolType)}</td>
                     <td data-clipboard-type="token-pool">
                       <Address
-                        contractUrl={getExplorerAddressUrl(network.explorer)(network.tokenPoolAddress)}
+                        contractUrl={getExplorerAddressUrl(
+                          network.explorer,
+                          network.chainType
+                        )(network.tokenPoolAddress)}
                         address={network.tokenPoolAddress}
                         endLength={6}
                       />

--- a/src/config/data/ccip/data.ts
+++ b/src/config/data/ccip/data.ts
@@ -423,12 +423,13 @@ export const getAllNetworks = ({ filter }: { filter: Environment }): Network[] =
     const explorer = getExplorer(supportedChain)
     const router = chains[chain].router
     if (!explorer) throw Error(`Explorer not found for ${supportedChain}`)
-    const routerExplorerUrl = getExplorerAddressUrl(explorer)(router.address)
-    const nativeToken = getNativeCurrency(supportedChain)
-    if (!nativeToken) throw Error(`Native token not found for ${supportedChain}`)
 
     // Determine chain type based on chain name
     const { chainType } = getChainTypeAndFamily(supportedChain)
+
+    const routerExplorerUrl = getExplorerAddressUrl(explorer, chainType)(router.address)
+    const nativeToken = getNativeCurrency(supportedChain)
+    if (!nativeToken) throw Error(`Native token not found for ${supportedChain}`)
 
     allChains.push({
       name: title,


### PR DESCRIPTION
This pull request updates how explorer URLs are generated for token and pool addresses by ensuring the chain type is passed to the `getExplorerAddressUrl` function. This change improves compatibility with multiple chain types and ensures correct URL formatting throughout the codebase.

**Explorer URL generation improvements:**

* Updated calls to `getExplorerAddressUrl` in `TokenChainsTable.tsx` to include the `chainType` parameter when generating URLs for token and pool addresses, ensuring accurate explorer links for different chain types.
* Modified `getAllNetworks` in `data.ts` to pass `chainType` to `getExplorerAddressUrl` when constructing the router explorer URL, aligning with the new function signature and supporting multiple chain types.