### PR TITLE
refresh dir

### DIFF
--- a/src/config/data/ccip/v1_2_0/mainnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/lanes.json
@@ -32058,20 +32058,6 @@
             }
           }
         },
-        "LINK": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            }
-          }
-        },
         "RETH": {
           "rateLimiterConfig": {
             "in": {
@@ -40503,20 +40489,6 @@
               "capacity": "5000000000",
               "isEnabled": true,
               "rate": "462963"
-            }
-          }
-        },
-        "LINK": {
-          "rateLimiterConfig": {
-            "in": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
-            },
-            "out": {
-              "capacity": "0",
-              "isEnabled": false,
-              "rate": "0"
             }
           }
         },

--- a/src/config/data/ccip/v1_2_0/testnet/lanes.json
+++ b/src/config/data/ccip/v1_2_0/testnet/lanes.json
@@ -308,6 +308,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -347,6 +361,20 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
+            }
+          }
+        },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -457,6 +485,20 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
+            }
+          }
+        },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -606,6 +648,22 @@
         "address": "0xea625b219f9B4e48e7E0E50958ba80192dCc15B9",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
+      },
+      "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "sei-testnet-atlantic": {
@@ -643,13 +701,13 @@
     },
     "wemix-testnet": {
       "offRamp": {
-        "address": "0x15CcAbf0e3484D4872e25b883163D8cB724d4832",
-        "version": "1.5.0"
+        "address": "0x3F1f176e347235858DD6Db905DDBA09Eaf25478a",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x1ff99E67986E83bb5BA34143BaA2735853e5738c",
+        "address": "0xA5D5B0B844c8f11B61F28AC98BBA84dEA9b80953",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -894,13 +952,13 @@
   "bitcoin-testnet-sepolia-bob-1": {
     "ethereum-testnet-sepolia": {
       "offRamp": {
-        "address": "0xF83d81725354e3108d70588f3B660eE2B84d6e1f",
-        "version": "1.5.0"
+        "address": "0x4d8193f845Eb3540e0BdA9451296600362E22B15",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x0d5B74EBdB4DdD0d2070BDc7AE00C3958eB8377F",
+        "address": "0x056A1FAb28562750a54063E37DDc66d506e320d2",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -986,6 +1044,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -1036,6 +1108,20 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
+            }
+          }
+        },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -1118,6 +1204,20 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
+            }
+          }
+        },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         }
@@ -1237,13 +1337,13 @@
     },
     "wemix-testnet": {
       "offRamp": {
-        "address": "0xc985571900DCa62387f93F882AB550472531f5DB",
-        "version": "1.5.0"
+        "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0xbc85704EDb79ea84E9D3C18965F7f6A16B0a0440",
+        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -1712,6 +1812,20 @@
             }
           }
         },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "USDC": {
           "rateLimiterConfig": {
             "in": {
@@ -1839,13 +1953,13 @@
     },
     "bitcoin-testnet-sepolia-bob-1": {
       "offRamp": {
-        "address": "0x043e5e99C2442Dd6acba2836E209Bb746FFD5202",
-        "version": "1.5.0"
+        "address": "0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x98A719473D96480F08bd649D8f9a38707cC10f5E",
+        "address": "0x23a5084Fa78104F3DF11C63Ae59fcac4f6AD9DeE",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -1900,6 +2014,20 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
+            }
+          }
+        },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -2260,6 +2388,20 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
+            }
+          }
+        },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -2723,13 +2865,13 @@
     },
     "ethereum-testnet-sepolia-zksync-1": {
       "offRamp": {
-        "address": "0x9f5dC467A5c97068A1c2987486B8b768275627eD",
-        "version": "1.5.0"
+        "address": "0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0xA2865E4f36760f5fa5c8F958336120f2DF0d974b",
+        "address": "0x23a5084Fa78104F3DF11C63Ae59fcac4f6AD9DeE",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -2840,6 +2982,20 @@
           }
         },
         "syrupUSDT": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "USDC": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -3085,13 +3241,13 @@
     },
     "plume-testnet-sepolia": {
       "offRamp": {
-        "address": "0x8Cf89015f43418DEE1dc80a92b0df427C1dB0C4A",
-        "version": "1.5.0"
+        "address": "0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x95942e480d50cB035bd39D0B19eb230c9479c981",
+        "address": "0x23a5084Fa78104F3DF11C63Ae59fcac4f6AD9DeE",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -3215,6 +3371,22 @@
         "address": "0x20d4d35c78bC4C6DA4F575566095F8Fe6A8f9F42",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
+      },
+      "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "sei-testnet-atlantic": {
@@ -4010,13 +4182,13 @@
     },
     "wemix-testnet": {
       "offRamp": {
-        "address": "0x11d486E92d291704D1E25cDbAeee687237247826",
-        "version": "1.5.0"
+        "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x2F3Daf77A663603826c7750E956b6555DE6f8250",
+        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -4169,6 +4341,20 @@
             }
           }
         },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
         "USDC": {
           "rateLimiterConfig": {
             "in": {
@@ -4223,6 +4409,20 @@
               "rate": "167000000000000000000"
             }
           }
+        },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
         }
       }
     },
@@ -4262,6 +4462,20 @@
               "capacity": "100000000000000000000000",
               "isEnabled": true,
               "rate": "167000000000000000000"
+            }
+          }
+        },
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
             }
           }
         },
@@ -4568,13 +4782,13 @@
     },
     "wemix-testnet": {
       "offRamp": {
-        "address": "0xd6A47F592409F6a13F70a3CB20876986284aC162",
-        "version": "1.5.0"
+        "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0xb44896429367F8b42ad9279813e09D1218B09898",
+        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       }
     },
     "xdai-testnet-chiado": {
@@ -5390,13 +5604,13 @@
     },
     "wemix-testnet": {
       "offRamp": {
-        "address": "0x0FA15Bc42D4999d964CBf0161489Bd392DEE834e",
-        "version": "1.5.0"
+        "address": "0x30D197C6F5bE050D5525dD94d01760FaCdB67e7C",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0xB9Ef21C04d8340b223e9C1d7a09f332609c70300",
+        "address": "0x8F5bED5F7601025b12A97b01584220C12e343986",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -5677,13 +5891,13 @@
   "ethereum-testnet-sepolia-zksync-1": {
     "ethereum-testnet-sepolia": {
       "offRamp": {
-        "address": "0x19Ea9A42cd3682928aF19990dDb3904250D00a1D",
-        "version": "1.5.0"
+        "address": "0xAeD05b8B54c546dDF7d98e991F7Fa4882f414c49",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0xC38536521fde8556351aB7C4D3ea23b64AFbBbab",
+        "address": "0xBAc7BFf8B08358e9d0330020C45774BB87cf2a23",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -5822,6 +6036,20 @@
           }
         },
         "syrupUSDT": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        },
+        "USDC": {
           "rateLimiterConfig": {
             "in": {
               "capacity": "0",
@@ -6269,13 +6497,13 @@
   "plume-testnet-sepolia": {
     "ethereum-testnet-sepolia": {
       "offRamp": {
-        "address": "0x29784Fc3945B31cd166d1486dB5C7765c5D06f44",
-        "version": "1.5.0"
+        "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x17bf6a1fA5d73390Fe47Ea4DF3Bc305d5ABfc7e9",
+        "address": "0x28A025d34c830BF212f5D2357C8DcAB32dD92A20",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -6661,13 +6889,13 @@
     },
     "wemix-testnet": {
       "offRamp": {
-        "address": "0xa85481273f8C112e96ED7476202F06D6131cf069",
-        "version": "1.5.0"
+        "address": "0x056A1FAb28562750a54063E37DDc66d506e320d2",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x7D6c93E49E46cc983a677c283EAb27CbbC94e3C4",
+        "address": "0xF4EbCC2c077d3939434C7Ab0572660c5A45e4df5",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -6752,6 +6980,22 @@
         "address": "0xaE3ccf32f09C181b94d93677cD6defF510ad39db",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
+      },
+      "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     },
     "ethereum-testnet-sepolia": {
@@ -6763,6 +7007,22 @@
         "address": "0x3cBceab6ed072efE90b5c381EFfaccc611857938",
         "enforceOutOfOrder": false,
         "version": "1.5.0"
+      },
+      "supportedTokens": {
+        "LBTC": {
+          "rateLimiterConfig": {
+            "in": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            },
+            "out": {
+              "capacity": "0",
+              "isEnabled": false,
+              "rate": "0"
+            }
+          }
+        }
       }
     }
   },
@@ -7344,13 +7604,13 @@
   "wemix-testnet": {
     "avalanche-fuji-testnet": {
       "offRamp": {
-        "address": "0x60536c757c2BBf72cC68A1933F7e336d03Bb68fe",
-        "version": "1.5.0"
+        "address": "0x995ab3eC29E1660A93cFddAA19C710A1b5afCCc9",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x7802B6804bbE7486229ac6D3519f0057c50b40a9",
+        "address": "0x6D5035E99D19b436814BFBA65065EfFE2DF34726",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -7385,13 +7645,13 @@
     },
     "bsc-testnet": {
       "offRamp": {
-        "address": "0xb858077FbE1E55cD7a9092Eb6d5403e068c14EAf",
-        "version": "1.5.0"
+        "address": "0x995ab3eC29E1660A93cFddAA19C710A1b5afCCc9",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0xd25B8c70CB43022Bdc3aC417E2Cf5159294d95A1",
+        "address": "0x6D5035E99D19b436814BFBA65065EfFE2DF34726",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -7467,13 +7727,13 @@
     },
     "ethereum-testnet-sepolia-arbitrum-1": {
       "offRamp": {
-        "address": "0xB5492C8A71130B486fAD1091Db683584767A3957",
-        "version": "1.5.0"
+        "address": "0x995ab3eC29E1660A93cFddAA19C710A1b5afCCc9",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0xa5Be8C619F61505548992D9820c5c485b030C7B0",
+        "address": "0x6D5035E99D19b436814BFBA65065EfFE2DF34726",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -7508,13 +7768,13 @@
     },
     "ethereum-testnet-sepolia-base-1": {
       "offRamp": {
-        "address": "0x317B5898c4f712A15C27e65a9e421276BCBFEA89",
-        "version": "1.5.0"
+        "address": "0x995ab3eC29E1660A93cFddAA19C710A1b5afCCc9",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x633cD85aCA588E6095cA77e5Ce3655797b704cd5",
+        "address": "0x6D5035E99D19b436814BFBA65065EfFE2DF34726",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       }
     },
     "ethereum-testnet-sepolia-kroma-1": {
@@ -7546,13 +7806,13 @@
     },
     "ethereum-testnet-sepolia-optimism-1": {
       "offRamp": {
-        "address": "0x995Fc17FC12b67f75D3cBf3bC71BD9af65671E78",
-        "version": "1.5.0"
+        "address": "0x995ab3eC29E1660A93cFddAA19C710A1b5afCCc9",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0xB37607C6BD4562F32967dE87D14663D59e3f655d",
+        "address": "0x6D5035E99D19b436814BFBA65065EfFE2DF34726",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {
@@ -7587,13 +7847,13 @@
     },
     "polygon-testnet-amoy": {
       "offRamp": {
-        "address": "0xd7b5B4F8FF7a87cC92f7B3058365862859d9E057",
-        "version": "1.5.0"
+        "address": "0x995ab3eC29E1660A93cFddAA19C710A1b5afCCc9",
+        "version": "1.6.0"
       },
       "onRamp": {
-        "address": "0x0c972752F9aC3255cE45b440f9bBC6500676c4e6",
+        "address": "0x6D5035E99D19b436814BFBA65065EfFE2DF34726",
         "enforceOutOfOrder": false,
-        "version": "1.5.0"
+        "version": "1.6.0"
       },
       "supportedTokens": {
         "CCIP-BnM": {

--- a/src/config/data/ccip/v1_2_0/testnet/tokens.json
+++ b/src/config/data/ccip/v1_2_0/testnet/tokens.json
@@ -636,6 +636,53 @@
       "tokenAddress": "0xb13Cfa6f8B2Eed2C37fB00fF0c1A59807C585810"
     }
   },
+  "LBTC": {
+    "avalanche-fuji-testnet": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "Lombard Staked Bitcoin",
+      "poolAddress": "0x5670d25418Be55c90Df00D2FBF1d66EAa9436A0C",
+      "poolType": "burnMint",
+      "symbol": "LBTC",
+      "tokenAddress": "0x107Fc7d90484534704dD2A9e24c7BD45DB4dD1B5"
+    },
+    "bsc-testnet": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "Lombard Staked Bitcoin",
+      "poolAddress": "0xc82E470433429F6bC2f2eAa8064C262A1EC627BE",
+      "poolType": "burnMint",
+      "symbol": "LBTC",
+      "tokenAddress": "0x107Fc7d90484534704dD2A9e24c7BD45DB4dD1B5"
+    },
+    "ethereum-testnet-sepolia": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "Lombard Staked Bitcoin",
+      "poolAddress": "0x8867A40CfF489f0De05AD61731ca8F2c7c0fEb71",
+      "poolType": "burnMint",
+      "symbol": "LBTC",
+      "tokenAddress": "0x107Fc7d90484534704dD2A9e24c7BD45DB4dD1B5"
+    },
+    "ethereum-testnet-sepolia-base-1": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "Lombard Staked Bitcoin",
+      "poolAddress": "0x5670d25418Be55c90Df00D2FBF1d66EAa9436A0C",
+      "poolType": "burnMint",
+      "symbol": "LBTC",
+      "tokenAddress": "0x107Fc7d90484534704dD2A9e24c7BD45DB4dD1B5"
+    },
+    "polygon-testnet-tatara": {
+      "allowListEnabled": false,
+      "decimals": 8,
+      "name": "LBTC",
+      "poolAddress": "0x258A8De76f64010e6098B4Fd5BD8855280d551A1",
+      "poolType": "burnMint",
+      "symbol": "LBTC",
+      "tokenAddress": "0x107Fc7d90484534704dD2A9e24c7BD45DB4dD1B5"
+    }
+  },
   "LINK": {
     "abstract-testnet": {
       "allowListEnabled": false,
@@ -1396,6 +1443,15 @@
       "poolType": "usdc",
       "symbol": "USDC",
       "tokenAddress": "0x31d0220469e10c4E71834a79b1f276d740d3768F"
+    },
+    "ink-testnet-sepolia": {
+      "allowListEnabled": false,
+      "decimals": 6,
+      "name": "USDC",
+      "poolAddress": "0x85d4CfFC273b0766bFa1402d890c71DF167CC2AD",
+      "poolType": "burnMint",
+      "symbol": "USDC",
+      "tokenAddress": "0xbE57BAC491DE9A260aBB6BA2c9Ad4c5D2Eaea09a"
     },
     "polygon-testnet-amoy": {
       "allowListEnabled": false,


### PR DESCRIPTION
This pull request updates token configuration files for the CCIP v1.2.0 release, primarily adding new token support on testnets and cleaning up mainnet lane configurations. The most notable changes are the addition of the LBTC token to several testnets, the inclusion of USDC on a new testnet, and the removal of unused LINK configurations from mainnet lanes.

**Token additions and configuration updates:**

* Added the LBTC ("Lombard Staked Bitcoin") token configuration to multiple testnets, including Avalanche Fuji, BSC Testnet, Ethereum Sepolia, Ethereum Sepolia Base-1, and Polygon Tatara, with appropriate pool addresses and metadata.
* Added USDC token configuration for the new `ink-testnet-sepolia` testnet, including pool and token addresses.

**Mainnet lane configuration cleanup:**

* Removed the unused LINK token `rateLimiterConfig` entries from the mainnet lanes configuration in `lanes.json`, cleaning up zeroed and disabled configurations. [[1]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L32061-L32074) [[2]](diffhunk://#diff-b164fc5a30b147936f54f068274980bfd2dcbe919ced745997633103fbfb8844L40509-L40522)