### PR TITLE
update dir

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -518,14 +518,14 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "2800000000",
+              "capacity": "200000000",
               "isEnabled": true,
-              "rate": "100000000"
+              "rate": "2315"
             },
             "out": {
-              "capacity": "2800000000",
+              "capacity": "200000000",
               "isEnabled": true,
-              "rate": "100000000"
+              "rate": "2315"
             }
           }
         },
@@ -2305,6 +2305,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "BTC.b": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "LBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -7339,6 +7353,20 @@
             }
           }
         },
+        "W0G": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "WLFI": {
           "rateLimiterConfig": {
             "in": {
@@ -9576,6 +9604,20 @@
         "version": "1.5.0"
       },
       "supportedTokens": {
+        "GHO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            },
+            "out": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            }
+          }
+        },
         "VRTX": {
           "rateLimiterConfig": {
             "in": {
@@ -11413,6 +11455,20 @@
           }
         },
         "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "W0G": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -15639,6 +15695,20 @@
             }
           }
         },
+        "W0G": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "WMTX": {
           "rateLimiterConfig": {
             "in": {
@@ -17896,6 +17966,20 @@
         "version": "1.5.0"
       },
       "supportedTokens": {
+        "GHO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            },
+            "out": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            }
+          }
+        },
         "VRTX": {
           "rateLimiterConfig": {
             "in": {
@@ -17934,6 +18018,20 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
+            }
+          }
+        },
+        "GHO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            },
+            "out": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
             }
           }
         },
@@ -18250,6 +18348,20 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000",
+              "isEnabled": true,
+              "rate": "2315"
+            },
+            "out": {
+              "capacity": "5000000",
+              "isEnabled": true,
+              "rate": "2315"
             }
           }
         },
@@ -20395,6 +20507,20 @@
               "capacity": "200000000",
               "isEnabled": true,
               "rate": "2315"
+            }
+          }
+        },
+        "USD1": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -26572,6 +26698,20 @@
             }
           }
         },
+        "GHO": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            },
+            "out": {
+              "capacity": "1500000000000000000000000",
+              "isEnabled": true,
+              "rate": "300000000000000000000"
+            }
+          }
+        },
         "LEASH": {
           "rateLimiterConfig": {
             "in": {
@@ -26736,6 +26876,20 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000",
+              "isEnabled": true,
+              "rate": "2315"
+            },
+            "out": {
+              "capacity": "5000000",
+              "isEnabled": true,
+              "rate": "2315"
             }
           }
         },
@@ -27357,6 +27511,20 @@
               "capacity": "200000000",
               "isEnabled": true,
               "rate": "2315"
+            }
+          }
+        },
+        "USD1": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -29370,6 +29538,20 @@
           }
         },
         "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "W0G": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -32263,6 +32445,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "BTC.b": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "LBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -32642,6 +32838,22 @@
         "address": "0xcDca5D374e46A6DDDab50bD2D9acB8c796eC35C3",
         "enforceOutOfOrder": true,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "W0G": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "sonic-mainnet": {
@@ -34899,6 +35111,20 @@
             }
           }
         },
+        "W0G": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "WLFI": {
           "rateLimiterConfig": {
             "in": {
@@ -34983,6 +35209,20 @@
           }
         },
         "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "W0G": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -35122,6 +35362,20 @@
           }
         },
         "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "W0G": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -35517,6 +35771,20 @@
             }
           }
         },
+        "W0G": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "WFRAGSOL": {
           "rateLimiterConfig": {
             "in": {
@@ -35636,6 +35904,22 @@
         "address": "Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C",
         "enforceOutOfOrder": true,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "W0G": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "plasma-mainnet": {

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -1953,6 +1953,15 @@
       "symbol": "GHO",
       "tokenAddress": "0xfc421aD3C883Bf9E7C4f42dE845C4e4405799e73"
     },
+    "ethereum-mainnet-mantle-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Gho Token",
+      "poolAddress": "0xDe6539018B095353A40753Dc54C91C68c9487D4E",
+      "poolType": "burnMint",
+      "symbol": "GHO",
+      "tokenAddress": "0xfc421aD3C883Bf9E7C4f42dE845C4e4405799e73"
+    },
     "mainnet": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -6196,6 +6205,15 @@
       "symbol": "uniBTC",
       "tokenAddress": "0x93919784C523f39CACaa98Ee0a9d96c3F32b593e"
     },
+    "ethereum-mainnet-mode-1": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "uniBTC",
+      "poolAddress": "0x5A1764254dE62FC55a08E907c712565545615dDb",
+      "poolType": "burnMint",
+      "symbol": "uniBTC",
+      "tokenAddress": "0x6B2a01A5f79dEb4c2f3c0eDa7b01DF456FbD726a"
+    },
     "ethereum-mainnet-optimism-1": {
       "allowListEnabled": false,
       "decimals": 8,
@@ -6409,6 +6427,15 @@
       "decimals": 18,
       "name": "World Liberty Financial USD",
       "poolAddress": "0xf58A2e303e519f6A1b772137995871967e30391a",
+      "poolType": "burnMint",
+      "symbol": "USD1",
+      "tokenAddress": "0x111111d2bf19e43C34263401e0CAd979eD1cdb61"
+    },
+    "ethereum-mainnet-xlayer-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "World Liberty Financial USD",
+      "poolAddress": "0x500E140CCb4Ca279aCF585cc53C4613a7D7BCF27",
       "poolType": "burnMint",
       "symbol": "USD1",
       "tokenAddress": "0x111111d2bf19e43C34263401e0CAd979eD1cdb61"
@@ -6733,7 +6760,7 @@
       "allowListEnabled": false,
       "decimals": 18,
       "name": "OpenEden Open Dollar",
-      "poolAddress": "0x017566aAD2C164011b9c6552Df3Eb7a8c5c11590",
+      "poolAddress": "0x05F8B8bC8026cE0B75c36aBB0e96b6baccCFB018",
       "poolType": "burnMint",
       "symbol": "USDO",
       "tokenAddress": "0x87e617C7484aDE79FcD90db58BEB82B057facb48"
@@ -7095,6 +7122,15 @@
       "poolType": "burnMint",
       "symbol": "W0G",
       "tokenAddress": "0xB267Cc10fa4c54dB1fD5A6e9cAFbB98C16cC9b97"
+    },
+    "solana-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 9,
+      "name": "Wrapped 0G",
+      "poolAddress": "4owiysYefgqx68wtTzED1tm6QhtcSKKJBgKmwRMbccNZ",
+      "poolType": "burnMint",
+      "symbol": "W0G",
+      "tokenAddress": "gNyJyS9pQt33o4y4L3gdWZAF2XHgPrCBRQuaiCZStMe"
     }
   },
   "WAB": {


### PR DESCRIPTION
This pull request updates the CCIP mainnet configuration to add support for several new tokens, adjust rate limiter settings for existing tokens, and update some pool addresses. The main changes include adding new token definitions and rate limiter configurations for `GHO`, `BTC.b`, `uniBTC`, `USD1`, and `W0G` across various lanes and networks, as well as updating the pool address for `USDO`.

**Token additions and configuration updates:**

* Added new token `GHO` with full rate limiter configuration to multiple lanes and updated `tokens.json` to include `GHO` for the `ethereum-mainnet-mantle-1` network. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R9607-R9620) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R17969-R17982) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R18024-R18037) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R26701-R26714) [[5]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R1956-R1964)
* Added new token `BTC.b` with rate limiter configuration in multiple lanes. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R2308-R2321) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R32448-R32461)
* Added and configured new tokens `uniBTC` and `USD1` in several lanes and updated `tokens.json` to include `uniBTC` for `ethereum-mainnet-mode-1` and `USD1` for `ethereum-mainnet-xlayer-1`. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R18354-R18367) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R26882-R26895) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R20512-R20525) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R27516-R27529) [[5]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R6208-R6216) [[6]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R6434-R6442)
* Added support for `W0G` token, including rate limiter configuration (with rate limiting disabled) across multiple lanes and added the token to `tokens.json` for `solana-mainnet`. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R7356-R7369) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R11471-R11484) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R15698-R15711) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R29554-R29567) [[5]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R32841-R32856) [[6]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R35114-R35127) [[7]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R35225-R35238) [[8]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R35378-R35391) [[9]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R35774-R35787) [[10]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R35907-R35922) [[11]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49R7125-R7133)

**Rate limiter adjustments:**

* Significantly reduced the `capacity` and `rate` values for `uniBTC` in its rate limiter configuration to reflect new limits.

**Other configuration updates:**

* Updated the `poolAddress` for the `USDO` token.