### PR TITLE
Bob

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -597,6 +597,20 @@
             }
           }
         },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "LEND": {
           "rateLimiterConfig": {
             "in": {
@@ -1009,6 +1023,20 @@
               "capacity": "1000000000000000000000000",
               "isEnabled": true,
               "rate": "11574074070000000000"
+            }
+          }
+        },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
             }
           }
         },
@@ -2181,6 +2209,20 @@
             }
           }
         },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "SILO": {
           "rateLimiterConfig": {
             "in": {
@@ -2328,20 +2370,6 @@
               "capacity": "2500000000000000000",
               "isEnabled": true,
               "rate": "115740000000000"
-            }
-          }
-        },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
             }
           }
         },
@@ -2538,20 +2566,6 @@
             }
           }
         },
-        "brBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
-            }
-          }
-        },
         "sDOLA": {
           "rateLimiterConfig": {
             "in": {
@@ -2563,20 +2577,6 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
-            }
-          }
-        },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
             }
           }
         }
@@ -2602,22 +2602,6 @@
         "address": "0x3423C922911956b1Ccbc2b5d4f38216a6f4299b4",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
-            }
-          }
-        }
       }
     },
     "mainnet": {
@@ -2698,6 +2682,20 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
+            }
+          }
+        },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
             }
           }
         },
@@ -3190,20 +3188,6 @@
             }
           }
         },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "200000000",
-              "isEnabled": true,
-              "rate": "2315"
-            }
-          }
-        },
         "xSolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -3231,6 +3215,20 @@
         "version": "1.5.0"
       },
       "supportedTokens": {
+        "BOB": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -3530,6 +3528,20 @@
         "version": "1.5.0"
       },
       "supportedTokens": {
+        "BOB": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -4017,6 +4029,20 @@
             }
           }
         },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "LEND": {
           "rateLimiterConfig": {
             "in": {
@@ -4279,6 +4305,20 @@
         "version": "1.5.0"
       },
       "supportedTokens": {
+        "BOB": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -4551,20 +4591,6 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
-            }
-          }
-        },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
             }
           }
         },
@@ -4900,20 +4926,6 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
-            }
-          }
-        },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
             }
           }
         },
@@ -5332,20 +5344,6 @@
             }
           }
         },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
-            }
-          }
-        },
         "xGold": {
           "rateLimiterConfig": {
             "in": {
@@ -5472,6 +5470,20 @@
           }
         },
         "BKN": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "BOB": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -7091,6 +7103,20 @@
         "version": "1.5.0"
       },
       "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -7789,20 +7815,6 @@
             }
           }
         },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
-            }
-          }
-        },
         "USDFI": {
           "rateLimiterConfig": {
             "in": {
@@ -8324,20 +8336,6 @@
               "capacity": "200000000000000000000000",
               "isEnabled": true,
               "rate": "2314000000000000000"
-            }
-          }
-        },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
             }
           }
         },
@@ -10822,6 +10820,20 @@
             }
           }
         },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "LEND": {
           "rateLimiterConfig": {
             "in": {
@@ -11003,20 +11015,6 @@
             }
           }
         },
-        "brBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
-            }
-          }
-        },
         "sDOLA": {
           "rateLimiterConfig": {
             "in": {
@@ -11028,20 +11026,6 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
-            }
-          }
-        },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
             }
           }
         }
@@ -11345,20 +11329,6 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
-            }
-          }
-        },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
             }
           }
         },
@@ -11875,20 +11845,6 @@
             }
           }
         },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
-            }
-          }
-        },
         "USD+": {
           "rateLimiterConfig": {
             "in": {
@@ -12249,6 +12205,20 @@
             }
           }
         },
+        "LsETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -12468,20 +12438,6 @@
               "capacity": "400000000000",
               "isEnabled": true,
               "rate": "41600000"
-            }
-          }
-        },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
             }
           }
         },
@@ -12709,22 +12665,6 @@
         "address": "0xee85aEfb15b9489563A6a29891ebe0750AA1A7Ae",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
-      },
-      "supportedTokens": {
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
-            }
-          }
-        }
       }
     },
     "mainnet": {
@@ -15962,6 +15902,20 @@
             }
           }
         },
+        "LsETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -16149,6 +16103,20 @@
           }
         },
         "LEASH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "LsETH": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -16700,20 +16668,6 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
-            }
-          }
-        },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "200000000",
-              "isEnabled": true,
-              "rate": "2315"
             }
           }
         },
@@ -17306,20 +17260,6 @@
               "capacity": "400000000000",
               "isEnabled": true,
               "rate": "41600000"
-            }
-          }
-        },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
             }
           }
         },
@@ -19457,6 +19397,22 @@
         "address": "0xD4D2841Ac332075833AE86eb49ce7aF9f353cd21",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        }
       }
     }
   },
@@ -19495,6 +19451,17 @@
       }
     },
     "mainnet": {
+      "offRamp": {
+        "address": "0xa132F089492CcE5f1D79483a9e4552f37266ed01",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0xdd8aF6046349EDFD40123E0b616286cEC08010ed",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
+      }
+    },
+    "tac-mainnet": {
       "offRamp": {
         "address": "0xa132F089492CcE5f1D79483a9e4552f37266ed01",
         "version": "1.6.0"
@@ -19582,22 +19549,6 @@
         "address": "0x4122fe199B6e489a89f54c67245Be33bf602935F",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
-            }
-          }
-        }
       }
     },
     "bsc-mainnet": {
@@ -19622,20 +19573,6 @@
               "capacity": "2500000000000000000",
               "isEnabled": true,
               "rate": "115740000000000"
-            }
-          }
-        },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
             }
           }
         },
@@ -19678,22 +19615,6 @@
         "address": "0x72f6000D70B291C67bED898214156d01383274b1",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
-      },
-      "supportedTokens": {
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "2",
-              "isEnabled": true,
-              "rate": "1"
-            }
-          }
-        }
       }
     },
     "mainnet": {
@@ -20590,6 +20511,20 @@
             }
           }
         },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "pufETH": {
           "rateLimiterConfig": {
             "in": {
@@ -20715,14 +20650,14 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -20795,6 +20730,20 @@
         "version": "1.5.0"
       },
       "supportedTokens": {
+        "BOB": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -20922,14 +20871,14 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "11574"
+              "rate": "1"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "11574"
+              "rate": "1"
             }
           }
         }
@@ -21053,6 +21002,20 @@
           }
         },
         "BKN": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "BOB": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -21803,17 +21766,31 @@
         "version": "1.5.0"
       },
       "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         }
@@ -24254,6 +24231,20 @@
             }
           }
         },
+        "LsETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "rsETH": {
           "rateLimiterConfig": {
             "in": {
@@ -24529,20 +24520,6 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
-            }
-          }
-        },
-        "uniBTC": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "200000000",
-              "isEnabled": true,
-              "rate": "2315"
-            },
-            "out": {
-              "capacity": "200000000",
-              "isEnabled": true,
-              "rate": "2315"
             }
           }
         },
@@ -25372,6 +25349,22 @@
         "address": "0x913814782144864e523C3FdB78E3ca25D2c2aeCa",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        }
       }
     },
     "everclear-mainnet": {
@@ -25518,14 +25511,14 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -27111,14 +27104,14 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             },
             "out": {
-              "capacity": "200000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "1"
             }
           }
         },
@@ -27216,6 +27209,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "LINK": {
           "rateLimiterConfig": {
             "in": {
@@ -32550,6 +32557,20 @@
             }
           }
         },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "SILO": {
           "rateLimiterConfig": {
             "in": {
@@ -33363,6 +33384,17 @@
         "version": "1.6.0"
       }
     },
+    "everclear-mainnet": {
+      "offRamp": {
+        "address": "0x3201a20D2a33820C0DaC8Bc93C4819755C2a8c7F",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x51e2A24742Db77604B881d6781Ee16B5b8fcBE29",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
+      }
+    },
     "mainnet": {
       "offRamp": {
         "address": "0x3201a20D2a33820C0DaC8Bc93C4819755C2a8c7F",
@@ -33374,6 +33406,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "LINK": {
           "rateLimiterConfig": {
             "in": {

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -446,6 +446,35 @@
       "tokenAddress": "0xC28f1D82874ccFebFE6afDAB3c685D5E709067E5"
     }
   },
+  "BOB": {
+    "bitcoin-mainnet-bob-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "BOB",
+      "poolAddress": "0xf924B3Ac2d63145Ad88BcD2621a63Cd7D650673e",
+      "poolType": "lockRelease",
+      "symbol": "BOB",
+      "tokenAddress": "0xB0BD54846a92b214C04A63B26AD7Dc5e19A60808"
+    },
+    "bsc-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "BOB",
+      "poolAddress": "0x7E685254A1c696CF8A72a2F05d3eDBf18Ea624Bb",
+      "poolType": "burnMint",
+      "symbol": "BOB",
+      "tokenAddress": "0x52B5fB4B0F6572B8C44d0251Cc224513ac5eB7E7"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "BOB",
+      "poolAddress": "0x9Dfaaa0826b8D81Ea7Cf7ED95619574bcb47d6EA",
+      "poolType": "burnMint",
+      "symbol": "BOB",
+      "tokenAddress": "0xC9746F73cC33a36c2cD55b8aEFD732586946Cedd"
+    }
+  },
   "BOLD": {
     "avalanche-mainnet": {
       "allowListEnabled": false,
@@ -2011,6 +2040,15 @@
       "symbol": "LBTC",
       "tokenAddress": "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
     },
+    "berachain-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "Lombard Staked Bitcoin",
+      "poolAddress": "0xc6c22D4Be6Cc50E6D01BD6325b6cD715A52f8154",
+      "poolType": "burnMint",
+      "symbol": "LBTC",
+      "tokenAddress": "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
+    },
     "bsc-mainnet": {
       "allowListEnabled": false,
       "decimals": 8,
@@ -2020,11 +2058,29 @@
       "symbol": "LBTC",
       "tokenAddress": "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
     },
+    "corn-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "Lombard Staked Bitcoin",
+      "poolAddress": "0x770D1bbdca08e3272233709B27C004F510bfDf86",
+      "poolType": "burnMint",
+      "symbol": "LBTC",
+      "tokenAddress": "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
+    },
     "ethereum-mainnet-base-1": {
       "allowListEnabled": false,
       "decimals": 8,
       "name": "Lombard Staked Bitcoin",
       "poolAddress": "0x2A70CbF60a9252Ff312719885088283f930750BA",
+      "poolType": "burnMint",
+      "symbol": "LBTC",
+      "tokenAddress": "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
+    },
+    "etherlink-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "Lombard Staked Bitcoin",
+      "poolAddress": "0x9Ef2919f333Cdf13Fb609C0341bE0c852f691788",
       "poolType": "burnMint",
       "symbol": "LBTC",
       "tokenAddress": "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
@@ -2052,6 +2108,15 @@
       "decimals": 8,
       "name": "Lombard Staked Bitcoin",
       "poolAddress": "0x775C438b07d5667aEFa3DE493A7cc2Df3a199E99",
+      "poolType": "burnMint",
+      "symbol": "LBTC",
+      "tokenAddress": "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
+    },
+    "tac-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "Lombard Staked Bitcoin",
+      "poolAddress": "0xAe5E2940Fc01C0f8076D36749509C75E43da0C70",
       "poolType": "burnMint",
       "symbol": "LBTC",
       "tokenAddress": "0xecAc9C5F704e954931349Da37F60E39f515c11c1"
@@ -2903,6 +2968,15 @@
       "decimals": 18,
       "name": "Liquid Staked ETH",
       "poolAddress": "0x3A4e3B9a4fb73A4015b4AFe1efe02214B614D591",
+      "poolType": "burnMint",
+      "symbol": "LsETH",
+      "tokenAddress": "0xB29749498954A3A821ec37BdE86e386dF3cE30B6"
+    },
+    "ethereum-mainnet-linea-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Liquid Staked ETH",
+      "poolAddress": "0xE939C02E92e9E66d1F0D8E4F099E7d3d269a8a11",
       "poolType": "burnMint",
       "symbol": "LsETH",
       "tokenAddress": "0xB29749498954A3A821ec37BdE86e386dF3cE30B6"
@@ -5571,15 +5645,6 @@
       "poolType": "burnMint",
       "symbol": "uniBTC",
       "tokenAddress": "0x93919784C523f39CACaa98Ee0a9d96c3F32b593e"
-    },
-    "ethereum-mainnet-mode-1": {
-      "allowListEnabled": false,
-      "decimals": 8,
-      "name": "uniBTC",
-      "poolAddress": "0x5A1764254dE62FC55a08E907c712565545615dDb",
-      "poolType": "burnMint",
-      "symbol": "uniBTC",
-      "tokenAddress": "0x6B2a01A5f79dEb4c2f3c0eDa7b01DF456FbD726a"
     },
     "ethereum-mainnet-optimism-1": {
       "allowListEnabled": false,


### PR DESCRIPTION
This pull request updates the `tokens.json` configuration to add support for several new tokens and networks, and removes one token entry. The changes mainly involve expanding cross-chain support for existing tokens and introducing a new token, BOB.

**New token and expanded cross-chain support:**

* Added configuration for the new token `BOB` across three networks: `bitcoin-mainnet-bob-1`, `bsc-mainnet`, and `mainnet`, including pool addresses, token addresses, and pool types.
* Added `Lombard Staked Bitcoin (LBTC)` support on four new networks: `berachain-mainnet`, `corn-mainnet`, `etherlink-mainnet`, and `tac-mainnet`, with corresponding pool and token addresses. [[1]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R2043-R2051) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R2061-R2069) [[3]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R2079-R2087) [[4]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R2114-R2122)
* Added `Liquid Staked ETH (LsETH)` support for the `ethereum-mainnet-linea-1` network.

**Token removal:**

* Removed the `uniBTC` entry for the `ethereum-mainnet-mode-1` network, including its pool and token addresses.