### PR TITLE
add fusd

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -1964,6 +1964,20 @@
             }
           }
         },
+        "FUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "GHO": {
           "rateLimiterConfig": {
             "in": {
@@ -2721,6 +2735,20 @@
       },
       "supportedTokens": {
         "BOLD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "FUSD": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -23001,6 +23029,20 @@
             }
           }
         },
+        "FUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "GHO": {
           "rateLimiterConfig": {
             "in": {
@@ -30815,6 +30857,20 @@
             }
           }
         },
+        "FUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "LBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -37867,6 +37923,20 @@
             }
           }
         },
+        "FUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "LBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -38424,6 +38494,20 @@
               "capacity": "100000000000000000000",
               "isEnabled": true,
               "rate": "9260000000000000"
+            }
+          }
+        },
+        "FUSD": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -1914,6 +1914,44 @@
       "tokenAddress": "DuEy8wWrzCUun5ZbbG9hkVqXqqicpTQw8gB7nEAzpCHQ"
     }
   },
+  "FUSD": {
+    "avalanche-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "FinChain Dollar",
+      "poolAddress": "0xC73a36EC9950530256C051b3740412A067F64589",
+      "poolType": "burnMint",
+      "symbol": "FUSD",
+      "tokenAddress": "0x9f6714C302ffe3c3bAFaf2Ccb44201fF64f6371C"
+    },
+    "mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "FinChain Dollar",
+      "poolAddress": "0x91FEbCFB698CC2e653f7e053205a347957F325D1",
+      "poolType": "burnMint",
+      "symbol": "FUSD",
+      "tokenAddress": "0x9f6714C302ffe3c3bAFaf2Ccb44201fF64f6371C"
+    },
+    "solana-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 9,
+      "name": "FinChain Dollar LP",
+      "poolAddress": "366ddoqBtdUaPG4ikA6zbkvbDyW51fR9DtHjxseKk9HK",
+      "poolType": "burnMint",
+      "symbol": "FUSDLP",
+      "tokenAddress": "51tpgun58apNKgrk96xAVUCN5yC7cDzt3EHov9UjBh3Q"
+    },
+    "sonic-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "FinChain Dollar",
+      "poolAddress": "0xFf5d2C5b907ED4c88CEE5B0cF1D280e4Df3176fd",
+      "poolType": "burnMint",
+      "symbol": "FUSD",
+      "tokenAddress": "0x9f6714C302ffe3c3bAFaf2Ccb44201fF64f6371C"
+    }
+  },
   "GEN": {
     "ethereum-mainnet-base-1": {
       "allowListEnabled": false,


### PR DESCRIPTION
This pull request adds support for the FUSD (FinChain Dollar) token across multiple mainnets in the configuration files. The changes include defining FUSD token metadata for several networks and configuring its rate limiter settings in the `lanes.json` file.

Token configuration additions:

* Added FUSD token metadata for `avalanche-mainnet`, `mainnet`, `solana-mainnet`, and `sonic-mainnet` in `tokens.json`, including details like `decimals`, `name`, `symbol`, `poolAddress`, and `tokenAddress`.

Rate limiter configuration:

* Added FUSD to multiple locations in `lanes.json` with a `rateLimiterConfig` where both inbound and outbound limits are disabled (`isEnabled: false`, `capacity: "0"`, `rate: "0"`), ensuring no rate limiting is applied to FUSD transfers. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R1967-R1980) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R2751-R2764) [[3]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R23032-R23045) [[4]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R30860-R30873) [[5]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R37926-R37939) [[6]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844R38500-R38513)