### PR TITLE
Fix codesample copy page api

### DIFF
--- a/scripts/cleanup-vercel-function.mjs
+++ b/scripts/cleanup-vercel-function.mjs
@@ -22,12 +22,13 @@ async function cleanup() {
   console.log(`📦 Size before: ${sizeBefore}`)
 
   // Remove large files/directories that are served statically by CDN
+  // Note: public/samples is kept because the /api/page-markdown endpoint needs to read these files
   const itemsToRemove = [
     `${FUNCTION_DIR}/public/images`,
     `${FUNCTION_DIR}/public/search-index.json`,
     `${FUNCTION_DIR}/public/files`,
     `${FUNCTION_DIR}/public/default-og-image.png`,
-    `${FUNCTION_DIR}/public/samples`,
+    // `${FUNCTION_DIR}/public/samples`, // Kept for API route access
     `${FUNCTION_DIR}/public/changelog.json`,
   ]
 

--- a/src/lib/markdown/componentHandlers.ts
+++ b/src/lib/markdown/componentHandlers.ts
@@ -424,7 +424,8 @@ export function handleCodeSample(
       } as Parent
     } else {
       // Try to inline the code
-      const possiblePaths = [path.resolve(`public/${src}`), path.resolve(src), path.resolve(`src/${src}`)]
+      const publicPath = path.join(process.cwd(), "public", src)
+      const possiblePaths = [publicPath, path.resolve(src), path.join(process.cwd(), "src", src)]
 
       let codeContent: string | null = null
       for (const p of possiblePaths) {


### PR DESCRIPTION
This pull request makes targeted improvements to file handling in both the Vercel function cleanup script and the Markdown code sample handler. The main focus is to ensure that necessary sample files remain available for API endpoints and to make path resolution for code samples more robust.

File retention and cleanup:

* Updated `scripts/cleanup-vercel-function.mjs` to keep the `public/samples` directory, as it is required by the `/api/page-markdown` endpoint, preventing its accidental removal during cleanup.

Path resolution improvements:

* Modified `src/lib/markdown/componentHandlers.ts` to resolve code sample paths more reliably by explicitly joining the process's working directory with the `public` and `src` folders, improving compatibility across different environments.