### PR TITLE
Update ccip-execution-latency.mdx

### DIFF
--- a/src/content/ccip/ccip-execution-latency.mdx
+++ b/src/content/ccip/ccip-execution-latency.mdx
@@ -151,6 +151,7 @@ This section provides an overview of the finality methods CCIP uses to determine
 | Metis             | Finality tag                              | 2 hours                     |
 | Mind Network      | Finality tag                              | 1 hour                      |
 | Mode              | Finality tag                              | 37 minutes                  |
+| Monad             | [Block depth](#block-depth) (120 blocks)  | 48 seconds                  |
 | OP                | Finality tag                              | 20 minutes                  |
 | Polygon           | [Block depth](#block-depth) (500 blocks)  | 17 minutes                  |
 | Polygon zkEVM     | Finality tag                              | 2 hours                     |


### PR DESCRIPTION
This pull request adds new information to the CCIP execution latency documentation by including details for the Monad network. The update specifies Monad's finality method, block depth, and expected latency.

- **Documentation Update:**
  - Added Monad network to the CCIP execution latency table, specifying its use of block depth (120 blocks) as the finality method and an expected latency of 48 seconds.