### PR TITLE
add details on what happens when a feed is shutdown

### DIFF
--- a/reports/llms-report.json
+++ b/reports/llms-report.json
@@ -1,5 +1,5 @@
 {
-  "startedAt": "2025-12-09T23:41:23.311Z",
+  "startedAt": "2025-12-10T23:13:13.756Z",
   "siteBase": "https://docs.chain.link",
   "sections": [
     {
@@ -38,9 +38,9 @@
       "section": "data-feeds",
       "pagesProcessed": 37,
       "outputPath": "src/content/data-feeds/llms-full.txt",
-      "bytes": 302589,
-      "prevBytes": 302327,
-      "deltaBytes": 262
+      "bytes": 302816,
+      "prevBytes": 302589,
+      "deltaBytes": 227
     },
     {
       "section": "data-streams",
@@ -123,5 +123,5 @@
       "deltaBytes": 0
     }
   ],
-  "finishedAt": "2025-12-09T23:41:27.135Z"
+  "finishedAt": "2025-12-10T23:13:17.715Z"
 }

--- a/src/content/data-feeds/llms-full.txt
+++ b/src/content/data-feeds/llms-full.txt
@@ -3216,6 +3216,14 @@ Data feeds managed by Chainlink Labs will be considered for deprecation if they 
 
 Known users of these feeds will be contacted directly about the feeds' deprecation. Notifications will also be posted on the [Feeds Scheduled For Deprecation](/data-feeds/deprecating-feeds) page and on our [Discord channel](https://discord.com/channels/592041321326182401/991444378335838318) with two weeks of notice before they are shut down.
 
+
+<Aside type="note" title="Data Feed Shutdown Behavior">
+  Once a feed is shutdown, calls to the feed will behave as follows:
+
+  - `lastAnswer` will return `0`
+  - `latestRoundData` will revert with no data available
+</Aside>
+
 ## Market hours
 
 In addition to categories, be aware that markets for several assets are actively traded only during certain hours. Listed data feeds include an attribute describing their market hours. Chainlink Labs recommends using these feeds only during their specified hours:

--- a/src/content/data-feeds/selecting-data-feeds.mdx
+++ b/src/content/data-feeds/selecting-data-feeds.mdx
@@ -103,7 +103,12 @@ Data feeds managed by Chainlink Labs will be considered for deprecation if they 
 
 Known users of these feeds will be contacted directly about the feeds' deprecation. Notifications will also be posted on the [Feeds Scheduled For Deprecation](/data-feeds/deprecating-feeds) page and on our [Discord channel](https://discord.com/channels/592041321326182401/991444378335838318) with two weeks of notice before they are shut down.
 
-Once a feed is shutdown, 0 is returned when calling `lastAnswer` and no response is returned when calling `latestRoundData`.
+{/* prettier-ignore */}
+<Aside type="note" title="Data Feed Shutdown Behavior">
+  Once a feed is shutdown, calls to the feed will behave as follows: 
+  - `lastAnswer` will return `0` 
+  - `latestRoundData` will revert with no data available
+</Aside>
 
 ## Market hours
 


### PR DESCRIPTION
## Closing issues

closes #3275

## Description

It's not clear right now what happens when you try to call a feed after it's been shutdown. This PR makes it clear.

## Changes

- Add explicit details for what happens when you try to call a feed that has been shutdown