### PR TITLE
TS base64 encoding requirement for EVM log triggers (ref page)

### DIFF
--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -14995,14 +14995,22 @@ export async function main() {
 
 # SDK Reference: EVM Log Trigger
 Source: https://docs.chain.link/cre/reference/sdk/triggers/evm-log-trigger-ts
-Last Updated: 2026-01-20
+Last Updated: 2026-01-26
 
 The EVM Log Trigger fires when a specific log (event) is emitted by an onchain smart contract.
 
 ## Creating the trigger
 
+<Aside type="note" title="Base64 Encoding Required">
+  **All addresses and topic values must be base64 encoded** using the `hexToBase64()` helper function from the CRE SDK.
+  While the workflow simulator accepts raw hex strings for convenience during development, **deployed workflows require
+  base64 encoding**. Always use `hexToBase64()` on addresses and topic values to ensure your workflow works in both
+  simulation and production.
+</Aside>
+
 ```typescript
-import { EVMClient, getNetwork } from "@chainlink/cre-sdk"
+import { EVMClient, getNetwork, hexToBase64 } from "@chainlink/cre-sdk"
+import { keccak256, toBytes } from "viem"
 
 // Create an EVMClient instance with a chain selector
 const network = getNetwork({
@@ -15015,18 +15023,17 @@ const evmClient = new EVMClient(network.chainSelector.selector)
 
 // Basic log trigger for a contract address
 const trigger = evmClient.logTrigger({
-  addresses: ["0x123...abc"],
+  addresses: [hexToBase64("0x123...abc")],
 })
 
 // With topics for event filtering
+const transferEventHash = keccak256(toBytes("Transfer(address,address,uint256)"))
+
 const trigger = evmClient.logTrigger({
-  addresses: ["0x123...abc"],
+  addresses: [hexToBase64("0x123...abc")],
   topics: [
     {
-      values: [
-        // Keccak256 hash of "Transfer(address,address,uint256)"
-        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-      ],
+      values: [hexToBase64(transferEventHash)],
     },
   ],
 })
@@ -15038,8 +15045,8 @@ The `logTrigger()` method accepts a configuration object with the following fiel
 
 | Field        | Type            | Description                                                                                                                                                                                                                                                                                                                                                                                               |
 | ------------ | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `addresses`  | `string[]`      | A list of contract addresses to monitor (as hex strings, e.g., `"0x..."`). At least one address is required.                                                                                                                                                                                                                                                                                              |
-| `topics`     | `TopicValues[]` | Optional. A fixed 4-element array to filter event topics. The first element contains event signatures, and the next three elements contain indexed argument values. An empty array element acts as a wildcard.                                                                                                                                                                                            |
+| `addresses`  | `string[]`      | **Required.** A list of contract addresses to monitor. **Must be base64 encoded** using `hexToBase64()`. At least one address is required.                                                                                                                                                                                                                                                                |
+| `topics`     | `TopicValues[]` | Optional. An array to filter event topics. The first element contains event signatures, and the next three elements contain indexed argument values. An empty array element acts as a wildcard. **All topic values must be base64 encoded** using `hexToBase64()`.                                                                                                                                        |
 | `confidence` | `string`        | Optional. The block confirmation level to monitor. Can be: <ul><li>**`"CONFIDENCE_LEVEL_LATEST"`**: The most recent block (fastest but least secure).</li><li>**`"CONFIDENCE_LEVEL_SAFE"` (default)**: A block unlikely to be reorged but not yet irreversible.</li><li>**`"CONFIDENCE_LEVEL_FINALIZED"`**: A block considered irreversible (safest, but requires waiting longer for finality).</li></ul> |
 
 <Aside type="note" title="Finality details">
@@ -15051,9 +15058,9 @@ The `logTrigger()` method accepts a configuration object with the following fiel
 
 The `topics` array uses a special format for filtering events:
 
-| Field    | Type       | Description                                         |
-| -------- | ---------- | --------------------------------------------------- |
-| `values` | `string[]` | Array of possible values for a topic (hex strings). |
+| Field    | Type       | Description                                                                             |
+| -------- | ---------- | --------------------------------------------------------------------------------------- |
+| `values` | `string[]` | Array of possible values for a topic. **Must be base64 encoded** using `hexToBase64()`. |
 
 **Topic array structure:**
 
@@ -15062,19 +15069,36 @@ The `topics` array uses a special format for filtering events:
 - **`topics[2]`**: Optional. Values for the second indexed argument. Can be empty (wildcard).
 - **`topics[3]`**: Optional. Values for the third indexed argument. Can be empty (wildcard).
 
+<Aside type="caution" title="Topic values must be padded to 32 bytes and base64 encoded">
+  EVM logs always store indexed parameters as **32-byte values**. When filtering on topics 1, 2, or 3:
+
+  1. **Pad your values to 32 bytes** using `padHex(value, { size: 32 })` from viem (e.g., addresses are 20 bytes and must be padded)
+  2. **Convert to base64** using `hexToBase64()` from the CRE SDK
+
+  If you don't pad correctly, your filter won't match the actual log topics and the trigger will not fire.
+
+  Topic 0 (the event signature from `keccak256`) is already 32 bytes and doesn't need padding.
+</Aside>
+
 **Example:**
 
 ```typescript
+import { hexToBase64 } from "@chainlink/cre-sdk"
+import { keccak256, toBytes, padHex } from "viem"
+
+const transferEventHash = keccak256(toBytes("Transfer(address,address,uint256)"))
+const fromAddress = "0xabcdef..." as `0x${string}`
+
 const trigger = evmClient.logTrigger({
-  addresses: ["0x1234567890abcdef..."],
+  addresses: [hexToBase64("0x1234567890abcdef...")],
   topics: [
-    // Topic 0: Event signature (Transfer event)
+    // Topic 0: Event signature (Transfer event) - already 32 bytes
     {
-      values: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"],
+      values: [hexToBase64(transferEventHash)],
     },
-    // Topic 1: From address (indexed parameter 1)
+    // Topic 1: From address (indexed parameter 1) - must pad from 20 to 32 bytes
     {
-      values: ["0x000000000000000000000000abcdef..."],
+      values: [hexToBase64(padHex(fromAddress, { size: 32 }))],
     },
     // Topic 2: Empty (wildcard for any "to" address)
     {
@@ -15181,7 +15205,16 @@ const onLogTrigger = (runtime: Runtime<Config>, log: EVMLog): string => {
 ## Complete Example
 
 ```typescript
-import { EVMClient, handler, bytesToHex, getNetwork, Runner, type Runtime, type EVMLog } from "@chainlink/cre-sdk"
+import {
+  EVMClient,
+  handler,
+  bytesToHex,
+  getNetwork,
+  Runner,
+  hexToBase64,
+  type Runtime,
+  type EVMLog,
+} from "@chainlink/cre-sdk"
 
 type Config = {
   chainSelectorName: string
@@ -15221,7 +15254,7 @@ const initWorkflow = (config: Config) => {
   return [
     handler(
       evmClient.logTrigger({
-        addresses: [config.contractAddress],
+        addresses: [hexToBase64(config.contractAddress)],
       }),
       onLogTrigger
     ),

--- a/src/content/cre/reference/sdk/triggers/evm-log-trigger-ts.mdx
+++ b/src/content/cre/reference/sdk/triggers/evm-log-trigger-ts.mdx
@@ -7,7 +7,7 @@ pageId: "reference-sdk-evm-log-trigger"
 metadata:
   description: "Reference for TypeScript EVM Log Trigger: Config interface, Payload fields, and topic filtering for event-driven workflows."
   datePublished: "2025-11-04"
-  lastModified: "2026-01-20"
+  lastModified: "2026-01-26"
 ---
 
 import { Aside } from "@components"
@@ -16,8 +16,16 @@ The EVM Log Trigger fires when a specific log (event) is emitted by an onchain s
 
 ## Creating the trigger
 
+<Aside type="note" title="Base64 Encoding Required">
+  **All addresses and topic values must be base64 encoded** using the `hexToBase64()` helper function from the CRE SDK.
+  While the workflow simulator accepts raw hex strings for convenience during development, **deployed workflows require
+  base64 encoding**. Always use `hexToBase64()` on addresses and topic values to ensure your workflow works in both
+  simulation and production.
+</Aside>
+
 ```typescript
-import { EVMClient, getNetwork } from "@chainlink/cre-sdk"
+import { EVMClient, getNetwork, hexToBase64 } from "@chainlink/cre-sdk"
+import { keccak256, toBytes } from "viem"
 
 // Create an EVMClient instance with a chain selector
 const network = getNetwork({
@@ -30,18 +38,17 @@ const evmClient = new EVMClient(network.chainSelector.selector)
 
 // Basic log trigger for a contract address
 const trigger = evmClient.logTrigger({
-  addresses: ["0x123...abc"],
+  addresses: [hexToBase64("0x123...abc")],
 })
 
 // With topics for event filtering
+const transferEventHash = keccak256(toBytes("Transfer(address,address,uint256)"))
+
 const trigger = evmClient.logTrigger({
-  addresses: ["0x123...abc"],
+  addresses: [hexToBase64("0x123...abc")],
   topics: [
     {
-      values: [
-        // Keccak256 hash of "Transfer(address,address,uint256)"
-        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-      ],
+      values: [hexToBase64(transferEventHash)],
     },
   ],
 })
@@ -53,8 +60,8 @@ The `logTrigger()` method accepts a configuration object with the following fiel
 
 | <div style="width: 100px;">Field</div> | <div style="width: 140px;">Type</div> | Description                                                                                                                                                                                                                                                                                                                                                                                               |
 | -------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `addresses`                            | `string[]`                            | A list of contract addresses to monitor (as hex strings, e.g., `"0x..."`). At least one address is required.                                                                                                                                                                                                                                                                                              |
-| `topics`                               | `TopicValues[]`                       | Optional. A fixed 4-element array to filter event topics. The first element contains event signatures, and the next three elements contain indexed argument values. An empty array element acts as a wildcard.                                                                                                                                                                                            |
+| `addresses`                            | `string[]`                            | **Required.** A list of contract addresses to monitor. **Must be base64 encoded** using `hexToBase64()`. At least one address is required.                                                                                                                                                                                                                                                                |
+| `topics`                               | `TopicValues[]`                       | Optional. An array to filter event topics. The first element contains event signatures, and the next three elements contain indexed argument values. An empty array element acts as a wildcard. **All topic values must be base64 encoded** using `hexToBase64()`.                                                                                                                                        |
 | `confidence`                           | `string`                              | Optional. The block confirmation level to monitor. Can be: <ul><li>**`"CONFIDENCE_LEVEL_LATEST"`**: The most recent block (fastest but least secure).</li><li>**`"CONFIDENCE_LEVEL_SAFE"` (default)**: A block unlikely to be reorged but not yet irreversible.</li><li>**`"CONFIDENCE_LEVEL_FINALIZED"`**: A block considered irreversible (safest, but requires waiting longer for finality).</li></ul> |
 
 <Aside type="note" title="Finality details">
@@ -66,9 +73,9 @@ The `logTrigger()` method accepts a configuration object with the following fiel
 
 The `topics` array uses a special format for filtering events:
 
-| Field    | Type       | Description                                         |
-| -------- | ---------- | --------------------------------------------------- |
-| `values` | `string[]` | Array of possible values for a topic (hex strings). |
+| Field    | Type       | Description                                                                             |
+| -------- | ---------- | --------------------------------------------------------------------------------------- |
+| `values` | `string[]` | Array of possible values for a topic. **Must be base64 encoded** using `hexToBase64()`. |
 
 **Topic array structure:**
 
@@ -77,19 +84,37 @@ The `topics` array uses a special format for filtering events:
 - **`topics[2]`**: Optional. Values for the second indexed argument. Can be empty (wildcard).
 - **`topics[3]`**: Optional. Values for the third indexed argument. Can be empty (wildcard).
 
+<Aside type="caution" title="Topic values must be padded to 32 bytes and base64 encoded">
+EVM logs always store indexed parameters as **32-byte values**. When filtering on topics 1, 2, or 3:
+
+1. **Pad your values to 32 bytes** using `padHex(value, { size: 32 })` from viem (e.g., addresses are 20 bytes and must be padded)
+1. **Convert to base64** using `hexToBase64()` from the CRE SDK
+
+If you don't pad correctly, your filter won't match the actual log topics and the trigger will not fire.
+
+Topic 0 (the event signature from `keccak256`) is already 32 bytes and doesn't need padding.
+
+</Aside>
+
 **Example:**
 
 ```typescript
+import { hexToBase64 } from "@chainlink/cre-sdk"
+import { keccak256, toBytes, padHex } from "viem"
+
+const transferEventHash = keccak256(toBytes("Transfer(address,address,uint256)"))
+const fromAddress = "0xabcdef..." as `0x${string}`
+
 const trigger = evmClient.logTrigger({
-  addresses: ["0x1234567890abcdef..."],
+  addresses: [hexToBase64("0x1234567890abcdef...")],
   topics: [
-    // Topic 0: Event signature (Transfer event)
+    // Topic 0: Event signature (Transfer event) - already 32 bytes
     {
-      values: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"],
+      values: [hexToBase64(transferEventHash)],
     },
-    // Topic 1: From address (indexed parameter 1)
+    // Topic 1: From address (indexed parameter 1) - must pad from 20 to 32 bytes
     {
-      values: ["0x000000000000000000000000abcdef..."],
+      values: [hexToBase64(padHex(fromAddress, { size: 32 }))],
     },
     // Topic 2: Empty (wildcard for any "to" address)
     {
@@ -196,7 +221,16 @@ const onLogTrigger = (runtime: Runtime<Config>, log: EVMLog): string => {
 ## Complete Example
 
 ```typescript
-import { EVMClient, handler, bytesToHex, getNetwork, Runner, type Runtime, type EVMLog } from "@chainlink/cre-sdk"
+import {
+  EVMClient,
+  handler,
+  bytesToHex,
+  getNetwork,
+  Runner,
+  hexToBase64,
+  type Runtime,
+  type EVMLog,
+} from "@chainlink/cre-sdk"
 
 type Config = {
   chainSelectorName: string
@@ -236,7 +270,7 @@ const initWorkflow = (config: Config) => {
   return [
     handler(
       evmClient.logTrigger({
-        addresses: [config.contractAddress],
+        addresses: [hexToBase64(config.contractAddress)],
       }),
       onLogTrigger
     ),


### PR DESCRIPTION
This pull request updates the EVM Log Trigger documentation and code examples to clarify and enforce the requirement that all contract addresses and event topic values must be base64 encoded using the `hexToBase64()` helper function from the CRE SDK. It also provides guidance on padding topic values to 32 bytes and updates all relevant examples and field descriptions accordingly. These changes ensure users avoid common errors when developing and deploying workflows.

**Documentation and Example Updates:**

* Added clear notes and cautions explaining that all addresses and topic values must be base64 encoded with `hexToBase64()`, and that topic values (except event signatures) must be padded to 32 bytes using `padHex` before encoding. [[1]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L14998-R15013) [[2]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4R15072-R15101) [[3]](diffhunk://#diff-c490352f7f090d47a9b02039c36ab2d80b9679c68eed7ffaaa6ff3b9657771deR19-R28) [[4]](diffhunk://#diff-c490352f7f090d47a9b02039c36ab2d80b9679c68eed7ffaaa6ff3b9657771deR87-R117)
* Updated all code examples to use `hexToBase64()` for addresses and topic values, and to demonstrate proper padding of indexed topic parameters. [[1]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L15018-R15036) [[2]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L15184-R15217) [[3]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L15224-R15257) [[4]](diffhunk://#diff-c490352f7f090d47a9b02039c36ab2d80b9679c68eed7ffaaa6ff3b9657771deL33-R51) [[5]](diffhunk://#diff-c490352f7f090d47a9b02039c36ab2d80b9679c68eed7ffaaa6ff3b9657771deL199-R233) [[6]](diffhunk://#diff-c490352f7f090d47a9b02039c36ab2d80b9679c68eed7ffaaa6ff3b9657771deL239-R273)

**Field and Type Descriptions:**

* Revised the documentation tables for `addresses` and `topics` fields to explicitly state the base64 encoding requirement and the use of `hexToBase64()`. [[1]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L15041-R15049) [[2]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L15055-R15063) [[3]](diffhunk://#diff-c490352f7f090d47a9b02039c36ab2d80b9679c68eed7ffaaa6ff3b9657771deL56-R64) [[4]](diffhunk://#diff-c490352f7f090d47a9b02039c36ab2d80b9679c68eed7ffaaa6ff3b9657771deL70-R78)