### PR TITLE
ci: verify llms-full*.txt files are up-to-date in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -326,5 +326,15 @@ jobs:
             npm ci --prefer-offline --no-audit
           fi
 
+      - name: Regenerate LLM files
+        run: npm run generate:llms
+
+      - name: Check LLM files are up-to-date
+        run: |
+          if ! git diff --exit-code 'src/content/**/llms-full*.txt'; then
+            echo "LLM files are out of date. Run 'npm run generate:llms' and commit the result."
+            exit 1
+          fi
+
       - name: Validate LLM files
         run: npm run check:llms


### PR DESCRIPTION
The pre-commit hook regenerates `llms-full*.txt` files on every commit, but can be bypassed with `--no-verify`. This adds a CI check to the `validate-llms` job that re-runs `generate:llms `and fails if the committed files don't match the generated output, ensuring stale LLM files are always caught before merge.