### PR TITLE
update ccip directory

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -878,6 +878,20 @@
             }
           }
         },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SDY": {
           "rateLimiterConfig": {
             "in": {
@@ -2792,6 +2806,20 @@
             }
           }
         },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -2862,6 +2890,20 @@
           }
         },
         "DOLO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "savUSD": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -3050,6 +3092,20 @@
           }
         },
         "pufETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "savUSD": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -4548,6 +4604,20 @@
             }
           }
         },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -4901,6 +4971,20 @@
               "capacity": "50000000000000000000000",
               "isEnabled": true,
               "rate": "580000000000000000"
+            }
+          }
+        },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -8082,6 +8166,20 @@
             }
           }
         },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SDY": {
           "rateLimiterConfig": {
             "in": {
@@ -8250,6 +8348,20 @@
           }
         },
         "DOLO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "savUSD": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -8440,6 +8552,20 @@
               "capacity": "50000000000000000000000",
               "isEnabled": true,
               "rate": "580000000000000000"
+            }
+          }
+        },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -9367,6 +9493,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -10303,6 +10443,20 @@
             }
           }
         },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SD": {
           "rateLimiterConfig": {
             "in": {
@@ -11176,6 +11330,20 @@
               "capacity": "1500000000000000000000000",
               "isEnabled": true,
               "rate": "300000000000000000000"
+            }
+          }
+        },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -17049,6 +17217,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -22181,6 +22363,20 @@
             }
           }
         },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "sDOLA": {
           "rateLimiterConfig": {
             "in": {
@@ -24101,6 +24297,20 @@
           }
         },
         "pufETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "savUSD": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -28622,12 +28832,12 @@
         "APRS": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "30000000000000000000000000",
+              "capacity": "30000000000000000570425344",
               "isEnabled": true,
-              "rate": "347222200000000000000"
+              "rate": "347222200000000032768"
             },
             "out": {
-              "capacity": "27000000000000000000000000",
+              "capacity": "27000000000000000083886080",
               "isEnabled": true,
               "rate": "312500000000000000000"
             }
@@ -32675,6 +32885,20 @@
               "rate": "300000000000000000000"
             }
           }
+        },
+        "savUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -33621,12 +33845,12 @@
         "APRS": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "30000000000000000000000000",
+              "capacity": "30000000000000000570425344",
               "isEnabled": true,
-              "rate": "347222200000000000000"
+              "rate": "347222200000000032768"
             },
             "out": {
-              "capacity": "27000000000000000000000000",
+              "capacity": "27000000000000000083886080",
               "isEnabled": true,
               "rate": "312500000000000000000"
             }

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -148,11 +148,11 @@
     "ronin-mainnet": {
       "allowListEnabled": false,
       "decimals": 18,
-      "name": "Aperios",
-      "poolAddress": "0x5dbBF90Ad00130Fd2Eb788016DcB3E4dFbD0C519",
+      "name": "Apeiros",
+      "poolAddress": "0xe2712A0C09DfB8031857Adb8D73Eb04997D271bA",
       "poolType": "burnMint",
       "symbol": "APRS",
-      "tokenAddress": "0x7894b3088d069E70895EFfA4e8f7D2c243Fd04C1"
+      "tokenAddress": "0xB1eC71BE31da4fF603970c0d88584eF2aF102F38"
     }
   },
   "APT": {
@@ -4541,6 +4541,15 @@
       "symbol": "savUSD",
       "tokenAddress": "0x06d47F3fb376649c3A9Dafe069B3D6E35572219E"
     },
+    "berachain-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Staked avUSD",
+      "poolAddress": "0x59E2a16B388999D0d258e52623aC97F8841c37d2",
+      "poolType": "burnMint",
+      "symbol": "savUSD",
+      "tokenAddress": "0xa744Fe3688291aC3A4a7eC917678783aD9946a1E"
+    },
     "bsc-mainnet": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -4549,6 +4558,15 @@
       "poolType": "burnMint",
       "symbol": "savUSD",
       "tokenAddress": "0x14063733875204b35D20D5Fc52C7B5569aD00335"
+    },
+    "ethereum-mainnet-arbitrum-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Staked avUSD",
+      "poolAddress": "0xC164b8232ca67D2f8dDA43CF75CbE8161E6861D8",
+      "poolType": "burnMint",
+      "symbol": "savUSD",
+      "tokenAddress": "0xA322e23a357cB7C596A7a834102B9d6d5b15da3e"
     },
     "ethereum-mainnet-linea-1": {
       "allowListEnabled": false,

--- a/src/config/data/ccip/v1_2_0/testnet/chains.json
+++ b/src/config/data/ccip/v1_2_0/testnet/chains.json
@@ -405,7 +405,7 @@
   "ethereum-testnet-holesky": {
     "armProxy": {
       "address": "0x8607115fd037d4f182b0eBaEC3cF08Df67080d05",
-      "version": "1.0.0"
+      "version": "1.5.0"
     },
     "chainSelector": "7717148896336251131",
     "feeTokens": ["LINK", "WETH"],
@@ -1276,21 +1276,21 @@
   },
   "monad-testnet": {
     "armProxy": {
-      "address": "0xaBe6C62737539bEA929647187C3bF13455B33c84",
+      "address": "0xD610B8f58689de7755947C05342A2DFaC30ebD57",
       "version": "1.0.0"
     },
     "chainSelector": "2183018362218727504",
-    "feeTokens": ["LINK", "WMON"],
+    "feeTokens": ["LINK", "WETH", "WMON"],
     "registryModule": {
-      "address": "0x4b90270eAca902fBb9B3bbFd185F82A137a29739",
-      "version": "1.5.0"
+      "address": "0x524B83ae8208490151339c626fd0E35b964483e3",
+      "version": "1.6.0"
     },
     "router": {
-      "address": "0x5f16e51e3Dcb255480F090157DD01bA962a53E54",
+      "address": "0x5aD0A67f4Da0E8665a3fbf15E4215A780407Cf33",
       "version": "1.2.0"
     },
     "tokenAdminRegistry": {
-      "address": "0x9f4fa39d257cBe5A69F4E4A22a3E8bf62CAF5218",
+      "address": "0xd3e461C55676B10634a5F81b747c324B85686Dd1",
       "version": "1.5.0"
     },
     "tokenPoolFactory": {
@@ -1437,7 +1437,7 @@
   "polygon-testnet-tatara": {
     "armProxy": {
       "address": "0xAD8BeA8bC5Fe468Dc1F7BbEce59A86584407255f",
-      "version": "1.0.0"
+      "version": "1.5.0"
     },
     "chainSelector": "9090863410735740267",
     "feeTokens": ["LINK", "WETH"],

--- a/src/config/data/ccip/v1_2_0/testnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/testnet/lanes.json
@@ -1098,17 +1098,6 @@
         "version": "1.5.0"
       }
     },
-    "monad-testnet": {
-      "offRamp": {
-        "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
-        "version": "1.6.0"
-      },
-      "onRamp": {
-        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
-        "enforceOutOfOrder": false,
-        "version": "1.6.0"
-      }
-    },
     "polygon-testnet-amoy": {
       "offRamp": {
         "address": "0xAAe325adbc9C5a28e4e94Fef170D55de2CA9aA01",
@@ -1603,6 +1592,17 @@
             }
           }
         }
+      }
+    },
+    "sei-testnet-atlantic": {
+      "offRamp": {
+        "address": "0x13090F92dd97d5eb6E2C42f3a4709A3a923236d4",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0xE11e310ebb56996669E1A2AA189f54C581a2a6bC",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
       }
     }
   },
@@ -3077,13 +3077,29 @@
     },
     "monad-testnet": {
       "offRamp": {
-        "address": "0x0722A87F804475a1ae11dea7b48F4c98efF336E9",
-        "version": "1.5.0"
+        "address": "0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x4241a9515Bb02D44b51F9a5a8c76B9Da84a07d43",
+        "address": "0x23a5084Fa78104F3DF11C63Ae59fcac4f6AD9DeE",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "CCIP-BnM": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "neox-testnet-t4": {
@@ -3972,17 +3988,6 @@
         "version": "1.5.0"
       }
     },
-    "monad-testnet": {
-      "offRamp": {
-        "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
-        "version": "1.6.0"
-      },
-      "onRamp": {
-        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
-        "enforceOutOfOrder": false,
-        "version": "1.6.0"
-      }
-    },
     "polygon-testnet-amoy": {
       "offRamp": {
         "address": "0xB6C02E529D90B55fe64fbC27df6ad7890339A13f",
@@ -4489,17 +4494,6 @@
       }
     },
     "memento-testnet": {
-      "offRamp": {
-        "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
-        "version": "1.6.0"
-      },
-      "onRamp": {
-        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
-        "enforceOutOfOrder": false,
-        "version": "1.6.0"
-      }
-    },
-    "monad-testnet": {
       "offRamp": {
         "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
         "version": "1.6.0"
@@ -5314,17 +5308,6 @@
         "version": "1.5.0"
       }
     },
-    "monad-testnet": {
-      "offRamp": {
-        "address": "0x30D197C6F5bE050D5525dD94d01760FaCdB67e7C",
-        "version": "1.6.0"
-      },
-      "onRamp": {
-        "address": "0x8F5bED5F7601025b12A97b01584220C12e343986",
-        "enforceOutOfOrder": false,
-        "version": "1.6.0"
-      }
-    },
     "polygon-testnet-amoy": {
       "offRamp": {
         "address": "0x4cEeFa55AF23dFD27Cf926e8eFB1D1bCcD24526E",
@@ -6005,6 +5988,17 @@
         }
       }
     },
+    "pharos-atlantic-testnet": {
+      "offRamp": {
+        "address": "0xFA5F1e092dE0907EE761fad89184B8E8AcC9089D",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x1f5EF38782b6B7C6DE489406b8EE504e46F05a18",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
+      }
+    },
     "polygon-testnet-amoy": {
       "offRamp": {
         "address": "0xFA5F1e092dE0907EE761fad89184B8E8AcC9089D",
@@ -6188,81 +6182,31 @@
         "version": "1.5.0"
       }
     },
-    "bsc-testnet": {
-      "offRamp": {
-        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
-        "version": "1.6.0"
-      },
-      "onRamp": {
-        "address": "0x289639CB51704043213d2E8806d19979eD8533e4",
-        "enforceOutOfOrder": false,
-        "version": "1.6.0"
-      }
-    },
     "ethereum-testnet-sepolia": {
       "offRamp": {
-        "address": "0xA3E6DFf295BBC809ea145D48d72fe1414f5F7646",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x43099E299B6d9f77Cda1b2756d53896fcFa2A576",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
-    "ethereum-testnet-sepolia-arbitrum-1": {
-      "offRamp": {
-        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
+        "address": "0x5Dc49Ec54B92F7D493bC8126c0730DA74605cc00",
         "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x289639CB51704043213d2E8806d19979eD8533e4",
+        "address": "0x65B023D3D4Ea880B835BF2CDE48B296Ee7157EcE",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
-      }
-    },
-    "ethereum-testnet-sepolia-base-1": {
-      "offRamp": {
-        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
-        "version": "1.6.0"
       },
-      "onRamp": {
-        "address": "0x289639CB51704043213d2E8806d19979eD8533e4",
-        "enforceOutOfOrder": false,
-        "version": "1.6.0"
-      }
-    },
-    "ethereum-testnet-sepolia-optimism-1": {
-      "offRamp": {
-        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
-        "version": "1.6.0"
-      },
-      "onRamp": {
-        "address": "0x289639CB51704043213d2E8806d19979eD8533e4",
-        "enforceOutOfOrder": false,
-        "version": "1.6.0"
-      }
-    },
-    "polygon-testnet-tatara": {
-      "offRamp": {
-        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
-        "version": "1.6.0"
-      },
-      "onRamp": {
-        "address": "0x289639CB51704043213d2E8806d19979eD8533e4",
-        "enforceOutOfOrder": false,
-        "version": "1.6.0"
-      }
-    },
-    "solana-devnet": {
-      "offRamp": {
-        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
-        "version": "1.6.0"
-      },
-      "onRamp": {
-        "address": "0x289639CB51704043213d2E8806d19979eD8533e4",
-        "enforceOutOfOrder": true,
-        "version": "1.6.0"
+      "supportedTokens": {
+        "CCIP-BnM": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "sonic-testnet-blaze": {
@@ -6292,6 +6236,17 @@
   },
   "pharos-atlantic-testnet": {
     "ethereum-testnet-sepolia": {
+      "offRamp": {
+        "address": "0x4D8785d2D1Fa810C0B39A688AEB46146e79a4569",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x22af2fDb6Ec9E5AF82585Ee0efb65b5E46086841",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
+      }
+    },
+    "jovay-testnet": {
       "offRamp": {
         "address": "0x4D8785d2D1Fa810C0B39A688AEB46146e79a4569",
         "version": "1.6.0"
@@ -6841,28 +6796,6 @@
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       }
-    },
-    "monad-testnet": {
-      "offRamp": {
-        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
-        "version": "1.6.0"
-      },
-      "onRamp": {
-        "address": "0x289639CB51704043213d2E8806d19979eD8533e4",
-        "enforceOutOfOrder": false,
-        "version": "1.6.0"
-      }
-    },
-    "solana-devnet": {
-      "offRamp": {
-        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
-        "version": "1.6.0"
-      },
-      "onRamp": {
-        "address": "0x289639CB51704043213d2E8806d19979eD8533e4",
-        "enforceOutOfOrder": true,
-        "version": "1.6.0"
-      }
     }
   },
   "ronin-testnet-saigon": {
@@ -6929,6 +6862,17 @@
         "address": "0x1331D0CC0fC29c5B363e8A46e596eb3629fA287b",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
+      }
+    },
+    "ethereum-testnet-hoodi": {
+      "offRamp": {
+        "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
       }
     },
     "ethereum-testnet-sepolia": {
@@ -7367,17 +7311,6 @@
         "version": "1.6.0"
       }
     },
-    "monad-testnet": {
-      "offRamp": {
-        "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
-        "version": "1.6.0"
-      },
-      "onRamp": {
-        "address": "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C",
-        "enforceOutOfOrder": true,
-        "version": "1.6.0"
-      }
-    },
     "plasma-testnet": {
       "offRamp": {
         "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
@@ -7414,17 +7347,6 @@
             }
           }
         }
-      }
-    },
-    "polygon-testnet-tatara": {
-      "offRamp": {
-        "address": "offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm",
-        "version": "1.6.0"
-      },
-      "onRamp": {
-        "address": "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C",
-        "enforceOutOfOrder": true,
-        "version": "1.6.0"
       }
     },
     "sei-testnet-atlantic": {

--- a/src/config/data/ccip/v1_2_0/testnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/testnet/tokens.json
@@ -336,6 +336,15 @@
       "symbol": "CCIP-BnM",
       "tokenAddress": "0x56408DC41E35d3E8E92A16bc94787438df9387a1"
     },
+    "monad-testnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "CCIP-BnM",
+      "poolAddress": "0xb58c4B87b31F7a6C569D68B3Bb91F8621E0fa7B0",
+      "poolType": "burnMint",
+      "symbol": "CCIP-BnM",
+      "tokenAddress": "0xb3B832Acd77fd31aCA5Bd7159d34e5063EC4c09f"
+    },
     "plume-testnet-sepolia": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -1128,7 +1137,7 @@
       "name": "ChainLink Token",
       "poolType": "feeTokenOnly",
       "symbol": "LINK",
-      "tokenAddress": "0x6fE981Dbd557f81ff66836af0932cba535Cbc343"
+      "tokenAddress": "0xe5e3a4fF1773d043a387b16Ceb3c91cC49bAFD54"
     },
     "neox-testnet-t4": {
       "allowListEnabled": false,
@@ -1834,6 +1843,14 @@
       "symbol": "WETH",
       "tokenAddress": "0x4200000000000000000000000000000000000006"
     },
+    "monad-testnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Wrapped Ether",
+      "poolType": "feeTokenOnly",
+      "symbol": "WETH",
+      "tokenAddress": "0xdE4E7FED43FAC37EB21aA0643d9852f75332eab8"
+    },
     "plasma-testnet": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -1961,10 +1978,10 @@
     "monad-testnet": {
       "allowListEnabled": false,
       "decimals": 18,
-      "name": "Wrapped Monad",
+      "name": "Wrapped MON",
       "poolType": "feeTokenOnly",
       "symbol": "WMON",
-      "tokenAddress": "0x760AfE86e5de5fa0Ee542fc7B7B713e1c5425701"
+      "tokenAddress": "0xFb8bf4c1CC7a94c73D209a149eA2AbEa852BC541"
     }
   },
   "WOKB": {


### PR DESCRIPTION
This pull request updates several configuration files to add support for the `savUSD` token across multiple mainnet chains, introduces new or updated rate limiter settings, and makes several additional updates and corrections to testnet and mainnet token and lane configurations. The most significant changes are grouped below.

**Mainnet Token and Lane Configuration Updates:**

* Added `savUSD` as a supported token to multiple chains in `lanes.json` with rate limiter configuration set to disabled and zero capacity/rate. This ensures the token is recognized but not actively rate-limited or enabled for transfers yet. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R881-R894) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R2809-R2822) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R2906-R2919) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R3108-R3121) [[5]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R4607-R4620) [[6]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R4977-R4990) [[7]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R8169-R8182) [[8]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R8364-R8377) [[9]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R8558-R8571) [[10]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R9496-R9509) [[11]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R10446-R10459) [[12]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R11335-R11348) [[13]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R17220-R17233) [[14]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R22366-R22379) [[15]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R24313-R24326) [[16]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R32888-R32901)
* Added `savUSD` token details for `berachain-mainnet` and `ethereum-mainnet-arbitrum-1` in `tokens.json`, including pool and token addresses, decimals, and other metadata. [[1]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R4544-R4552) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R4562-R4570)

**Mainnet Token Corrections:**

* Corrected the name, pool address, and token address for `APRS` (Apeiros) on `ronin-mainnet` in `tokens.json`.
* Updated rate limiter capacities and rates for `APRS` in `lanes.json` to reflect new values. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L28625-R28840) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L33624-R33853)

**Testnet Chain and Lane Configuration Updates:**

* Updated addresses, versions, and fee token lists for `monad-testnet` and other testnets in `chains.json`, reflecting new deployments and support for additional fee tokens. [[1]](diffhunk://#diff-b401f7649971c54aa2b2ae67a377771d1ece35ae87e9aa8d448c6d442e1cc76eL1279-R1293) [[2]](diffhunk://#diff-b401f7649971c54aa2b2ae67a377771d1ece35ae87e9aa8d448c6d442e1cc76eL408-R408) [[3]](diffhunk://#diff-b401f7649971c54aa2b2ae67a377771d1ece35ae87e9aa8d448c6d442e1cc76eL1440-R1440)
* Updated `monad-testnet` on/off ramp addresses and versions in `lanes.json`, and added support for `CCIP-BnM` with a disabled rate limiter.
* Added lane configuration for `sei-testnet-atlantic` in `lanes.json`.
* Removed duplicate or outdated `monad-testnet` lane entries from `lanes.json`. [[1]](diffhunk://#diff-8bb3b28e63cff333bbf04c302b8b3d8b647cb85c2e6b44785402761a2f5f2a72L1101-L1111) [[2]](diffhunk://#diff-8bb3b28e63cff333bbf04c302b8b3d8b647cb85c2e6b44785402761a2f5f2a72L3975-L3985) [[3]](diffhunk://#diff-8bb3b28e63cff333bbf04c302b8b3d8b647cb85c2e6b44785402761a2f5f2a72L4502-L4512)

These updates collectively improve token support, correct configuration errors, and ensure the latest contract addresses and settings are reflected in the configuration files.