### PR TITLE
update ccip config api

### DIFF
--- a/src/config/data/ccip/selectors.yml
+++ b/src/config/data/ccip/selectors.yml
@@ -1066,3 +1066,7 @@ selectors:
     selector: "1804312132722180201"
     name: "hemi-mainnet"
     network_type: mainnet
+  202601:
+    selector: "1091131740251125869"
+    name: "ethereum-testnet-sepolia-ronin-1"
+    network_type: testnet

--- a/src/lib/api/cacheHeaders.ts
+++ b/src/lib/api/cacheHeaders.ts
@@ -1,12 +1,26 @@
 /**
- * Shared cache header configurations for API endpoints
+ * Shared cache and CORS header configurations for API endpoints
  *
  * Cache Strategy:
  * - 5-minute CDN cache (s-max-age=300)
  * - Stale-while-revalidate for graceful degradation
  * - CDN-specific headers for Vercel optimization
  * - No browser cache (CDN-only caching)
+ *
+ * CORS Policy:
+ * - Open access (Access-Control-Allow-Origin: *)
+ * - Public, read-only API designed for cross-origin consumption
  */
+
+/**
+ * CORS headers for cross-origin access
+ * Enables browser-based clients (dApps, scripts) to consume the API
+ */
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+}
 
 /**
  * Standard cache headers for all API endpoints
@@ -26,6 +40,7 @@ export const standardCacheHeaders = {
  */
 export const textPlainHeaders = {
   "Content-Type": "text/plain; charset=utf-8",
+  ...corsHeaders,
   ...standardCacheHeaders,
 }
 
@@ -35,6 +50,7 @@ export const textPlainHeaders = {
  */
 export const jsonHeaders = {
   "Content-Type": "application/json",
+  ...corsHeaders,
   ...standardCacheHeaders,
 }
 
@@ -44,4 +60,5 @@ export const jsonHeaders = {
  */
 export const commonHeaders = {
   "Content-Type": "application/json",
+  ...corsHeaders,
 }

--- a/src/lib/ccip/services/lane-data.ts
+++ b/src/lib/ccip/services/lane-data.ts
@@ -20,6 +20,7 @@ import {
   getChainTypeAndFamily,
   directoryToSupportedChain,
 } from "../../../features/utils/index.ts"
+import { getSelectorEntry } from "@config/data/ccip/selectors.ts"
 
 export const prerender = false
 
@@ -214,11 +215,16 @@ export class LaneDataService {
         return null
       }
 
+      // Resolve internalId from the selector YAML name (consistent with chains and tokens endpoints)
+      // Falls back to the RDD directory key if the selector entry is not found
+      const selectorEntry = getSelectorEntry(chainId, chainType)
+      const internalId = selectorEntry?.name ?? chainKey
+
       return {
         chainId,
         displayName,
         selector,
-        internalId: chainKey,
+        internalId,
         chainType,
         chainFamily,
       }


### PR DESCRIPTION
This pull request introduces improvements to API header management and enhances chain selector support. The main changes include adding CORS headers to all API responses, introducing a new testnet selector, and updating the internal ID resolution logic for chain data.

**API header and CORS improvements:**
* Added a new `corsHeaders` object in `cacheHeaders.ts` to enable open CORS access, and applied these headers to all standard API response headers (`jsonHeaders`, `textPlainHeaders`, and `commonHeaders`). [[1]](diffhunk://#diff-8dbee9031f89e398dfef1519a4ebfc5b8d81f97f7e7fed52f78df8d8f255db10L2-R24) [[2]](diffhunk://#diff-8dbee9031f89e398dfef1519a4ebfc5b8d81f97f7e7fed52f78df8d8f255db10R43) [[3]](diffhunk://#diff-8dbee9031f89e398dfef1519a4ebfc5b8d81f97f7e7fed52f78df8d8f255db10R53) [[4]](diffhunk://#diff-8dbee9031f89e398dfef1519a4ebfc5b8d81f97f7e7fed52f78df8d8f255db10R63)

**Chain selector and internal ID enhancements:**
* Added a new selector entry for `ethereum-testnet-sepolia-ronin-1` in the `selectors.yml` configuration.
* Updated `LaneDataService` in `lane-data.ts` to resolve the `internalId` from the selector YAML entry name, falling back to the RDD directory key if not found, for consistency across endpoints. [[1]](diffhunk://#diff-f47cd5c039fbf418b0ef56d9f3dc0310d15a3ad4f5e2a4021252c8e30ba8ea10R23) [[2]](diffhunk://#diff-f47cd5c039fbf418b0ef56d9f3dc0310d15a3ad4f5e2a4021252c8e30ba8ea10R218-R227)