### PR TITLE
refresh dir

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/chains.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/chains.json
@@ -436,7 +436,7 @@
       "version": "1.0.0"
     },
     "chainSelector": "8788096068760390840",
-    "feeTokens": ["LINK", "wzkCRO"],
+    "feeTokens": ["LINK", "WZKCRO"],
     "registryModule": {
       "address": "0x5Fa0fa2f1dE61BddD68dc8902b59Eaa028BE6F57",
       "version": "1.6.0"
@@ -458,8 +458,8 @@
     "chainSelector": "8805746078405598895",
     "feeTokens": ["LINK", "WMETIS"],
     "registryModule": {
-      "address": "0xE4B147224Db9B6E3776E4B3CEda31b3cE232e2FA",
-      "version": "1.5.0"
+      "address": "0xE939C02E92e9E66d1F0D8E4F099E7d3d269a8a11",
+      "version": "1.6.0"
     },
     "router": {
       "address": "0x7b9FB8717D306e2e08ce2e1Efa81F026bf9AD13c",

--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -409,20 +409,6 @@
               "rate": "2315"
             }
           }
-        },
-        "USD1": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            }
-          }
         }
       }
     },
@@ -571,20 +557,6 @@
               "rate": "2315"
             }
           }
-        },
-        "USD1": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            }
-          }
         }
       }
     },
@@ -661,6 +633,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "savUSD": {
           "rateLimiterConfig": {
             "in": {
@@ -785,6 +771,20 @@
           }
         },
         "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "NXPC": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -2950,6 +2950,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        },
         "savUSD": {
           "rateLimiterConfig": {
             "in": {
@@ -3005,6 +3019,20 @@
             }
           }
         },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "xSolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -3057,6 +3085,20 @@
               "capacity": "5000000000000000000000000",
               "isEnabled": true,
               "rate": "58000000000000000000"
+            }
+          }
+        },
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -3237,7 +3279,35 @@
             }
           }
         },
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "sDOLA": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "uniBTC": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -3284,6 +3354,36 @@
         "address": "0x3423C922911956b1Ccbc2b5d4f38216a6f4299b4",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
+      },
+      "supportedTokens": {
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "mainnet": {
@@ -3498,6 +3598,22 @@
         "address": "0xc23071a8AE83671f37bdA1DaDBC745a9780f632A",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        }
       }
     },
     "sei-mainnet": {
@@ -3531,6 +3647,22 @@
         "address": "0xc23071a8AE83671f37bdA1DaDBC745a9780f632A",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        }
       }
     },
     "stable-mainnet": {
@@ -3936,6 +4068,20 @@
               "capacity": "2500000000000000000",
               "isEnabled": true,
               "rate": "115740000000000"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -4588,9 +4734,9 @@
         "stBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
             },
             "out": {
               "capacity": "0",
@@ -4754,20 +4900,6 @@
               "rate": "2315"
             }
           }
-        },
-        "USD1": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            }
-          }
         }
       }
     },
@@ -4811,6 +4943,20 @@
           }
         },
         "LEND": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "NXPC": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -4932,6 +5078,20 @@
               "capacity": "5000000000000000000000000",
               "isEnabled": true,
               "rate": "58000000000000000000"
+            }
+          }
+        },
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -5158,9 +5318,9 @@
         "stBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
+              "capacity": "2",
+              "isEnabled": true,
+              "rate": "1"
             },
             "out": {
               "capacity": "0",
@@ -5386,6 +5546,20 @@
             }
           }
         },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "USDFI": {
           "rateLimiterConfig": {
             "in": {
@@ -5581,6 +5755,20 @@
             }
           }
         },
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "CHEX": {
           "rateLimiterConfig": {
             "in": {
@@ -5645,9 +5833,9 @@
               "rate": "462963"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -5750,6 +5938,20 @@
           }
         },
         "TRADE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "uniBTC": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -6235,6 +6437,20 @@
         "version": "1.5.0"
       },
       "supportedTokens": {
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -6246,6 +6462,20 @@
               "capacity": "2500000000000000000",
               "isEnabled": true,
               "rate": "115740000000000"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -6589,9 +6819,9 @@
               "rate": "462963"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -7487,6 +7717,20 @@
             }
           }
         },
+        "NXPC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "W0G": {
           "rateLimiterConfig": {
             "in": {
@@ -7571,14 +7815,14 @@
         "LBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "5000000000",
+              "capacity": "1000000000",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "92593"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -7650,6 +7894,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "$PAAL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "BR": {
           "rateLimiterConfig": {
             "in": {
@@ -7887,6 +8145,20 @@
             }
           }
         },
+        "SolvBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC.JUP": {
           "rateLimiterConfig": {
             "in": {
@@ -7898,6 +8170,20 @@
               "capacity": "100000000000000000000",
               "isEnabled": true,
               "rate": "1157400000000000"
+            }
+          }
+        },
+        "xSolvBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -7922,9 +8208,9 @@
               "rate": "462963"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -8395,6 +8681,22 @@
         "address": "0x6525923279256B8a86c1C01cF5955eB00C39B048",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "etherlink-mainnet": {
@@ -9167,6 +9469,20 @@
             }
           }
         },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "USDFI": {
           "rateLimiterConfig": {
             "in": {
@@ -9426,14 +9742,14 @@
         "EARNM": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "625000000000000000000000",
-              "isEnabled": true,
-              "rate": "173600000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "625000000000000000000000",
-              "isEnabled": true,
-              "rate": "173600000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -9686,6 +10002,20 @@
               "capacity": "200000000000000000000000",
               "isEnabled": true,
               "rate": "2314000000000000000"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -10694,14 +11024,14 @@
         "EARNM": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "625000000000000000000000",
-              "isEnabled": true,
-              "rate": "173600000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "625000000000000000000000",
-              "isEnabled": true,
-              "rate": "173600000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -10730,20 +11060,6 @@
               "capacity": "1000000000000000000000",
               "isEnabled": true,
               "rate": "56000000000000000"
-            }
-          }
-        },
-        "FHE": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
             }
           }
         },
@@ -11603,14 +11919,14 @@
         "EARNM": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "100000000000000000000000000",
-              "isEnabled": true,
-              "rate": "27778000000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "100000000000000000000000000",
-              "isEnabled": true,
-              "rate": "27778000000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -12514,7 +12830,35 @@
             }
           }
         },
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "sDOLA": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "uniBTC": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -12677,6 +13021,20 @@
             }
           }
         },
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "CHEX": {
           "rateLimiterConfig": {
             "in": {
@@ -12741,9 +13099,9 @@
               "rate": "462963"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -12846,6 +13204,20 @@
           }
         },
         "TRADE": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "uniBTC": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -13020,6 +13392,22 @@
         "address": "0xee85aEfb15b9489563A6a29891ebe0750AA1A7Ae",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "ethereum-mainnet-arbitrum-1": {
@@ -13134,14 +13522,14 @@
         "EARNM": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "625000000000000000000000",
-              "isEnabled": true,
-              "rate": "173600000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "625000000000000000000000",
-              "isEnabled": true,
-              "rate": "173600000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -13394,6 +13782,20 @@
               "capacity": "200000000000000000000000",
               "isEnabled": true,
               "rate": "2314000000000000000"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -13854,6 +14256,20 @@
             }
           }
         },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "VRTX": {
           "rateLimiterConfig": {
             "in": {
@@ -14059,6 +14475,20 @@
               "capacity": "400000000000",
               "isEnabled": true,
               "rate": "41600000"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -14297,6 +14727,36 @@
         "address": "0xee85aEfb15b9489563A6a29891ebe0750AA1A7Ae",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "kaia-mainnet": {
@@ -14548,14 +15008,14 @@
         "EARNM": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "625000000000000000000000",
-              "isEnabled": true,
-              "rate": "173600000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "625000000000000000000000",
-              "isEnabled": true,
-              "rate": "173600000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -14665,9 +15125,9 @@
               "rate": "462963"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -15527,14 +15987,14 @@
         "EARNM": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "100000000000000000000000000",
-              "isEnabled": true,
-              "rate": "27778000000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "100000000000000000000000000",
-              "isEnabled": true,
-              "rate": "27778000000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -15981,14 +16441,14 @@
         "LBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "5000000000",
+              "capacity": "1000000000",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "92593"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         }
@@ -16226,6 +16686,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "$PAAL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "elizaOS": {
           "rateLimiterConfig": {
             "in": {
@@ -16456,9 +16930,9 @@
               "rate": "462963"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -17488,6 +17962,22 @@
         "address": "0x530Ae314EC3fA038bd9A215095E37295ec76162a",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "wstETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "plasma-mainnet": {
@@ -17499,6 +17989,22 @@
         "address": "0x530Ae314EC3fA038bd9A215095E37295ec76162a",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "wstETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "sei-mainnet": {
@@ -18736,6 +19242,20 @@
             }
           }
         },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "VRTX": {
           "rateLimiterConfig": {
             "in": {
@@ -19102,6 +19622,20 @@
         "version": "1.5.0"
       },
       "supportedTokens": {
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            },
+            "out": {
+              "capacity": "200000000",
+              "isEnabled": true,
+              "rate": "2315"
+            }
+          }
+        },
         "wUSDx": {
           "rateLimiterConfig": {
             "in": {
@@ -19805,6 +20339,20 @@
             }
           }
         },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "USDC": {
           "rateLimiterConfig": {
             "in": {
@@ -19984,6 +20532,20 @@
         "version": "1.5.0"
       },
       "supportedTokens": {
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "wUSDx": {
           "rateLimiterConfig": {
             "in": {
@@ -22264,6 +22826,36 @@
         "address": "0x4122fe199B6e489a89f54c67245Be33bf602935F",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
+      },
+      "supportedTokens": {
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "bsc-mainnet": {
@@ -22277,6 +22869,20 @@
         "version": "1.5.0"
       },
       "supportedTokens": {
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -22288,6 +22894,20 @@
               "capacity": "2500000000000000000",
               "isEnabled": true,
               "rate": "115740000000000"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -22330,6 +22950,36 @@
         "address": "0x72f6000D70B291C67bED898214156d01383274b1",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "brBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "uniBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "kaia-mainnet": {
@@ -22407,6 +23057,20 @@
               "capacity": "2500000000000000000",
               "isEnabled": true,
               "rate": "115740000000000"
+            }
+          }
+        },
+        "syrupUSDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -22884,20 +23548,6 @@
               "capacity": "200000000",
               "isEnabled": true,
               "rate": "2315"
-            }
-          }
-        },
-        "USD1": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
             }
           }
         }
@@ -24209,9 +24859,9 @@
               "rate": "462963"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -25171,14 +25821,14 @@
         "EARNM": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "625000000000000000000000",
-              "isEnabled": true,
-              "rate": "173600000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "625000000000000000000000",
-              "isEnabled": true,
-              "rate": "173600000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -25207,20 +25857,6 @@
               "capacity": "1000000000000000000000",
               "isEnabled": true,
               "rate": "56000000000000000"
-            }
-          }
-        },
-        "FHE": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
             }
           }
         },
@@ -26276,14 +26912,14 @@
         "EARNM": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "625000000000000000000000",
-              "isEnabled": true,
-              "rate": "173600000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "625000000000000000000000",
-              "isEnabled": true,
-              "rate": "173600000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -26393,9 +27029,9 @@
               "rate": "462963"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -28946,6 +29582,20 @@
             }
           }
         },
+        "syrupUSDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -29147,6 +29797,20 @@
             }
           }
         },
+        "BYTES": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "100000000000000000000000",
+              "isEnabled": true,
+              "rate": "2320000000000000000"
+            },
+            "out": {
+              "capacity": "100000000000000000000000",
+              "isEnabled": true,
+              "rate": "2320000000000000000"
+            }
+          }
+        },
         "DFX": {
           "rateLimiterConfig": {
             "in": {
@@ -29164,14 +29828,14 @@
         "EARNM": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "50000000000000000000000000",
-              "isEnabled": true,
-              "rate": "13889000000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "50000000000000000000000000",
-              "isEnabled": true,
-              "rate": "13889000000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -30505,6 +31169,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "$PAAL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "brBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -30690,9 +31368,9 @@
         "uniBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "200000000",
+              "capacity": "55000000000",
               "isEnabled": true,
-              "rate": "2315"
+              "rate": "636574"
             },
             "out": {
               "capacity": "200000000",
@@ -30987,9 +31665,9 @@
               "rate": "462963"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -32049,14 +32727,14 @@
         "EARNM": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "100000000000000000000000000",
-              "isEnabled": true,
-              "rate": "27778000000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "100000000000000000000000000",
-              "isEnabled": true,
-              "rate": "27778000000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -32272,14 +32950,14 @@
         "EARNM": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "100000000000000000000000000",
-              "isEnabled": true,
-              "rate": "27778000000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "100000000000000000000000000",
-              "isEnabled": true,
-              "rate": "27778000000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -32834,6 +33512,20 @@
             }
           }
         },
+        "BYTES": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "100000000000000000000000",
+              "isEnabled": true,
+              "rate": "2320000000000000000"
+            },
+            "out": {
+              "capacity": "100000000000000000000000",
+              "isEnabled": true,
+              "rate": "2320000000000000000"
+            }
+          }
+        },
         "DFX": {
           "rateLimiterConfig": {
             "in": {
@@ -32851,14 +33543,14 @@
         "EARNM": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "50000000000000000000000000",
-              "isEnabled": true,
-              "rate": "13889000000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             },
             "out": {
-              "capacity": "50000000000000000000000000",
-              "isEnabled": true,
-              "rate": "13889000000000000000000"
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -33948,6 +34640,20 @@
             }
           }
         },
+        "NXPC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "W0G": {
           "rateLimiterConfig": {
             "in": {
@@ -34055,6 +34761,22 @@
         "address": "0xcDca5D374e46A6DDDab50bD2D9acB8c796eC35C3",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "wstETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "ethereum-mainnet-optimism-1": {
@@ -34213,6 +34935,22 @@
         "address": "0xcDca5D374e46A6DDDab50bD2D9acB8c796eC35C3",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "wstETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "polygon-mainnet-katana": {
@@ -34730,6 +35468,22 @@
         "address": "0x8FE3B17E6B0863aeEA3D38DF063AEa39D4Ab1602",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "wstETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "ethereum-mainnet-linea-1": {
@@ -34929,6 +35683,22 @@
         "address": "0x8FE3B17E6B0863aeEA3D38DF063AEa39D4Ab1602",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "wstETH": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "solana-mainnet": {
@@ -35313,6 +36083,22 @@
         "address": "0xc23071a8AE83671f37bdA1DaDBC745a9780f632A",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        }
       }
     },
     "bsc-mainnet": {
@@ -35329,14 +36115,14 @@
         "LBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "5000000000",
+              "capacity": "1000000000",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "92593"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -35381,14 +36167,14 @@
         "LBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "5000000000",
+              "capacity": "1000000000",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "92593"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         }
@@ -35567,14 +36353,14 @@
         "LBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "5000000000",
+              "capacity": "1000000000",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "92593"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         }
@@ -36619,6 +37405,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "$PAAL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "BR": {
           "rateLimiterConfig": {
             "in": {
@@ -36925,6 +37725,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "$PAAL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "elizaOS": {
           "rateLimiterConfig": {
             "in": {
@@ -37195,6 +38009,20 @@
         "version": "1.6.0"
       },
       "supportedTokens": {
+        "$PAAL": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "brBTC": {
           "rateLimiterConfig": {
             "in": {
@@ -37806,6 +38634,20 @@
             }
           }
         },
+        "SolvBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "SolvBTC.JUP": {
           "rateLimiterConfig": {
             "in": {
@@ -37817,6 +38659,20 @@
               "capacity": "100000000000000000000",
               "isEnabled": true,
               "rate": "1157400000000000"
+            }
+          }
+        },
+        "xSolvBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -38240,6 +39096,22 @@
         "address": "0x76a443768A5e3B8d1AED0105FC250877841Deb40",
         "enforceOutOfOrder": false,
         "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            },
+            "out": {
+              "capacity": "5000000000",
+              "isEnabled": true,
+              "rate": "462963"
+            }
+          }
+        }
       }
     },
     "bitcoin-mainnet-bob-1": {
@@ -38288,9 +39160,9 @@
               "rate": "462963"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -38490,9 +39362,9 @@
               "rate": "462963"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -38755,9 +39627,9 @@
               "rate": "462963"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         },
@@ -38996,14 +39868,14 @@
         "LBTC": {
           "rateLimiterConfig": {
             "in": {
-              "capacity": "5000000000",
+              "capacity": "1000000000",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "92593"
             },
             "out": {
-              "capacity": "5000000000",
+              "capacity": "2",
               "isEnabled": true,
-              "rate": "462963"
+              "rate": "1"
             }
           }
         }

--- a/src/config/data/ccip/v1_2_0/mainnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/tokens.json
@@ -26,6 +26,15 @@
       "poolType": "lockRelease",
       "symbol": "$PAAL",
       "tokenAddress": "0x14feE680690900BA0ccCfC76AD70Fd1b95D10e16"
+    },
+    "solana-mainnet": {
+      "allowListEnabled": false,
+      "decimals": 9,
+      "name": "Paal AI",
+      "poolAddress": "8uR4nmsVphTgosuJMQDAAmHqkwr24t6pFhWwaSKVdwoJ",
+      "poolType": "burnMint",
+      "symbol": "PAAL",
+      "tokenAddress": "PAALhGKVeiWMAatwxnwuvXoHHxYQoftLLhkgmXgFdmM"
     }
   },
   "1XMM": {
@@ -1784,7 +1793,7 @@
     "solana-mainnet": {
       "allowListEnabled": false,
       "decimals": 6,
-      "name": "eUSX ",
+      "name": "eUSX",
       "poolAddress": "3BLXohtpL2iyHsJLYzp4fmy9ZjbjE7ocPfDMFaU7U3gD",
       "poolType": "lockRelease",
       "symbol": "eUSX",
@@ -1840,15 +1849,6 @@
       "poolType": "burnMint",
       "symbol": "FHE",
       "tokenAddress": "0xd55C9fB62E176a8Eb6968f32958FeFDD0962727E"
-    },
-    "ethereum-mainnet-arbitrum-1": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "MindNetwork FHE Token",
-      "poolAddress": "0xCf2B643114b1098E5bc09B49f4D73C6A8Ea1c871",
-      "poolType": "burnMint",
-      "symbol": "FHE",
-      "tokenAddress": "0x8096cD953Fa2ABa1E60Dad27A3e58d71dF2F62F1"
     },
     "mainnet": {
       "allowListEnabled": false,
@@ -1952,15 +1952,6 @@
       "poolType": "burnMint",
       "symbol": "FUSD",
       "tokenAddress": "0x9f6714C302ffe3c3bAFaf2Ccb44201fF64f6371C"
-    },
-    "solana-mainnet": {
-      "allowListEnabled": false,
-      "decimals": 9,
-      "name": "FinChain Dollar LP",
-      "poolAddress": "366ddoqBtdUaPG4ikA6zbkvbDyW51fR9DtHjxseKk9HK",
-      "poolType": "burnMint",
-      "symbol": "FUSDLP",
-      "tokenAddress": "51tpgun58apNKgrk96xAVUCN5yC7cDzt3EHov9UjBh3Q"
     },
     "sonic-mainnet": {
       "allowListEnabled": false,
@@ -2149,7 +2140,7 @@
       "name": "iLuminary Token",
       "poolAddress": "GhgD4CQxPxrV3Ad3xaZn6AAJ6f1R5rKN3n2gkBzQ23jU",
       "poolType": "burnMint",
-      "symbol": "ILMT",
+      "symbol": "iLMT",
       "tokenAddress": "Au6V6WrkjWZYSdCJtJFYPysZXr1qncHXZshZ7w8SnDjv"
     }
   },
@@ -3663,7 +3654,7 @@
     "solana-mainnet": {
       "allowListEnabled": false,
       "decimals": 6,
-      "name": "Michi",
+      "name": "michi",
       "poolAddress": "ATyY7SaiayLnp3teH3c4jRBGiPinSSZyt2gHNNN9C6BV",
       "poolType": "lockRelease",
       "symbol": "$michi",
@@ -3939,11 +3930,11 @@
     "bsc-mainnet": {
       "allowListEnabled": false,
       "decimals": 18,
-      "name": "Nexpace",
-      "poolAddress": "0xEB8a99EDdFA50375E58033c187A4b65EC3c6B40C",
+      "name": "NXPC",
+      "poolAddress": "0x6f6645D608F56D04E5f36719865Df4b2c9Bc6794",
       "poolType": "burnMint",
       "symbol": "NXPC",
-      "tokenAddress": "0x9f2c4FD0a0BFF91723089775C73394E72c0fC116"
+      "tokenAddress": "0xf2b51CC1850fEd939658317a22d73d3482767591"
     },
     "monad-mainnet": {
       "allowListEnabled": false,
@@ -3953,15 +3944,6 @@
       "poolType": "burnMint",
       "symbol": "NXPC",
       "tokenAddress": "0xD33F18D8d48CbbB2f8b47063DE97f94De0D49B99"
-    },
-    "ronin-mainnet": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "Nexpace",
-      "poolAddress": "0x6f9234e7ffdC4Fda751f13269a6584582B9F3C8d",
-      "poolType": "burnMint",
-      "symbol": "NXPC",
-      "tokenAddress": "0x1B601A055711FeE5Ea965bC2AE341e2e4a79D622"
     }
   },
   "OHM": {
@@ -6487,15 +6469,6 @@
       "symbol": "USD1",
       "tokenAddress": "0x111111d2bf19e43C34263401e0CAd979eD1cdb61"
     },
-    "aptos-mainnet": {
-      "allowListEnabled": false,
-      "decimals": 6,
-      "name": "World Liberty Financial USD",
-      "poolAddress": "0x1eb155d08acc900954b6ccee01659b390399ae81ad4c582b73d41374c475caf6",
-      "poolType": "burnMint",
-      "symbol": "USD1",
-      "tokenAddress": "0x05fabd1b12e39967a3c24e91b7b8f67719a6dacee74f3c8b9fb7d93e855437d2"
-    },
     "bsc-mainnet": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -7384,15 +7357,6 @@
       "poolType": "burnMint",
       "symbol": "WBTC",
       "tokenAddress": "0xCa3Eb64F3DFd7861C76070e3d1492eE5ee20cdC3"
-    },
-    "shibarium-mainnet": {
-      "allowListEnabled": false,
-      "decimals": 8,
-      "name": "SOU Wrapped BTC",
-      "poolAddress": "0x40cb57c0e25A816C7bD120E1b0403bD30fDf47B2",
-      "poolType": "burnMint",
-      "symbol": "WBTC",
-      "tokenAddress": "0x8370b2bC5Ff68C1A9dD75780EC39FE5D52BD8846"
     }
   },
   "WBTCN": {
@@ -8549,7 +8513,7 @@
       "tokenAddress": "0xc9B53AB2679f573e480d01e0f49e2B5CFB7a3EAb"
     }
   },
-  "wzkCRO": {
+  "WZKCRO": {
     "cronos-zkevm-mainnet": {
       "allowListEnabled": false,
       "decimals": 18,

--- a/src/config/data/ccip/v1_2_0/testnet/chains.json
+++ b/src/config/data/ccip/v1_2_0/testnet/chains.json
@@ -1,28 +1,4 @@
 {
-  "0g-testnet-galileo": {
-    "armProxy": {
-      "address": "0x83eBE7Ceb4916C3Cb86662f65b353E4324390059",
-      "version": "1.5.0"
-    },
-    "chainSelector": "2131427466778448014",
-    "feeTokens": ["LINK", "OG"],
-    "registryModule": {
-      "address": "0xf1C53C1f9d0e5872a454Da43E6dbC93d019325e1",
-      "version": "1.5.0"
-    },
-    "router": {
-      "address": "0x5c21Bb4Bd151Bd6Fa2E6d7d1b63B83485529Cdb4",
-      "version": "1.2.0"
-    },
-    "tokenAdminRegistry": {
-      "address": "0xE75f53017a840d761b44aaa83AAf5cdEb0760733",
-      "version": "1.5.0"
-    },
-    "tokenPoolFactory": {
-      "address": "0xF60CF5EAb0d8249F872056E0F236F58AcF61fF89",
-      "version": "1.5.1"
-    }
-  },
   "abstract-testnet": {
     "armProxy": {
       "address": "0xDcF391514C1ede0B8629A45Da710d3D7228B543C",
@@ -358,30 +334,6 @@
       "version": "1.5.1"
     }
   },
-  "celo-testnet-alfajores": {
-    "armProxy": {
-      "address": "0x7A394C616A7347dc91C40159929e1c9a435cb83A",
-      "version": "1.0.0"
-    },
-    "chainSelector": "3552045678561919002",
-    "feeTokens": ["LINK", "WCELO"],
-    "registryModule": {
-      "address": "0xa8c380Ecd336401Ee896Df33b93F1c76b749C902",
-      "version": "1.5.0"
-    },
-    "router": {
-      "address": "0xb00E95b773528E2Ea724DB06B75113F239D15Dca",
-      "version": "1.2.0"
-    },
-    "tokenAdminRegistry": {
-      "address": "0x5585040bED214fdC60c9cE8c3E8a9c52CE19f4Ea",
-      "version": "1.5.0"
-    },
-    "tokenPoolFactory": {
-      "address": "0xc2e3A3C18ccb634622B57fF119a1C8C7f12e8C0c",
-      "version": "1.5.1"
-    }
-  },
   "core-testnet": {
     "armProxy": {
       "address": "0xF39a1260F4E3345D810e1b8aA569200e1D27A998",
@@ -462,37 +414,13 @@
       "version": "1.5.0"
     }
   },
-  "ethereum-testnet-holesky": {
-    "armProxy": {
-      "address": "0x8607115fd037d4f182b0eBaEC3cF08Df67080d05",
-      "version": "1.5.0"
-    },
-    "chainSelector": "7717148896336251131",
-    "feeTokens": ["LINK", "WETH"],
-    "registryModule": {
-      "address": "0x86fedc5f0b89131A31eBdaa2737EC81acD382264",
-      "version": "1.5.0"
-    },
-    "router": {
-      "address": "0xb9531b46fE8808fB3659e39704953c2B1112DD43",
-      "version": "1.2.0"
-    },
-    "tokenAdminRegistry": {
-      "address": "0x9cC9981c187a79365eAF1880F65DE866eBf039Dc",
-      "version": "1.5.0"
-    },
-    "tokenPoolFactory": {
-      "address": "0xc2e3A3C18ccb634622B57fF119a1C8C7f12e8C0c",
-      "version": "1.5.1"
-    }
-  },
   "ethereum-testnet-holesky-fraxtal-1": {
     "armProxy": {
       "address": "0x9496599d8C12955028E615B26D014c1387E771cb",
       "version": "1.0.0"
     },
     "chainSelector": "8901520481741771655",
-    "feeTokens": ["frxETH", "LINK", "WFRXETH"],
+    "feeTokens": ["LINK", "WFRAX"],
     "registryModule": {
       "address": "0x9F6a9ac622384d0e11E8e018CB0a77B2B81091Ee",
       "version": "1.5.0"
@@ -576,7 +504,7 @@
       "version": "1.0.0"
     },
     "chainSelector": "16015286601757825753",
-    "feeTokens": ["LINK", "WETH"],
+    "feeTokens": ["GHO", "LINK", "WETH"],
     "registryModule": {
       "address": "0xa3c796d480638d7476792230da1E2ADa86e031b0",
       "version": "1.6.0"
@@ -624,7 +552,7 @@
       "version": "1.0.0"
     },
     "chainSelector": "3478487238524512106",
-    "feeTokens": ["LINK", "WETH"],
+    "feeTokens": ["GHO", "LINK", "WETH"],
     "registryModule": {
       "address": "0xaD417c0611dBD225471D31F056b8B6beC1CBC153",
       "version": "1.6.0"
@@ -1018,30 +946,6 @@
       "version": "1.5.1"
     }
   },
-  "ethereum-testnet-sepolia-xlayer-1": {
-    "armProxy": {
-      "address": "0xdE9f213a88F5ef96a99E75c1ff4fD363e9F48762",
-      "version": "1.0.0"
-    },
-    "chainSelector": "2066098519157881736",
-    "feeTokens": ["LINK", "WOKB"],
-    "registryModule": {
-      "address": "0x59b17C30Ec5470499d3DA9Af2B0b24B0Ea3FFC98",
-      "version": "1.5.0"
-    },
-    "router": {
-      "address": "0xc5F5330C4793AF46872a9eC15b76a007A96a4152",
-      "version": "1.2.0"
-    },
-    "tokenAdminRegistry": {
-      "address": "0x5feC18341A1A5C33803633Af79182d7619a2cb63",
-      "version": "1.5.0"
-    },
-    "tokenPoolFactory": {
-      "address": "0x5931822f394baBC2AACF4588E98FC77a9f5aa8C9",
-      "version": "1.5.1"
-    }
-  },
   "ethereum-testnet-sepolia-zksync-1": {
     "armProxy": {
       "address": "0x3DA20FD3D8a8f8c1f1A5fD03648147143608C467",
@@ -1344,7 +1248,7 @@
       "version": "1.0.0"
     },
     "chainSelector": "2217764097022649312",
-    "feeTokens": ["LINK", "WGAS10"],
+    "feeTokens": ["LINK", "WGAS"],
     "registryModule": {
       "address": "0xd54205E00835B63Db005ADEF8d99E4984601ACAf",
       "version": "1.6.0"

--- a/src/config/data/ccip/v1_2_0/testnet/decom.json
+++ b/src/config/data/ccip/v1_2_0/testnet/decom.json
@@ -4,5 +4,17 @@
   },
   "sonic-testnet-blaze": {
     "chainSelector": "3676871237479449268"
+  },
+  "0g-testnet-galileo": {
+    "chainSelector": "2131427466778448014"
+  },
+  "celo-testnet-alfajores": {
+    "chainSelector": "3552045678561919002"
+  },
+  "ethereum-testnet-holesky": {
+    "chainSelector": "7717148896336251131"
+  },
+  "ethereum-testnet-sepolia-xlayer-1": {
+    "chainSelector": "2066098519157881736"
   }
 }

--- a/src/config/data/ccip/v1_2_0/testnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/testnet/lanes.json
@@ -1,17 +1,4 @@
 {
-  "0g-testnet-galileo": {
-    "ethereum-testnet-sepolia": {
-      "offRamp": {
-        "address": "0xe089873F7196734cCa9D73a82B91757E41fE893d",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x53b65b38661be9903aF85C46dBfd3dB6BE89eE1C",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    }
-  },
   "abstract-testnet": {
     "ethereum-testnet-sepolia": {
       "offRamp": {
@@ -417,6 +404,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -513,6 +514,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -565,6 +580,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -599,22 +628,6 @@
         "address": "0x083142Ce4B6494BdD294C6a818b2074C6De65De8",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
       }
     },
     "solana-devnet": {
@@ -987,17 +1000,6 @@
         "version": "1.5.0"
       }
     },
-    "ethereum-testnet-holesky": {
-      "offRamp": {
-        "address": "0x0f0CB292f31CC7b2C2B0B7269990084D0681D50e",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x437F8Dca0255Cf0b703bB9F0D48a19ce6eC34341",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
     "ethereum-testnet-sepolia": {
       "offRamp": {
         "address": "0xB513523aee87f838e78b32d2Bacaaf2e94D9f0f9",
@@ -1048,6 +1050,33 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
+            }
+          }
+        }
+      }
+    },
+    "ethereum-testnet-sepolia-arbitrum-1": {
+      "offRamp": {
+        "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "CCIP-BnM": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "100000000000000000000000",
+              "isEnabled": true,
+              "rate": "167000000000000000000"
+            },
+            "out": {
+              "capacity": "100000000000000000000000",
+              "isEnabled": true,
+              "rate": "167000000000000000000"
             }
           }
         }
@@ -1289,71 +1318,6 @@
       }
     }
   },
-  "celo-testnet-alfajores": {
-    "ethereum-testnet-sepolia": {
-      "offRamp": {
-        "address": "0xF6dB68333D14f6a0c1123cc420ea60980aEDA0Eb",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x68A4f57A499563192C606a898BAf503A43fcDB4D",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        },
-        "CCIP-LnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
-      }
-    },
-    "ethereum-testnet-sepolia-base-1": {
-      "offRamp": {
-        "address": "0xe1991a0Aa9dc7e6A03C1567B0932240044B42B0B",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x0b888FB4530a0CDac4B01A00ac7356e4647033e9",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
-    "ethereum-testnet-sepolia-optimism-1": {
-      "offRamp": {
-        "address": "0x94c0B1caC1d2a447D6f99170d48eb6f5A757c390",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x913c529fd0a1779a47d1Ac4fCe15303A9679E6Bd",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    }
-  },
   "core-testnet": {
     "ethereum-testnet-sepolia": {
       "offRamp": {
@@ -1432,123 +1396,6 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
-            }
-          }
-        }
-      }
-    }
-  },
-  "ethereum-testnet-holesky": {
-    "bsc-testnet": {
-      "offRamp": {
-        "address": "0xE76f8eCA0bb251f342fc89cE9006613a5668184b",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x7939efE4A3259Ee6849E5Da44a44bB43841Cfd99",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
-    "ethereum-testnet-sepolia-arbitrum-1": {
-      "offRamp": {
-        "address": "0xE2B12C0f0AD91583419424894d38D1547Da34C44",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x3c2D56b94F84a61ed3a91904360Eb5e2307D28Ae",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
-    "ethereum-testnet-sepolia-base-1": {
-      "offRamp": {
-        "address": "0xD51b52F612Fe76fb7B41335491cdae148D6eA112",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x515336F1001aBC57Aa9d4a73115fa9451B5b4271",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
-    "ethereum-testnet-sepolia-linea-1": {
-      "offRamp": {
-        "address": "0xF0c08dC0d5Bf2888BeA07159e0630a187a8Aa688",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x9C629759b9676b7a62BC4Da5F4a8D531d740A155",
-        "enforceOutOfOrder": true,
-        "version": "1.5.0"
-      }
-    },
-    "ethereum-testnet-sepolia-mantle-1": {
-      "offRamp": {
-        "address": "0xc925456Fc62563656FDA1Ab21AcB3ec850646CaE",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x456011c47aD4182027273B66087c8a8E8B7bb22b",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
-    "ethereum-testnet-sepolia-scroll-1": {
-      "offRamp": {
-        "address": "0xec4F7939E2A084FdF1a842F428D182f2928e7d56",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x6f59B07261BC04909EF0DD4EbD6b37C0Db5A7026",
-        "enforceOutOfOrder": true,
-        "version": "1.5.0"
-      }
-    },
-    "ink-testnet-sepolia": {
-      "offRamp": {
-        "address": "0xFeDdC16fF86f95525E72EB64A03F0808B79919f7",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x63DB37E5BC7Fde4073426D78b5EB00D66Ead14D1",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
-    "polygon-testnet-amoy": {
-      "offRamp": {
-        "address": "0x9fB7896E3511c83bCACfDc19c97C21b730a42c42",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0xaF984db833d0E8532FBbAa44525FbC9a464Ad9C2",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
-    "polygon-testnet-tatara": {
-      "offRamp": {
-        "address": "0x6dB4DDc3535b7E9cF68bE537212D034f39B5a0fE",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x6842AE14462a55A92d000EcF86975EA161d861f3",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
             }
           }
         }
@@ -1694,17 +1541,6 @@
     }
   },
   "ethereum-testnet-sepolia": {
-    "0g-testnet-galileo": {
-      "offRamp": {
-        "address": "0x6609C7A86A4e06B0a957CcC001a1D7790783139a",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x7A7f18Dbdc62E5348f920691cc17dC7B494d8f1A",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
     "abstract-testnet": {
       "offRamp": {
         "address": "0x172960786b8633CbFaaFAfC71f4378C7822A3297",
@@ -2065,47 +1901,6 @@
               "capacity": "0",
               "isEnabled": false,
               "rate": "0"
-            }
-          }
-        }
-      }
-    },
-    "celo-testnet-alfajores": {
-      "offRamp": {
-        "address": "0x4F146d34Be5E273e576ef158Bd7070eC22708D20",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x1163D1F7D75eEb1C4f4c6912d3cF9642027aFD30",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        },
-        "CCIP-LnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
             }
           }
         }
@@ -2902,33 +2697,6 @@
         }
       }
     },
-    "ethereum-testnet-sepolia-xlayer-1": {
-      "offRamp": {
-        "address": "0xD95e09783Fc5ebEe424c59b33Ee27607F945187D",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0xD49E5238f2B990c487EA287CffD5c1E48C729A16",
-        "enforceOutOfOrder": true,
-        "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-LnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
-      }
-    },
     "ethereum-testnet-sepolia-zksync-1": {
       "offRamp": {
         "address": "0x9f5dC467A5c97068A1c2987486B8b768275627eD",
@@ -3461,22 +3229,6 @@
         "address": "0x46588E7EFab168f94cccAF1a5B19cC22Cdc144e5",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
       }
     },
     "solana-devnet": {
@@ -3878,6 +3630,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -3892,15 +3658,31 @@
         "version": "1.5.0"
       }
     },
-    "ethereum-testnet-holesky": {
+    "bsc-testnet": {
       "offRamp": {
-        "address": "0x24494cBF071C93F486e833eE291d7fE0F5e14564",
-        "version": "1.5.0"
+        "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0xbadA6B820Cf630a9853d6dd590fc90fCcAE8C12e",
+        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
+      },
+      "supportedTokens": {
+        "CCIP-BnM": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "100000000000000000000000",
+              "isEnabled": true,
+              "rate": "167000000000000000000"
+            },
+            "out": {
+              "capacity": "100000000000000000000000",
+              "isEnabled": true,
+              "rate": "167000000000000000000"
+            }
+          }
+        }
       }
     },
     "ethereum-testnet-sepolia": {
@@ -4021,6 +3803,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -4073,6 +3869,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -4096,6 +3906,22 @@
         "address": "0x4127A86e622603696FD4D78f5975f9F62A1f1CD2",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
+      },
+      "supportedTokens": {
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "shibarium-testnet-puppynet": {
@@ -4107,22 +3933,6 @@
         "address": "0x4E96f1b8976a1E275433f31809BE1deB62614C9e",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
       }
     },
     "solana-devnet": {
@@ -4381,28 +4191,6 @@
         }
       }
     },
-    "celo-testnet-alfajores": {
-      "offRamp": {
-        "address": "0xf5811Db4c3eb003096755EfABD0bc81bE1474c03",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0xf0dA140F2AF6a1468F69a3017a6629E100616653",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
-    "ethereum-testnet-holesky": {
-      "offRamp": {
-        "address": "0x696d82B951CB43581485C7028BeA0b5470Dc9195",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0xCB8657f4a64a0a3465AA10c9f7aC11b28Eb3F6F4",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
     "ethereum-testnet-sepolia": {
       "offRamp": {
         "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
@@ -4510,6 +4298,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -4603,6 +4405,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -4648,6 +4464,22 @@
         "address": "0xB388a2401A81ff9f400E0Ef1714F4d7e63520C90",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
+      },
+      "supportedTokens": {
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "shibarium-testnet-puppynet": {
@@ -4659,22 +4491,6 @@
         "address": "0xB887f730E862F6D49A829dB820d040ea4d5B73A6",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
       }
     },
     "solana-devnet": {
@@ -4940,17 +4756,6 @@
     }
   },
   "ethereum-testnet-sepolia-linea-1": {
-    "ethereum-testnet-holesky": {
-      "offRamp": {
-        "address": "0xEf7E0bD2CE0E8dE1b7A3875E710cDdA5267B17d6",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x6955b6a6F33F5f69CBaED4B6b612fbc3726CCf05",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
     "ethereum-testnet-sepolia": {
       "offRamp": {
         "address": "0x0fE4CcA5Edff61f13c1ddF3Badba8319978Be1c3",
@@ -5020,17 +4825,6 @@
     }
   },
   "ethereum-testnet-sepolia-mantle-1": {
-    "ethereum-testnet-holesky": {
-      "offRamp": {
-        "address": "0x6B8758cC7EEdbddBFfbc884d1E56f8b31e6b8457",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x83E662c0774e0331B99A1B2FF89b9c67aF181D1c",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
     "ethereum-testnet-sepolia": {
       "offRamp": {
         "address": "0x4d8193f845Eb3540e0BdA9451296600362E22B15",
@@ -5237,18 +5031,21 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
-      }
-    },
-    "celo-testnet-alfajores": {
-      "offRamp": {
-        "address": "0xC4aE97223eD5E10296a1587a1C5b97D9977F2756",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0xe0aD5783cE2D62da86e3ad6442455C859AE52261",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
       }
     },
     "ethereum-testnet-sepolia": {
@@ -5344,6 +5141,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -5383,6 +5194,20 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
+            }
+          }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -5448,6 +5273,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -5460,22 +5299,6 @@
         "address": "0x7a6C65037005484721BeA2e90DBD50dDF1F7b8D8",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
       }
     },
     "solana-devnet": {
@@ -5632,17 +5455,6 @@
     }
   },
   "ethereum-testnet-sepolia-scroll-1": {
-    "ethereum-testnet-holesky": {
-      "offRamp": {
-        "address": "0x055B3f1971d6d5927334E909777631E9e69302ED",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x2aa5e0e32C2082DE2Ef6530bA0B8Fc9DDDb0B1Fa",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
     "ethereum-testnet-sepolia": {
       "offRamp": {
         "address": "0x87d23dd164D40905462A63e8AC47bFD734111386",
@@ -5816,35 +5628,6 @@
       }
     }
   },
-  "ethereum-testnet-sepolia-xlayer-1": {
-    "ethereum-testnet-sepolia": {
-      "offRamp": {
-        "address": "0x6571CfA0e2ccdC57466C71AcA3B6D1BF1965c4b0",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x546FC6e8ff1F7D7E0264eE44709BC519fCDb07Dc",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-LnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
-      }
-    }
-  },
   "ethereum-testnet-sepolia-zksync-1": {
     "ethereum-testnet-sepolia": {
       "offRamp": {
@@ -5949,17 +5732,6 @@
       },
       "onRamp": {
         "address": "0xD57356C663951CDde47225FDE6f3091237bdf1a5",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      }
-    },
-    "ethereum-testnet-holesky": {
-      "offRamp": {
-        "address": "0x928d6EB7298Be6E758Ba92258c6A6b5b2A932Cf4",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x513e772B9634B43BF21DBB24C3F1D6950724422c",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
       }
@@ -6277,6 +6049,17 @@
         "version": "1.5.0"
       }
     },
+    "bsc-testnet": {
+      "offRamp": {
+        "address": "0x5Dc49Ec54B92F7D493bC8126c0730DA74605cc00",
+        "version": "1.6.0"
+      },
+      "onRamp": {
+        "address": "0x65B023D3D4Ea880B835BF2CDE48B296Ee7157EcE",
+        "enforceOutOfOrder": false,
+        "version": "1.6.0"
+      }
+    },
     "ethereum-testnet-sepolia": {
       "offRamp": {
         "address": "0x5Dc49Ec54B92F7D493bC8126c0730DA74605cc00",
@@ -6537,6 +6320,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -6579,17 +6376,6 @@
             }
           }
         }
-      }
-    },
-    "ethereum-testnet-holesky": {
-      "offRamp": {
-        "address": "0x82a86A62f985B6d0e9Eef04e96cf1632A7a0d800",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0xE22532fEafFE2Fd10ddd75D02bf4A73048fCc871",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
       }
     },
     "ethereum-testnet-sepolia": {
@@ -6656,6 +6442,22 @@
         "address": "0x5b4942F603D039650AD0CfF8Bed0C49Fa6827Ed6",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
+      },
+      "supportedTokens": {
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "ethereum-testnet-sepolia-base-1": {
@@ -6667,6 +6469,22 @@
         "address": "0x82e28024D67F1e7BaF0b76FCf05e684f3aA11F96",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
+      },
+      "supportedTokens": {
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "ethereum-testnet-sepolia-optimism-1": {
@@ -6705,6 +6523,20 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
+            }
+          }
+        },
+        "USDC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -6854,33 +6686,6 @@
         "version": "1.5.0"
       }
     },
-    "ethereum-testnet-holesky": {
-      "offRamp": {
-        "address": "0xfd93B85e556322Ab1694fa84c9CA72b28B866e83",
-        "version": "1.5.0"
-      },
-      "onRamp": {
-        "address": "0x07Bbd058Bb5729AB9876EeFe4FD83bce5fE89Ebc",
-        "enforceOutOfOrder": false,
-        "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
-      }
-    },
     "ethereum-testnet-sepolia": {
       "offRamp": {
         "address": "0xc3c95ccd9059371E826E06B25b8E4Aa2B21df538",
@@ -6965,22 +6770,6 @@
         "address": "0xa869C6FB661a9C0917f302EEfA075A4DC8812457",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
       }
     },
     "ethereum-testnet-sepolia": {
@@ -6992,22 +6781,6 @@
         "address": "0x69fb9813d3843e26A49ecFe167b359f867556cA4",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
       }
     },
     "ethereum-testnet-sepolia-arbitrum-1": {
@@ -7019,22 +6792,6 @@
         "address": "0x86C1B14E073F4047BBeEA89Ed297F58e008b59C8",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
       }
     },
     "ethereum-testnet-sepolia-base-1": {
@@ -7046,22 +6803,6 @@
         "address": "0xa666beB279E52801bCB6E5c9B18B3A3b406e0e8b",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
       }
     },
     "ethereum-testnet-sepolia-optimism-1": {
@@ -7073,22 +6814,6 @@
         "address": "0x4e51a29698Da5d1d49134d03879B66630b62C687",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
-      },
-      "supportedTokens": {
-        "CCIP-BnM": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            },
-            "out": {
-              "capacity": "100000000000000000000000",
-              "isEnabled": true,
-              "rate": "167000000000000000000"
-            }
-          }
-        }
       }
     },
     "solana-devnet": {

--- a/src/config/data/ccip/v1_2_0/testnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/testnet/tokens.json
@@ -111,15 +111,6 @@
       "symbol": "CCIP-BnM",
       "tokenAddress": "0xbFA2ACd33ED6EEc0ed3Cc06bF1ac38d22b36B9e9"
     },
-    "celo-testnet-alfajores": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "CCIP-BnM",
-      "poolAddress": "0x0833975C065e821C84bE70C4935916579b5a0731",
-      "poolType": "burnMint",
-      "symbol": "CCIP-BnM",
-      "tokenAddress": "0x7e503dd1dAF90117A1b79953321043d9E6815C72"
-    },
     "cronos-testnet": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -137,15 +128,6 @@
       "poolType": "burnMint",
       "symbol": "CCIP-BnM",
       "tokenAddress": "0x4A92387cE022FDae06c2e49020be7B24AAB16070"
-    },
-    "ethereum-testnet-holesky": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "CCIP-BnM",
-      "poolAddress": "0xcF8830447D5D7A02f0f5e0406C29FA3B7E27EB57",
-      "poolType": "burnMint",
-      "symbol": "CCIP-BnM",
-      "tokenAddress": "0xdd578844095DB1837A96c353F8f237f6cDC79bED"
     },
     "ethereum-testnet-holesky-fraxtal-1": {
       "allowListEnabled": false,
@@ -390,15 +372,6 @@
       "symbol": "CCIP-BnM",
       "tokenAddress": "0xcab0EF91Bee323d1A617c0a027eE753aFd6997E4"
     },
-    "polygon-testnet-tatara": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "CCIP-BnM",
-      "poolAddress": "0x9116547A104C4Bb2531EacdC5A6695019eea5387",
-      "poolType": "burnMint",
-      "symbol": "CCIP-BnM",
-      "tokenAddress": "0xc3B04ce056D8E44AA43BE1e23D554ef2AA3a9f58"
-    },
     "sei-testnet-atlantic": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -407,15 +380,6 @@
       "poolType": "burnMint",
       "symbol": "CCIP-BnM",
       "tokenAddress": "0x271F22d029c6edFc9469faE189C4F43E457F257C"
-    },
-    "shibarium-testnet-puppynet": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "CCIP-BnM",
-      "poolAddress": "0x694f112E941472c8806b853Db714c29387396FBb",
-      "poolType": "burnMint",
-      "symbol": "CCIP-BnM",
-      "tokenAddress": "0x81249b4bD91A8706eE67a2f422DB82258D4947ad"
     },
     "solana-devnet": {
       "allowListEnabled": false,
@@ -499,15 +463,6 @@
       "poolType": "burnMint",
       "symbol": "clCCIP-LnM",
       "tokenAddress": "0x79a4Fc27f69323660f5Bfc12dEe21c3cC14f5901"
-    },
-    "celo-testnet-alfajores": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "clCCIP-LnM",
-      "poolAddress": "0x049627974516Eb171FD91EdE659a291e17836eD7",
-      "poolType": "burnMint",
-      "symbol": "clCCIP-LnM",
-      "tokenAddress": "0x7F4e739D40E58BBd59dAD388171d18e37B26326f"
     },
     "ethereum-testnet-sepolia": {
       "allowListEnabled": false,
@@ -617,15 +572,6 @@
       "symbol": "clCCIP-LnM",
       "tokenAddress": "0x0298e204F9131d45EEb436D693f32C6eA1190622"
     },
-    "ethereum-testnet-sepolia-xlayer-1": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "clCCIP-LnM",
-      "poolAddress": "0x48d73fcEc510aCED85E7aC288A896AB614C73Af2",
-      "poolType": "burnMint",
-      "symbol": "clCCIP-LnM",
-      "tokenAddress": "0xd70f29744f03F10b7EC2443Bd294B7E62D654c5b"
-    },
     "ethereum-testnet-sepolia-zksync-1": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -672,25 +618,25 @@
       "tokenAddress": "0x30DeCD269277b8094c00B0bacC3aCaF3fF4Da7fB"
     }
   },
-  "frxETH": {
-    "ethereum-testnet-holesky-fraxtal-1": {
+  "GHO": {
+    "ethereum-testnet-sepolia": {
       "allowListEnabled": false,
       "decimals": 18,
-      "name": "Frax Ether",
+      "name": "Gho Token",
       "poolType": "feeTokenOnly",
-      "symbol": "frxETH",
-      "tokenAddress": "0xFC00000000000000000000000000000000000006"
+      "symbol": "GHO",
+      "tokenAddress": "0xc4bF5CbDaBE595361438F8c6a187bDc330539c60"
+    },
+    "ethereum-testnet-sepolia-arbitrum-1": {
+      "allowListEnabled": false,
+      "decimals": 18,
+      "name": "Gho Token",
+      "poolType": "feeTokenOnly",
+      "symbol": "GHO",
+      "tokenAddress": "0xb13Cfa6f8B2Eed2C37fB00fF0c1A59807C585810"
     }
   },
   "LINK": {
-    "0g-testnet-galileo": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "ChainLink Token",
-      "poolType": "feeTokenOnly",
-      "symbol": "LINK",
-      "tokenAddress": "0xd211Bd4ff8fd68C16016C5c7a66b6e10F6227C49"
-    },
     "abstract-testnet": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -811,14 +757,6 @@
       "symbol": "LINK",
       "tokenAddress": "0x84b9B910527Ad5C03A9Ca831909E21e236EA7b06"
     },
-    "celo-testnet-alfajores": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "ChainLink Token",
-      "poolType": "feeTokenOnly",
-      "symbol": "LINK",
-      "tokenAddress": "0x32E08557B14FaD8908025619797221281D439071"
-    },
     "core-testnet": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -850,14 +788,6 @@
       "poolType": "feeTokenOnly",
       "symbol": "LINK",
       "tokenAddress": "0xe5e3a4fF1773d043a387b16Ceb3c91cC49bAFD54"
-    },
-    "ethereum-testnet-holesky": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "ChainLink Token",
-      "poolType": "feeTokenOnly",
-      "symbol": "LINK",
-      "tokenAddress": "0x685cE6742351ae9b618F383883D6d1e0c5A31B4B"
     },
     "ethereum-testnet-holesky-fraxtal-1": {
       "allowListEnabled": false,
@@ -1017,7 +947,7 @@
       "name": "ChainLink Token",
       "poolType": "feeTokenOnly",
       "symbol": "LINK",
-      "tokenAddress": "0x231d45b53C905c3d6201318156BDC725c9c3B9B1"
+      "tokenAddress": "0x7273ebbB21F8D8AcF2bC12E71a08937712E9E40c"
     },
     "ethereum-testnet-sepolia-soneium-1": {
       "allowListEnabled": false,
@@ -1042,14 +972,6 @@
       "poolType": "feeTokenOnly",
       "symbol": "LINK",
       "tokenAddress": "0xC82Ea35634BcE95C394B6BC00626f827bB0F4801"
-    },
-    "ethereum-testnet-sepolia-xlayer-1": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "ChainLink Token",
-      "poolType": "feeTokenOnly",
-      "symbol": "LINK",
-      "tokenAddress": "0x724593f6FCb0De4E6902d4C55D7C74DaA2AF0E55"
     },
     "ethereum-testnet-sepolia-zksync-1": {
       "allowListEnabled": false,
@@ -1308,16 +1230,6 @@
       "tokenAddress": "0xBEDDEB2DF8904cdBCFB6Bf29b91d122D5Ae4eb7e"
     }
   },
-  "OG": {
-    "0g-testnet-galileo": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "Wrapped A0GI",
-      "poolType": "feeTokenOnly",
-      "symbol": "WA0GI",
-      "tokenAddress": "0x1Cd0690fF9a693f5EF2dD976660a8dAFc81A109c"
-    }
-  },
   "syrupUSDC": {
     "ethereum-testnet-sepolia": {
       "allowListEnabled": false,
@@ -1426,7 +1338,7 @@
     "avalanche-fuji-testnet": {
       "allowListEnabled": false,
       "decimals": 6,
-      "name": "USDC",
+      "name": "USD Coin",
       "poolAddress": "0x2f79e049f552E600D5d8118923278Aa0fCD67179",
       "poolType": "usdc",
       "symbol": "USDC",
@@ -1608,16 +1520,6 @@
       "tokenAddress": "0xda5dDd7270381A7C2717aD10D1c0ecB19e3CDFb2"
     }
   },
-  "WCELO": {
-    "celo-testnet-alfajores": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "Wrapped Celo",
-      "poolType": "feeTokenOnly",
-      "symbol": "WCELO",
-      "tokenAddress": "0x99604d0e2EfE7ABFb58BdE565b5330Bb46Ab3Dca"
-    }
-  },
   "WCORE": {
     "core-testnet": {
       "allowListEnabled": false,
@@ -1672,14 +1574,6 @@
       "poolType": "feeTokenOnly",
       "symbol": "WETH",
       "tokenAddress": "0x4200000000000000000000000000000000000006"
-    },
-    "ethereum-testnet-holesky": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "Wrapped Ether",
-      "poolType": "feeTokenOnly",
-      "symbol": "WETH",
-      "tokenAddress": "0x94373a4919B3240D86eA41593D5eBa789FEF3848"
     },
     "ethereum-testnet-holesky-taiko-1": {
       "allowListEnabled": false,
@@ -1938,17 +1832,17 @@
       "tokenAddress": "0x4200000000000000000000000000000000000006"
     }
   },
-  "WFRXETH": {
+  "WFRAX": {
     "ethereum-testnet-holesky-fraxtal-1": {
       "allowListEnabled": false,
       "decimals": 18,
-      "name": "Wrapped Frax Ether",
+      "name": "Frax Ether",
       "poolType": "feeTokenOnly",
-      "symbol": "wfrxETH",
+      "symbol": "frxETH",
       "tokenAddress": "0xFC00000000000000000000000000000000000006"
     }
   },
-  "WGAS10": {
+  "WGAS": {
     "neox-testnet-t4": {
       "allowListEnabled": false,
       "decimals": 18,
@@ -2036,16 +1930,6 @@
       "poolType": "feeTokenOnly",
       "symbol": "WMON",
       "tokenAddress": "0xFb8bf4c1CC7a94c73D209a149eA2AbEa852BC541"
-    }
-  },
-  "WOKB": {
-    "ethereum-testnet-sepolia-xlayer-1": {
-      "allowListEnabled": false,
-      "decimals": 18,
-      "name": "Wrapped OKB",
-      "poolType": "feeTokenOnly",
-      "symbol": "WOKB",
-      "tokenAddress": "0xa7b9C3a116b20bEDDdBE4d90ff97157f67F0bD97"
     }
   },
   "WPHRS": {


### PR DESCRIPTION
This pull request makes several updates to the CCIP configuration files, including both mainnet and testnet data. The changes include the addition and removal of token and chain configurations, updates to contract addresses and versions, as well as corrections to token and chain identifiers. The main themes are: keeping the configuration in sync with the latest deployments, cleaning up deprecated or unsupported chains/tokens, and fixing naming or symbol inconsistencies.

**Mainnet Configuration Updates**

* **Token and Symbol Corrections**
  - Corrected the symbol casing for `WZKCRO` and updated its references in both `chains.json` and `tokens.json` for consistency. [[1]](diffhunk://#diff-597b8d0301be33df45a6b4645e26f73ac96109253548dace4afaf6831828656dL439-R439) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L8552-R8516)
  - Updated the symbol for iLuminary Token from `ILMT` to `iLMT`.
  - Changed the name of `Michi` to lowercase `michi`.

* **Token and Chain Additions/Removals**
  - Added support for the `PAAL` token on Solana mainnet.
  - Removed several token entries for chains that are no longer supported or deprecated, including `ethereum-mainnet-arbitrum-1` for `FHE`, `ronin-mainnet` for `NXPC`, `aptos-mainnet` for `USD1`, `solana-mainnet` for `FUSDLP`, and `shibarium-mainnet` for `WBTC`. [[1]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L1844-L1852) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L3956-L3964) [[3]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L6490-L6498) [[4]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L1956-L1964) [[5]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L7387-L7395)

* **Address and Version Updates**
  - Updated the registry module address and version for the `WMETIS` chain.
  - Updated the `NXPC` token details (name, poolAddress, tokenAddress) on BSC mainnet.

**Testnet Configuration Updates**

* **Chain and Token Removals**
  - Removed several testnet chains and their associated tokens, including `0g-testnet-galileo`, `celo-testnet-alfajores`, `ethereum-testnet-holesky`, and `ethereum-testnet-sepolia-xlayer-1`, as well as related token entries. [[1]](diffhunk://#diff-b401f7649971c54aa2b2ae67a377771d1ece35ae87e9aa8d448c6d442e1cc76eL2-L25) [[2]](diffhunk://#diff-b401f7649971c54aa2b2ae67a377771d1ece35ae87e9aa8d448c6d442e1cc76eL361-L384) [[3]](diffhunk://#diff-b401f7649971c54aa2b2ae67a377771d1ece35ae87e9aa8d448c6d442e1cc76eL465-R423) [[4]](diffhunk://#diff-b401f7649971c54aa2b2ae67a377771d1ece35ae87e9aa8d448c6d442e1cc76eL1021-L1044) [[5]](diffhunk://#diff-c075353384fe1bbb8775ec4d8a4dd025194207d0858b70d148034a20d11a8174L114-L122) [[6]](diffhunk://#diff-c075353384fe1bbb8775ec4d8a4dd025194207d0858b70d148034a20d11a8174L141-L149) [[7]](diffhunk://#diff-c075353384fe1bbb8775ec4d8a4dd025194207d0858b70d148034a20d11a8174L393-L401) [[8]](diffhunk://#diff-c075353384fe1bbb8775ec4d8a4dd025194207d0858b70d148034a20d11a8174L411-L419) [[9]](diffhunk://#diff-c075353384fe1bbb8775ec4d8a4dd025194207d0858b70d148034a20d11a8174L503-L511) [[10]](diffhunk://#diff-c075353384fe1bbb8775ec4d8a4dd025194207d0858b70d148034a20d11a8174L620-L628) [[11]](diffhunk://#diff-c075353384fe1bbb8775ec4d8a4dd025194207d0858b70d148034a20d11a8174L814-L821)

* **Fee Token and Naming Updates**
  - Updated fee tokens for several testnets, such as replacing `frxETH` and `WFRXETH` with `WFRAX` for `ethereum-testnet-holesky-fraxtal-1`, and adding `GHO` as a fee token for `ethereum-testnet-sepolia` and `ethereum-testnet-sepolia-arbitrum-1`. [[1]](diffhunk://#diff-b401f7649971c54aa2b2ae67a377771d1ece35ae87e9aa8d448c6d442e1cc76eL465-R423) [[2]](diffhunk://#diff-b401f7649971c54aa2b2ae67a377771d1ece35ae87e9aa8d448c6d442e1cc76eL579-R507) [[3]](diffhunk://#diff-b401f7649971c54aa2b2ae67a377771d1ece35ae87e9aa8d448c6d442e1cc76eL627-R555) [[4]](diffhunk://#diff-c075353384fe1bbb8775ec4d8a4dd025194207d0858b70d148034a20d11a8174L675-R639)
  - Changed the fee token from `WGAS10` to `WGAS` for `zircuit-testnet`.

* **Decom File Updates**
  - Added chain selectors for several removed testnet chains to the `decom.json` file, likely to track decommissioned networks.

**General Clean-up and Consistency**

* Ensured token and chain identifiers, symbols, and addresses are consistent across all configuration files. [[1]](diffhunk://#diff-597b8d0301be33df45a6b4645e26f73ac96109253548dace4afaf6831828656dL439-R439) [[2]](diffhunk://#diff-54fc0c3b6e2c1d85820449574caddc93c6bb27a4980646f2d06fd53bef954a49L8552-R8516) [[3]](diffhunk://#diff-b401f7649971c54aa2b2ae67a377771d1ece35ae87e9aa8d448c6d442e1cc76eL1347-R1251)

These changes help maintain the accuracy and reliability of the CCIP configuration for both mainnet and testnet environments.