### PR TITLE
vooi

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -1262,6 +1262,48 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "avETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "avETHx": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "savBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "savETH": {
           "rateLimiterConfig": {
             "in": {
@@ -1686,7 +1728,35 @@
             }
           }
         },
+        "savBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "savETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "savUSD": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -5171,6 +5241,20 @@
             }
           }
         },
+        "savBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "savUSD": {
           "rateLimiterConfig": {
             "in": {
@@ -5773,6 +5857,34 @@
             }
           }
         },
+        "savBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SDT": {
           "rateLimiterConfig": {
             "in": {
@@ -6036,6 +6148,20 @@
               "capacity": "3000000000000000000000000",
               "isEnabled": true,
               "rate": "35000000000000000000"
+            }
+          }
+        },
+        "VOOI": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -15759,6 +15885,48 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "avETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "avETHx": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "savBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "savETH": {
           "rateLimiterConfig": {
             "in": {
@@ -15870,6 +16038,20 @@
       },
       "supportedTokens": {
         "AISTR": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "savBTC": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -16221,6 +16403,34 @@
             }
           }
         },
+        "avETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "avETHx": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "BONE": {
           "rateLimiterConfig": {
             "in": {
@@ -16277,7 +16487,35 @@
             }
           }
         },
+        "savBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "savETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "savUSD": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -20392,7 +20630,35 @@
             }
           }
         },
+        "savBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "savETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "savUSD": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -21031,14 +21297,14 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "2",
+              "capacity": "200000000",
               "isEnabled": true,
-              "rate": "1"
+              "rate": "2315"
             },
             "out": {
-              "capacity": "2",
+              "capacity": "200000000",
               "isEnabled": true,
-              "rate": "1"
+              "rate": "2315"
             }
           }
         }
@@ -21427,6 +21693,34 @@
             }
           }
         },
+        "savBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SDT": {
           "rateLimiterConfig": {
             "in": {
@@ -21690,6 +21984,20 @@
               "capacity": "3000000000000000000000000",
               "isEnabled": true,
               "rate": "35000000000000000000"
+            }
+          }
+        },
+        "VOOI": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -24377,6 +24685,34 @@
             }
           }
         },
+        "avETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "avETHx": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "BONE": {
           "rateLimiterConfig": {
             "in": {
@@ -24433,7 +24769,35 @@
             }
           }
         },
+        "savBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "savETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "savUSD": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -26359,6 +26723,20 @@
             }
           }
         },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "syrupUSDT": {
           "rateLimiterConfig": {
             "in": {
@@ -26535,6 +26913,20 @@
               "capacity": "5000000000",
               "isEnabled": true,
               "rate": "462963"
+            }
+          }
+        },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -30309,6 +30701,20 @@
             }
           }
         },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "syrupUSDT": {
           "rateLimiterConfig": {
             "in": {
@@ -30772,6 +31178,20 @@
               "capacity": "5000000000",
               "isEnabled": true,
               "rate": "462963"
+            }
+          }
+        },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -184,6 +184,15 @@
       "symbol": "avETH",
       "tokenAddress": "0x223767286Be11d09Ae778fF608687fe858d3A2b4"
     },
+    "ethereum-mainnet-linea-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "avETH",
+      "poolAddress": "0x9b52Ab55cFA7aB0079f84390b24Fdc0e5bF5Ab6F",
+      "poolType": "burnMint",
+      "symbol": "avETH",
+      "tokenAddress": "0x3449A9155Afc1Bab56A572FdfE22A3a2B803AaC4"
+    },
     "mainnet": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -203,6 +212,15 @@
       "poolType": "burnMint",
       "symbol": "avETHx",
       "tokenAddress": "0xDA63630094Aa23B7a49368b713d68dD98F547f98"
+    },
+    "ethereum-mainnet-linea-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "avETH MAX",
+      "poolAddress": "0x37912A5e451DC711D357E2dC6Bf9035235d6771f",
+      "poolType": "burnMint",
+      "symbol": "avETHx",
+      "tokenAddress": "0x01C9ABFebCDcb53E72bF017Fc1D17F9DB38F722a"
     },
     "mainnet": {
       "allowListEnabled": false,
@@ -4038,6 +4056,24 @@
       "poolType": "burnMint",
       "symbol": "savBTC",
       "tokenAddress": "0x19452d507b2738aDB8942cD2b0d52BB519f1790a"
+    },
+    "ethereum-mainnet-linea-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Staked avBTC",
+      "poolAddress": "0x5b0B44bB38E23193111e7AA03E380Ba841e58B17",
+      "poolType": "burnMint",
+      "symbol": "savBTC",
+      "tokenAddress": "0x45cF31aF4d67899674B50ab14093b55006fFf563"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Staked avBTC",
+      "poolAddress": "0x78991cd8ADDf98672A1201D70c6db46e21C25C57",
+      "poolType": "burnMint",
+      "symbol": "savBTC",
+      "tokenAddress": "0x92181c6f0FED1f1A30c0Ec131f41577F81924bf5"
     }
   },
   "savETH": {
@@ -4096,6 +4132,15 @@
       "poolType": "burnMint",
       "symbol": "savUSD",
       "tokenAddress": "0x5C247948fD58Bb02B6c4678d9940F5e6B9af1127"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Staked avUSD",
+      "poolAddress": "0x6d3B65eB14ad3546ab4Aa32cf8645a3610a9737b",
+      "poolType": "burnMint",
+      "symbol": "savUSD",
+      "tokenAddress": "0xb8D89678E75a973E74698c976716308abB8a46A4"
     },
     "plasma-mainnet": {
       "allowListEnabled": false,
@@ -6326,6 +6371,26 @@
       "poolType": "lockRelease",
       "symbol": "USX",
       "tokenAddress": "6FrrzDk5mQARGc1TDYoyVnSyRdds1t4PbtohCD6p3tgG"
+    }
+  },
+  "VOOI": {
+    "bsc-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "VOOI",
+      "poolAddress": "0x4D275A287B86E423E01CceE66F4e3313B5F47Cf7",
+      "poolType": "burnMint",
+      "symbol": "VOOI",
+      "tokenAddress": "0x876cEcb73c9ED1B1526F8e35C6a5a51a31BCF341"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "VOOI",
+      "poolAddress": "0x8B8461F822FDb00943C2c7d42aa17e1CDd5626F1",
+      "poolType": "lockRelease",
+      "symbol": "VOOI",
+      "tokenAddress": "0xb31561F0e2aaC72406103b1926356D756F07A481"
     }
   },
   "VRTX": {


### PR DESCRIPTION
This pull request updates the `tokens.json` configuration for the CCIP v1.2.0 mainnet by adding new token entries and expanding support for existing tokens across additional networks. The main changes involve introducing new pools for avETH, avETHx, savBTC, savUSD, and adding a new token, VOOI, with support on multiple networks.

**New token support and pool additions:**

* Added new pools for `avETH`, `avETHx`, and `savBTC` on the `ethereum-mainnet-linea-1` network, each with their respective addresses and configuration details. [[1]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R187-R195) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R216-R224) [[3]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R4059-R4076)
* Added a new pool for `savUSD` on the `mainnet` network.

**Introduction of new token:**

* Added a new token, `VOOI`, with pools on both `bsc-mainnet` and `mainnet`, including all relevant configuration parameters.