### PR TITLE
Update billing.mdx

### DIFF
--- a/src/content/ccip/billing.mdx
+++ b/src/content/ccip/billing.mdx
@@ -76,7 +76,7 @@ This cost is only relevant if the destination blockchain is a [L2 layer](https:/
 
 ### Network fee
 
-The fee paid to RMN node operators running the [Decentralized Oracle Network](/ccip/concepts/architecture/key-concepts#decentralized-oracle-network-don):
+The fee paid to node operators running the [Decentralized Oracle Network](/ccip/concepts/architecture/key-concepts#decentralized-oracle-network-don):
 
 #### Token transfers or programmable token transfers
 


### PR DESCRIPTION
This pull request makes a small wording change to the documentation for CCIP billing to clarify the description of network fees.

* Updated the network fee description to refer to "node operators" instead of "RMN node operators" in `src/content/ccip/billing.mdx`.
