### PR TITLE
httpConf capability & CLI v1.0.10

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -398,6 +398,13 @@
       "topic": "CCIP"
     },
     {
+      "category": "release",
+      "date": "2026-02-09",
+      "description": "CRE CLI version 1.0.10 is now available. This release fixes secret injection for the Confidential HTTP capability in the simulator — template placeholders now resolve correctly during simulation.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.0.9...v1.0.10)",
+      "title": "CRE CLI v1.0.10",
+      "topic": "CRE"
+    },
+    {
       "category": "integration",
       "date": "2026-02-09",
       "description": "Chainlink Data Feeds is available on MegaETH Mainnet. View the available price feed information on the [Price Feed Addresses](https://docs.chain.link/data-feeds/price-feeds/addresses?network=megaeth&page=1) page.",
@@ -616,6 +623,20 @@
       ],
       "title": "Added support to Data Feeds",
       "topic": "Data Feeds"
+    },
+    {
+      "category": "release",
+      "date": "2026-02-06",
+      "description": "CRE CLI version 1.0.9 is now available. This release adds experimental [Confidential HTTP](https://docs.chain.link/cre/capabilities/confidential-http) capability support in the simulator, allowing you to simulate workflows with privacy-preserving API calls.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.0.8...v1.0.9)",
+      "title": "CRE CLI v1.0.9",
+      "topic": "CRE"
+    },
+    {
+      "category": "release",
+      "date": "2026-02-06",
+      "description": "CRE CLI version 1.0.8 is now available. This release changes `chain-id` to `chain-selector` in simulator settings, adds support for longer workflow names, and fixes a logic bug in the template contract MessageEmitter.sol.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.0.7...v1.0.8)",
+      "title": "CRE CLI v1.0.8",
+      "topic": "CRE"
     },
     {
       "category": "release",

--- a/src/components/DownloadButton.tsx
+++ b/src/components/DownloadButton.tsx
@@ -15,7 +15,7 @@ export const DownloadButton = () => {
   }
 
   const handleClick = () => {
-    window.open("https://github.com/smartcontractkit/cre-cli/releases/tag/v1.0.7", "_blank", "noopener,noreferrer")
+    window.open("https://github.com/smartcontractkit/cre-cli/releases/tag/v1.0.10", "_blank", "noopener,noreferrer")
   }
 
   const handleMouseOver = (e) => {

--- a/src/config/sidebar.ts
+++ b/src/config/sidebar.ts
@@ -297,6 +297,20 @@ export const SIDEBAR: Partial<Record<Sections, SectionEntry[]>> = {
           ],
         },
         {
+          title: "Confidential API Interactions (Experimental)",
+          url: "cre/guides/workflow/using-confidential-http-client",
+          children: [
+            {
+              title: "Making Confidential Requests",
+              url: "cre/guides/workflow/using-confidential-http-client/making-requests",
+              highlightAsCurrent: [
+                "cre/guides/workflow/using-confidential-http-client/making-requests-ts",
+                "cre/guides/workflow/using-confidential-http-client/making-requests-go",
+              ],
+            },
+          ],
+        },
+        {
           title: "Secrets",
           url: "cre/guides/workflow/secrets",
           children: [
@@ -409,6 +423,11 @@ export const SIDEBAR: Partial<Record<Sections, SectionEntry[]>> = {
         { title: "Overview", url: "cre/capabilities" },
         { title: "Triggers", url: "cre/capabilities/triggers" },
         { title: "HTTP", url: "cre/capabilities/http" },
+        {
+          title: "Confidential HTTP (Experimental)",
+          url: "cre/capabilities/confidential-http",
+          highlightAsCurrent: ["cre/capabilities/confidential-http-ts", "cre/capabilities/confidential-http-go"],
+        },
         { title: "EVM Read & Write", url: "cre/capabilities/evm-read-write" },
       ],
     },
@@ -532,6 +551,14 @@ export const SIDEBAR: Partial<Record<Sections, SectionEntry[]>> = {
               title: "HTTP Client",
               url: "cre/reference/sdk/http-client",
               highlightAsCurrent: ["cre/reference/sdk/http-client-ts", "cre/reference/sdk/http-client-go"],
+            },
+            {
+              title: "Confidential HTTP Client (Experimental)",
+              url: "cre/reference/sdk/confidential-http-client",
+              highlightAsCurrent: [
+                "cre/reference/sdk/confidential-http-client-ts",
+                "cre/reference/sdk/confidential-http-client-go",
+              ],
             },
             {
               title: "Consensus & Aggregation",

--- a/src/content/cre/capabilities/confidential-http-go.mdx
+++ b/src/content/cre/capabilities/confidential-http-go.mdx
@@ -1,0 +1,117 @@
+---
+section: cre
+title: "The Confidential HTTP Capability (Experimental)"
+date: Last Modified
+sdkLang: "go"
+pageId: "confidential-http"
+metadata:
+  description: "CRE Confidential HTTP capability: make privacy-preserving API calls with enclave execution, secret injection, and optional response encryption."
+  datePublished: "2026-02-06"
+  lastModified: "2026-02-06"
+---
+
+import { Aside } from "@components"
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The **Confidential HTTP** capability is a privacy-preserving HTTP service powered by the Chainlink Privacy Standard. It enables your workflow to interact with external APIs while keeping sensitive data—such as API credentials, request body fields, and response data—confidential.
+
+## The problem it solves
+
+Traditional consensus mechanisms require all nodes to see and agree on the same data. While this provides strong reliability and tamper resistance, it creates challenges for use cases with strict privacy requirements:
+
+- **Regulatory compliance:** Some industries require that sensitive data never be exposed to multiple parties.
+- **Credential security:** High-risk API credentials could cause damage if compromised or exposed in node memory.
+- **Response privacy:** API responses may contain sensitive fields that should not be visible to the decentralized network.
+
+Confidential HTTP addresses these challenges by executing requests inside a **secure enclave** and offering optional **response encryption**.
+
+## How it works
+
+Confidential HTTP operates differently from the [regular HTTP capability](/cre/capabilities/http):
+
+1. **Request consensus:** Nodes in the Confidential HTTP DON reach quorum on the request parameters (forwarded by each Workflow DON node).
+1. **Secret retrieval:** The Confidential HTTP DON fetches encrypted secrets from the [Vault DON](/cre/guides/workflow/secrets/using-secrets-deployed).
+1. **Enclave execution:** Secrets are decrypted and injected into the request inside a secure enclave. The HTTP request executes from the enclave—credentials never exist in accessible memory.
+1. **Response:** The response is returned to your workflow. If `EncryptOutput` is enabled, the response body is encrypted before leaving the enclave.
+
+This approach ensures:
+
+- **Credential isolation:** Secrets are encrypted at rest and in transit, and are decrypted only inside the enclave—never in node memory.
+- **Response privacy:** You can optionally encrypt the full response body so that it leaves the enclave encrypted and can be decrypted only in your own backend service.
+- **Single execution:** Exactly one API call is made, not one per node.
+
+## What's kept confidential
+
+| Component                      | How it's protected                                                                                                                                                             |
+| :----------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Secrets** (API keys, tokens) | Fully confidential. Stored in the Vault DON, decrypted only inside the enclave.                                                                                                |
+| **Request body**               | Template-based injection: secrets referenced in the request body (e.g., `{{.myApiKey}}`) are resolved inside the enclave, so sensitive values never appear in workflow memory. |
+| **Response body**              | Optionally encrypted. When `EncryptOutput` is enabled, the full response is [AES-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode) encrypted before leaving the enclave. |
+
+## Use cases
+
+### Credential isolation
+
+A SaaS service fetches user data from an e-commerce provider API. The same credential could also modify user data if misused. Confidential HTTP ensures the credential is decrypted only inside the enclave, never accessible in node memory.
+
+### Response encryption
+
+A workflow calls a payment processor API to execute a transaction. The API response includes the transaction ID and success status, but also returns sensitive data like the user's account balance and an internal risk score. With Confidential HTTP and `EncryptOutput` enabled, the full response is encrypted before leaving the enclave—it can only be decrypted using the encryption key, for example in your own backend service.
+
+### Processing sensitive request data
+
+A workflow processes card transactions where the request contains card details and the API key provides processor access. Confidential HTTP keeps both the credentials and card details private through template-based injection, returning only the encrypted response to the workflow.
+
+### Guaranteed single execution
+
+An API endpoint cannot tolerate duplicate requests (e.g., initiating a payment or creating a unique transaction).
+
+With the [regular HTTP capability](/cre/capabilities/http), each node in the DON executes the request independently to reach consensus on the response. For non-idempotent operations, [`cacheSettings` mitigates](/cre/guides/workflow/using-http-client/post-request-go#1-understanding-single-execution-with-cachesettings) this by enabling nodes to share cached responses, reducing duplicate calls in most cases.
+
+Confidential HTTP takes a different approach: by design, only one request is ever made from the enclave after quorum is reached on the request parameters. This provides an **architectural guarantee** of single execution.
+
+## When to use Confidential HTTP vs. regular HTTP
+
+### Use Confidential HTTP when:
+
+- The API response contains sensitive data that should not be visible to the network
+- API credentials must never be accessible in node memory (enclave-only access)
+- You need exactly one API call with zero tolerance for duplicates
+- Regulatory or compliance requirements mandate data confidentiality
+
+### Use regular HTTP when:
+
+- **Querying multiple APIs and combining results**: For example, fetching prices from 3 different sources and computing a median. Each node calls all APIs, aggregates locally, then nodes reach consensus on the final value.
+
+- **Transforming data before consensus**: For example, parsing a complex API response, filtering fields, or performing calculations on the data before nodes agree on the result.
+
+- **Computing with a secret before the request**: For example, generating an HMAC signature for API authentication — use the [`runInNodeMode` pattern](/cre/guides/workflow/using-http-client/post-request-go#2-the-creruninnodemode-pattern-alternative) to access secrets and perform computations before making the request.
+
+- **No confidentiality requirements**: The API response doesn't contain sensitive data, and you don't need enclave-level protection for credentials.
+
+## Key differences from regular HTTP
+
+| Aspect                    | Regular HTTP                          | Confidential HTTP              |
+| :------------------------ | :------------------------------------ | :----------------------------- |
+| **API calls**             | One per node (multiple)\*             | Exactly one (single)           |
+| **Consensus target**      | Response data                         | Request parameters             |
+| **Execution environment** | Each node individually                | Secure enclave                 |
+| **Secrets exposure**      | Decrypted in Workflow DON node memory | Decrypted only in the enclave  |
+| **Response handling**     | Full response to all nodes            | Optionally encrypted (AES-GCM) |
+| **Data transformation**   | Supported in workflow code            | Not yet supported in enclave   |
+
+\*For non-idempotent operations (POST, PUT, PATCH, DELETE), [`cacheSettings`](/cre/guides/workflow/using-http-client/post-request#1-understanding-single-execution-with-cachesettings) enables nodes to share cached responses, reducing multiple calls to a single execution in most cases.
+
+<Aside type="note" title="Confidential Compute">
+  Confidential HTTP currently does not support complex data transformations within the enclave. A future **Confidential
+  Compute** capability will enable processing logic inside the enclave.
+</Aside>
+
+## Learn more
+
+- **[Confidential API Interactions Guide](/cre/guides/workflow/using-confidential-http-client)**: Learn how to use the SDK to invoke the Confidential HTTP capability.
+- **[Confidential HTTP Client SDK Reference](/cre/reference/sdk/confidential-http-client)**: See the detailed API reference for the `confidentialhttp.Client`.

--- a/src/content/cre/capabilities/confidential-http-ts.mdx
+++ b/src/content/cre/capabilities/confidential-http-ts.mdx
@@ -1,0 +1,117 @@
+---
+section: cre
+title: "The Confidential HTTP Capability (Experimental)"
+date: Last Modified
+sdkLang: "ts"
+pageId: "confidential-http"
+metadata:
+  description: "CRE Confidential HTTP capability: make privacy-preserving API calls with enclave execution, secret injection, and optional response encryption."
+  datePublished: "2026-02-06"
+  lastModified: "2026-02-06"
+---
+
+import { Aside } from "@components"
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The **Confidential HTTP** capability is a privacy-preserving HTTP service powered by the Chainlink Privacy Standard. It enables your workflow to interact with external APIs while keeping sensitive data—such as API credentials, request body fields, and response data—confidential.
+
+## The problem it solves
+
+Traditional consensus mechanisms require all nodes to see and agree on the same data. While this provides strong reliability and tamper resistance, it creates challenges for use cases with strict privacy requirements:
+
+- **Regulatory compliance:** Some industries require that sensitive data never be exposed to multiple parties.
+- **Credential security:** High-risk API credentials could cause damage if compromised or exposed in node memory.
+- **Response privacy:** API responses may contain sensitive fields that should not be visible to the decentralized network.
+
+Confidential HTTP addresses these challenges by executing requests inside a **secure enclave** and offering optional **response encryption**.
+
+## How it works
+
+Confidential HTTP operates differently from the [regular HTTP capability](/cre/capabilities/http):
+
+1. **Request consensus:** Nodes in the Confidential HTTP DON reach quorum on the request parameters (forwarded by each Workflow DON node).
+1. **Secret retrieval:** The Confidential HTTP DON fetches encrypted secrets from the [Vault DON](/cre/guides/workflow/secrets/using-secrets-deployed).
+1. **Enclave execution:** Secrets are decrypted and injected into the request inside a secure enclave. The HTTP request executes from the enclave—credentials never exist in accessible memory.
+1. **Response:** The response is returned to your workflow. If `EncryptOutput` is enabled, the response body is encrypted before leaving the enclave.
+
+This approach ensures:
+
+- **Credential isolation:** Secrets are encrypted at rest and in transit, and are decrypted only inside the enclave—never in node memory.
+- **Response privacy:** You can optionally encrypt the full response body so that it leaves the enclave encrypted and can be decrypted only in your own backend service.
+- **Single execution:** Exactly one API call is made, not one per node.
+
+## What's kept confidential
+
+| Component                      | How it's protected                                                                                                                                                             |
+| :----------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Secrets** (API keys, tokens) | Fully confidential. Stored in the Vault DON, decrypted only inside the enclave.                                                                                                |
+| **Request body**               | Template-based injection: secrets referenced in the request body (e.g., `{{.myApiKey}}`) are resolved inside the enclave, so sensitive values never appear in workflow memory. |
+| **Response body**              | Optionally encrypted. When `EncryptOutput` is enabled, the full response is [AES-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode) encrypted before leaving the enclave. |
+
+## Use cases
+
+### Credential isolation
+
+A SaaS service fetches user data from an e-commerce provider API. The same credential could also modify user data if misused. Confidential HTTP ensures the credential is decrypted only inside the enclave, never accessible in node memory.
+
+### Response encryption
+
+A workflow calls a payment processor API to execute a transaction. The API response includes the transaction ID and success status, but also returns sensitive data like the user's account balance and an internal risk score. With Confidential HTTP and `EncryptOutput` enabled, the full response is encrypted before leaving the enclave—it can only be decrypted using the encryption key, for example in your own backend service.
+
+### Processing sensitive request data
+
+A workflow processes card transactions where the request contains card details and the API key provides processor access. Confidential HTTP keeps both the credentials and card details private through template-based injection, returning only the encrypted response to the workflow.
+
+### Guaranteed single execution
+
+An API endpoint cannot tolerate duplicate requests (e.g., initiating a payment or creating a unique transaction).
+
+With the [regular HTTP capability](/cre/capabilities/http), each node in the DON executes the request independently to reach consensus on the response. For non-idempotent operations, [`cacheSettings` mitigates](/cre/guides/workflow/using-http-client/post-request-ts#1-understanding-single-execution-with-cachesettings) this by enabling nodes to share cached responses, reducing duplicate calls in most cases.
+
+Confidential HTTP takes a different approach: by design, only one request is ever made from the enclave after quorum is reached on the request parameters. This provides an **architectural guarantee** of single execution.
+
+## When to use Confidential HTTP vs. regular HTTP
+
+### Use Confidential HTTP when:
+
+- The API response contains sensitive data that should not be visible to the network
+- API credentials must never be accessible in node memory (enclave-only access)
+- You need exactly one API call with zero tolerance for duplicates
+- Regulatory or compliance requirements mandate data confidentiality
+
+### Use regular HTTP when:
+
+- **Querying multiple APIs and combining results**: For example, fetching prices from 3 different sources and computing a median. Each node calls all APIs, aggregates locally, then nodes reach consensus on the final value.
+
+- **Transforming data before consensus**: For example, parsing a complex API response, filtering fields, or performing calculations on the data before nodes agree on the result.
+
+- **Computing with a secret before the request**: For example, generating an HMAC signature for API authentication — use the [`runInNodeMode` pattern](/cre/guides/workflow/using-http-client/post-request-ts#2-the-low-level-runinnodemode-pattern) to access secrets and perform computations before making the request.
+
+- **No confidentiality requirements**: The API response doesn't contain sensitive data, and you don't need enclave-level protection for credentials.
+
+## Key differences from regular HTTP
+
+| Aspect                    | Regular HTTP                          | Confidential HTTP              |
+| :------------------------ | :------------------------------------ | :----------------------------- |
+| **API calls**             | One per node (multiple)\*             | Exactly one (single)           |
+| **Consensus target**      | Response data                         | Request parameters             |
+| **Execution environment** | Each node individually                | Secure enclave                 |
+| **Secrets exposure**      | Decrypted in Workflow DON node memory | Decrypted only in the enclave  |
+| **Response handling**     | Full response to all nodes            | Optionally encrypted (AES-GCM) |
+| **Data transformation**   | Supported in workflow code            | Not yet supported in enclave   |
+
+\*For non-idempotent operations (POST, PUT, PATCH, DELETE), [`cacheSettings`](/cre/guides/workflow/using-http-client/post-request#1-understanding-single-execution-with-cachesettings) enables nodes to share cached responses, reducing multiple calls to a single execution in most cases.
+
+<Aside type="note" title="Confidential Compute">
+  Confidential HTTP currently does not support complex data transformations within the enclave. A future **Confidential
+  Compute** capability will enable processing logic inside the enclave.
+</Aside>
+
+## Learn more
+
+- **[Confidential API Interactions Guide](/cre/guides/workflow/using-confidential-http-client)**: Learn how to use the SDK to invoke the Confidential HTTP capability.
+- **[Confidential HTTP Client SDK Reference](/cre/reference/sdk/confidential-http-client)**: See the detailed API reference for the `confidentialhttp.Client`.

--- a/src/content/cre/capabilities/index.mdx
+++ b/src/content/cre/capabilities/index.mdx
@@ -30,6 +30,7 @@ This section provides a high-level, conceptual overview of the capabilities curr
 
 - **[Triggers](/cre/capabilities/triggers)**: Event sources that start your workflow executions.
 - **[HTTP](/cre/capabilities/http)**: Fetch and post data from external APIs with decentralized consensus.
+- **[Confidential HTTP](/cre/capabilities/confidential-http)** _(Experimental)_: Make privacy-preserving API calls with enclave execution, secret injection, and optional response encryption.
 - **[EVM Read & Write](/cre/capabilities/evm-read-write)**: Interact with smart contracts on EVM-compatible blockchains with decentralized consensus.
 
-All execution capabilities (HTTP, EVM) automatically use [built-in consensus](/cre/concepts/consensus-computing) to validate results across multiple nodes, ensuring security and reliability.
+All execution capabilities (HTTP, Confidential HTTP, EVM) automatically use [built-in consensus](/cre/concepts/consensus-computing) to validate results across multiple nodes, ensuring security and reliability.

--- a/src/content/cre/getting-started/cli-installation/macos-linux.mdx
+++ b/src/content/cre/getting-started/cli-installation/macos-linux.mdx
@@ -5,13 +5,13 @@ title: "Installing the CRE CLI on macOS and Linux"
 metadata:
   description: "Install the CRE CLI on macOS or Linux: choose automatic script or manual setup, verify integrity, and get ready to build workflows."
   datePublished: "2025-11-04"
-  lastModified: "2026-01-29"
+  lastModified: "2026-02-10"
 ---
 
 import { Aside, CopyText, PageTabs } from "@components"
 import { DownloadButton } from "~/components/DownloadButton.tsx"
 
-This page explains how to install the CRE CLI on macOS or Linux. The recommended version at the time of writing is **v1.0.7**.
+This page explains how to install the CRE CLI on macOS or Linux. The recommended version at the time of writing is **v1.0.10**.
 
 <PageTabs
   pages={[
@@ -66,7 +66,7 @@ After the script completes, verify the installation:
 cre version
 ```
 
-**Expected output:** `cre version v1.0.7`
+**Expected output:** `cre version v1.0.10`
 
 <Aside type="note" title="macOS Gatekeeper">
   If you see warnings about "unrecognized developer/source" on macOS, run:{" "}
@@ -120,11 +120,11 @@ shasum -a 256 cre_darwin_arm64.zip
 Compare the output with the official checksum from the [CRE CLI releases page](https://github.com/smartcontractkit/cre-cli/releases):
 
 1. Go to https://github.com/smartcontractkit/cre-cli/releases
-1. Find the release version you downloaded (e.g., v1.0.7)
+1. Find the release version you downloaded (e.g., v1.0.10)
 1. Under the **Assets** section, locate your downloaded file
 1. Compare the SHA-256 checksum shown next to the file with your command output
 
-**Example:** For `cre_darwin_arm64.zip` in release v1.0.7, you'll see something like:
+**Example:** For `cre_darwin_arm64.zip` in release v1.0.10, you'll see something like:
 
 ```
 cre_darwin_arm64.zip
@@ -154,7 +154,7 @@ If the checksums match, the file is authentic and safe to install. If they don't
 1. **Rename the extracted binary to `cre`**
 
    ```bash
-   mv cre_v1.0.7_darwin_arm64 cre
+   mv cre_v1.0.10_darwin_arm64 cre
    ```
 
 1. **Make it executable**:
@@ -227,7 +227,7 @@ cre version
 
 **Expected output:**
 
-You should see version information: `cre version v1.0.7`.
+You should see version information: `cre version v1.0.10`.
 
 **If it doesn't work:**
 

--- a/src/content/cre/getting-started/cli-installation/windows.mdx
+++ b/src/content/cre/getting-started/cli-installation/windows.mdx
@@ -5,13 +5,13 @@ title: "Installing the CRE CLI on Windows"
 metadata:
   description: "Install the CRE CLI on Windows: use PowerShell for quick setup or manual installation, verify integrity, and start building workflows."
   datePublished: "2025-11-04"
-  lastModified: "2026-01-29"
+  lastModified: "2026-02-10"
 ---
 
 import { Aside, CopyText, PageTabs } from "@components"
 import { DownloadButton } from "~/components/DownloadButton.tsx"
 
-This page explains how to install the Chainlink Developer Platform CLI (also referred to as the CRE CLI) on Windows. The recommended version at the time of writing is **v1.0.7**.
+This page explains how to install the Chainlink Developer Platform CLI (also referred to as the CRE CLI) on Windows. The recommended version at the time of writing is **v1.0.10**.
 
 <PageTabs
   pages={[
@@ -65,7 +65,7 @@ After the script completes, **open a new PowerShell window** and verify the inst
 cre version
 ```
 
-**Expected output:** `cre version v1.0.7`
+**Expected output:** `cre version v1.0.10`
 
 ### Manual installation
 
@@ -96,11 +96,11 @@ Get-FileHash cre_windows_amd64.zip -Algorithm SHA256
 Compare the `Hash` value in the output with the official checksum from the [CRE CLI releases page](https://github.com/smartcontractkit/cre-cli/releases):
 
 1. Go to https://github.com/smartcontractkit/cre-cli/releases
-2. Find the release version you downloaded (e.g., v1.0.7)
+2. Find the release version you downloaded (e.g., v1.0.10)
 3. Under the **Assets** section, locate `cre_windows_amd64.zip`
 4. Compare the SHA-256 checksum shown next to the file with the `Hash` value from your PowerShell output
 
-**Example:** For `cre_windows_amd64.zip` in release v1.0.7, you'll see something like:
+**Example:** For `cre_windows_amd64.zip` in release v1.0.10, you'll see something like:
 
 ```
 cre_windows_amd64.zip
@@ -114,7 +114,7 @@ If the checksums match, the file is authentic and safe to install. If they don't
 1. Navigate to the directory where you downloaded the archive.
 1. Right-click the `.zip` file and select **Extract All...**.
 1. Choose a permanent location for the extracted folder (e.g., `C:\Program Files\cre-cli`).
-1. Inside the extracted folder, rename the file `cre_v1.0.7_windows_amd64.exe` to `cre.exe`.
+1. Inside the extracted folder, rename the file `cre_v1.0.10_windows_amd64.exe` to `cre.exe`.
 
 #### 3. Add the CLI to your PATH
 
@@ -139,7 +139,7 @@ Open a new **PowerShell** or **Command Prompt** window and run:
 cre version
 ```
 
-You should see version information: `cre version v1.0.7`.
+You should see version information: `cre version v1.0.10`.
 
 ## Next steps
 

--- a/src/content/cre/guides/workflow/using-confidential-http-client/index.mdx
+++ b/src/content/cre/guides/workflow/using-confidential-http-client/index.mdx
@@ -1,0 +1,25 @@
+---
+section: cre
+title: "Confidential API Interactions (Experimental)"
+date: Last Modified
+isIndex: true
+metadata:
+  description: "Make privacy-preserving API calls: learn to use Confidential HTTP for enclave execution, secret injection, and response encryption."
+  datePublished: "2026-02-06"
+  lastModified: "2026-02-06"
+---
+
+import { Aside } from "@components"
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The CRE SDK provides a Confidential HTTP client that allows your workflows to interact with external APIs while keeping sensitive data private. Requests execute inside a secure enclave, secrets are injected via templates, and responses can optionally be encrypted.
+
+For a conceptual overview of what Confidential HTTP is and how it differs from the regular HTTP capability, see [The Confidential HTTP Capability](/cre/capabilities/confidential-http).
+
+## Guides
+
+- **[Making Confidential Requests](/cre/guides/workflow/using-confidential-http-client/making-requests)**: Learn how to make a confidential HTTP request with secret injection and optional response encryption.

--- a/src/content/cre/guides/workflow/using-confidential-http-client/making-requests-go.mdx
+++ b/src/content/cre/guides/workflow/using-confidential-http-client/making-requests-go.mdx
@@ -1,0 +1,400 @@
+---
+section: cre
+title: "Making Confidential Requests"
+date: Last Modified
+sdkLang: "go"
+pageId: "guides-workflow-confidential-http-making-requests"
+metadata:
+  description: "Make confidential HTTP requests in Go: learn to use enclave execution, secret injection, and optional response encryption in your workflows."
+  datePublished: "2026-02-10"
+  lastModified: "2026-02-10"
+---
+
+import { Aside } from "@components"
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The `confidentialhttp.Client` is the SDK's interface for the underlying [Confidential HTTP Capability](/cre/capabilities/confidential-http). It allows your workflow to make privacy-preserving API calls where secrets are injected inside a secure enclave and responses can be optionally encrypted.
+
+Unlike the regular [`http.Client`](/cre/reference/sdk/http-client), the Confidential HTTP client:
+
+- Executes the request in a secure **enclave** (not on each node individually)
+- Injects secrets from the **Vault DON** using template syntax
+- Optionally **encrypts the response** before returning it to your workflow
+
+## Prerequisites
+
+This guide assumes you have:
+
+- A basic understanding of CRE. If you are new, complete the [Getting Started tutorial](/cre/getting-started/overview) first.
+- Familiarity with [secrets management](/cre/guides/workflow/secrets) in CRE.
+
+## Step-by-step example
+
+This example shows a workflow that makes a confidential POST request to an API, injecting an API secret into both the request body and headers using template syntax.
+
+### Step 1: Configure your workflow
+
+Add the API URL to your `config.json` file.
+
+```json
+{
+  "schedule": "0 */5 * * * *",
+  "url": "https://api.example.com/data"
+}
+```
+
+### Step 2: Set up secrets for simulation
+
+Confidential HTTP uses the `secrets.yaml` file. If you've already set up secrets for your project, you can reuse the same file. For a full walkthrough, see [Using Secrets in Simulation](/cre/guides/workflow/secrets/using-secrets-simulation).
+
+Add the secrets your confidential request needs to your `secrets.yaml`:
+
+```yaml
+# secrets.yaml
+secretsNames:
+  myApiKey:
+    - MY_API_KEY_ALL
+```
+
+Provide the actual value via an environment variable or `.env` file:
+
+```bash
+export MY_API_KEY_ALL="your-secret-api-key"
+```
+
+<Aside type="note" title="Verify secrets-path in workflow.yaml">
+  Make sure the `secrets-path` field in your `workflow.yaml` points to your `secrets.yaml` file (for example,
+  `"../secrets.yaml"` if it is at the project root). New projects created with the CLI may have this field empty by
+  default.
+</Aside>
+
+### Step 3: Build the confidential request
+
+The key difference from regular HTTP is how you construct the request. You provide:
+
+- An `HTTPRequest` with template placeholders (`{{.secretName}}`) in the body and/or headers
+- A list of `VaultDonSecrets` identifying which secrets to fetch from the Vault DON
+- An optional `EncryptOutput` flag to encrypt the response
+
+```go
+import (
+	"github.com/smartcontractkit/cre-sdk-go/capabilities/networking/confidentialhttp"
+	"github.com/smartcontractkit/cre-sdk-go/cre"
+)
+
+type Config struct {
+	Schedule string `json:"schedule"`
+	URL      string `json:"url"`
+}
+
+type Result struct {
+	TransactionID string `json:"transactionId" consensus:"identical"`
+	Status        string `json:"status"        consensus:"identical"`
+}
+```
+
+### Step 4: Implement the request logic
+
+Use `cre.RunInNodeMode` to make the confidential request. The `confidentialhttp.Client` requires a `NodeRuntime`:
+
+```go
+func makeConfidentialRequest(config Config, nodeRuntime cre.NodeRuntime) (Result, error) {
+	// 1. Define the request body with secret template placeholders
+	payload := `{"auth": "{{.myApiKey}}", "action": "getTransaction", "id": "tx-123"}`
+
+	// 2. Define headers with secret template placeholders
+	headers := map[string]*confidentialhttp.HeaderValues{
+		"Content-Type": {
+			Values: []string{"application/json"},
+		},
+		"Authorization": {
+			Values: []string{"Basic {{.myApiKey}}"},
+		},
+	}
+
+	// 3. Create the client and send the request
+	client := confidentialhttp.Client{}
+	resp, err := client.SendRequest(nodeRuntime, &confidentialhttp.ConfidentialHTTPRequest{
+		Request: &confidentialhttp.HTTPRequest{
+			Url:    config.URL,
+			Method: "POST",
+			Body:   &confidentialhttp.HTTPRequest_BodyString{BodyString: payload},
+			MultiHeaders: headers,
+		},
+		VaultDonSecrets: []*confidentialhttp.SecretIdentifier{
+			{Key: "myApiKey"},
+		},
+		EncryptOutput: false,
+	}).Await()
+	if err != nil {
+		return Result{}, fmt.Errorf("confidential HTTP request failed: %w", err)
+	}
+
+	// 4. Parse the response
+	var result Result
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		return Result{}, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return result, nil
+}
+```
+
+### Step 5: Wire it into your workflow
+
+Call the request function from your trigger handler using `cre.RunInNodeMode`:
+
+```go
+func onCronTrigger(config *Config, runtime cre.Runtime, outputs *cron.Payload) (string, error) {
+	result, err := cre.RunInNodeMode(*config, runtime,
+		makeConfidentialRequest,
+		cre.ConsensusIdenticalAggregation[Result](),
+	).Await()
+	if err != nil {
+		return "", fmt.Errorf("failed to get result: %w", err)
+	}
+
+	runtime.Logger().Info("Transaction result", "id", result.TransactionID, "status", result.Status)
+	return result.TransactionID, nil
+}
+```
+
+### Step 6: Simulate
+
+Run the simulation:
+
+```bash
+cre workflow simulate
+```
+
+## Template syntax for secrets
+
+Secrets are injected into request bodies and headers using Go template syntax: `{{.secretName}}`. The placeholder name must match the `Key` in your `VaultDonSecrets` list.
+
+**In the request body:**
+
+```json
+{ "auth": "{{.myApiKey}}", "data": "public-data" }
+```
+
+**In headers:**
+
+```go
+headers := map[string]*confidentialhttp.HeaderValues{
+	"Authorization": {
+		Values: []string{"Basic {{.myCredential}}"},
+	},
+}
+```
+
+The template placeholders are resolved inside the enclave. The actual secret values never appear in your workflow code or in node memory.
+
+## Response encryption
+
+By default, the API response is returned unencrypted (`EncryptOutput: false`). To encrypt the response body before it leaves the enclave, set `EncryptOutput: true` and provide an AES-256 encryption key as a Vault DON secret.
+
+### Setting up response encryption
+
+1. **Store an AES-256 key** as a Vault DON secret with the identifier `san_marino_aes_gcm_encryption_key`:
+
+   ```yaml
+   # secrets.yaml
+   secretsNames:
+     san_marino_aes_gcm_encryption_key:
+   	- AES_KEY_ALL
+   ```
+
+   The key must be a 256-bit (32 bytes) hex-encoded string:
+
+   ```bash
+   export AES_KEY_ALL="your-256-bit-hex-encoded-key"
+   ```
+
+1. **Include the key in your `VaultDonSecrets`** and set `EncryptOutput: true`:
+
+   ```go
+   resp, err := client.SendRequest(nodeRuntime, &confidentialhttp.ConfidentialHTTPRequest{
+   	Request: &confidentialhttp.HTTPRequest{
+   		Url:    config.URL,
+   		Method: "POST",
+   		Body:   &confidentialhttp.HTTPRequest_BodyString{BodyString: payload},
+   		MultiHeaders: headers,
+   	},
+   	VaultDonSecrets: []*confidentialhttp.SecretIdentifier{
+   		{Key: "myApiKey"},
+   		{Key: "san_marino_aes_gcm_encryption_key"},
+   	},
+   	EncryptOutput: true,
+   }).Await()
+   ```
+
+1. **Decrypt the response** in your own secure backend using AES-GCM. The encrypted response body is structured as `nonce || ciphertext || tag`:
+
+   ```go
+   import (
+   	"crypto/aes"
+   	"crypto/cipher"
+   	"encoding/hex"
+   )
+
+   func AESGCMDecrypt(blob []byte, key []byte) ([]byte, error) {
+   	block, err := aes.NewCipher(key)
+   	if err != nil {
+   		return nil, err
+   	}
+
+   	gcm, err := cipher.NewGCM(block)
+   	if err != nil {
+   		return nil, err
+   	}
+
+   	nonceSize := gcm.NonceSize()
+   	if len(blob) < nonceSize {
+   		return nil, fmt.Errorf("ciphertext too short")
+   	}
+
+   	nonce, ciphertext := blob[:nonceSize], blob[nonceSize:]
+   	return gcm.Open(nil, nonce, ciphertext, nil)
+   }
+   ```
+
+   {/* prettier-ignore */}
+   <Aside type="tip" title="Do not decrypt inside the workflow">
+	The purpose of response encryption is to keep the response confidential even within the decentralized network. Decrypt the response in your own secure backend service, not inside the workflow itself.
+	</Aside>
+
+## Complete example
+
+Here's the full workflow code for a confidential HTTP request with response encryption:
+
+```go
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/smartcontractkit/cre-sdk-go/capabilities/networking/confidentialhttp"
+	"github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron"
+	"github.com/smartcontractkit/cre-sdk-go/cre"
+)
+
+type Config struct {
+	Schedule string `json:"schedule"`
+	URL      string `json:"url"`
+}
+
+type Result struct {
+	TransactionID string `json:"transactionId" consensus:"identical"`
+	Status        string `json:"status"        consensus:"identical"`
+}
+
+func InitWorkflow(config *Config, logger *slog.Logger, secretsProvider cre.SecretsProvider) (cre.Workflow[*Config], error) {
+	cronTriggerCfg := &cron.Config{
+		Schedule: config.Schedule,
+	}
+
+	workflow := cre.Workflow[*Config]{
+		cre.Handler(
+			cron.Trigger(cronTriggerCfg),
+			onCronTrigger,
+		),
+	}
+
+	return workflow, nil
+}
+
+func onCronTrigger(config *Config, runtime cre.Runtime, outputs *cron.Payload) (string, error) {
+	result, err := cre.RunInNodeMode(*config, runtime,
+		makeConfidentialRequest,
+		cre.ConsensusIdenticalAggregation[Result](),
+	).Await()
+	if err != nil {
+		return "", fmt.Errorf("failed to get result: %w", err)
+	}
+
+	runtime.Logger().Info("Transaction result", "id", result.TransactionID, "status", result.Status)
+	return result.TransactionID, nil
+}
+
+func makeConfidentialRequest(config Config, nodeRuntime cre.NodeRuntime) (Result, error) {
+	payload := `{"auth": "{{.myApiKey}}", "action": "getTransaction", "id": "tx-123"}`
+
+	headers := map[string]*confidentialhttp.HeaderValues{
+		"Content-Type": {
+			Values: []string{"application/json"},
+		},
+		"Authorization": {
+			Values: []string{"Basic {{.myApiKey}}"},
+		},
+	}
+
+	client := confidentialhttp.Client{}
+	resp, err := client.SendRequest(nodeRuntime, &confidentialhttp.ConfidentialHTTPRequest{
+		Request: &confidentialhttp.HTTPRequest{
+			Url:    config.URL,
+			Method: "POST",
+			Body:   &confidentialhttp.HTTPRequest_BodyString{BodyString: payload},
+			MultiHeaders: headers,
+		},
+		VaultDonSecrets: []*confidentialhttp.SecretIdentifier{
+			{Key: "myApiKey"},
+			{Key: "san_marino_aes_gcm_encryption_key"},
+		},
+		EncryptOutput: true,
+	}).Await()
+	if err != nil {
+		return Result{}, fmt.Errorf("confidential HTTP request failed: %w", err)
+	}
+
+	// In a real workflow, you would forward the encrypted body to your
+	// secure backend for decryption. This inline decryption is shown
+	// for demonstration purposes only.
+	keyHex := os.Getenv("AES_KEY_ALL") // your 256-bit hex-encoded key
+	keyBytes, _ := hex.DecodeString(keyHex)
+	decrypted, err := AESGCMDecrypt(resp.Body, keyBytes)
+	if err != nil {
+		return Result{}, fmt.Errorf("failed to decrypt response: %w", err)
+	}
+
+	var result Result
+	if err := json.Unmarshal(decrypted, &result); err != nil {
+		return Result{}, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return result, nil
+}
+
+func AESGCMDecrypt(blob []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(blob) < nonceSize {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ciphertext := blob[:nonceSize], blob[nonceSize:]
+	return gcm.Open(nil, nonce, ciphertext, nil)
+}
+```
+
+## API reference
+
+For the full list of types and methods available on the Confidential HTTP client, see the [Confidential HTTP Client SDK Reference](/cre/reference/sdk/confidential-http-client-go).

--- a/src/content/cre/guides/workflow/using-confidential-http-client/making-requests-ts.mdx
+++ b/src/content/cre/guides/workflow/using-confidential-http-client/making-requests-ts.mdx
@@ -1,0 +1,319 @@
+---
+section: cre
+title: "Making Confidential Requests"
+date: Last Modified
+sdkLang: "ts"
+pageId: "guides-workflow-confidential-http-making-requests"
+metadata:
+  description: "Make confidential HTTP requests in TypeScript: learn to use enclave execution, secret injection, and optional response encryption in your workflows."
+  datePublished: "2026-02-10"
+  lastModified: "2026-02-10"
+---
+
+import { Aside } from "@components"
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The `ConfidentialHTTPClient` is the SDK's interface for the underlying [Confidential HTTP Capability](/cre/capabilities/confidential-http). It allows your workflow to make privacy-preserving API calls where secrets are injected inside a secure enclave and responses can be optionally encrypted.
+
+Unlike the regular [`HTTPClient`](/cre/reference/sdk/http-client), the Confidential HTTP client:
+
+- Executes the request in a secure **enclave** (not on each node individually)
+- Injects secrets from the **Vault DON** using template syntax
+- Optionally **encrypts the response** before returning it to your workflow
+
+## Prerequisites
+
+This guide assumes you have:
+
+- A basic understanding of CRE. If you are new, complete the [Getting Started tutorial](/cre/getting-started/overview) first.
+- Familiarity with [secrets management](/cre/guides/workflow/secrets) in CRE.
+
+## Step-by-step example
+
+This example shows a workflow that makes a confidential GET request to an API, injecting a secret into the request headers using template syntax.
+
+### Step 1: Configure your workflow
+
+Add the API URL to your `config.json` file.
+
+```json
+{
+  "schedule": "0 */5 * * * *",
+  "url": "https://api.example.com/data",
+  "owner": ""
+}
+```
+
+### Step 2: Set up secrets for simulation
+
+Confidential HTTP uses the `secrets.yaml` file. If you've already set up secrets for your project, you can reuse the same file. For a full walkthrough, see [Using Secrets in Simulation](/cre/guides/workflow/secrets/using-secrets-simulation).
+
+Add the secrets your confidential request needs to your `secrets.yaml`:
+
+```yaml
+# secrets.yaml
+secretsNames:
+  myApiKey:
+    - MY_API_KEY_ALL
+```
+
+Provide the actual value via an environment variable or `.env` file:
+
+```bash
+export MY_API_KEY_ALL="your-secret-api-key"
+```
+
+<Aside type="note" title="Verify secrets-path in workflow.yaml">
+  Make sure the `secrets-path` field in your `workflow.yaml` points to your `secrets.yaml` file (for example,
+  `"../secrets.yaml"` if it is at the project root). New projects created with the CLI may have this field empty by
+  default.
+</Aside>
+
+### Step 3: Define your types
+
+```typescript
+import { z } from "zod"
+
+const configSchema = z.object({
+  schedule: z.string(),
+  url: z.string(),
+  owner: z.string(),
+})
+
+type Config = z.infer<typeof configSchema>
+
+type TransactionResult = {
+  transactionId: string
+  status: string
+}
+```
+
+### Step 4: Implement the fetch function
+
+Create the function that will be passed to `sendRequest()`. This function receives a `ConfidentialHTTPSendRequester` and your config as parameters:
+
+```typescript
+import { type ConfidentialHTTPSendRequester, ok, json } from "@chainlink/cre-sdk"
+
+const fetchTransaction = (sendRequester: ConfidentialHTTPSendRequester, config: Config): TransactionResult => {
+  // 1. Send the confidential request
+  const response = sendRequester
+    .sendRequest({
+      request: {
+        url: config.url,
+        method: "GET",
+        multiHeaders: {
+          Authorization: { values: ["Basic {{.myApiKey}}"] },
+        },
+      },
+      vaultDonSecrets: [{ key: "myApiKey", owner: config.owner }],
+    })
+    .result()
+
+  // 2. Check the response status
+  if (!ok(response)) {
+    throw new Error(`HTTP request failed with status: ${response.statusCode}`)
+  }
+
+  // 3. Parse and return the result
+  return json(response) as TransactionResult
+}
+```
+
+### Step 5: Wire it into your workflow
+
+In your trigger handler, call `confHTTPClient.sendRequest()` with your fetch function and a consensus method:
+
+```typescript
+import {
+  CronCapability,
+  ConfidentialHTTPClient,
+  handler,
+  consensusIdenticalAggregation,
+  type Runtime,
+  Runner,
+} from "@chainlink/cre-sdk"
+
+const onCronTrigger = (runtime: Runtime<Config>): string => {
+  const confHTTPClient = new ConfidentialHTTPClient()
+
+  const result = confHTTPClient
+    .sendRequest(runtime, fetchTransaction, consensusIdenticalAggregation<TransactionResult>())(runtime.config)
+    .result()
+
+  runtime.log(`Transaction result: ${result.transactionId} — ${result.status}`)
+  return result.transactionId
+}
+```
+
+### Step 6: Simulate
+
+Run the simulation:
+
+```bash
+cre workflow simulate
+```
+
+## Template syntax for secrets
+
+Secrets are injected into request bodies and headers using Go template syntax: `{{.secretName}}`. The placeholder name must match the `key` in your `vaultDonSecrets` list.
+
+**In the request body:**
+
+```json
+{ "auth": "{{.myApiKey}}", "data": "public-data" }
+```
+
+**In headers:**
+
+```typescript
+multiHeaders: {
+  "Authorization": { values: ["Basic {{.myCredential}}"] },
+}
+```
+
+The template placeholders are resolved inside the enclave. The actual secret values never appear in your workflow code or in node memory.
+
+## Response encryption
+
+By default, the API response is returned unencrypted (`encryptOutput: false`). To encrypt the response body before it leaves the enclave, set `encryptOutput: true` and provide an AES-256 encryption key as a Vault DON secret.
+
+### Setting up response encryption
+
+1. **Store an AES-256 key** as a Vault DON secret with the identifier `san_marino_aes_gcm_encryption_key`:
+
+   ```yaml
+   # secrets.yaml
+   secretsNames:
+     san_marino_aes_gcm_encryption_key:
+       - AES_KEY_ALL
+   ```
+
+The key must be a 256-bit (32 bytes) hex-encoded string:
+
+```bash
+export AES_KEY_ALL="your-256-bit-hex-encoded-key"
+```
+
+1. **Include the key in your `vaultDonSecrets`** and set `encryptOutput: true`:
+
+   ```typescript
+   const response = sendRequester
+     .sendRequest({
+       request: {
+         url: config.url,
+         method: "GET",
+         multiHeaders: {
+           Authorization: { values: ["Basic {{.myApiKey}}"] },
+         },
+       },
+       vaultDonSecrets: [{ key: "myApiKey", owner: config.owner }, { key: "san_marino_aes_gcm_encryption_key" }],
+       encryptOutput: true,
+     })
+     .result()
+   ```
+
+1. **Decrypt the response** in your own backend service. The encrypted response body is structured as `nonce || ciphertext || tag` and uses AES-GCM encryption.
+
+{/* prettier-ignore */}
+<Aside type="caution" title="Do not decrypt inside the workflow">
+  The purpose of response encryption is to keep the response confidential even within the decentralized network. Decrypt
+  the response in your own backend service, not inside the workflow itself.
+</Aside>
+
+## Response helper functions
+
+The SDK response helpers `ok()`, `text()`, and `json()` work with Confidential HTTP responses just as they do with regular HTTP responses. For full documentation, see the [HTTP Client SDK Reference](/cre/reference/sdk/http-client-ts#helper-functions).
+
+## Complete example
+
+Here's the full workflow code for a confidential HTTP request with secret injection:
+
+```typescript
+import {
+  CronCapability,
+  ConfidentialHTTPClient,
+  handler,
+  consensusIdenticalAggregation,
+  ok,
+  json,
+  type ConfidentialHTTPSendRequester,
+  type Runtime,
+  Runner,
+} from "@chainlink/cre-sdk"
+import { z } from "zod"
+
+// Config schema
+const configSchema = z.object({
+  schedule: z.string(),
+  url: z.string(),
+  owner: z.string(),
+})
+
+type Config = z.infer<typeof configSchema>
+
+// Result type
+type TransactionResult = {
+  transactionId: string
+  status: string
+}
+
+// Fetch function — receives a ConfidentialHTTPSendRequester and config
+const fetchTransaction = (sendRequester: ConfidentialHTTPSendRequester, config: Config): TransactionResult => {
+  const response = sendRequester
+    .sendRequest({
+      request: {
+        url: config.url,
+        method: "GET",
+        multiHeaders: {
+          Authorization: { values: ["Basic {{.myApiKey}}"] },
+        },
+      },
+      vaultDonSecrets: [{ key: "myApiKey", owner: config.owner }],
+    })
+    .result()
+
+  if (!ok(response)) {
+    throw new Error(`HTTP request failed with status: ${response.statusCode}`)
+  }
+
+  return json(response) as TransactionResult
+}
+
+// Main workflow handler
+const onCronTrigger = (runtime: Runtime<Config>): string => {
+  const confHTTPClient = new ConfidentialHTTPClient()
+
+  const result = confHTTPClient
+    .sendRequest(runtime, fetchTransaction, consensusIdenticalAggregation<TransactionResult>())(runtime.config)
+    .result()
+
+  runtime.log(`Transaction result: ${result.transactionId} — ${result.status}`)
+  return result.transactionId
+}
+
+// Initialize workflow
+const initWorkflow = (config: Config) => {
+  return [
+    handler(
+      new CronCapability().trigger({
+        schedule: config.schedule,
+      }),
+      onCronTrigger
+    ),
+  ]
+}
+
+export async function main() {
+  const runner = await Runner.newRunner<Config>({ configSchema })
+  await runner.run(initWorkflow)
+}
+```
+
+## API reference
+
+For the full list of types and methods available on the Confidential HTTP client, see the [Confidential HTTP Client SDK Reference](/cre/reference/sdk/confidential-http-client-ts).

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -442,9 +442,51 @@ To help us assist you faster, please include:
 
 # Release Notes
 Source: https://docs.chain.link/cre/release-notes
-Last Updated: 2026-02-03
+Last Updated: 2026-02-10
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.0.10 - February 9, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.0.10" target="_blank">CRE CLI version 1.0.10</a> is now available.**
+
+- **Bug Fix**: Fixed secret injection for the [Confidential HTTP](/cre/capabilities/confidential-http) capability in the simulator — template placeholders (`{{.secretName}}`) now resolve correctly during `cre workflow simulate`
+- **Bug Fix**: Fixed project context not being set before writing changeset files
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.0.9...v1.0.10)
+
+## CLI v1.0.9 - February 6, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.0.9" target="_blank">CRE CLI version 1.0.9</a> is now available.**
+
+- **Confidential HTTP (Experimental)**: Added [Confidential HTTP](/cre/capabilities/confidential-http) capability support in the simulator. You can now simulate workflows that use privacy-preserving API calls with secret injection and optional response encryption.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.0.8...v1.0.9)
+
+## CLI v1.0.8 - February 6, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.0.8" target="_blank">CRE CLI version 1.0.8</a> is now available.**
+
+- Changed `chain-id` to `chain-selector` in simulator settings
+- Support for longer workflow names
+- Fixed a logic bug in the template contract `MessageEmitter.sol`
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.0.7...v1.0.8)
 
 ## New Networks Support - January 29, 2026
 
@@ -646,9 +688,9 @@ These guides explain how to install the Chainlink Developer Platform CLI (also r
 
 # Installing the CRE CLI on macOS and Linux
 Source: https://docs.chain.link/cre/getting-started/cli-installation/macos-linux
-Last Updated: 2026-01-29
+Last Updated: 2026-02-10
 
-This page explains how to install the CRE CLI on macOS or Linux. The recommended version at the time of writing is **v1.0.7**.
+This page explains how to install the CRE CLI on macOS or Linux. The recommended version at the time of writing is **v1.0.10**.
 
 ## Installation
 
@@ -679,7 +721,7 @@ After the script completes, verify the installation:
 cre version
 ```
 
-**Expected output:** `cre version v1.0.7`
+**Expected output:** `cre version v1.0.10`
 
 <Aside type="note" title="macOS Gatekeeper">
   If you see warnings about "unrecognized developer/source" on macOS, run:{" "}
@@ -727,11 +769,11 @@ shasum -a 256 cre_darwin_arm64.zip
 Compare the output with the official checksum from the [CRE CLI releases page](https://github.com/smartcontractkit/cre-cli/releases):
 
 1. Go to [https://github.com/smartcontractkit/cre-cli/releases](https://github.com/smartcontractkit/cre-cli/releases)
-2. Find the release version you downloaded (e.g., v1.0.7)
+2. Find the release version you downloaded (e.g., v1.0.10)
 3. Under the **Assets** section, locate your downloaded file
 4. Compare the SHA-256 checksum shown next to the file with your command output
 
-**Example:** For `cre_darwin_arm64.zip` in release v1.0.7, you'll see something like:
+**Example:** For `cre_darwin_arm64.zip` in release v1.0.10, you'll see something like:
 
 ```
 cre_darwin_arm64.zip
@@ -761,7 +803,7 @@ If the checksums match, the file is authentic and safe to install. If they don't
 3. **Rename the extracted binary to `cre`**
 
    ```bash
-   mv cre_v1.0.7_darwin_arm64 cre
+   mv cre_v1.0.10_darwin_arm64 cre
    ```
 
 4. **Make it executable**:
@@ -834,7 +876,7 @@ cre version
 
 **Expected output:**
 
-You should see version information: `cre version v1.0.7`.
+You should see version information: `cre version v1.0.10`.
 
 **If it doesn't work:**
 
@@ -871,9 +913,9 @@ Once you're authenticated, you're ready to build your first workflow:
 
 # Installing the CRE CLI on Windows
 Source: https://docs.chain.link/cre/getting-started/cli-installation/windows
-Last Updated: 2026-01-29
+Last Updated: 2026-02-10
 
-This page explains how to install the Chainlink Developer Platform CLI (also referred to as the CRE CLI) on Windows. The recommended version at the time of writing is **v1.0.7**.
+This page explains how to install the Chainlink Developer Platform CLI (also referred to as the CRE CLI) on Windows. The recommended version at the time of writing is **v1.0.10**.
 
 ## Installation
 
@@ -903,7 +945,7 @@ After the script completes, **open a new PowerShell window** and verify the inst
 cre version
 ```
 
-**Expected output:** `cre version v1.0.7`
+**Expected output:** `cre version v1.0.10`
 
 ### Manual installation
 
@@ -930,11 +972,11 @@ Get-FileHash cre_windows_amd64.zip -Algorithm SHA256
 Compare the `Hash` value in the output with the official checksum from the [CRE CLI releases page](https://github.com/smartcontractkit/cre-cli/releases):
 
 1. Go to [https://github.com/smartcontractkit/cre-cli/releases](https://github.com/smartcontractkit/cre-cli/releases)
-2. Find the release version you downloaded (e.g., v1.0.7)
+2. Find the release version you downloaded (e.g., v1.0.10)
 3. Under the **Assets** section, locate `cre_windows_amd64.zip`
 4. Compare the SHA-256 checksum shown next to the file with the `Hash` value from your PowerShell output
 
-**Example:** For `cre_windows_amd64.zip` in release v1.0.7, you'll see something like:
+**Example:** For `cre_windows_amd64.zip` in release v1.0.10, you'll see something like:
 
 ```
 cre_windows_amd64.zip
@@ -948,7 +990,7 @@ If the checksums match, the file is authentic and safe to install. If they don't
 1. Navigate to the directory where you downloaded the archive.
 2. Right-click the `.zip` file and select **Extract All...**.
 3. Choose a permanent location for the extracted folder (e.g., `C:\Program Files\cre-cli`).
-4. Inside the extracted folder, rename the file `cre_v1.0.7_windows_amd64.exe` to `cre.exe`.
+4. Inside the extracted folder, rename the file `cre_v1.0.10_windows_amd64.exe` to `cre.exe`.
 
 #### 3. Add the CLI to your PATH
 
@@ -973,7 +1015,7 @@ Open a new **PowerShell** or **Command Prompt** window and run:
 cre version
 ```
 
-You should see version information: `cre version v1.0.7`.
+You should see version information: `cre version v1.0.10`.
 
 ## Next steps
 
@@ -4439,6 +4481,25 @@ These guides will walk you through the common use cases for the HTTP client.
 
 ---
 
+# Confidential API Interactions (Experimental)
+Source: https://docs.chain.link/cre/guides/workflow/using-confidential-http-client
+Last Updated: 2026-02-06
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The CRE SDK provides a Confidential HTTP client that allows your workflows to interact with external APIs while keeping sensitive data private. Requests execute inside a secure enclave, secrets are injected via templates, and responses can optionally be encrypted.
+
+For a conceptual overview of what Confidential HTTP is and how it differs from the regular HTTP capability, see [The Confidential HTTP Capability](/cre/capabilities/confidential-http).
+
+## Guides
+
+- **[Making Confidential Requests](/cre/guides/workflow/using-confidential-http-client/making-requests)**: Learn how to make a confidential HTTP request with secret injection and optional response encryption.
+
+---
+
 # Managing Secrets
 Source: https://docs.chain.link/cre/guides/workflow/secrets
 Last Updated: 2025-11-04
@@ -7208,9 +7269,10 @@ This section provides a high-level, conceptual overview of the capabilities curr
 
 - **[Triggers](/cre/capabilities/triggers)**: Event sources that start your workflow executions.
 - **[HTTP](/cre/capabilities/http)**: Fetch and post data from external APIs with decentralized consensus.
+- **[Confidential HTTP](/cre/capabilities/confidential-http)** *(Experimental)*: Make privacy-preserving API calls with enclave execution, secret injection, and optional response encryption.
 - **[EVM Read & Write](/cre/capabilities/evm-read-write)**: Interact with smart contracts on EVM-compatible blockchains with decentralized consensus.
 
-All execution capabilities (HTTP, EVM) automatically use [built-in consensus](/cre/concepts/consensus-computing) to validate results across multiple nodes, ensuring security and reliability.
+All execution capabilities (HTTP, Confidential HTTP, EVM) automatically use [built-in consensus](/cre/concepts/consensus-computing) to validate results across multiple nodes, ensuring security and reliability.
 
 ---
 
@@ -7634,10 +7696,10 @@ See the [repository README](https://github.com/smartcontractkit/cre-gcp-predicti
 
 # CLI Reference
 Source: https://docs.chain.link/cre/reference/cli
-Last Updated: 2026-01-29
+Last Updated: 2026-02-10
 
-<Aside type="note" title="Required CLI Version: v1.0.7">
-  To ensure compatibility with the guides and examples in this documentation, please use version `v1.0.7` of the CRE
+<Aside type="note" title="Required CLI Version: v1.0.10">
+  To ensure compatibility with the guides and examples in this documentation, please use version `v1.0.10` of the CRE
   CLI. You can check your installed version by running `cre version`. Refer to the [CLI
   Installation](/cre/getting-started/cli-installation/macos-linux) guide for more information.
 </Aside>
@@ -8549,18 +8611,128 @@ cre version
 **Example output:**
 
 ```bash
-cre version v1.0.7
+cre version v1.0.10
 ```
 
 
 <Aside type="note" title="Version compatibility">
-  Always check that your CLI version matches the version recommended in the documentation. The current recommended version is **v1.0.7**. See the [CLI Installation guide](/cre/getting-started/cli-installation) for more information.
+  Always check that your CLI version matches the version recommended in the documentation. The current recommended version is **v1.0.10**. See the [CLI Installation guide](/cre/getting-started/cli-installation) for more information.
 </Aside>
 
 ## Learn more
 
 - [CLI Installation](/cre/getting-started/cli-installation) — How to install and update the CRE CLI
 - [CLI Reference](/cre/reference/cli) — Complete CLI command reference
+
+---
+
+# The Confidential HTTP Capability (Experimental)
+Source: https://docs.chain.link/cre/capabilities/confidential-http-go
+Last Updated: 2026-02-06
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The **Confidential HTTP** capability is a privacy-preserving HTTP service powered by the Chainlink Privacy Standard. It enables your workflow to interact with external APIs while keeping sensitive data—such as API credentials, request body fields, and response data—confidential.
+
+## The problem it solves
+
+Traditional consensus mechanisms require all nodes to see and agree on the same data. While this provides strong reliability and tamper resistance, it creates challenges for use cases with strict privacy requirements:
+
+- **Regulatory compliance:** Some industries require that sensitive data never be exposed to multiple parties.
+- **Credential security:** High-risk API credentials could cause damage if compromised or exposed in node memory.
+- **Response privacy:** API responses may contain sensitive fields that should not be visible to the decentralized network.
+
+Confidential HTTP addresses these challenges by executing requests inside a **secure enclave** and offering optional **response encryption**.
+
+## How it works
+
+Confidential HTTP operates differently from the [regular HTTP capability](/cre/capabilities/http):
+
+1. **Request consensus:** Nodes in the Confidential HTTP DON reach quorum on the request parameters (forwarded by each Workflow DON node).
+2. **Secret retrieval:** The Confidential HTTP DON fetches encrypted secrets from the [Vault DON](/cre/guides/workflow/secrets/using-secrets-deployed).
+3. **Enclave execution:** Secrets are decrypted and injected into the request inside a secure enclave. The HTTP request executes from the enclave—credentials never exist in accessible memory.
+4. **Response:** The response is returned to your workflow. If `EncryptOutput` is enabled, the response body is encrypted before leaving the enclave.
+
+This approach ensures:
+
+- **Credential isolation:** Secrets are encrypted at rest and in transit, and are decrypted only inside the enclave—never in node memory.
+- **Response privacy:** You can optionally encrypt the full response body so that it leaves the enclave encrypted and can be decrypted only in your own backend service.
+- **Single execution:** Exactly one API call is made, not one per node.
+
+## What's kept confidential
+
+| Component                      | How it's protected                                                                                                                                                             |
+| :----------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Secrets** (API keys, tokens) | Fully confidential. Stored in the Vault DON, decrypted only inside the enclave.                                                                                                |
+| **Request body**               | Template-based injection: secrets referenced in the request body (e.g., `{{.myApiKey}}`) are resolved inside the enclave, so sensitive values never appear in workflow memory. |
+| **Response body**              | Optionally encrypted. When `EncryptOutput` is enabled, the full response is [AES-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode) encrypted before leaving the enclave. |
+
+## Use cases
+
+### Credential isolation
+
+A SaaS service fetches user data from an e-commerce provider API. The same credential could also modify user data if misused. Confidential HTTP ensures the credential is decrypted only inside the enclave, never accessible in node memory.
+
+### Response encryption
+
+A workflow calls a payment processor API to execute a transaction. The API response includes the transaction ID and success status, but also returns sensitive data like the user's account balance and an internal risk score. With Confidential HTTP and `EncryptOutput` enabled, the full response is encrypted before leaving the enclave—it can only be decrypted using the encryption key, for example in your own backend service.
+
+### Processing sensitive request data
+
+A workflow processes card transactions where the request contains card details and the API key provides processor access. Confidential HTTP keeps both the credentials and card details private through template-based injection, returning only the encrypted response to the workflow.
+
+### Guaranteed single execution
+
+An API endpoint cannot tolerate duplicate requests (e.g., initiating a payment or creating a unique transaction).
+
+With the [regular HTTP capability](/cre/capabilities/http), each node in the DON executes the request independently to reach consensus on the response. For non-idempotent operations, [`cacheSettings` mitigates](/cre/guides/workflow/using-http-client/post-request-go#1-understanding-single-execution-with-cachesettings) this by enabling nodes to share cached responses, reducing duplicate calls in most cases.
+
+Confidential HTTP takes a different approach: by design, only one request is ever made from the enclave after quorum is reached on the request parameters. This provides an **architectural guarantee** of single execution.
+
+## When to use Confidential HTTP vs. regular HTTP
+
+### Use Confidential HTTP when:
+
+- The API response contains sensitive data that should not be visible to the network
+- API credentials must never be accessible in node memory (enclave-only access)
+- You need exactly one API call with zero tolerance for duplicates
+- Regulatory or compliance requirements mandate data confidentiality
+
+### Use regular HTTP when:
+
+- **Querying multiple APIs and combining results**: For example, fetching prices from 3 different sources and computing a median. Each node calls all APIs, aggregates locally, then nodes reach consensus on the final value.
+
+- **Transforming data before consensus**: For example, parsing a complex API response, filtering fields, or performing calculations on the data before nodes agree on the result.
+
+- **Computing with a secret before the request**: For example, generating an HMAC signature for API authentication — use the [`runInNodeMode` pattern](/cre/guides/workflow/using-http-client/post-request-go#2-the-creruninnodemode-pattern-alternative) to access secrets and perform computations before making the request.
+
+- **No confidentiality requirements**: The API response doesn't contain sensitive data, and you don't need enclave-level protection for credentials.
+
+## Key differences from regular HTTP
+
+| Aspect                    | Regular HTTP                          | Confidential HTTP              |
+| :------------------------ | :------------------------------------ | :----------------------------- |
+| **API calls**             | One per node (multiple)\*             | Exactly one (single)           |
+| **Consensus target**      | Response data                         | Request parameters             |
+| **Execution environment** | Each node individually                | Secure enclave                 |
+| **Secrets exposure**      | Decrypted in Workflow DON node memory | Decrypted only in the enclave  |
+| **Response handling**     | Full response to all nodes            | Optionally encrypted (AES-GCM) |
+| **Data transformation**   | Supported in workflow code            | Not yet supported in enclave   |
+
+\*For non-idempotent operations (POST, PUT, PATCH, DELETE), [`cacheSettings`](/cre/guides/workflow/using-http-client/post-request#1-understanding-single-execution-with-cachesettings) enables nodes to share cached responses, reducing multiple calls to a single execution in most cases.
+
+<Aside type="note" title="Confidential Compute">
+  Confidential HTTP currently does not support complex data transformations within the enclave. A future **Confidential
+  Compute** capability will enable processing logic inside the enclave.
+</Aside>
+
+## Learn more
+
+- **[Confidential API Interactions Guide](/cre/guides/workflow/using-confidential-http-client)**: Learn how to use the SDK to invoke the Confidential HTTP capability.
+- **[Confidential HTTP Client SDK Reference](/cre/reference/sdk/confidential-http-client)**: See the detailed API reference for the `confidentialhttp.Client`.
 
 ---
 
@@ -10567,6 +10739,399 @@ It's the **median of node observations** per round. It closely tracks real time 
 **What is the resolution?**
 
 New DON timestamps are produced continuously (multiple per second). Treat it as coarse-grained real time suitable for gating and logging, not sub-millisecond measurement.
+
+---
+
+# Making Confidential Requests
+Source: https://docs.chain.link/cre/guides/workflow/using-confidential-http-client/making-requests-go
+Last Updated: 2026-02-10
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The `confidentialhttp.Client` is the SDK's interface for the underlying [Confidential HTTP Capability](/cre/capabilities/confidential-http). It allows your workflow to make privacy-preserving API calls where secrets are injected inside a secure enclave and responses can be optionally encrypted.
+
+Unlike the regular [`http.Client`](/cre/reference/sdk/http-client), the Confidential HTTP client:
+
+- Executes the request in a secure **enclave** (not on each node individually)
+- Injects secrets from the **Vault DON** using template syntax
+- Optionally **encrypts the response** before returning it to your workflow
+
+## Prerequisites
+
+This guide assumes you have:
+
+- A basic understanding of CRE. If you are new, complete the [Getting Started tutorial](/cre/getting-started/overview) first.
+- Familiarity with [secrets management](/cre/guides/workflow/secrets) in CRE.
+
+## Step-by-step example
+
+This example shows a workflow that makes a confidential POST request to an API, injecting an API secret into both the request body and headers using template syntax.
+
+### Step 1: Configure your workflow
+
+Add the API URL to your `config.json` file.
+
+```json
+{
+  "schedule": "0 */5 * * * *",
+  "url": "https://api.example.com/data"
+}
+```
+
+### Step 2: Set up secrets for simulation
+
+Confidential HTTP uses the `secrets.yaml` file. If you've already set up secrets for your project, you can reuse the same file. For a full walkthrough, see [Using Secrets in Simulation](/cre/guides/workflow/secrets/using-secrets-simulation).
+
+Add the secrets your confidential request needs to your `secrets.yaml`:
+
+```yaml
+# secrets.yaml
+secretsNames:
+  myApiKey:
+    - MY_API_KEY_ALL
+```
+
+Provide the actual value via an environment variable or `.env` file:
+
+```bash
+export MY_API_KEY_ALL="your-secret-api-key"
+```
+
+<Aside type="note" title="Verify secrets-path in workflow.yaml">
+  Make sure the `secrets-path` field in your `workflow.yaml` points to your `secrets.yaml` file (for example,
+  `"../secrets.yaml"` if it is at the project root). New projects created with the CLI may have this field empty by
+  default.
+</Aside>
+
+### Step 3: Build the confidential request
+
+The key difference from regular HTTP is how you construct the request. You provide:
+
+- An `HTTPRequest` with template placeholders (`{{.secretName}}`) in the body and/or headers
+- A list of `VaultDonSecrets` identifying which secrets to fetch from the Vault DON
+- An optional `EncryptOutput` flag to encrypt the response
+
+```go
+import (
+	"github.com/smartcontractkit/cre-sdk-go/capabilities/networking/confidentialhttp"
+	"github.com/smartcontractkit/cre-sdk-go/cre"
+)
+
+type Config struct {
+	Schedule string `json:"schedule"`
+	URL      string `json:"url"`
+}
+
+type Result struct {
+	TransactionID string `json:"transactionId" consensus:"identical"`
+	Status        string `json:"status"        consensus:"identical"`
+}
+```
+
+### Step 4: Implement the request logic
+
+Use `cre.RunInNodeMode` to make the confidential request. The `confidentialhttp.Client` requires a `NodeRuntime`:
+
+```go
+func makeConfidentialRequest(config Config, nodeRuntime cre.NodeRuntime) (Result, error) {
+	// 1. Define the request body with secret template placeholders
+	payload := `{"auth": "{{.myApiKey}}", "action": "getTransaction", "id": "tx-123"}`
+
+	// 2. Define headers with secret template placeholders
+	headers := map[string]*confidentialhttp.HeaderValues{
+		"Content-Type": {
+			Values: []string{"application/json"},
+		},
+		"Authorization": {
+			Values: []string{"Basic {{.myApiKey}}"},
+		},
+	}
+
+	// 3. Create the client and send the request
+	client := confidentialhttp.Client{}
+	resp, err := client.SendRequest(nodeRuntime, &confidentialhttp.ConfidentialHTTPRequest{
+		Request: &confidentialhttp.HTTPRequest{
+			Url:    config.URL,
+			Method: "POST",
+			Body:   &confidentialhttp.HTTPRequest_BodyString{BodyString: payload},
+			MultiHeaders: headers,
+		},
+		VaultDonSecrets: []*confidentialhttp.SecretIdentifier{
+			{Key: "myApiKey"},
+		},
+		EncryptOutput: false,
+	}).Await()
+	if err != nil {
+		return Result{}, fmt.Errorf("confidential HTTP request failed: %w", err)
+	}
+
+	// 4. Parse the response
+	var result Result
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		return Result{}, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return result, nil
+}
+```
+
+### Step 5: Wire it into your workflow
+
+Call the request function from your trigger handler using `cre.RunInNodeMode`:
+
+```go
+func onCronTrigger(config *Config, runtime cre.Runtime, outputs *cron.Payload) (string, error) {
+	result, err := cre.RunInNodeMode(*config, runtime,
+		makeConfidentialRequest,
+		cre.ConsensusIdenticalAggregation[Result](),
+	).Await()
+	if err != nil {
+		return "", fmt.Errorf("failed to get result: %w", err)
+	}
+
+	runtime.Logger().Info("Transaction result", "id", result.TransactionID, "status", result.Status)
+	return result.TransactionID, nil
+}
+```
+
+### Step 6: Simulate
+
+Run the simulation:
+
+```bash
+cre workflow simulate
+```
+
+## Template syntax for secrets
+
+Secrets are injected into request bodies and headers using Go template syntax: `{{.secretName}}`. The placeholder name must match the `Key` in your `VaultDonSecrets` list.
+
+**In the request body:**
+
+```json
+{ "auth": "{{.myApiKey}}", "data": "public-data" }
+```
+
+**In headers:**
+
+```go
+headers := map[string]*confidentialhttp.HeaderValues{
+	"Authorization": {
+		Values: []string{"Basic {{.myCredential}}"},
+	},
+}
+```
+
+The template placeholders are resolved inside the enclave. The actual secret values never appear in your workflow code or in node memory.
+
+## Response encryption
+
+By default, the API response is returned unencrypted (`EncryptOutput: false`). To encrypt the response body before it leaves the enclave, set `EncryptOutput: true` and provide an AES-256 encryption key as a Vault DON secret.
+
+### Setting up response encryption
+
+1. **Store an AES-256 key** as a Vault DON secret with the identifier `san_marino_aes_gcm_encryption_key`:
+
+   ```yaml
+   # secrets.yaml
+   secretsNames:
+     san_marino_aes_gcm_encryption_key:
+   	- AES_KEY_ALL
+   ```
+
+   The key must be a 256-bit (32 bytes) hex-encoded string:
+
+   ```bash
+   export AES_KEY_ALL="your-256-bit-hex-encoded-key"
+   ```
+
+2. **Include the key in your `VaultDonSecrets`** and set `EncryptOutput: true`:
+
+   ```go
+   resp, err := client.SendRequest(nodeRuntime, &confidentialhttp.ConfidentialHTTPRequest{
+   	Request: &confidentialhttp.HTTPRequest{
+   		Url:    config.URL,
+   		Method: "POST",
+   		Body:   &confidentialhttp.HTTPRequest_BodyString{BodyString: payload},
+   		MultiHeaders: headers,
+   	},
+   	VaultDonSecrets: []*confidentialhttp.SecretIdentifier{
+   		{Key: "myApiKey"},
+   		{Key: "san_marino_aes_gcm_encryption_key"},
+   	},
+   	EncryptOutput: true,
+   }).Await()
+   ```
+
+3. **Decrypt the response** in your own secure backend using AES-GCM. The encrypted response body is structured as `nonce || ciphertext || tag`:
+
+   ```go
+   import (
+   	"crypto/aes"
+   	"crypto/cipher"
+   	"encoding/hex"
+   )
+
+   func AESGCMDecrypt(blob []byte, key []byte) ([]byte, error) {
+   	block, err := aes.NewCipher(key)
+   	if err != nil {
+   		return nil, err
+   	}
+
+   	gcm, err := cipher.NewGCM(block)
+   	if err != nil {
+   		return nil, err
+   	}
+
+   	nonceSize := gcm.NonceSize()
+   	if len(blob) < nonceSize {
+   		return nil, fmt.Errorf("ciphertext too short")
+   	}
+
+   	nonce, ciphertext := blob[:nonceSize], blob[nonceSize:]
+   	return gcm.Open(nil, nonce, ciphertext, nil)
+   }
+   ```
+
+
+   <Aside type="tip" title="Do not decrypt inside the workflow">
+     The purpose of response encryption is to keep the response confidential even within the decentralized network. Decrypt the response in your own secure backend service, not inside the workflow itself.
+   </Aside>
+
+## Complete example
+
+Here's the full workflow code for a confidential HTTP request with response encryption:
+
+```go
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/smartcontractkit/cre-sdk-go/capabilities/networking/confidentialhttp"
+	"github.com/smartcontractkit/cre-sdk-go/capabilities/scheduler/cron"
+	"github.com/smartcontractkit/cre-sdk-go/cre"
+)
+
+type Config struct {
+	Schedule string `json:"schedule"`
+	URL      string `json:"url"`
+}
+
+type Result struct {
+	TransactionID string `json:"transactionId" consensus:"identical"`
+	Status        string `json:"status"        consensus:"identical"`
+}
+
+func InitWorkflow(config *Config, logger *slog.Logger, secretsProvider cre.SecretsProvider) (cre.Workflow[*Config], error) {
+	cronTriggerCfg := &cron.Config{
+		Schedule: config.Schedule,
+	}
+
+	workflow := cre.Workflow[*Config]{
+		cre.Handler(
+			cron.Trigger(cronTriggerCfg),
+			onCronTrigger,
+		),
+	}
+
+	return workflow, nil
+}
+
+func onCronTrigger(config *Config, runtime cre.Runtime, outputs *cron.Payload) (string, error) {
+	result, err := cre.RunInNodeMode(*config, runtime,
+		makeConfidentialRequest,
+		cre.ConsensusIdenticalAggregation[Result](),
+	).Await()
+	if err != nil {
+		return "", fmt.Errorf("failed to get result: %w", err)
+	}
+
+	runtime.Logger().Info("Transaction result", "id", result.TransactionID, "status", result.Status)
+	return result.TransactionID, nil
+}
+
+func makeConfidentialRequest(config Config, nodeRuntime cre.NodeRuntime) (Result, error) {
+	payload := `{"auth": "{{.myApiKey}}", "action": "getTransaction", "id": "tx-123"}`
+
+	headers := map[string]*confidentialhttp.HeaderValues{
+		"Content-Type": {
+			Values: []string{"application/json"},
+		},
+		"Authorization": {
+			Values: []string{"Basic {{.myApiKey}}"},
+		},
+	}
+
+	client := confidentialhttp.Client{}
+	resp, err := client.SendRequest(nodeRuntime, &confidentialhttp.ConfidentialHTTPRequest{
+		Request: &confidentialhttp.HTTPRequest{
+			Url:    config.URL,
+			Method: "POST",
+			Body:   &confidentialhttp.HTTPRequest_BodyString{BodyString: payload},
+			MultiHeaders: headers,
+		},
+		VaultDonSecrets: []*confidentialhttp.SecretIdentifier{
+			{Key: "myApiKey"},
+			{Key: "san_marino_aes_gcm_encryption_key"},
+		},
+		EncryptOutput: true,
+	}).Await()
+	if err != nil {
+		return Result{}, fmt.Errorf("confidential HTTP request failed: %w", err)
+	}
+
+	// In a real workflow, you would forward the encrypted body to your
+	// secure backend for decryption. This inline decryption is shown
+	// for demonstration purposes only.
+	keyHex := os.Getenv("AES_KEY_ALL") // your 256-bit hex-encoded key
+	keyBytes, _ := hex.DecodeString(keyHex)
+	decrypted, err := AESGCMDecrypt(resp.Body, keyBytes)
+	if err != nil {
+		return Result{}, fmt.Errorf("failed to decrypt response: %w", err)
+	}
+
+	var result Result
+	if err := json.Unmarshal(decrypted, &result); err != nil {
+		return Result{}, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return result, nil
+}
+
+func AESGCMDecrypt(blob []byte, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(blob) < nonceSize {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ciphertext := blob[:nonceSize], blob[nonceSize:]
+	return gcm.Open(nil, nonce, ciphertext, nil)
+}
+```
+
+## API reference
+
+For the full list of types and methods available on the Confidential HTTP client, see the [Confidential HTTP Client SDK Reference](/cre/reference/sdk/confidential-http-client-go).
 
 ---
 
@@ -13703,6 +14268,283 @@ For a list of which versions support which networks, see [Supported Networks](/c
 
 ---
 
+# SDK Reference: Confidential HTTP Client
+Source: https://docs.chain.link/cre/reference/sdk/confidential-http-client-go
+Last Updated: 2026-02-10
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The [Confidential HTTP](/cre/capabilities/confidential-http-go) Client lets you make privacy-preserving requests to external APIs from your workflow. Unlike the regular [`http.Client`](/cre/reference/sdk/http-client), the request executes inside a secure enclave, secrets are injected via templates, and responses can be optionally encrypted.
+
+- For use cases and a conceptual overview, see [The Confidential HTTP Capability](/cre/capabilities/confidential-http-go)
+- **Guide:** [Making Confidential Requests](/cre/guides/workflow/using-confidential-http-client/making-requests-go)
+
+## Quick reference
+
+| Method                                                         | Description                                                |
+| -------------------------------------------------------------- | ---------------------------------------------------------- |
+| [`confidentialhttp.SendRequest`](#confidentialhttpsendrequest) | High-level helper with automatic `RunInNodeMode` wrapping  |
+| [`client.SendRequest`](#clientsendrequest)                     | Low-level method requiring manual `RunInNodeMode` wrapping |
+
+## Core types
+
+### `confidentialhttp.ConfidentialHTTPRequest`
+
+The top-level request type that combines an HTTP request with Vault DON secrets and encryption settings.
+
+| Field             | Type                  | Description                                                                                                                                 |
+| ----------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Request`         | `*HTTPRequest`        | The HTTP request to execute inside the enclave. See [`HTTPRequest`](#confidentialhttphttprequest).                                          |
+| `VaultDonSecrets` | `[]*SecretIdentifier` | List of secrets to fetch from the Vault DON and make available in the enclave. See [`SecretIdentifier`](#confidentialhttpsecretidentifier). |
+| `EncryptOutput`   | `bool`                | If `true`, encrypts the response body before it leaves the enclave. See [Response encryption](#response-encryption). Default: `false`.      |
+
+### `confidentialhttp.HTTPRequest`
+
+Defines the HTTP request that will be executed inside the enclave.
+
+| Field                  | Type                       | Description                                                                                                   |
+| ---------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `Url`                  | `string`                   | The URL of the API endpoint.                                                                                  |
+| `Method`               | `string`                   | The HTTP method (e.g., `"GET"`, `"POST"`).                                                                    |
+| `Body`                 | `isHTTPRequest_Body`       | The request body. Use `HTTPRequest_BodyString` for string templates or `HTTPRequest_BodyBytes` for raw bytes. |
+| `MultiHeaders`         | `map[string]*HeaderValues` | Request headers. Supports multiple values per key and template syntax for secret injection.                   |
+| `TemplatePublicValues` | `map[string]string`        | Public (non-secret) values used to fill template placeholders in the body and headers.                        |
+| `CustomRootCaCertPem`  | `[]byte`                   | Optional custom root CA certificate (PEM format) for verifying the external server's TLS certificate.         |
+| `Timeout`              | `*durationpb.Duration`     | Optional request timeout.                                                                                     |
+
+#### Setting the request body
+
+The `Body` field is a `oneof` type with two options:
+
+**String template (recommended for secret injection):**
+
+```go
+Body: &confidentialhttp.HTTPRequest_BodyString{
+	BodyString: `{"auth": "{{.myApiKey}}", "action": "getData"}`,
+},
+```
+
+**Raw bytes:**
+
+```go
+Body: &confidentialhttp.HTTPRequest_BodyBytes{
+	BodyBytes: []byte(`{"action": "getData"}`),
+},
+```
+
+### `confidentialhttp.HTTPResponse`
+
+The response returned from the enclave after the HTTP request completes.
+
+| Field          | Type                       | Description                                                                                                                          |
+| -------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `StatusCode`   | `uint32`                   | The HTTP status code.                                                                                                                |
+| `Body`         | `[]byte`                   | The response body. If `EncryptOutput` is `true`, this contains the encrypted body (see [Response encryption](#response-encryption)). |
+| `MultiHeaders` | `map[string]*HeaderValues` | The HTTP response headers.                                                                                                           |
+
+### `confidentialhttp.SecretIdentifier`
+
+Identifies a secret stored in the Vault DON.
+
+| Field       | Type      | Description                                                                                                       |
+| ----------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
+| `Key`       | `string`  | The logical name of the secret. Must match the template placeholder (e.g., `"myApiKey"` matches `{{.myApiKey}}`). |
+| `Namespace` | `string`  | The secret namespace.                                                                                             |
+| `Owner`     | `*string` | Optional. The owner address for the secret.                                                                       |
+
+### `confidentialhttp.HeaderValues`
+
+Represents multiple values for a single HTTP header key.
+
+| Field    | Type       | Description                                                                                      |
+| -------- | ---------- | ------------------------------------------------------------------------------------------------ |
+| `Values` | `[]string` | The header values. Supports template syntax for secret injection (e.g., `"Basic {{.myToken}}"`). |
+
+## Making requests
+
+### `confidentialhttp.SendRequest`
+
+The high-level helper function for making confidential HTTP requests. Automatically handles the `cre.RunInNodeMode` pattern.
+
+**Signature:**
+
+```go
+func SendRequest[C, T any](
+	config C,
+	runtime cre.Runtime,
+	client *Client,
+	fn func(config C, logger *slog.Logger, sendRequester *SendRequester) (T, error),
+	ca cre.ConsensusAggregation[T],
+) cre.Promise[T]
+```
+
+**Parameters:**
+
+- `config`: Your workflow's configuration struct, passed to `fn`.
+- `runtime`: The top-level `cre.Runtime` from your trigger callback.
+- `client`: An initialized `*confidentialhttp.Client`.
+- `fn`: Your request logic function that receives `config`, `logger`, and `sendRequester`.
+- `ca`: The [consensus aggregation method](/cre/reference/sdk/consensus).
+
+**Example:**
+
+```go
+func fetchData(config *Config, logger *slog.Logger, sendRequester *confidentialhttp.SendRequester) (*Result, error) {
+	resp, err := sendRequester.SendRequest(&confidentialhttp.ConfidentialHTTPRequest{
+		Request: &confidentialhttp.HTTPRequest{
+			Url:    config.URL,
+			Method: "GET",
+			MultiHeaders: map[string]*confidentialhttp.HeaderValues{
+				"Authorization": {Values: []string{"Basic {{.apiKey}}"}},
+			},
+		},
+		VaultDonSecrets: []*confidentialhttp.SecretIdentifier{
+			{Key: "apiKey"},
+		},
+	}).Await()
+	if err != nil {
+		return nil, err
+	}
+	// Parse resp.Body...
+	return &Result{}, nil
+}
+
+// In your trigger callback
+client := &confidentialhttp.Client{}
+result, err := confidentialhttp.SendRequest(config, runtime, client,
+	fetchData,
+	cre.ConsensusIdenticalAggregation[*Result](),
+).Await()
+```
+
+### `client.SendRequest`
+
+The lower-level method for making confidential HTTP requests. Must be manually wrapped in `cre.RunInNodeMode`.
+
+**Signature:**
+
+```go
+func (c *Client) SendRequest(runtime cre.NodeRuntime, input *ConfidentialHTTPRequest) cre.Promise[*HTTPResponse]
+```
+
+**Parameters:**
+
+- `runtime`: A `cre.NodeRuntime` provided by `cre.RunInNodeMode`.
+- `input`: A `*ConfidentialHTTPRequest` containing the request, secrets, and encryption settings.
+
+**Returns:**
+
+- `cre.Promise[*HTTPResponse]`
+
+**Example:**
+
+```go
+result, err := cre.RunInNodeMode(config, runtime,
+	func(config Config, nodeRuntime cre.NodeRuntime) (Result, error) {
+		client := confidentialhttp.Client{}
+		resp, err := client.SendRequest(nodeRuntime, &confidentialhttp.ConfidentialHTTPRequest{
+			Request: &confidentialhttp.HTTPRequest{
+				Url:    config.URL,
+				Method: "POST",
+				Body:   &confidentialhttp.HTTPRequest_BodyString{BodyString: `{"auth": "{{.apiKey}}"}`},
+				MultiHeaders: map[string]*confidentialhttp.HeaderValues{
+					"Content-Type": {Values: []string{"application/json"}},
+				},
+			},
+			VaultDonSecrets: []*confidentialhttp.SecretIdentifier{
+				{Key: "apiKey"},
+			},
+		}).Await()
+		if err != nil {
+			return Result{}, err
+		}
+		// Parse and return...
+		return Result{}, nil
+	},
+	cre.ConsensusIdenticalAggregation[Result](),
+).Await()
+```
+
+**Guide:** [Making Confidential Requests](/cre/guides/workflow/using-confidential-http-client/making-requests-go)
+
+## Template syntax
+
+Secrets are injected into the request body and headers using Go template syntax: `{{.secretName}}`. The placeholder name must match the `Key` field in the corresponding `SecretIdentifier`.
+
+**Body template:**
+
+```go
+Body: &confidentialhttp.HTTPRequest_BodyString{
+	BodyString: `{"apiKey": "{{.myApiKey}}", "method": "{{.method}}", "params": []}`,
+},
+```
+
+**Header template:**
+
+```go
+MultiHeaders: map[string]*confidentialhttp.HeaderValues{
+	"Authorization": {Values: []string{"Basic {{.myCredential}}"}},
+},
+```
+
+### `TemplatePublicValues` (optional)
+
+Every `{{.placeholder}}` in your body or headers is resolved inside the enclave. By default, placeholders are filled with **secrets** from `VaultDonSecrets`. But sometimes you have a placeholder value that isn't secret — for example, an RPC method name or a public parameter. That's what `TemplatePublicValues` is for: it lets you inject **non-secret** values into the same template.
+
+This is purely a convenience. You could always hardcode the value directly in the body string instead:
+
+```go
+// These two are equivalent:
+
+// Option 1: hardcoded in the body string
+Body: &confidentialhttp.HTTPRequest_BodyString{BodyString: `{"method": "eth_blockNumber", "auth": "{{.apiKey}}"}`}
+
+// Option 2: using TemplatePublicValues
+Body: &confidentialhttp.HTTPRequest_BodyString{BodyString: `{"method": "{{.method}}", "auth": "{{.apiKey}}"}`}
+TemplatePublicValues: map[string]string{"method": "eth_blockNumber"}
+```
+
+`TemplatePublicValues` is useful when you want to keep the template generic and pass in dynamic values (e.g., from config) without string concatenation.
+
+**Example with both secret and public values:**
+
+```go
+Request: &confidentialhttp.HTTPRequest{
+	Url:    config.URL,
+	Method: "POST",
+	Body:   &confidentialhttp.HTTPRequest_BodyString{BodyString: `{"method": "{{.rpcMethod}}", "auth": "{{.apiKey}}"}`},
+	TemplatePublicValues: map[string]string{
+		"rpcMethod": config.RPCMethod,   // dynamic value from config, not a secret
+	},
+},
+VaultDonSecrets: []*confidentialhttp.SecretIdentifier{
+	{Key: "apiKey"},   // secret, from Vault DON
+},
+```
+
+In this example, `{{.rpcMethod}}` is resolved from `TemplatePublicValues` (a dynamic, non-secret value from your workflow config) and `{{.apiKey}}` is resolved from the Vault DON (a secret). Both are resolved inside the enclave.
+
+## Response encryption
+
+The `EncryptOutput` field controls whether the response body is encrypted before leaving the enclave.
+
+| `EncryptOutput`   | Secret key provided                                      | Behavior                                                      |
+| ----------------- | -------------------------------------------------------- | ------------------------------------------------------------- |
+| `false` (default) | —                                                        | Response returned unencrypted.                                |
+| `true`            | `san_marino_aes_gcm_encryption_key` in `VaultDonSecrets` | Response AES-GCM encrypted with your symmetric key.           |
+| `true`            | No key provided                                          | Response TDH2 encrypted with the Vault DON master public key. |
+
+**AES-GCM encryption** is the recommended approach. Store a 256-bit (32-byte) AES key as a Vault DON secret with the identifier `san_marino_aes_gcm_encryption_key`, then decrypt the response in your own secure backend.
+
+The encrypted response body is structured as `nonce || ciphertext || tag`.
+
+For a complete decryption example, see the [Making Confidential Requests guide](/cre/guides/workflow/using-confidential-http-client/making-requests-go#response-encryption).
+
+---
+
 # SDK Reference: Consensus & Aggregation
 Source: https://docs.chain.link/cre/reference/sdk/consensus-go
 Last Updated: 2025-11-04
@@ -14864,6 +15706,7 @@ The SDK Reference is broken down into several pages, each corresponding to a cor
 - **[Triggers](/cre/reference/sdk/triggers)**: Details the configuration and payload structures for all available trigger types (`Cron`, `HTTP`, `EVM Log`).
 - **[EVM Client](/cre/reference/sdk/evm-client)**: Provides a reference for the `evm.Client`, the primary tool for all EVM interactions, including reads and writes.
 - **[HTTP Client](/cre/reference/sdk/http-client)**: Provides a reference for the `http.Client`, used for making offchain API requests from individual nodes.
+- **[Confidential HTTP Client](/cre/reference/sdk/confidential-http-client)** *(Experimental)*: Provides a reference for the `confidentialhttp.Client`, used for privacy-preserving API requests with enclave execution and optional response encryption.
 - **[Consensus & Aggregation](/cre/reference/sdk/consensus)**: Describes how to use aggregators like `ConsensusMedianAggregation` and `ConsensusAggregationFromTags` with `RunInNodeMode` to process and consolidate data from multiple nodes.
 
 ## Contract Bindings

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -442,9 +442,51 @@ To help us assist you faster, please include:
 
 # Release Notes
 Source: https://docs.chain.link/cre/release-notes
-Last Updated: 2026-02-03
+Last Updated: 2026-02-10
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.0.10 - February 9, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.0.10" target="_blank">CRE CLI version 1.0.10</a> is now available.**
+
+- **Bug Fix**: Fixed secret injection for the [Confidential HTTP](/cre/capabilities/confidential-http) capability in the simulator — template placeholders (`{{.secretName}}`) now resolve correctly during `cre workflow simulate`
+- **Bug Fix**: Fixed project context not being set before writing changeset files
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.0.9...v1.0.10)
+
+## CLI v1.0.9 - February 6, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.0.9" target="_blank">CRE CLI version 1.0.9</a> is now available.**
+
+- **Confidential HTTP (Experimental)**: Added [Confidential HTTP](/cre/capabilities/confidential-http) capability support in the simulator. You can now simulate workflows that use privacy-preserving API calls with secret injection and optional response encryption.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.0.8...v1.0.9)
+
+## CLI v1.0.8 - February 6, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.0.8" target="_blank">CRE CLI version 1.0.8</a> is now available.**
+
+- Changed `chain-id` to `chain-selector` in simulator settings
+- Support for longer workflow names
+- Fixed a logic bug in the template contract `MessageEmitter.sol`
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.0.7...v1.0.8)
 
 ## New Networks Support - January 29, 2026
 
@@ -646,9 +688,9 @@ These guides explain how to install the Chainlink Developer Platform CLI (also r
 
 # Installing the CRE CLI on macOS and Linux
 Source: https://docs.chain.link/cre/getting-started/cli-installation/macos-linux
-Last Updated: 2026-01-29
+Last Updated: 2026-02-10
 
-This page explains how to install the CRE CLI on macOS or Linux. The recommended version at the time of writing is **v1.0.7**.
+This page explains how to install the CRE CLI on macOS or Linux. The recommended version at the time of writing is **v1.0.10**.
 
 ## Installation
 
@@ -679,7 +721,7 @@ After the script completes, verify the installation:
 cre version
 ```
 
-**Expected output:** `cre version v1.0.7`
+**Expected output:** `cre version v1.0.10`
 
 <Aside type="note" title="macOS Gatekeeper">
   If you see warnings about "unrecognized developer/source" on macOS, run:{" "}
@@ -727,11 +769,11 @@ shasum -a 256 cre_darwin_arm64.zip
 Compare the output with the official checksum from the [CRE CLI releases page](https://github.com/smartcontractkit/cre-cli/releases):
 
 1. Go to [https://github.com/smartcontractkit/cre-cli/releases](https://github.com/smartcontractkit/cre-cli/releases)
-2. Find the release version you downloaded (e.g., v1.0.7)
+2. Find the release version you downloaded (e.g., v1.0.10)
 3. Under the **Assets** section, locate your downloaded file
 4. Compare the SHA-256 checksum shown next to the file with your command output
 
-**Example:** For `cre_darwin_arm64.zip` in release v1.0.7, you'll see something like:
+**Example:** For `cre_darwin_arm64.zip` in release v1.0.10, you'll see something like:
 
 ```
 cre_darwin_arm64.zip
@@ -761,7 +803,7 @@ If the checksums match, the file is authentic and safe to install. If they don't
 3. **Rename the extracted binary to `cre`**
 
    ```bash
-   mv cre_v1.0.7_darwin_arm64 cre
+   mv cre_v1.0.10_darwin_arm64 cre
    ```
 
 4. **Make it executable**:
@@ -834,7 +876,7 @@ cre version
 
 **Expected output:**
 
-You should see version information: `cre version v1.0.7`.
+You should see version information: `cre version v1.0.10`.
 
 **If it doesn't work:**
 
@@ -871,9 +913,9 @@ Once you're authenticated, you're ready to build your first workflow:
 
 # Installing the CRE CLI on Windows
 Source: https://docs.chain.link/cre/getting-started/cli-installation/windows
-Last Updated: 2026-01-29
+Last Updated: 2026-02-10
 
-This page explains how to install the Chainlink Developer Platform CLI (also referred to as the CRE CLI) on Windows. The recommended version at the time of writing is **v1.0.7**.
+This page explains how to install the Chainlink Developer Platform CLI (also referred to as the CRE CLI) on Windows. The recommended version at the time of writing is **v1.0.10**.
 
 ## Installation
 
@@ -903,7 +945,7 @@ After the script completes, **open a new PowerShell window** and verify the inst
 cre version
 ```
 
-**Expected output:** `cre version v1.0.7`
+**Expected output:** `cre version v1.0.10`
 
 ### Manual installation
 
@@ -930,11 +972,11 @@ Get-FileHash cre_windows_amd64.zip -Algorithm SHA256
 Compare the `Hash` value in the output with the official checksum from the [CRE CLI releases page](https://github.com/smartcontractkit/cre-cli/releases):
 
 1. Go to [https://github.com/smartcontractkit/cre-cli/releases](https://github.com/smartcontractkit/cre-cli/releases)
-2. Find the release version you downloaded (e.g., v1.0.7)
+2. Find the release version you downloaded (e.g., v1.0.10)
 3. Under the **Assets** section, locate `cre_windows_amd64.zip`
 4. Compare the SHA-256 checksum shown next to the file with the `Hash` value from your PowerShell output
 
-**Example:** For `cre_windows_amd64.zip` in release v1.0.7, you'll see something like:
+**Example:** For `cre_windows_amd64.zip` in release v1.0.10, you'll see something like:
 
 ```
 cre_windows_amd64.zip
@@ -948,7 +990,7 @@ If the checksums match, the file is authentic and safe to install. If they don't
 1. Navigate to the directory where you downloaded the archive.
 2. Right-click the `.zip` file and select **Extract All...**.
 3. Choose a permanent location for the extracted folder (e.g., `C:\Program Files\cre-cli`).
-4. Inside the extracted folder, rename the file `cre_v1.0.7_windows_amd64.exe` to `cre.exe`.
+4. Inside the extracted folder, rename the file `cre_v1.0.10_windows_amd64.exe` to `cre.exe`.
 
 #### 3. Add the CLI to your PATH
 
@@ -973,7 +1015,7 @@ Open a new **PowerShell** or **Command Prompt** window and run:
 cre version
 ```
 
-You should see version information: `cre version v1.0.7`.
+You should see version information: `cre version v1.0.10`.
 
 ## Next steps
 
@@ -3370,6 +3412,25 @@ These guides will walk you through the common use cases for the HTTP client.
 - **[Making GET Requests](/cre/guides/workflow/using-http-client/get-request)**: Learn how to fetch data from a public API using a `GET` request.
 - **[Making POST Requests](/cre/guides/workflow/using-http-client/post-request)**: Learn how to send data to an external endpoint using a `POST` request.
 - **[Submitting Reports via HTTP](/cre/guides/workflow/using-http-client/submitting-reports-http)**: Learn how to submit cryptographically signed reports to an external HTTP endpoint.
+
+---
+
+# Confidential API Interactions (Experimental)
+Source: https://docs.chain.link/cre/guides/workflow/using-confidential-http-client
+Last Updated: 2026-02-06
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The CRE SDK provides a Confidential HTTP client that allows your workflows to interact with external APIs while keeping sensitive data private. Requests execute inside a secure enclave, secrets are injected via templates, and responses can optionally be encrypted.
+
+For a conceptual overview of what Confidential HTTP is and how it differs from the regular HTTP capability, see [The Confidential HTTP Capability](/cre/capabilities/confidential-http).
+
+## Guides
+
+- **[Making Confidential Requests](/cre/guides/workflow/using-confidential-http-client/making-requests)**: Learn how to make a confidential HTTP request with secret injection and optional response encryption.
 
 ---
 
@@ -5922,9 +5983,10 @@ This section provides a high-level, conceptual overview of the capabilities curr
 
 - **[Triggers](/cre/capabilities/triggers)**: Event sources that start your workflow executions.
 - **[HTTP](/cre/capabilities/http)**: Fetch and post data from external APIs with decentralized consensus.
+- **[Confidential HTTP](/cre/capabilities/confidential-http)** *(Experimental)*: Make privacy-preserving API calls with enclave execution, secret injection, and optional response encryption.
 - **[EVM Read & Write](/cre/capabilities/evm-read-write)**: Interact with smart contracts on EVM-compatible blockchains with decentralized consensus.
 
-All execution capabilities (HTTP, EVM) automatically use [built-in consensus](/cre/concepts/consensus-computing) to validate results across multiple nodes, ensuring security and reliability.
+All execution capabilities (HTTP, Confidential HTTP, EVM) automatically use [built-in consensus](/cre/concepts/consensus-computing) to validate results across multiple nodes, ensuring security and reliability.
 
 ---
 
@@ -6403,10 +6465,10 @@ See the [repository README](https://github.com/smartcontractkit/cre-gcp-predicti
 
 # CLI Reference
 Source: https://docs.chain.link/cre/reference/cli
-Last Updated: 2026-01-29
+Last Updated: 2026-02-10
 
-<Aside type="note" title="Required CLI Version: v1.0.7">
-  To ensure compatibility with the guides and examples in this documentation, please use version `v1.0.7` of the CRE
+<Aside type="note" title="Required CLI Version: v1.0.10">
+  To ensure compatibility with the guides and examples in this documentation, please use version `v1.0.10` of the CRE
   CLI. You can check your installed version by running `cre version`. Refer to the [CLI
   Installation](/cre/getting-started/cli-installation/macos-linux) guide for more information.
 </Aside>
@@ -7318,18 +7380,128 @@ cre version
 **Example output:**
 
 ```bash
-cre version v1.0.7
+cre version v1.0.10
 ```
 
 
 <Aside type="note" title="Version compatibility">
-  Always check that your CLI version matches the version recommended in the documentation. The current recommended version is **v1.0.7**. See the [CLI Installation guide](/cre/getting-started/cli-installation) for more information.
+  Always check that your CLI version matches the version recommended in the documentation. The current recommended version is **v1.0.10**. See the [CLI Installation guide](/cre/getting-started/cli-installation) for more information.
 </Aside>
 
 ## Learn more
 
 - [CLI Installation](/cre/getting-started/cli-installation) — How to install and update the CRE CLI
 - [CLI Reference](/cre/reference/cli) — Complete CLI command reference
+
+---
+
+# The Confidential HTTP Capability (Experimental)
+Source: https://docs.chain.link/cre/capabilities/confidential-http-ts
+Last Updated: 2026-02-06
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The **Confidential HTTP** capability is a privacy-preserving HTTP service powered by the Chainlink Privacy Standard. It enables your workflow to interact with external APIs while keeping sensitive data—such as API credentials, request body fields, and response data—confidential.
+
+## The problem it solves
+
+Traditional consensus mechanisms require all nodes to see and agree on the same data. While this provides strong reliability and tamper resistance, it creates challenges for use cases with strict privacy requirements:
+
+- **Regulatory compliance:** Some industries require that sensitive data never be exposed to multiple parties.
+- **Credential security:** High-risk API credentials could cause damage if compromised or exposed in node memory.
+- **Response privacy:** API responses may contain sensitive fields that should not be visible to the decentralized network.
+
+Confidential HTTP addresses these challenges by executing requests inside a **secure enclave** and offering optional **response encryption**.
+
+## How it works
+
+Confidential HTTP operates differently from the [regular HTTP capability](/cre/capabilities/http):
+
+1. **Request consensus:** Nodes in the Confidential HTTP DON reach quorum on the request parameters (forwarded by each Workflow DON node).
+2. **Secret retrieval:** The Confidential HTTP DON fetches encrypted secrets from the [Vault DON](/cre/guides/workflow/secrets/using-secrets-deployed).
+3. **Enclave execution:** Secrets are decrypted and injected into the request inside a secure enclave. The HTTP request executes from the enclave—credentials never exist in accessible memory.
+4. **Response:** The response is returned to your workflow. If `EncryptOutput` is enabled, the response body is encrypted before leaving the enclave.
+
+This approach ensures:
+
+- **Credential isolation:** Secrets are encrypted at rest and in transit, and are decrypted only inside the enclave—never in node memory.
+- **Response privacy:** You can optionally encrypt the full response body so that it leaves the enclave encrypted and can be decrypted only in your own backend service.
+- **Single execution:** Exactly one API call is made, not one per node.
+
+## What's kept confidential
+
+| Component                      | How it's protected                                                                                                                                                             |
+| :----------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Secrets** (API keys, tokens) | Fully confidential. Stored in the Vault DON, decrypted only inside the enclave.                                                                                                |
+| **Request body**               | Template-based injection: secrets referenced in the request body (e.g., `{{.myApiKey}}`) are resolved inside the enclave, so sensitive values never appear in workflow memory. |
+| **Response body**              | Optionally encrypted. When `EncryptOutput` is enabled, the full response is [AES-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode) encrypted before leaving the enclave. |
+
+## Use cases
+
+### Credential isolation
+
+A SaaS service fetches user data from an e-commerce provider API. The same credential could also modify user data if misused. Confidential HTTP ensures the credential is decrypted only inside the enclave, never accessible in node memory.
+
+### Response encryption
+
+A workflow calls a payment processor API to execute a transaction. The API response includes the transaction ID and success status, but also returns sensitive data like the user's account balance and an internal risk score. With Confidential HTTP and `EncryptOutput` enabled, the full response is encrypted before leaving the enclave—it can only be decrypted using the encryption key, for example in your own backend service.
+
+### Processing sensitive request data
+
+A workflow processes card transactions where the request contains card details and the API key provides processor access. Confidential HTTP keeps both the credentials and card details private through template-based injection, returning only the encrypted response to the workflow.
+
+### Guaranteed single execution
+
+An API endpoint cannot tolerate duplicate requests (e.g., initiating a payment or creating a unique transaction).
+
+With the [regular HTTP capability](/cre/capabilities/http), each node in the DON executes the request independently to reach consensus on the response. For non-idempotent operations, [`cacheSettings` mitigates](/cre/guides/workflow/using-http-client/post-request-ts#1-understanding-single-execution-with-cachesettings) this by enabling nodes to share cached responses, reducing duplicate calls in most cases.
+
+Confidential HTTP takes a different approach: by design, only one request is ever made from the enclave after quorum is reached on the request parameters. This provides an **architectural guarantee** of single execution.
+
+## When to use Confidential HTTP vs. regular HTTP
+
+### Use Confidential HTTP when:
+
+- The API response contains sensitive data that should not be visible to the network
+- API credentials must never be accessible in node memory (enclave-only access)
+- You need exactly one API call with zero tolerance for duplicates
+- Regulatory or compliance requirements mandate data confidentiality
+
+### Use regular HTTP when:
+
+- **Querying multiple APIs and combining results**: For example, fetching prices from 3 different sources and computing a median. Each node calls all APIs, aggregates locally, then nodes reach consensus on the final value.
+
+- **Transforming data before consensus**: For example, parsing a complex API response, filtering fields, or performing calculations on the data before nodes agree on the result.
+
+- **Computing with a secret before the request**: For example, generating an HMAC signature for API authentication — use the [`runInNodeMode` pattern](/cre/guides/workflow/using-http-client/post-request-ts#2-the-low-level-runinnodemode-pattern) to access secrets and perform computations before making the request.
+
+- **No confidentiality requirements**: The API response doesn't contain sensitive data, and you don't need enclave-level protection for credentials.
+
+## Key differences from regular HTTP
+
+| Aspect                    | Regular HTTP                          | Confidential HTTP              |
+| :------------------------ | :------------------------------------ | :----------------------------- |
+| **API calls**             | One per node (multiple)\*             | Exactly one (single)           |
+| **Consensus target**      | Response data                         | Request parameters             |
+| **Execution environment** | Each node individually                | Secure enclave                 |
+| **Secrets exposure**      | Decrypted in Workflow DON node memory | Decrypted only in the enclave  |
+| **Response handling**     | Full response to all nodes            | Optionally encrypted (AES-GCM) |
+| **Data transformation**   | Supported in workflow code            | Not yet supported in enclave   |
+
+\*For non-idempotent operations (POST, PUT, PATCH, DELETE), [`cacheSettings`](/cre/guides/workflow/using-http-client/post-request#1-understanding-single-execution-with-cachesettings) enables nodes to share cached responses, reducing multiple calls to a single execution in most cases.
+
+<Aside type="note" title="Confidential Compute">
+  Confidential HTTP currently does not support complex data transformations within the enclave. A future **Confidential
+  Compute** capability will enable processing logic inside the enclave.
+</Aside>
+
+## Learn more
+
+- **[Confidential API Interactions Guide](/cre/guides/workflow/using-confidential-http-client)**: Learn how to use the SDK to invoke the Confidential HTTP capability.
+- **[Confidential HTTP Client SDK Reference](/cre/reference/sdk/confidential-http-client)**: See the detailed API reference for the `confidentialhttp.Client`.
 
 ---
 
@@ -9469,6 +9641,318 @@ New DON timestamps are produced continuously (multiple per second). Treat it as 
 **Why can't I use `Date.now()`?**
 
 `Date.now()` reads the local system clock, which differs slightly on each node. This breaks consensus—nodes may execute different code paths and fail to agree on the workflow result.
+
+---
+
+# Making Confidential Requests
+Source: https://docs.chain.link/cre/guides/workflow/using-confidential-http-client/making-requests-ts
+Last Updated: 2026-02-10
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The `ConfidentialHTTPClient` is the SDK's interface for the underlying [Confidential HTTP Capability](/cre/capabilities/confidential-http). It allows your workflow to make privacy-preserving API calls where secrets are injected inside a secure enclave and responses can be optionally encrypted.
+
+Unlike the regular [`HTTPClient`](/cre/reference/sdk/http-client), the Confidential HTTP client:
+
+- Executes the request in a secure **enclave** (not on each node individually)
+- Injects secrets from the **Vault DON** using template syntax
+- Optionally **encrypts the response** before returning it to your workflow
+
+## Prerequisites
+
+This guide assumes you have:
+
+- A basic understanding of CRE. If you are new, complete the [Getting Started tutorial](/cre/getting-started/overview) first.
+- Familiarity with [secrets management](/cre/guides/workflow/secrets) in CRE.
+
+## Step-by-step example
+
+This example shows a workflow that makes a confidential GET request to an API, injecting a secret into the request headers using template syntax.
+
+### Step 1: Configure your workflow
+
+Add the API URL to your `config.json` file.
+
+```json
+{
+  "schedule": "0 */5 * * * *",
+  "url": "https://api.example.com/data",
+  "owner": ""
+}
+```
+
+### Step 2: Set up secrets for simulation
+
+Confidential HTTP uses the `secrets.yaml` file. If you've already set up secrets for your project, you can reuse the same file. For a full walkthrough, see [Using Secrets in Simulation](/cre/guides/workflow/secrets/using-secrets-simulation).
+
+Add the secrets your confidential request needs to your `secrets.yaml`:
+
+```yaml
+# secrets.yaml
+secretsNames:
+  myApiKey:
+    - MY_API_KEY_ALL
+```
+
+Provide the actual value via an environment variable or `.env` file:
+
+```bash
+export MY_API_KEY_ALL="your-secret-api-key"
+```
+
+<Aside type="note" title="Verify secrets-path in workflow.yaml">
+  Make sure the `secrets-path` field in your `workflow.yaml` points to your `secrets.yaml` file (for example,
+  `"../secrets.yaml"` if it is at the project root). New projects created with the CLI may have this field empty by
+  default.
+</Aside>
+
+### Step 3: Define your types
+
+```typescript
+import { z } from "zod"
+
+const configSchema = z.object({
+  schedule: z.string(),
+  url: z.string(),
+  owner: z.string(),
+})
+
+type Config = z.infer<typeof configSchema>
+
+type TransactionResult = {
+  transactionId: string
+  status: string
+}
+```
+
+### Step 4: Implement the fetch function
+
+Create the function that will be passed to `sendRequest()`. This function receives a `ConfidentialHTTPSendRequester` and your config as parameters:
+
+```typescript
+import { type ConfidentialHTTPSendRequester, ok, json } from "@chainlink/cre-sdk"
+
+const fetchTransaction = (sendRequester: ConfidentialHTTPSendRequester, config: Config): TransactionResult => {
+  // 1. Send the confidential request
+  const response = sendRequester
+    .sendRequest({
+      request: {
+        url: config.url,
+        method: "GET",
+        multiHeaders: {
+          Authorization: { values: ["Basic {{.myApiKey}}"] },
+        },
+      },
+      vaultDonSecrets: [{ key: "myApiKey", owner: config.owner }],
+    })
+    .result()
+
+  // 2. Check the response status
+  if (!ok(response)) {
+    throw new Error(`HTTP request failed with status: ${response.statusCode}`)
+  }
+
+  // 3. Parse and return the result
+  return json(response) as TransactionResult
+}
+```
+
+### Step 5: Wire it into your workflow
+
+In your trigger handler, call `confHTTPClient.sendRequest()` with your fetch function and a consensus method:
+
+```typescript
+import {
+  CronCapability,
+  ConfidentialHTTPClient,
+  handler,
+  consensusIdenticalAggregation,
+  type Runtime,
+  Runner,
+} from "@chainlink/cre-sdk"
+
+const onCronTrigger = (runtime: Runtime<Config>): string => {
+  const confHTTPClient = new ConfidentialHTTPClient()
+
+  const result = confHTTPClient
+    .sendRequest(runtime, fetchTransaction, consensusIdenticalAggregation<TransactionResult>())(runtime.config)
+    .result()
+
+  runtime.log(`Transaction result: ${result.transactionId} — ${result.status}`)
+  return result.transactionId
+}
+```
+
+### Step 6: Simulate
+
+Run the simulation:
+
+```bash
+cre workflow simulate
+```
+
+## Template syntax for secrets
+
+Secrets are injected into request bodies and headers using Go template syntax: `{{.secretName}}`. The placeholder name must match the `key` in your `vaultDonSecrets` list.
+
+**In the request body:**
+
+```json
+{ "auth": "{{.myApiKey}}", "data": "public-data" }
+```
+
+**In headers:**
+
+```typescript
+multiHeaders: {
+  "Authorization": { values: ["Basic {{.myCredential}}"] },
+}
+```
+
+The template placeholders are resolved inside the enclave. The actual secret values never appear in your workflow code or in node memory.
+
+## Response encryption
+
+By default, the API response is returned unencrypted (`encryptOutput: false`). To encrypt the response body before it leaves the enclave, set `encryptOutput: true` and provide an AES-256 encryption key as a Vault DON secret.
+
+### Setting up response encryption
+
+1. **Store an AES-256 key** as a Vault DON secret with the identifier `san_marino_aes_gcm_encryption_key`:
+
+   ```yaml
+   # secrets.yaml
+   secretsNames:
+     san_marino_aes_gcm_encryption_key:
+       - AES_KEY_ALL
+   ```
+
+The key must be a 256-bit (32 bytes) hex-encoded string:
+
+```bash
+export AES_KEY_ALL="your-256-bit-hex-encoded-key"
+```
+
+1. **Include the key in your `vaultDonSecrets`** and set `encryptOutput: true`:
+
+   ```typescript
+   const response = sendRequester
+     .sendRequest({
+       request: {
+         url: config.url,
+         method: "GET",
+         multiHeaders: {
+           Authorization: { values: ["Basic {{.myApiKey}}"] },
+         },
+       },
+       vaultDonSecrets: [{ key: "myApiKey", owner: config.owner }, { key: "san_marino_aes_gcm_encryption_key" }],
+       encryptOutput: true,
+     })
+     .result()
+   ```
+
+2. **Decrypt the response** in your own backend service. The encrypted response body is structured as `nonce || ciphertext || tag` and uses AES-GCM encryption.
+
+
+<Aside type="caution" title="Do not decrypt inside the workflow">
+  The purpose of response encryption is to keep the response confidential even within the decentralized network. Decrypt
+  the response in your own backend service, not inside the workflow itself.
+</Aside>
+
+## Response helper functions
+
+The SDK response helpers `ok()`, `text()`, and `json()` work with Confidential HTTP responses just as they do with regular HTTP responses. For full documentation, see the [HTTP Client SDK Reference](/cre/reference/sdk/http-client-ts#helper-functions).
+
+## Complete example
+
+Here's the full workflow code for a confidential HTTP request with secret injection:
+
+```typescript
+import {
+  CronCapability,
+  ConfidentialHTTPClient,
+  handler,
+  consensusIdenticalAggregation,
+  ok,
+  json,
+  type ConfidentialHTTPSendRequester,
+  type Runtime,
+  Runner,
+} from "@chainlink/cre-sdk"
+import { z } from "zod"
+
+// Config schema
+const configSchema = z.object({
+  schedule: z.string(),
+  url: z.string(),
+  owner: z.string(),
+})
+
+type Config = z.infer<typeof configSchema>
+
+// Result type
+type TransactionResult = {
+  transactionId: string
+  status: string
+}
+
+// Fetch function — receives a ConfidentialHTTPSendRequester and config
+const fetchTransaction = (sendRequester: ConfidentialHTTPSendRequester, config: Config): TransactionResult => {
+  const response = sendRequester
+    .sendRequest({
+      request: {
+        url: config.url,
+        method: "GET",
+        multiHeaders: {
+          Authorization: { values: ["Basic {{.myApiKey}}"] },
+        },
+      },
+      vaultDonSecrets: [{ key: "myApiKey", owner: config.owner }],
+    })
+    .result()
+
+  if (!ok(response)) {
+    throw new Error(`HTTP request failed with status: ${response.statusCode}`)
+  }
+
+  return json(response) as TransactionResult
+}
+
+// Main workflow handler
+const onCronTrigger = (runtime: Runtime<Config>): string => {
+  const confHTTPClient = new ConfidentialHTTPClient()
+
+  const result = confHTTPClient
+    .sendRequest(runtime, fetchTransaction, consensusIdenticalAggregation<TransactionResult>())(runtime.config)
+    .result()
+
+  runtime.log(`Transaction result: ${result.transactionId} — ${result.status}`)
+  return result.transactionId
+}
+
+// Initialize workflow
+const initWorkflow = (config: Config) => {
+  return [
+    handler(
+      new CronCapability().trigger({
+        schedule: config.schedule,
+      }),
+      onCronTrigger
+    ),
+  ]
+}
+
+export async function main() {
+  const runner = await Runner.newRunner<Config>({ configSchema })
+  await runner.run(initWorkflow)
+}
+```
+
+## API reference
+
+For the full list of types and methods available on the Confidential HTTP client, see the [Confidential HTTP Client SDK Reference](/cre/reference/sdk/confidential-http-client-ts).
 
 ---
 
@@ -12865,6 +13349,320 @@ For a list of which versions support which networks, see [Supported Networks](/c
 
 ---
 
+# SDK Reference: Confidential HTTP Client
+Source: https://docs.chain.link/cre/reference/sdk/confidential-http-client-ts
+Last Updated: 2026-02-10
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The [Confidential HTTP](/cre/capabilities/confidential-http-ts) Client lets you make privacy-preserving requests to external APIs from your workflow. Unlike the regular [`HTTPClient`](/cre/reference/sdk/http-client), the request executes inside a secure enclave, secrets are injected via templates, and responses can be optionally encrypted.
+
+- For use cases and a conceptual overview, see [The Confidential HTTP Capability](/cre/capabilities/confidential-http-ts)
+- **Guide:** [Making Confidential Requests](/cre/guides/workflow/using-confidential-http-client/making-requests-ts)
+
+## Quick reference
+
+| Method                                              | Description                                                                            |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [`sendRequest` (high-level)](#sendrequest)          | **Recommended.** Makes a confidential HTTP request with built-in consensus and typing. |
+| [`sendRequest` (low-level)](#low-level-sendrequest) | Makes a confidential HTTP request manually inside a `runInNodeMode` block.             |
+
+## Core types
+
+
+<Aside type="note" title="Runtime types vs JSON types">
+  Each core type has a corresponding `Json` variant (e.g., `ConfidentialHTTPRequest` and `ConfidentialHTTPRequestJson`). The `Json` variant is the plain JSON-serializable form of the protobuf message. Both forms are accepted wherever a type is required.
+</Aside>
+
+### `ConfidentialHTTPRequest` / `ConfidentialHTTPRequestJson`
+
+The top-level request type that combines an HTTP request with Vault DON secrets and encryption settings.
+
+| Field             | Type                                             | Description                                                                                                                                       |
+| ----------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `request`         | `HTTPRequest` \| `HTTPRequestJson`               | The HTTP request to execute inside the enclave. See [`HTTPRequest`](#httprequest--httprequestjson).                                               |
+| `vaultDonSecrets` | `SecretIdentifier[]` \| `SecretIdentifierJson[]` | List of secrets to fetch from the Vault DON and make available in the enclave. See [`SecretIdentifier`](#secretidentifier--secretidentifierjson). |
+| `encryptOutput`   | `boolean`                                        | If `true`, encrypts the response body before it leaves the enclave. See [Response encryption](#response-encryption). Default: `false`.            |
+
+### `HTTPRequest` / `HTTPRequestJson`
+
+Defines the HTTP request that will be executed inside the enclave.
+
+| Field                  | Type                                         | Description                                                                                               |
+| ---------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `url`                  | `string`                                     | The URL of the API endpoint.                                                                              |
+| `method`               | `string`                                     | The HTTP method (e.g., `"GET"`, `"POST"`).                                                                |
+| `bodyString`           | `string` (optional)                          | The request body as a string template. Use this for secret injection with `{{.secretName}}` placeholders. |
+| `bodyBytes`            | `Uint8Array` \| `string` (optional)          | The request body as raw bytes (base64-encoded in JSON format).                                            |
+| `multiHeaders`         | `{ [key: string]: HeaderValues }` (optional) | Request headers. Supports multiple values per key and template syntax for secret injection.               |
+| `templatePublicValues` | `{ [key: string]: string }` (optional)       | Public (non-secret) values used to fill template placeholders in the body and headers.                    |
+| `customRootCaCertPem`  | `Uint8Array` \| `string` (optional)          | Optional custom root CA certificate (PEM format) for verifying the external server's TLS certificate.     |
+| `timeout`              | `Duration` \| `DurationJson` (optional)      | Optional request timeout (e.g., `"5s"`).                                                                  |
+
+
+<Aside type="note" title="bodyString vs bodyBytes">
+  The request body is a `oneof` field. Use `bodyString` for string templates with secret injection, or `bodyBytes` for raw binary data. Only one should be provided.
+</Aside>
+
+### `HTTPResponse` / `HTTPResponseJson`
+
+The response returned from the enclave after the HTTP request completes.
+
+| Field          | Type                              | Description                                                                                                                          |
+| -------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `statusCode`   | `number`                          | The HTTP status code.                                                                                                                |
+| `body`         | `Uint8Array` \| `string` (base64) | The response body. If `encryptOutput` is `true`, this contains the encrypted body (see [Response encryption](#response-encryption)). |
+| `multiHeaders` | `{ [key: string]: HeaderValues }` | The HTTP response headers.                                                                                                           |
+
+### `SecretIdentifier` / `SecretIdentifierJson`
+
+Identifies a secret stored in the Vault DON.
+
+| Field       | Type                | Description                                                                                                       |
+| ----------- | ------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `key`       | `string`            | The logical name of the secret. Must match the template placeholder (e.g., `"myApiKey"` matches `{{.myApiKey}}`). |
+| `namespace` | `string`            | The secret namespace.                                                                                             |
+| `owner`     | `string` (optional) | Optional. The owner address for the secret.                                                                       |
+
+### `HeaderValues` / `HeaderValuesJson`
+
+Represents multiple values for a single HTTP header key.
+
+| Field    | Type       | Description                                                                                      |
+| -------- | ---------- | ------------------------------------------------------------------------------------------------ |
+| `values` | `string[]` | The header values. Supports template syntax for secret injection (e.g., `"Basic {{.myToken}}"`). |
+
+### `ConfidentialHTTPSendRequester`
+
+The object passed to your fetch function when using the [high-level `sendRequest`](#sendrequest) pattern. It wraps the low-level client and provides a single method:
+
+| Method                                                                                                       | Description                                                 |
+| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
+| `sendRequest(input: ConfidentialHTTPRequest \| ConfidentialHTTPRequestJson): { result: () => HTTPResponse }` | Sends a confidential HTTP request and returns the response. |
+
+You don't create this object yourself — it is provided by the SDK when your function is called.
+
+## Making requests
+
+### `sendRequest()`
+
+**Recommended.** The high-level `sendRequest` method handles `runInNodeMode` wrapping and consensus for you. You provide a function that receives a `ConfidentialHTTPSendRequester` and your arguments, and the SDK takes care of the rest.
+
+**Signature:**
+
+```typescript
+sendRequest<TArgs extends unknown[], TOutput>(
+  runtime: Runtime<unknown>,
+  fn: (sendRequester: ConfidentialHTTPSendRequester, ...args: TArgs) => TOutput,
+  consensusAggregation: ConsensusAggregation<TOutput, true>,
+  unwrapOptions?: UnwrapOptions<TOutput>,
+): (...args: TArgs) => { result: () => TOutput }
+```
+
+**Parameters:**
+
+- `runtime`: The `Runtime` instance from your trigger handler.
+- `fn`: A function that receives a `ConfidentialHTTPSendRequester` plus any additional arguments you pass. Use the `sendRequester` to make the confidential request and return the parsed result.
+- `consensusAggregation`: The consensus strategy (e.g., `consensusIdenticalAggregation()`, `consensusMedianAggregation()`).
+- `unwrapOptions` (optional): Advanced option for controlling how complex (non-primitive) output types are unwrapped during consensus. Not needed for most use cases.
+
+**Returns:**
+
+A curried function that accepts `...args` and returns an object with a `.result()` method.
+
+**Example:**
+
+```typescript
+import {
+  ConfidentialHTTPClient,
+  consensusIdenticalAggregation,
+  ok,
+  json,
+  type ConfidentialHTTPSendRequester,
+  type Runtime,
+} from "@chainlink/cre-sdk"
+
+type Config = { url: string; owner: string }
+type APIResult = { data: string }
+
+// 1. Define your fetch function
+const fetchData = (sendRequester: ConfidentialHTTPSendRequester, config: Config): APIResult => {
+  const response = sendRequester
+    .sendRequest({
+      request: {
+        url: config.url,
+        method: "GET",
+        multiHeaders: {
+          Authorization: { values: ["Basic {{.apiKey}}"] },
+        },
+      },
+      vaultDonSecrets: [{ key: "apiKey", owner: config.owner }],
+    })
+    .result()
+
+  if (!ok(response)) {
+    throw new Error(`Request failed: ${response.statusCode}`)
+  }
+
+  return json(response) as APIResult
+}
+
+// 2. Call sendRequest in your trigger handler
+const onCronTrigger = (runtime: Runtime<Config>): string => {
+  const confHTTPClient = new ConfidentialHTTPClient()
+
+  const result = confHTTPClient
+    .sendRequest(runtime, fetchData, consensusIdenticalAggregation<APIResult>())(runtime.config)
+    .result()
+
+  return result.data
+}
+```
+
+### Low-level `sendRequest()`
+
+The low-level overload gives you direct access to the client within a `runtime.runInNodeMode()` block. For Confidential HTTP, this offers minimal practical advantages over the high-level pattern because the API call already executes as a single request inside the enclave. Use this only if you have a specific reason to manage the `runInNodeMode` wrapping manually.
+
+**Signature:**
+
+```typescript
+sendRequest(
+  runtime: NodeRuntime<unknown>,
+  input: ConfidentialHTTPRequest | ConfidentialHTTPRequestJson
+): { result: () => HTTPResponse }
+```
+
+**Parameters:**
+
+- `runtime`: A `NodeRuntime` instance provided by `runtime.runInNodeMode()`.
+- `input`: A `ConfidentialHTTPRequest` or `ConfidentialHTTPRequestJson` object containing the request, secrets, and encryption settings.
+
+**Returns:**
+
+An object with a `.result()` method that blocks until the request completes and returns the `HTTPResponse`.
+
+**Example:**
+
+```typescript
+import {
+  ConfidentialHTTPClient,
+  consensusIdenticalAggregation,
+  type Runtime,
+  type NodeRuntime,
+} from "@chainlink/cre-sdk"
+
+type Config = { url: string }
+
+const fetchData = (nodeRuntime: NodeRuntime<Config>): string => {
+  const client = new ConfidentialHTTPClient()
+
+  const resp = client
+    .sendRequest(nodeRuntime, {
+      request: {
+        url: nodeRuntime.config.url,
+        method: "GET",
+        multiHeaders: {
+          Authorization: { values: ["Basic {{.apiKey}}"] },
+        },
+      },
+      vaultDonSecrets: [{ key: "apiKey" }],
+      encryptOutput: false,
+    })
+    .result()
+
+  if (resp.statusCode !== 200) {
+    throw new Error(`Request failed with status: ${resp.statusCode}`)
+  }
+
+  const bodyText = new TextDecoder().decode(resp.body)
+  return bodyText
+}
+
+// In your workflow
+const onCronTrigger = (runtime: Runtime<Config>): string => {
+  const result = runtime.runInNodeMode(fetchData, consensusIdenticalAggregation<string>())().result()
+
+  runtime.log(`Result: ${result}`)
+  return result
+}
+```
+
+## Template syntax
+
+Secrets are injected into the request body and headers using Go template syntax: `{{.secretName}}`. The placeholder name must match the `key` field in the corresponding `SecretIdentifier`.
+
+**Body template:**
+
+```typescript
+bodyString: '{"apiKey": "{{.myApiKey}}", "method": "{{.method}}", "params": []}',
+```
+
+**Header template:**
+
+```typescript
+multiHeaders: {
+  "Authorization": { values: ["Basic {{.myCredential}}"] },
+},
+```
+
+### `templatePublicValues` (optional)
+
+Every `{{.placeholder}}` in your body or headers is resolved inside the enclave. By default, placeholders are filled with **secrets** from `vaultDonSecrets`. But sometimes you have a placeholder value that isn't secret — for example, an RPC method name or a public parameter. That's what `templatePublicValues` is for: it lets you inject **non-secret** values into the same template.
+
+This is purely a convenience. You could always hardcode the value directly in the body string instead:
+
+```typescript
+// These two are equivalent:
+
+// Option 1: hardcoded in the body string
+bodyString: '{"method": "eth_blockNumber", "auth": "{{.apiKey}}"}'
+
+// Option 2: using templatePublicValues
+bodyString: '{"method": "{{.method}}", "auth": "{{.apiKey}}"}'
+templatePublicValues: {
+  method: "eth_blockNumber"
+}
+```
+
+`templatePublicValues` is useful when you want to keep the template generic and pass in dynamic values (e.g., from config) without string concatenation.
+
+**Example with both secret and public values:**
+
+```typescript
+request: {
+  url: config.url,
+  method: "POST",
+  bodyString: '{"method": "{{.rpcMethod}}", "auth": "{{.apiKey}}"}',
+  templatePublicValues: {
+    rpcMethod: config.rpcMethod,   // dynamic value from config, not a secret
+  },
+},
+vaultDonSecrets: [{ key: "apiKey", owner: config.owner }],  // secret, from Vault DON
+```
+
+In this example, `{{.rpcMethod}}` is resolved from `templatePublicValues` (a dynamic, non-secret value from your workflow config) and `{{.apiKey}}` is resolved from the Vault DON (a secret). Both are resolved inside the enclave.
+
+## Response encryption
+
+The `encryptOutput` field controls whether the response body is encrypted before leaving the enclave.
+
+| encryptOutput     | Secret key provided                                      | Behavior                                                      |
+| ----------------- | -------------------------------------------------------- | ------------------------------------------------------------- |
+| `false` (default) | —                                                        | Response returned unencrypted.                                |
+| `true`            | `san_marino_aes_gcm_encryption_key` in `vaultDonSecrets` | Response AES-GCM encrypted with your symmetric key.           |
+| `true`            | No key provided                                          | Response TDH2 encrypted with the Vault DON master public key. |
+
+**AES-GCM encryption** is the recommended approach. Store a 256-bit (32-byte) AES key as a Vault DON secret with the identifier `san_marino_aes_gcm_encryption_key`, then decrypt the response in your own backend.
+
+The encrypted response body is structured as `nonce || ciphertext || tag`.
+
+For a complete example with response encryption, see the [Making Confidential Requests guide](/cre/guides/workflow/using-confidential-http-client/making-requests-ts#response-encryption).
+
+---
+
 # SDK Reference: Consensus & Aggregation
 Source: https://docs.chain.link/cre/reference/sdk/consensus-ts
 Last Updated: 2026-01-20
@@ -15116,6 +15914,7 @@ The SDK Reference is broken down into several pages, each corresponding to a cor
 - **[Triggers](/cre/reference/sdk/triggers/overview-ts)**: Details the configuration and payload structures for all available trigger types (`Cron`, `HTTP`, `EVM Log`).
 - **[EVM Client](/cre/reference/sdk/evm-client-ts)**: Provides a reference for the `EVMClient`, the primary tool for all EVM interactions, including reads and writes.
 - **[HTTP Client](/cre/reference/sdk/http-client-ts)**: Provides a reference for the `HTTPClient`, used for making offchain API requests from individual nodes.
+- **[Confidential HTTP Client](/cre/reference/sdk/confidential-http-client-ts)** *(Experimental)*: Provides a reference for the `ConfidentialHTTPClient`, used for privacy-preserving API requests with enclave execution and optional response encryption.
 - **[Consensus & Aggregation](/cre/reference/sdk/consensus-ts)**: Describes how to use aggregators like `consensusMedianAggregation` and `ConsensusAggregationByFields` with `runtime.runInNodeMode()` to process and consolidate data from multiple nodes.
 
 ## Package Structure

--- a/src/content/cre/reference/cli/index.mdx
+++ b/src/content/cre/reference/cli/index.mdx
@@ -6,13 +6,13 @@ isIndex: true
 metadata:
   description: "Explore all CRE CLI commands: complete reference for project setup, workflow deployment, account management, and development tools."
   datePublished: "2025-11-04"
-  lastModified: "2026-01-29"
+  lastModified: "2026-02-10"
 ---
 
 import { Aside } from "@components"
 
-<Aside type="note" title="Required CLI Version: v1.0.7">
-  To ensure compatibility with the guides and examples in this documentation, please use version `v1.0.7` of the CRE
+<Aside type="note" title="Required CLI Version: v1.0.10">
+  To ensure compatibility with the guides and examples in this documentation, please use version `v1.0.10` of the CRE
   CLI. You can check your installed version by running `cre version`. Refer to the [CLI
   Installation](/cre/getting-started/cli-installation/macos-linux) guide for more information.
 </Aside>

--- a/src/content/cre/reference/cli/utilities.mdx
+++ b/src/content/cre/reference/cli/utilities.mdx
@@ -58,12 +58,12 @@ cre version
 **Example output:**
 
 ```bash
-cre version v1.0.7
+cre version v1.0.10
 ```
 
 {/* prettier-ignore */}
 <Aside type="note" title="Version compatibility">
-  Always check that your CLI version matches the version recommended in the documentation. The current recommended version is **v1.0.7**. See the [CLI Installation guide](/cre/getting-started/cli-installation) for more information.
+  Always check that your CLI version matches the version recommended in the documentation. The current recommended version is **v1.0.10**. See the [CLI Installation guide](/cre/getting-started/cli-installation) for more information.
 </Aside>
 
 ## Learn more

--- a/src/content/cre/reference/sdk/confidential-http-client-go.mdx
+++ b/src/content/cre/reference/sdk/confidential-http-client-go.mdx
@@ -1,0 +1,284 @@
+---
+section: cre
+title: "SDK Reference: Confidential HTTP Client"
+date: Last Modified
+sdkLang: "go"
+pageId: "reference-sdk-confidential-http-client"
+metadata:
+  description: "Reference for Go Confidential HTTP Client: complete API for privacy-preserving requests with enclave execution, secret injection, and response encryption."
+  datePublished: "2026-02-10"
+  lastModified: "2026-02-10"
+---
+
+import { Aside } from "@components"
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The [Confidential HTTP](/cre/capabilities/confidential-http-go) Client lets you make privacy-preserving requests to external APIs from your workflow. Unlike the regular [`http.Client`](/cre/reference/sdk/http-client), the request executes inside a secure enclave, secrets are injected via templates, and responses can be optionally encrypted.
+
+- For use cases and a conceptual overview, see [The Confidential HTTP Capability](/cre/capabilities/confidential-http-go)
+- **Guide:** [Making Confidential Requests](/cre/guides/workflow/using-confidential-http-client/making-requests-go)
+
+## Quick reference
+
+| Method                                                         | Description                                                |
+| -------------------------------------------------------------- | ---------------------------------------------------------- |
+| [`confidentialhttp.SendRequest`](#confidentialhttpsendrequest) | High-level helper with automatic `RunInNodeMode` wrapping  |
+| [`client.SendRequest`](#clientsendrequest)                     | Low-level method requiring manual `RunInNodeMode` wrapping |
+
+## Core types
+
+### `confidentialhttp.ConfidentialHTTPRequest`
+
+The top-level request type that combines an HTTP request with Vault DON secrets and encryption settings.
+
+| <div style="width: 140px;">Field</div> | <div style="width: 200px;">Type</div> | Description                                                                                                                                 |
+| -------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Request`                              | `*HTTPRequest`                        | The HTTP request to execute inside the enclave. See [`HTTPRequest`](#confidentialhttphttprequest).                                          |
+| `VaultDonSecrets`                      | `[]*SecretIdentifier`                 | List of secrets to fetch from the Vault DON and make available in the enclave. See [`SecretIdentifier`](#confidentialhttpsecretidentifier). |
+| `EncryptOutput`                        | `bool`                                | If `true`, encrypts the response body before it leaves the enclave. See [Response encryption](#response-encryption). Default: `false`.      |
+
+### `confidentialhttp.HTTPRequest`
+
+Defines the HTTP request that will be executed inside the enclave.
+
+| <div style="width: 150px;">Field</div> | <div style="width: 250px;">Type</div> | Description                                                                                                   |
+| -------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `Url`                                  | `string`                              | The URL of the API endpoint.                                                                                  |
+| `Method`                               | `string`                              | The HTTP method (e.g., `"GET"`, `"POST"`).                                                                    |
+| `Body`                                 | `isHTTPRequest_Body`                  | The request body. Use `HTTPRequest_BodyString` for string templates or `HTTPRequest_BodyBytes` for raw bytes. |
+| `MultiHeaders`                         | `map[string]*HeaderValues`            | Request headers. Supports multiple values per key and template syntax for secret injection.                   |
+| `TemplatePublicValues`                 | `map[string]string`                   | Public (non-secret) values used to fill template placeholders in the body and headers.                        |
+| `CustomRootCaCertPem`                  | `[]byte`                              | Optional custom root CA certificate (PEM format) for verifying the external server's TLS certificate.         |
+| `Timeout`                              | `*durationpb.Duration`                | Optional request timeout.                                                                                     |
+
+#### Setting the request body
+
+The `Body` field is a `oneof` type with two options:
+
+**String template (recommended for secret injection):**
+
+```go
+Body: &confidentialhttp.HTTPRequest_BodyString{
+	BodyString: `{"auth": "{{.myApiKey}}", "action": "getData"}`,
+},
+```
+
+**Raw bytes:**
+
+```go
+Body: &confidentialhttp.HTTPRequest_BodyBytes{
+	BodyBytes: []byte(`{"action": "getData"}`),
+},
+```
+
+### `confidentialhttp.HTTPResponse`
+
+The response returned from the enclave after the HTTP request completes.
+
+| Field          | Type                       | Description                                                                                                                          |
+| -------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `StatusCode`   | `uint32`                   | The HTTP status code.                                                                                                                |
+| `Body`         | `[]byte`                   | The response body. If `EncryptOutput` is `true`, this contains the encrypted body (see [Response encryption](#response-encryption)). |
+| `MultiHeaders` | `map[string]*HeaderValues` | The HTTP response headers.                                                                                                           |
+
+### `confidentialhttp.SecretIdentifier`
+
+Identifies a secret stored in the Vault DON.
+
+| Field       | Type      | Description                                                                                                       |
+| ----------- | --------- | ----------------------------------------------------------------------------------------------------------------- |
+| `Key`       | `string`  | The logical name of the secret. Must match the template placeholder (e.g., `"myApiKey"` matches `{{.myApiKey}}`). |
+| `Namespace` | `string`  | The secret namespace.                                                                                             |
+| `Owner`     | `*string` | Optional. The owner address for the secret.                                                                       |
+
+### `confidentialhttp.HeaderValues`
+
+Represents multiple values for a single HTTP header key.
+
+| Field    | Type       | Description                                                                                      |
+| -------- | ---------- | ------------------------------------------------------------------------------------------------ |
+| `Values` | `[]string` | The header values. Supports template syntax for secret injection (e.g., `"Basic {{.myToken}}"`). |
+
+## Making requests
+
+### `confidentialhttp.SendRequest`
+
+The high-level helper function for making confidential HTTP requests. Automatically handles the `cre.RunInNodeMode` pattern.
+
+**Signature:**
+
+```go
+func SendRequest[C, T any](
+	config C,
+	runtime cre.Runtime,
+	client *Client,
+	fn func(config C, logger *slog.Logger, sendRequester *SendRequester) (T, error),
+	ca cre.ConsensusAggregation[T],
+) cre.Promise[T]
+```
+
+**Parameters:**
+
+- `config`: Your workflow's configuration struct, passed to `fn`.
+- `runtime`: The top-level `cre.Runtime` from your trigger callback.
+- `client`: An initialized `*confidentialhttp.Client`.
+- `fn`: Your request logic function that receives `config`, `logger`, and `sendRequester`.
+- `ca`: The [consensus aggregation method](/cre/reference/sdk/consensus).
+
+**Example:**
+
+```go
+func fetchData(config *Config, logger *slog.Logger, sendRequester *confidentialhttp.SendRequester) (*Result, error) {
+	resp, err := sendRequester.SendRequest(&confidentialhttp.ConfidentialHTTPRequest{
+		Request: &confidentialhttp.HTTPRequest{
+			Url:    config.URL,
+			Method: "GET",
+			MultiHeaders: map[string]*confidentialhttp.HeaderValues{
+				"Authorization": {Values: []string{"Basic {{.apiKey}}"}},
+			},
+		},
+		VaultDonSecrets: []*confidentialhttp.SecretIdentifier{
+			{Key: "apiKey"},
+		},
+	}).Await()
+	if err != nil {
+		return nil, err
+	}
+	// Parse resp.Body...
+	return &Result{}, nil
+}
+
+// In your trigger callback
+client := &confidentialhttp.Client{}
+result, err := confidentialhttp.SendRequest(config, runtime, client,
+	fetchData,
+	cre.ConsensusIdenticalAggregation[*Result](),
+).Await()
+```
+
+### `client.SendRequest`
+
+The lower-level method for making confidential HTTP requests. Must be manually wrapped in `cre.RunInNodeMode`.
+
+**Signature:**
+
+```go
+func (c *Client) SendRequest(runtime cre.NodeRuntime, input *ConfidentialHTTPRequest) cre.Promise[*HTTPResponse]
+```
+
+**Parameters:**
+
+- `runtime`: A `cre.NodeRuntime` provided by `cre.RunInNodeMode`.
+- `input`: A `*ConfidentialHTTPRequest` containing the request, secrets, and encryption settings.
+
+**Returns:**
+
+- `cre.Promise[*HTTPResponse]`
+
+**Example:**
+
+```go
+result, err := cre.RunInNodeMode(config, runtime,
+	func(config Config, nodeRuntime cre.NodeRuntime) (Result, error) {
+		client := confidentialhttp.Client{}
+		resp, err := client.SendRequest(nodeRuntime, &confidentialhttp.ConfidentialHTTPRequest{
+			Request: &confidentialhttp.HTTPRequest{
+				Url:    config.URL,
+				Method: "POST",
+				Body:   &confidentialhttp.HTTPRequest_BodyString{BodyString: `{"auth": "{{.apiKey}}"}`},
+				MultiHeaders: map[string]*confidentialhttp.HeaderValues{
+					"Content-Type": {Values: []string{"application/json"}},
+				},
+			},
+			VaultDonSecrets: []*confidentialhttp.SecretIdentifier{
+				{Key: "apiKey"},
+			},
+		}).Await()
+		if err != nil {
+			return Result{}, err
+		}
+		// Parse and return...
+		return Result{}, nil
+	},
+	cre.ConsensusIdenticalAggregation[Result](),
+).Await()
+```
+
+**Guide:** [Making Confidential Requests](/cre/guides/workflow/using-confidential-http-client/making-requests-go)
+
+## Template syntax
+
+Secrets are injected into the request body and headers using Go template syntax: `{{.secretName}}`. The placeholder name must match the `Key` field in the corresponding `SecretIdentifier`.
+
+**Body template:**
+
+```go
+Body: &confidentialhttp.HTTPRequest_BodyString{
+	BodyString: `{"apiKey": "{{.myApiKey}}", "method": "{{.method}}", "params": []}`,
+},
+```
+
+**Header template:**
+
+```go
+MultiHeaders: map[string]*confidentialhttp.HeaderValues{
+	"Authorization": {Values: []string{"Basic {{.myCredential}}"}},
+},
+```
+
+### `TemplatePublicValues` (optional)
+
+Every `{{.placeholder}}` in your body or headers is resolved inside the enclave. By default, placeholders are filled with **secrets** from `VaultDonSecrets`. But sometimes you have a placeholder value that isn't secret — for example, an RPC method name or a public parameter. That's what `TemplatePublicValues` is for: it lets you inject **non-secret** values into the same template.
+
+This is purely a convenience. You could always hardcode the value directly in the body string instead:
+
+```go
+// These two are equivalent:
+
+// Option 1: hardcoded in the body string
+Body: &confidentialhttp.HTTPRequest_BodyString{BodyString: `{"method": "eth_blockNumber", "auth": "{{.apiKey}}"}`}
+
+// Option 2: using TemplatePublicValues
+Body: &confidentialhttp.HTTPRequest_BodyString{BodyString: `{"method": "{{.method}}", "auth": "{{.apiKey}}"}`}
+TemplatePublicValues: map[string]string{"method": "eth_blockNumber"}
+```
+
+`TemplatePublicValues` is useful when you want to keep the template generic and pass in dynamic values (e.g., from config) without string concatenation.
+
+**Example with both secret and public values:**
+
+```go
+Request: &confidentialhttp.HTTPRequest{
+	Url:    config.URL,
+	Method: "POST",
+	Body:   &confidentialhttp.HTTPRequest_BodyString{BodyString: `{"method": "{{.rpcMethod}}", "auth": "{{.apiKey}}"}`},
+	TemplatePublicValues: map[string]string{
+		"rpcMethod": config.RPCMethod,   // dynamic value from config, not a secret
+	},
+},
+VaultDonSecrets: []*confidentialhttp.SecretIdentifier{
+	{Key: "apiKey"},   // secret, from Vault DON
+},
+```
+
+In this example, `{{.rpcMethod}}` is resolved from `TemplatePublicValues` (a dynamic, non-secret value from your workflow config) and `{{.apiKey}}` is resolved from the Vault DON (a secret). Both are resolved inside the enclave.
+
+## Response encryption
+
+The `EncryptOutput` field controls whether the response body is encrypted before leaving the enclave.
+
+| `EncryptOutput`   | Secret key provided                                      | Behavior                                                      |
+| ----------------- | -------------------------------------------------------- | ------------------------------------------------------------- |
+| `false` (default) | —                                                        | Response returned unencrypted.                                |
+| `true`            | `san_marino_aes_gcm_encryption_key` in `VaultDonSecrets` | Response AES-GCM encrypted with your symmetric key.           |
+| `true`            | No key provided                                          | Response TDH2 encrypted with the Vault DON master public key. |
+
+**AES-GCM encryption** is the recommended approach. Store a 256-bit (32-byte) AES key as a Vault DON secret with the identifier `san_marino_aes_gcm_encryption_key`, then decrypt the response in your own secure backend.
+
+The encrypted response body is structured as `nonce || ciphertext || tag`.
+
+For a complete decryption example, see the [Making Confidential Requests guide](/cre/guides/workflow/using-confidential-http-client/making-requests-go#response-encryption).

--- a/src/content/cre/reference/sdk/confidential-http-client-ts.mdx
+++ b/src/content/cre/reference/sdk/confidential-http-client-ts.mdx
@@ -1,0 +1,321 @@
+---
+section: cre
+title: "SDK Reference: Confidential HTTP Client"
+date: Last Modified
+sdkLang: "ts"
+pageId: "reference-sdk-confidential-http-client"
+metadata:
+  description: "Reference for TypeScript Confidential HTTP Client: complete API for privacy-preserving requests with enclave execution, secret injection, and response encryption."
+  datePublished: "2026-02-10"
+  lastModified: "2026-02-10"
+---
+
+import { Aside } from "@components"
+
+<Aside type="caution" title="Experimental — Simulation only">
+  Confidential HTTP is an **experimental** capability available for `cre workflow simulate` only. It cannot be used with
+  `cre workflow deploy` at this time.
+</Aside>
+
+The [Confidential HTTP](/cre/capabilities/confidential-http-ts) Client lets you make privacy-preserving requests to external APIs from your workflow. Unlike the regular [`HTTPClient`](/cre/reference/sdk/http-client), the request executes inside a secure enclave, secrets are injected via templates, and responses can be optionally encrypted.
+
+- For use cases and a conceptual overview, see [The Confidential HTTP Capability](/cre/capabilities/confidential-http-ts)
+- **Guide:** [Making Confidential Requests](/cre/guides/workflow/using-confidential-http-client/making-requests-ts)
+
+## Quick reference
+
+| Method                                              | Description                                                                            |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [`sendRequest` (high-level)](#sendrequest)          | **Recommended.** Makes a confidential HTTP request with built-in consensus and typing. |
+| [`sendRequest` (low-level)](#low-level-sendrequest) | Makes a confidential HTTP request manually inside a `runInNodeMode` block.             |
+
+## Core types
+
+{/* prettier-ignore */}
+<Aside type="note" title="Runtime types vs JSON types">
+  Each core type has a corresponding `Json` variant (e.g., `ConfidentialHTTPRequest` and `ConfidentialHTTPRequestJson`). The `Json` variant is the plain JSON-serializable form of the protobuf message. Both forms are accepted wherever a type is required.
+</Aside>
+
+### `ConfidentialHTTPRequest` / `ConfidentialHTTPRequestJson`
+
+The top-level request type that combines an HTTP request with Vault DON secrets and encryption settings.
+
+| <div style="width: 140px;">Field</div> | <div style="width: 230px;">Type</div>            | Description                                                                                                                                       |
+| -------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `request`                              | `HTTPRequest` \| `HTTPRequestJson`               | The HTTP request to execute inside the enclave. See [`HTTPRequest`](#httprequest--httprequestjson).                                               |
+| `vaultDonSecrets`                      | `SecretIdentifier[]` \| `SecretIdentifierJson[]` | List of secrets to fetch from the Vault DON and make available in the enclave. See [`SecretIdentifier`](#secretidentifier--secretidentifierjson). |
+| `encryptOutput`                        | `boolean`                                        | If `true`, encrypts the response body before it leaves the enclave. See [Response encryption](#response-encryption). Default: `false`.            |
+
+### `HTTPRequest` / `HTTPRequestJson`
+
+Defines the HTTP request that will be executed inside the enclave.
+
+| <div style="width: 170px;">Field</div> | <div style="width: 250px;">Type</div>        | Description                                                                                               |
+| -------------------------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `url`                                  | `string`                                     | The URL of the API endpoint.                                                                              |
+| `method`                               | `string`                                     | The HTTP method (e.g., `"GET"`, `"POST"`).                                                                |
+| `bodyString`                           | `string` (optional)                          | The request body as a string template. Use this for secret injection with `{{.secretName}}` placeholders. |
+| `bodyBytes`                            | `Uint8Array` \| `string` (optional)          | The request body as raw bytes (base64-encoded in JSON format).                                            |
+| `multiHeaders`                         | `{ [key: string]: HeaderValues }` (optional) | Request headers. Supports multiple values per key and template syntax for secret injection.               |
+| `templatePublicValues`                 | `{ [key: string]: string }` (optional)       | Public (non-secret) values used to fill template placeholders in the body and headers.                    |
+| `customRootCaCertPem`                  | `Uint8Array` \| `string` (optional)          | Optional custom root CA certificate (PEM format) for verifying the external server's TLS certificate.     |
+| `timeout`                              | `Duration` \| `DurationJson` (optional)      | Optional request timeout (e.g., `"5s"`).                                                                  |
+
+{/* prettier-ignore */}
+<Aside type="note" title="bodyString vs bodyBytes">
+  The request body is a `oneof` field. Use `bodyString` for string templates with secret injection, or `bodyBytes` for raw binary data. Only one should be provided.
+</Aside>
+
+### `HTTPResponse` / `HTTPResponseJson`
+
+The response returned from the enclave after the HTTP request completes.
+
+| <div style="width: 130px;">Field</div> | <div style="width: 260px;">Type</div> | Description                                                                                                                          |
+| -------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `statusCode`                           | `number`                              | The HTTP status code.                                                                                                                |
+| `body`                                 | `Uint8Array` \| `string` (base64)     | The response body. If `encryptOutput` is `true`, this contains the encrypted body (see [Response encryption](#response-encryption)). |
+| `multiHeaders`                         | `{ [key: string]: HeaderValues }`     | The HTTP response headers.                                                                                                           |
+
+### `SecretIdentifier` / `SecretIdentifierJson`
+
+Identifies a secret stored in the Vault DON.
+
+| Field       | Type                | Description                                                                                                       |
+| ----------- | ------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `key`       | `string`            | The logical name of the secret. Must match the template placeholder (e.g., `"myApiKey"` matches `{{.myApiKey}}`). |
+| `namespace` | `string`            | The secret namespace.                                                                                             |
+| `owner`     | `string` (optional) | Optional. The owner address for the secret.                                                                       |
+
+### `HeaderValues` / `HeaderValuesJson`
+
+Represents multiple values for a single HTTP header key.
+
+| <div style="width: 130px;">Field</div> | <div style="width: 130px;">Type</div> | Description                                                                                      |
+| -------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `values`                               | `string[]`                            | The header values. Supports template syntax for secret injection (e.g., `"Basic {{.myToken}}"`). |
+
+### `ConfidentialHTTPSendRequester`
+
+The object passed to your fetch function when using the [high-level `sendRequest`](#sendrequest) pattern. It wraps the low-level client and provides a single method:
+
+| Method                                                                                                       | Description                                                 |
+| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
+| `sendRequest(input: ConfidentialHTTPRequest \| ConfidentialHTTPRequestJson): { result: () => HTTPResponse }` | Sends a confidential HTTP request and returns the response. |
+
+You don't create this object yourself — it is provided by the SDK when your function is called.
+
+## Making requests
+
+### `sendRequest()`
+
+**Recommended.** The high-level `sendRequest` method handles `runInNodeMode` wrapping and consensus for you. You provide a function that receives a `ConfidentialHTTPSendRequester` and your arguments, and the SDK takes care of the rest.
+
+**Signature:**
+
+```typescript
+sendRequest<TArgs extends unknown[], TOutput>(
+  runtime: Runtime<unknown>,
+  fn: (sendRequester: ConfidentialHTTPSendRequester, ...args: TArgs) => TOutput,
+  consensusAggregation: ConsensusAggregation<TOutput, true>,
+  unwrapOptions?: UnwrapOptions<TOutput>,
+): (...args: TArgs) => { result: () => TOutput }
+```
+
+**Parameters:**
+
+- `runtime`: The `Runtime` instance from your trigger handler.
+- `fn`: A function that receives a `ConfidentialHTTPSendRequester` plus any additional arguments you pass. Use the `sendRequester` to make the confidential request and return the parsed result.
+- `consensusAggregation`: The consensus strategy (e.g., `consensusIdenticalAggregation()`, `consensusMedianAggregation()`).
+- `unwrapOptions` (optional): Advanced option for controlling how complex (non-primitive) output types are unwrapped during consensus. Not needed for most use cases.
+
+**Returns:**
+
+A curried function that accepts `...args` and returns an object with a `.result()` method.
+
+**Example:**
+
+```typescript
+import {
+  ConfidentialHTTPClient,
+  consensusIdenticalAggregation,
+  ok,
+  json,
+  type ConfidentialHTTPSendRequester,
+  type Runtime,
+} from "@chainlink/cre-sdk"
+
+type Config = { url: string; owner: string }
+type APIResult = { data: string }
+
+// 1. Define your fetch function
+const fetchData = (sendRequester: ConfidentialHTTPSendRequester, config: Config): APIResult => {
+  const response = sendRequester
+    .sendRequest({
+      request: {
+        url: config.url,
+        method: "GET",
+        multiHeaders: {
+          Authorization: { values: ["Basic {{.apiKey}}"] },
+        },
+      },
+      vaultDonSecrets: [{ key: "apiKey", owner: config.owner }],
+    })
+    .result()
+
+  if (!ok(response)) {
+    throw new Error(`Request failed: ${response.statusCode}`)
+  }
+
+  return json(response) as APIResult
+}
+
+// 2. Call sendRequest in your trigger handler
+const onCronTrigger = (runtime: Runtime<Config>): string => {
+  const confHTTPClient = new ConfidentialHTTPClient()
+
+  const result = confHTTPClient
+    .sendRequest(runtime, fetchData, consensusIdenticalAggregation<APIResult>())(runtime.config)
+    .result()
+
+  return result.data
+}
+```
+
+### Low-level `sendRequest()`
+
+The low-level overload gives you direct access to the client within a `runtime.runInNodeMode()` block. For Confidential HTTP, this offers minimal practical advantages over the high-level pattern because the API call already executes as a single request inside the enclave. Use this only if you have a specific reason to manage the `runInNodeMode` wrapping manually.
+
+**Signature:**
+
+```typescript
+sendRequest(
+  runtime: NodeRuntime<unknown>,
+  input: ConfidentialHTTPRequest | ConfidentialHTTPRequestJson
+): { result: () => HTTPResponse }
+```
+
+**Parameters:**
+
+- `runtime`: A `NodeRuntime` instance provided by `runtime.runInNodeMode()`.
+- `input`: A `ConfidentialHTTPRequest` or `ConfidentialHTTPRequestJson` object containing the request, secrets, and encryption settings.
+
+**Returns:**
+
+An object with a `.result()` method that blocks until the request completes and returns the `HTTPResponse`.
+
+**Example:**
+
+```typescript
+import {
+  ConfidentialHTTPClient,
+  consensusIdenticalAggregation,
+  type Runtime,
+  type NodeRuntime,
+} from "@chainlink/cre-sdk"
+
+type Config = { url: string }
+
+const fetchData = (nodeRuntime: NodeRuntime<Config>): string => {
+  const client = new ConfidentialHTTPClient()
+
+  const resp = client
+    .sendRequest(nodeRuntime, {
+      request: {
+        url: nodeRuntime.config.url,
+        method: "GET",
+        multiHeaders: {
+          Authorization: { values: ["Basic {{.apiKey}}"] },
+        },
+      },
+      vaultDonSecrets: [{ key: "apiKey" }],
+      encryptOutput: false,
+    })
+    .result()
+
+  if (resp.statusCode !== 200) {
+    throw new Error(`Request failed with status: ${resp.statusCode}`)
+  }
+
+  const bodyText = new TextDecoder().decode(resp.body)
+  return bodyText
+}
+
+// In your workflow
+const onCronTrigger = (runtime: Runtime<Config>): string => {
+  const result = runtime.runInNodeMode(fetchData, consensusIdenticalAggregation<string>())().result()
+
+  runtime.log(`Result: ${result}`)
+  return result
+}
+```
+
+## Template syntax
+
+Secrets are injected into the request body and headers using Go template syntax: `{{.secretName}}`. The placeholder name must match the `key` field in the corresponding `SecretIdentifier`.
+
+**Body template:**
+
+```typescript
+bodyString: '{"apiKey": "{{.myApiKey}}", "method": "{{.method}}", "params": []}',
+```
+
+**Header template:**
+
+```typescript
+multiHeaders: {
+  "Authorization": { values: ["Basic {{.myCredential}}"] },
+},
+```
+
+### `templatePublicValues` (optional)
+
+Every `{{.placeholder}}` in your body or headers is resolved inside the enclave. By default, placeholders are filled with **secrets** from `vaultDonSecrets`. But sometimes you have a placeholder value that isn't secret — for example, an RPC method name or a public parameter. That's what `templatePublicValues` is for: it lets you inject **non-secret** values into the same template.
+
+This is purely a convenience. You could always hardcode the value directly in the body string instead:
+
+```typescript
+// These two are equivalent:
+
+// Option 1: hardcoded in the body string
+bodyString: '{"method": "eth_blockNumber", "auth": "{{.apiKey}}"}'
+
+// Option 2: using templatePublicValues
+bodyString: '{"method": "{{.method}}", "auth": "{{.apiKey}}"}'
+templatePublicValues: {
+  method: "eth_blockNumber"
+}
+```
+
+`templatePublicValues` is useful when you want to keep the template generic and pass in dynamic values (e.g., from config) without string concatenation.
+
+**Example with both secret and public values:**
+
+```typescript
+request: {
+  url: config.url,
+  method: "POST",
+  bodyString: '{"method": "{{.rpcMethod}}", "auth": "{{.apiKey}}"}',
+  templatePublicValues: {
+    rpcMethod: config.rpcMethod,   // dynamic value from config, not a secret
+  },
+},
+vaultDonSecrets: [{ key: "apiKey", owner: config.owner }],  // secret, from Vault DON
+```
+
+In this example, `{{.rpcMethod}}` is resolved from `templatePublicValues` (a dynamic, non-secret value from your workflow config) and `{{.apiKey}}` is resolved from the Vault DON (a secret). Both are resolved inside the enclave.
+
+## Response encryption
+
+The `encryptOutput` field controls whether the response body is encrypted before leaving the enclave.
+
+| encryptOutput     | Secret key provided                                      | Behavior                                                      |
+| ----------------- | -------------------------------------------------------- | ------------------------------------------------------------- |
+| `false` (default) | —                                                        | Response returned unencrypted.                                |
+| `true`            | `san_marino_aes_gcm_encryption_key` in `vaultDonSecrets` | Response AES-GCM encrypted with your symmetric key.           |
+| `true`            | No key provided                                          | Response TDH2 encrypted with the Vault DON master public key. |
+
+**AES-GCM encryption** is the recommended approach. Store a 256-bit (32-byte) AES key as a Vault DON secret with the identifier `san_marino_aes_gcm_encryption_key`, then decrypt the response in your own backend.
+
+The encrypted response body is structured as `nonce || ciphertext || tag`.
+
+For a complete example with response encryption, see the [Making Confidential Requests guide](/cre/guides/workflow/using-confidential-http-client/making-requests-ts#response-encryption).

--- a/src/content/cre/reference/sdk/overview-go.mdx
+++ b/src/content/cre/reference/sdk/overview-go.mdx
@@ -22,6 +22,7 @@ The SDK Reference is broken down into several pages, each corresponding to a cor
 - **[Triggers](/cre/reference/sdk/triggers)**: Details the configuration and payload structures for all available trigger types (`Cron`, `HTTP`, `EVM Log`).
 - **[EVM Client](/cre/reference/sdk/evm-client)**: Provides a reference for the `evm.Client`, the primary tool for all EVM interactions, including reads and writes.
 - **[HTTP Client](/cre/reference/sdk/http-client)**: Provides a reference for the `http.Client`, used for making offchain API requests from individual nodes.
+- **[Confidential HTTP Client](/cre/reference/sdk/confidential-http-client)** _(Experimental)_: Provides a reference for the `confidentialhttp.Client`, used for privacy-preserving API requests with enclave execution and optional response encryption.
 - **[Consensus & Aggregation](/cre/reference/sdk/consensus)**: Describes how to use aggregators like `ConsensusMedianAggregation` and `ConsensusAggregationFromTags` with `RunInNodeMode` to process and consolidate data from multiple nodes.
 
 ## Contract Bindings

--- a/src/content/cre/reference/sdk/overview-ts.mdx
+++ b/src/content/cre/reference/sdk/overview-ts.mdx
@@ -22,6 +22,7 @@ The SDK Reference is broken down into several pages, each corresponding to a cor
 - **[Triggers](/cre/reference/sdk/triggers/overview-ts)**: Details the configuration and payload structures for all available trigger types (`Cron`, `HTTP`, `EVM Log`).
 - **[EVM Client](/cre/reference/sdk/evm-client-ts)**: Provides a reference for the `EVMClient`, the primary tool for all EVM interactions, including reads and writes.
 - **[HTTP Client](/cre/reference/sdk/http-client-ts)**: Provides a reference for the `HTTPClient`, used for making offchain API requests from individual nodes.
+- **[Confidential HTTP Client](/cre/reference/sdk/confidential-http-client-ts)** _(Experimental)_: Provides a reference for the `ConfidentialHTTPClient`, used for privacy-preserving API requests with enclave execution and optional response encryption.
 - **[Consensus & Aggregation](/cre/reference/sdk/consensus-ts)**: Describes how to use aggregators like `consensusMedianAggregation` and `ConsensusAggregationByFields` with `runtime.runInNodeMode()` to process and consolidate data from multiple nodes.
 
 ## Package Structure

--- a/src/content/cre/release-notes.mdx
+++ b/src/content/cre/release-notes.mdx
@@ -5,12 +5,54 @@ date: Last Modified
 metadata:
   description: "Discover what's new in CRE: latest features, changes, and improvements in each release of the Chainlink Runtime Environment."
   datePublished: "2025-11-04"
-  lastModified: "2026-02-03"
+  lastModified: "2026-02-10"
 ---
 
 import { Aside } from "@components"
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.0.10 - February 9, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.0.10" target="_blank">CRE CLI version 1.0.10</a> is now available.**
+
+- **Bug Fix**: Fixed secret injection for the [Confidential HTTP](/cre/capabilities/confidential-http) capability in the simulator — template placeholders (`{{.secretName}}`) now resolve correctly during `cre workflow simulate`
+- **Bug Fix**: Fixed project context not being set before writing changeset files
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.0.9...v1.0.10)
+
+## CLI v1.0.9 - February 6, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.0.9" target="_blank">CRE CLI version 1.0.9</a> is now available.**
+
+- **Confidential HTTP (Experimental)**: Added [Confidential HTTP](/cre/capabilities/confidential-http) capability support in the simulator. You can now simulate workflows that use privacy-preserving API calls with secret injection and optional response encryption.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.0.8...v1.0.9)
+
+## CLI v1.0.8 - February 6, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.0.8" target="_blank">CRE CLI version 1.0.8</a> is now available.**
+
+- Changed `chain-id` to `chain-selector` in simulator settings
+- Support for longer workflow names
+- Fixed a logic bug in the template contract `MessageEmitter.sol`
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.0.7...v1.0.8)
 
 ## New Networks Support - January 29, 2026
 


### PR DESCRIPTION
This pull request introduces documentation and UI updates for the new Confidential HTTP capability in CRE, which is an experimental privacy-preserving feature for API calls, and updates the documentation site and changelog to reflect recent CLI releases (v1.0.8, v1.0.9, v1.0.10). The changes include new documentation pages, sidebar navigation updates, and a download button update for the latest CLI release.

**Confidential HTTP Capability Documentation:**

* Added new documentation pages for the Confidential HTTP capability, detailing its purpose, architecture, use cases, and differences from regular HTTP, for both TypeScript and Go SDKs (`src/content/cre/capabilities/confidential-http-ts.mdx`, `src/content/cre/capabilities/confidential-http-go.mdx`). [[1]](diffhunk://#diff-199d2fb824369906f61a8a4e76f833c1222b3edfa9bd0af2f2bcd0151386e571R1-R117) [[2]](diffhunk://#diff-2a53a9992d08613fa0f4830eb4b53e5dc926ca0dabac6543b48f41a7820746bcR1-R117)
* Updated the capabilities overview to include Confidential HTTP as an experimental feature, and clarified that consensus applies to Confidential HTTP as well (`src/content/cre/capabilities/index.mdx`).

**Navigation and Reference Updates:**

* Updated the sidebar navigation to add Confidential HTTP under capabilities, guides, and SDK reference sections, including experimental labeling and appropriate highlighting for related pages (`src/config/sidebar.ts`). [[1]](diffhunk://#diff-d6089daa2dd1e8916f282347f13c40b762a0617e7524ae687640f7a1d685a8b2R299-R312) [[2]](diffhunk://#diff-d6089daa2dd1e8916f282347f13c40b762a0617e7524ae687640f7a1d685a8b2R426-R430) [[3]](diffhunk://#diff-d6089daa2dd1e8916f282347f13c40b762a0617e7524ae687640f7a1d685a8b2R555-R562)

**Release and Changelog Updates:**

* Added changelog entries for CRE CLI releases v1.0.8, v1.0.9 (introducing Confidential HTTP simulation), and v1.0.10 (bugfix for secret injection), with descriptions and GitHub links (`public/changelog.json`). [[1]](diffhunk://#diff-5323f35752748a8eb45ef9c8e62cda3a9d5b83c420d2feb0e307e66676bb2558R400-R406) [[2]](diffhunk://#diff-5323f35752748a8eb45ef9c8e62cda3a9d5b83c420d2feb0e307e66676bb2558R627-R640)
* Updated the download button to point to the latest CLI release v1.0.10 (`src/components/DownloadButton.tsx`).