### PR TITLE
Update redirects.json

### DIFF
--- a/src/features/redirects/redirects.json
+++ b/src/features/redirects/redirects.json
@@ -2569,6 +2569,11 @@
       "source": "ccip/tools-resources/tools",
       "destination": "ccip/tools-resources/cli",
       "statusCode": 301
+    },
+    {
+      "source": "ccip/concepts/architecture/offchain/risk-management-network",
+      "destination": "ccip/concepts/architecture/offchain/overview",
+      "statusCode": 301
     }
   ]
 }


### PR DESCRIPTION
This pull request introduces a new redirect to the `redirects.json` file, ensuring users are sent to the correct documentation page. The change helps keep navigation up-to-date as content is reorganized.

Redirect updates:

* Added a redirect from `ccip/concepts/architecture/offchain/risk-management-network` to `ccip/concepts/architecture/offchain/overview` with a 301 status code.
