### PR TITLE
fix(ccip): add tutorial root Overview entries to enable chain-family switching

### DIFF
--- a/src/config/sidebar/__tests__/__snapshots__/ccip-dynamic.test.ts.snap
+++ b/src/config/sidebar/__tests__/__snapshots__/ccip-dynamic.test.ts.snap
@@ -486,6 +486,34 @@ exports[`CCIP Sidebar Configuration Snapshot should match the expected sidebar s
       {
         "chainTypes": [
           "evm",
+        ],
+        "title": "Overview",
+        "url": "ccip/tutorials/evm",
+      },
+      {
+        "chainTypes": [
+          "solana",
+        ],
+        "title": "Overview",
+        "url": "ccip/tutorials/svm",
+      },
+      {
+        "chainTypes": [
+          "aptos",
+        ],
+        "title": "Overview",
+        "url": "ccip/tutorials/aptos",
+      },
+      {
+        "chainTypes": [
+          "ton",
+        ],
+        "title": "Overview",
+        "url": "ccip/tutorials/ton",
+      },
+      {
+        "chainTypes": [
+          "evm",
           "solana",
           "aptos",
         ],

--- a/src/config/sidebar/ccip-dynamic.ts
+++ b/src/config/sidebar/ccip-dynamic.ts
@@ -375,6 +375,26 @@ export const CCIP_SIDEBAR_CONTENT: SectionEntry[] = [
     section: "Tutorials",
     contents: [
       {
+        title: "Overview",
+        url: "ccip/tutorials/evm",
+        chainTypes: ["evm"],
+      },
+      {
+        title: "Overview",
+        url: "ccip/tutorials/svm",
+        chainTypes: ["solana"],
+      },
+      {
+        title: "Overview",
+        url: "ccip/tutorials/aptos",
+        chainTypes: ["aptos"],
+      },
+      {
+        title: "Overview",
+        url: "ccip/tutorials/ton",
+        chainTypes: ["ton"],
+      },
+      {
         title: "Acquire Test Tokens",
         url: "ccip/test-tokens",
         chainTypes: ["evm", "solana", "aptos"],

--- a/src/content/ccip/llms-full.txt
+++ b/src/content/ccip/llms-full.txt
@@ -6992,6 +6992,190 @@ Maintain thorough documentation of multisig operations and provide training for 
 
 ---
 
+# CCIP Tutorials (EVM)
+Source: https://docs.chain.link/ccip/tutorials/evm
+Last Updated: 2025-05-19
+
+You can explore several comprehensive guides to learn about cross-chain interoperability using CCIP. These tutorials provide step-by-step instructions to help you understand different patterns that you can incorporate into your blockchain projects.
+
+## Guides
+
+- [Transfer Tokens](/ccip/tutorials/evm/transfer-tokens-from-contract)
+- [Transfer Tokens with Data](/ccip/tutorials/evm/programmable-token-transfers)
+- [Transfer Tokens with Data - Defensive Example](/ccip/tutorials/evm/programmable-token-transfers-defensive)
+- [Cross-Chain Token (CCT)](/ccip/tutorials/evm/cross-chain-tokens)
+- [Test CCIP Locally](/ccip/tutorials/evm/test-ccip-locally)
+- [Offchain](/ccip/tutorials/offchain)
+- [Transfer USDC with Data](/ccip/tutorials/evm/usdc)
+- [Send Arbitrary Data](/ccip/tutorials/evm/send-arbitrary-data)
+- [Send Arbitrary Data and Receive Transfer Confirmation: A -> B -> A](/ccip/tutorials/evm/send-arbitrary-data-receipt-acknowledgment)
+- [Manual Execution](/ccip/tutorials/evm/manual-execution)
+- [Optimizing Gas Limit Settings in CCIP Messages](/ccip/tutorials/evm/ccipreceive-gaslimit)
+- [Acquire Test Tokens](/ccip/test-tokens)
+
+---
+
+# CCIP Tutorials (SVM)
+Source: https://docs.chain.link/ccip/tutorials/svm
+Last Updated: 2025-08-22
+
+Chainlink CCIP enables secure cross-chain communication between Solana and EVM blockchains. These tutorials will help you implement cross-chain functionality in both directions.
+
+## Getting Started
+
+Before diving into specific implementations, ensure you understand the fundamentals:
+
+- [Prerequisites for SVM to EVM Tutorials](/ccip/tutorials/svm/source/prerequisites) - Set up your development environment for Solana-based CCIP development
+- [Implementing CCIP Receivers](/ccip/tutorials/svm/receivers) - Learn how to build secure Solana programs that can receive cross-chain messages
+
+## Using Solana as a Source Chain
+
+Send messages and tokens from Solana to EVM chains:
+
+- [SVM to EVM Guide](/ccip/tutorials/svm/source) - Comprehensive guide for building all types of CCIP messages from Solana to EVM chains
+- [Token Transfers](/ccip/tutorials/svm/source/token-transfers) - Transfer tokens from Solana to EVM chains without executing code on the destination
+
+## Using Solana as a Destination Chain
+
+Send messages and tokens from EVM chains to Solana:
+
+- [EVM to SVM Guide](/ccip/tutorials/svm/destination) - Comprehensive guide for building all types of CCIP messages from EVM chains to Solana
+- [Token Transfers](/ccip/tutorials/svm/destination/token-transfers) - Transfer tokens from EVM chains to Solana wallets
+- [Arbitrary Messaging](/ccip/tutorials/svm/destination/arbitrary-messaging) - Send data from EVM chains to execute programs on Solana
+
+## Cross-Chain Token (CCT) Standard
+
+Implement cross-chain tokens that can transfer between Solana and EVM chains using different governance approaches:
+
+- [Cross-Chain Token Tutorials](/ccip/tutorials/svm/cross-chain-tokens) - Complete guide to implementing cross-chain tokens with various governance models
+- [Direct Mint Authority Transfer](/ccip/tutorials/svm/cross-chain-tokens/direct-mint-authority) - Simplified approach for development and testing environments
+- [SPL Token Multisig Tutorial](/ccip/tutorials/svm/cross-chain-tokens/spl-token-multisig-tutorial) - Educational multisig concepts for learning governance patterns
+- [Production Multisig Governance](/ccip/tutorials/svm/cross-chain-tokens/production-multisig-tutorial) - Enterprise-grade dual-layer governance for production deployments
+
+## Architecture Reference
+
+Key Differences from EVM:
+
+- **Account Model:** Solana uses an account-based architecture where programs are stateless and all data is stored in accounts
+- **PDAs:** Program Derived Addresses provide deterministic storage for Solana programs
+- **Explicit Access:** Programs can only access accounts explicitly provided to them
+- **Token Accounts:** Each token requires a separate Associated Token Account (ATA)
+
+Message Types:
+
+- **Token Transfers:** Send tokens across chains without program execution
+- **Arbitrary Messaging:** Send data to trigger program execution on the destination chain
+- **Programmable Token Transfers:** Send both tokens and data in a single message to trigger program execution with token transfers
+
+<Aside type="note">
+  These tutorials use the Solana Devnet and Ethereum Sepolia testnet for demonstration purposes. When deploying to
+  production, make sure to thoroughly test your implementation and follow all security best practices.
+</Aside>
+
+---
+
+# CCIP Tutorials (Aptos)
+Source: https://docs.chain.link/ccip/tutorials/aptos
+Last Updated: 2025-09-03
+
+Chainlink CCIP enables secure cross-chain communication between Aptos and EVM blockchains. These tutorials will help you implement cross-chain functionality in both directions.
+
+## Getting Started
+
+Before diving into specific implementations, ensure you understand the fundamentals:
+
+- [Prerequisites for Aptos to EVM Tutorials](/ccip/tutorials/aptos/source/prerequisites) - Set up your development environment for Aptos -> EVM CCIP development.
+- [Prerequisites for EVM to Aptos Tutorials](/ccip/tutorials/aptos/destination/prerequisites) - Set up your development environment for EVM -> Aptos CCIP development.
+
+## Using Aptos as a Source Chain
+
+Send messages and tokens from Aptos to EVM chains:
+
+- [Aptos to EVM Guide](/ccip/tutorials/aptos/source) - Comprehensive guide for building all types of CCIP messages from Aptos to EVM chains.
+- [Token Transfers](/ccip/tutorials/aptos/source/token-transfers) - Transfer tokens from Aptos to EVM chains without executing code on the destination.
+
+## Using Aptos as a Destination Chain
+
+Send messages and tokens from EVM chains to Aptos:
+
+- [EVM to Aptos Guide](/ccip/tutorials/aptos/destination) - Comprehensive guide for building all types of CCIP messages from EVM chains to Aptos.
+- [Token Transfers](/ccip/tutorials/aptos/destination/token-transfers) - Transfer tokens from EVM chains to Aptos wallets.
+  {/* - [Arbitrary Messaging](/ccip/tutorials/aptos/destination/arbitrary-messaging) - Send data from EVM chains to execute programs on Aptos */}
+
+## Architecture Reference
+
+Key Differences from EVM:
+
+- **Account Model:** Aptos uses an account-based model where code (modules) and data (resources) are stored directly within accounts.
+- **Resource Model:** The Move language on Aptos uses a resource model that provides strong ownership and access control, ensuring resources cannot be duplicated or accidentally destroyed.
+- **Explicit Access:** Modules define functions that can explicitly access and modify the resources stored within an account.
+- **Fungible Assets:** Tokens are typically handled via the Fungible Asset standard, where assets are stored as resources within an owner's account.
+
+Message Types:
+
+- **Token Transfers:** Send tokens across chains without program execution.
+- **Arbitrary Messaging:** Send data to trigger program execution on the destination chain.
+- **Programmable Token Transfers:** Send both tokens and data in a single message to trigger program execution with token transfers.
+
+<Aside type="note">
+  These tutorials use the Aptos Testnet and Ethereum Sepolia testnet for demonstration purposes. When deploying to
+  production, make sure to thoroughly test your implementation and follow all security best practices.
+</Aside>
+
+---
+
+# CCIP Tutorials (TON)
+Source: https://docs.chain.link/ccip/tutorials/ton
+Last Updated: 2026-03-29
+
+Chainlink CCIP enables secure cross-chain communication between TON and EVM blockchains. These tutorials will help you implement cross-chain arbitrary messaging in both directions.
+
+## Getting Started
+
+Before diving into specific implementations, ensure you understand the fundamentals:
+
+- [Prerequisites for TON to EVM Tutorials](/ccip/tutorials/ton/source/prerequisites) - Set up your development environment for TON → EVM CCIP development.
+- [Prerequisites for EVM to TON Tutorials](/ccip/tutorials/ton/destination/prerequisites) - Set up your development environment for EVM → TON CCIP development.
+
+## Implementing CCIP Receivers on TON
+
+Before sending any cross-chain message to TON, you need a receiver contract deployed on TON Testnet:
+
+- [Implementing CCIP Receivers](/ccip/tutorials/ton/receivers) - Understand the TON CCIP receiver protocol and deploy a `MessageReceiver`, `MinimalReceiver`, or `ReceiverWithValidateAndConfirm` contract.
+
+## Using TON as a Source Chain
+
+Send messages from TON to EVM chains:
+
+- [TON to EVM Guide](/ccip/tutorials/ton/source) - Guide for building CCIP messages from TON to EVM chains.
+- [Arbitrary Messaging](/ccip/tutorials/ton/source/arbitrary-messaging) - Send a data payload from a TON wallet to a receiver contract on Ethereum Sepolia.
+
+## Using TON as a Destination Chain
+
+Send messages from EVM chains to TON:
+
+- [EVM to TON Guide](/ccip/tutorials/ton/destination) - Guide for building CCIP messages from EVM chains to TON.
+- [Arbitrary Messaging](/ccip/tutorials/ton/destination/arbitrary-messaging) - Send a data payload from Ethereum Sepolia to a receiver contract on TON Testnet.
+
+## Architecture Reference
+
+Key Differences from EVM:
+
+- **Cell-Based Storage:** TON uses a Cell data structure (TL-B format) instead of ABI-encoded byte arrays. All CCIP message fields are serialized into Cells using builder primitives.
+- **Actor Model:** TON contracts communicate by passing messages between actors. CCIP delivery follows a multi-step internal message flow: `Receiver_CCIPReceive` → contract logic → `Router_CCIPReceiveConfirm`.
+- **Tolk Language:** TON smart contracts in the starter kit are written in Tolk, a statically-typed language that compiles to TVM bytecode.
+
+Message Types:
+
+- **Arbitrary Messaging:** Send a data payload to trigger logic execution on the destination chain. Currently the only supported message type on TON CCIP lanes.
+
+<Aside type="note">
+  These tutorials use TON Testnet and Ethereum Sepolia for demonstration purposes. When deploying to production, make
+  sure to thoroughly test your implementation and follow all security best practices.
+</Aside>
+
+---
+
 # CCIP Test Tokens - Faucets for EVM and Solana
 Source: https://docs.chain.link/ccip/test-tokens
 Last Updated: 2025-08-19
@@ -67141,56 +67325,6 @@ Understanding these limits is essential for building reliable cross-chain applic
 
 ---
 
-# CCIP Tutorials (Aptos)
-Source: https://docs.chain.link/ccip/tutorials/aptos
-Last Updated: 2025-09-03
-
-Chainlink CCIP enables secure cross-chain communication between Aptos and EVM blockchains. These tutorials will help you implement cross-chain functionality in both directions.
-
-## Getting Started
-
-Before diving into specific implementations, ensure you understand the fundamentals:
-
-- [Prerequisites for Aptos to EVM Tutorials](/ccip/tutorials/aptos/source/prerequisites) - Set up your development environment for Aptos -> EVM CCIP development.
-- [Prerequisites for EVM to Aptos Tutorials](/ccip/tutorials/aptos/destination/prerequisites) - Set up your development environment for EVM -> Aptos CCIP development.
-
-## Using Aptos as a Source Chain
-
-Send messages and tokens from Aptos to EVM chains:
-
-- [Aptos to EVM Guide](/ccip/tutorials/aptos/source) - Comprehensive guide for building all types of CCIP messages from Aptos to EVM chains.
-- [Token Transfers](/ccip/tutorials/aptos/source/token-transfers) - Transfer tokens from Aptos to EVM chains without executing code on the destination.
-
-## Using Aptos as a Destination Chain
-
-Send messages and tokens from EVM chains to Aptos:
-
-- [EVM to Aptos Guide](/ccip/tutorials/aptos/destination) - Comprehensive guide for building all types of CCIP messages from EVM chains to Aptos.
-- [Token Transfers](/ccip/tutorials/aptos/destination/token-transfers) - Transfer tokens from EVM chains to Aptos wallets.
-  {/* - [Arbitrary Messaging](/ccip/tutorials/aptos/destination/arbitrary-messaging) - Send data from EVM chains to execute programs on Aptos */}
-
-## Architecture Reference
-
-Key Differences from EVM:
-
-- **Account Model:** Aptos uses an account-based model where code (modules) and data (resources) are stored directly within accounts.
-- **Resource Model:** The Move language on Aptos uses a resource model that provides strong ownership and access control, ensuring resources cannot be duplicated or accidentally destroyed.
-- **Explicit Access:** Modules define functions that can explicitly access and modify the resources stored within an account.
-- **Fungible Assets:** Tokens are typically handled via the Fungible Asset standard, where assets are stored as resources within an owner's account.
-
-Message Types:
-
-- **Token Transfers:** Send tokens across chains without program execution.
-- **Arbitrary Messaging:** Send data to trigger program execution on the destination chain.
-- **Programmable Token Transfers:** Send both tokens and data in a single message to trigger program execution with token transfers.
-
-<Aside type="note">
-  These tutorials use the Aptos Testnet and Ethereum Sepolia testnet for demonstration purposes. When deploying to
-  production, make sure to thoroughly test your implementation and follow all security best practices.
-</Aside>
-
----
-
 # Add CCIP Networks for Cross-Chain Token Tutorials (Foundry)
 Source: https://docs.chain.link/ccip/tutorials/evm/cross-chain-tokens/configure-additional-networks-foundry
 Last Updated: 2025-10-30
@@ -68724,29 +68858,6 @@ In the example below, we use a token pool at address `0xeB841acbc25549D4deB6Ed94
 
 ---
 
-# CCIP Tutorials (EVM)
-Source: https://docs.chain.link/ccip/tutorials/evm
-Last Updated: 2025-05-19
-
-You can explore several comprehensive guides to learn about cross-chain interoperability using CCIP. These tutorials provide step-by-step instructions to help you understand different patterns that you can incorporate into your blockchain projects.
-
-## Guides
-
-- [Transfer Tokens](/ccip/tutorials/evm/transfer-tokens-from-contract)
-- [Transfer Tokens with Data](/ccip/tutorials/evm/programmable-token-transfers)
-- [Transfer Tokens with Data - Defensive Example](/ccip/tutorials/evm/programmable-token-transfers-defensive)
-- [Cross-Chain Token (CCT)](/ccip/tutorials/evm/cross-chain-tokens)
-- [Test CCIP Locally](/ccip/tutorials/evm/test-ccip-locally)
-- [Offchain](/ccip/tutorials/offchain)
-- [Transfer USDC with Data](/ccip/tutorials/evm/usdc)
-- [Send Arbitrary Data](/ccip/tutorials/evm/send-arbitrary-data)
-- [Send Arbitrary Data and Receive Transfer Confirmation: A -> B -> A](/ccip/tutorials/evm/send-arbitrary-data-receipt-acknowledgment)
-- [Manual Execution](/ccip/tutorials/evm/manual-execution)
-- [Optimizing Gas Limit Settings in CCIP Messages](/ccip/tutorials/evm/ccipreceive-gaslimit)
-- [Acquire Test Tokens](/ccip/test-tokens)
-
----
-
 # ChainlinkCCIP Tutorials
 Source: https://docs.chain.link/ccip/tutorials
 Last Updated: 2026-03-29
@@ -68761,114 +68872,3 @@ Choose the tutorial section based on your blockchain platform:
 - [SVM Tutorials](/ccip/tutorials/svm) - Tutorials for Solana Virtual Machine chains
 - [Aptos Tutorials](/ccip/tutorials/aptos) - Tutorials for Aptos chain
 - [TON Tutorials](/ccip/tutorials/ton) - Tutorials for the TON blockchain
-
----
-
-# CCIP Tutorials (SVM)
-Source: https://docs.chain.link/ccip/tutorials/svm
-Last Updated: 2025-08-22
-
-Chainlink CCIP enables secure cross-chain communication between Solana and EVM blockchains. These tutorials will help you implement cross-chain functionality in both directions.
-
-## Getting Started
-
-Before diving into specific implementations, ensure you understand the fundamentals:
-
-- [Prerequisites for SVM to EVM Tutorials](/ccip/tutorials/svm/source/prerequisites) - Set up your development environment for Solana-based CCIP development
-- [Implementing CCIP Receivers](/ccip/tutorials/svm/receivers) - Learn how to build secure Solana programs that can receive cross-chain messages
-
-## Using Solana as a Source Chain
-
-Send messages and tokens from Solana to EVM chains:
-
-- [SVM to EVM Guide](/ccip/tutorials/svm/source) - Comprehensive guide for building all types of CCIP messages from Solana to EVM chains
-- [Token Transfers](/ccip/tutorials/svm/source/token-transfers) - Transfer tokens from Solana to EVM chains without executing code on the destination
-
-## Using Solana as a Destination Chain
-
-Send messages and tokens from EVM chains to Solana:
-
-- [EVM to SVM Guide](/ccip/tutorials/svm/destination) - Comprehensive guide for building all types of CCIP messages from EVM chains to Solana
-- [Token Transfers](/ccip/tutorials/svm/destination/token-transfers) - Transfer tokens from EVM chains to Solana wallets
-- [Arbitrary Messaging](/ccip/tutorials/svm/destination/arbitrary-messaging) - Send data from EVM chains to execute programs on Solana
-
-## Cross-Chain Token (CCT) Standard
-
-Implement cross-chain tokens that can transfer between Solana and EVM chains using different governance approaches:
-
-- [Cross-Chain Token Tutorials](/ccip/tutorials/svm/cross-chain-tokens) - Complete guide to implementing cross-chain tokens with various governance models
-- [Direct Mint Authority Transfer](/ccip/tutorials/svm/cross-chain-tokens/direct-mint-authority) - Simplified approach for development and testing environments
-- [SPL Token Multisig Tutorial](/ccip/tutorials/svm/cross-chain-tokens/spl-token-multisig-tutorial) - Educational multisig concepts for learning governance patterns
-- [Production Multisig Governance](/ccip/tutorials/svm/cross-chain-tokens/production-multisig-tutorial) - Enterprise-grade dual-layer governance for production deployments
-
-## Architecture Reference
-
-Key Differences from EVM:
-
-- **Account Model:** Solana uses an account-based architecture where programs are stateless and all data is stored in accounts
-- **PDAs:** Program Derived Addresses provide deterministic storage for Solana programs
-- **Explicit Access:** Programs can only access accounts explicitly provided to them
-- **Token Accounts:** Each token requires a separate Associated Token Account (ATA)
-
-Message Types:
-
-- **Token Transfers:** Send tokens across chains without program execution
-- **Arbitrary Messaging:** Send data to trigger program execution on the destination chain
-- **Programmable Token Transfers:** Send both tokens and data in a single message to trigger program execution with token transfers
-
-<Aside type="note">
-  These tutorials use the Solana Devnet and Ethereum Sepolia testnet for demonstration purposes. When deploying to
-  production, make sure to thoroughly test your implementation and follow all security best practices.
-</Aside>
-
----
-
-# CCIP Tutorials (TON)
-Source: https://docs.chain.link/ccip/tutorials/ton
-Last Updated: 2026-03-29
-
-Chainlink CCIP enables secure cross-chain communication between TON and EVM blockchains. These tutorials will help you implement cross-chain arbitrary messaging in both directions.
-
-## Getting Started
-
-Before diving into specific implementations, ensure you understand the fundamentals:
-
-- [Prerequisites for TON to EVM Tutorials](/ccip/tutorials/ton/source/prerequisites) - Set up your development environment for TON → EVM CCIP development.
-- [Prerequisites for EVM to TON Tutorials](/ccip/tutorials/ton/destination/prerequisites) - Set up your development environment for EVM → TON CCIP development.
-
-## Implementing CCIP Receivers on TON
-
-Before sending any cross-chain message to TON, you need a receiver contract deployed on TON Testnet:
-
-- [Implementing CCIP Receivers](/ccip/tutorials/ton/receivers) - Understand the TON CCIP receiver protocol and deploy a `MessageReceiver`, `MinimalReceiver`, or `ReceiverWithValidateAndConfirm` contract.
-
-## Using TON as a Source Chain
-
-Send messages from TON to EVM chains:
-
-- [TON to EVM Guide](/ccip/tutorials/ton/source) - Guide for building CCIP messages from TON to EVM chains.
-- [Arbitrary Messaging](/ccip/tutorials/ton/source/arbitrary-messaging) - Send a data payload from a TON wallet to a receiver contract on Ethereum Sepolia.
-
-## Using TON as a Destination Chain
-
-Send messages from EVM chains to TON:
-
-- [EVM to TON Guide](/ccip/tutorials/ton/destination) - Guide for building CCIP messages from EVM chains to TON.
-- [Arbitrary Messaging](/ccip/tutorials/ton/destination/arbitrary-messaging) - Send a data payload from Ethereum Sepolia to a receiver contract on TON Testnet.
-
-## Architecture Reference
-
-Key Differences from EVM:
-
-- **Cell-Based Storage:** TON uses a Cell data structure (TL-B format) instead of ABI-encoded byte arrays. All CCIP message fields are serialized into Cells using builder primitives.
-- **Actor Model:** TON contracts communicate by passing messages between actors. CCIP delivery follows a multi-step internal message flow: `Receiver_CCIPReceive` → contract logic → `Router_CCIPReceiveConfirm`.
-- **Tolk Language:** TON smart contracts in the starter kit are written in Tolk, a statically-typed language that compiles to TVM bytecode.
-
-Message Types:
-
-- **Arbitrary Messaging:** Send a data payload to trigger logic execution on the destination chain. Currently the only supported message type on TON CCIP lanes.
-
-<Aside type="note">
-  These tutorials use TON Testnet and Ethereum Sepolia for demonstration purposes. When deploying to production, make
-  sure to thoroughly test your implementation and follow all security best practices.
-</Aside>


### PR DESCRIPTION
Navigating to a tutorial root URL (e.g. `/ccip/tutorials/ton`) and switching the chain-family selector had no effect because those URLs weren't registered in the sidebar config. The navigation utility couldn't find the current page, fell through to the ultimate fallback, and stayed on the same URL.

Adds four `"Overview"` entries at the top of the Tutorials section — one per chain family (`evm`, `solana`, `aptos`, `ton`) — pointing to their respective index pages.