### PR TITLE
docs(ccip/ton): add TON service limits page

### DIFF
--- a/src/config/sidebar/__tests__/__snapshots__/ccip-dynamic.test.ts.snap
+++ b/src/config/sidebar/__tests__/__snapshots__/ccip-dynamic.test.ts.snap
@@ -70,6 +70,13 @@ exports[`CCIP Sidebar Configuration Snapshot should match the expected sidebar s
         "url": "ccip/service-limits/aptos",
       },
       {
+        "chainTypes": [
+          "ton",
+        ],
+        "title": "Service Limits",
+        "url": "ccip/service-limits/ton",
+      },
+      {
         "title": "Service Responsibility",
         "url": "ccip/service-responsibility",
       },

--- a/src/config/sidebar/ccip-dynamic.ts
+++ b/src/config/sidebar/ccip-dynamic.ts
@@ -81,11 +81,11 @@ export const CCIP_SIDEBAR_CONTENT: SectionEntry[] = [
         url: "ccip/service-limits/aptos",
         chainTypes: ["aptos"],
       },
-      // {
-      //   title: "Service Limits",
-      //   url: "ccip/service-limits/ton",
-      //   chainTypes: ["ton"],
-      // },
+      {
+        title: "Service Limits",
+        url: "ccip/service-limits/ton",
+        chainTypes: ["ton"],
+      },
       {
         title: "Service Responsibility",
         url: "ccip/service-responsibility",

--- a/src/content/ccip/llms-full.txt
+++ b/src/content/ccip/llms-full.txt
@@ -768,6 +768,49 @@ These limits apply to messages sent from the Aptos blockchain to an EVM-compatib
 
 ---
 
+# CCIP Service Limits (TON)
+Source: https://docs.chain.link/ccip/service-limits/ton
+Last Updated: 2026-04-13
+
+<Aside type="note" title="Contact for Exception Requests">
+  If you consistently need more gas for your use case, please reach out to your Chainlink Labs point of contact or
+  contact us via this [contact form](https://chain.link/ccip-contact).
+</Aside>
+
+## EVM to TON
+
+These limits apply to messages sent from an EVM-compatible chain to the TON blockchain.
+
+| Item                        | Description                                                                                                                | Limit                 |
+| :-------------------------- | :------------------------------------------------------------------------------------------------------------------------- | :-------------------- |
+| Maximum message data length | The data payload sent within the CCIP message.                                                                             | 30,000 bytes          |
+| Message execution gas limit | The user-specified `gasLimit` (in nanoTON) in `extraArgs` for the execution of the `ccipReceive` function on TON.          | 4,200,000,000 nanoTON |
+| Smart Execution time window | The maximum duration that CCIP will attempt to automatically execute a message on TON before manual execution is required. | 8 hours               |
+| Out of Order execution      | The `allowOutOfOrderExecution` parameter in the `extraArgs` of a CCIP message from an EVM chain.                           | Must be `true`        |
+
+## TON to EVM
+
+These limits apply to messages sent from the TON blockchain to an EVM-compatible chain.
+
+| Item                        | Description                                                                                                                | Limit          |
+| :-------------------------- | :------------------------------------------------------------------------------------------------------------------------- | :------------- |
+| Maximum message data length | The data payload sent within the CCIP message.                                                                             | 30,000 bytes   |
+| Message execution gas limit | The user-specified `gasLimit` in `extraArgs` for the execution of the `ccipReceive` function on the destination EVM chain. | 3,000,000 gas  |
+| Smart Execution time window | The maximum duration for the execution of a CCIP message on the destination EVM chain before manual execution is required. | 8 hours        |
+| Out of Order execution      | The `allowOutOfOrderExecution` parameter in the `extraArgs` of a CCIP message from TON.                                    | Must be `true` |
+
+<Aside type="caution" title="Educational Example Disclaimer">
+  This page includes an educational example to use a Chainlink system, product, or service and is provided to
+  demonstrate how to interact with Chainlink's systems, products, and services to integrate them into your own. This
+  template is provided "AS IS" and "AS AVAILABLE" without warranties of any kind, it has not been audited, and it may be
+  missing key checks or error handling to make the usage of the system, product or service more clear. Do not use the
+  code in this example in a production environment without completing your own audits and application of best practices.
+  Neither Chainlink Labs, the Chainlink Foundation, nor Chainlink node operators are responsible for unintended outputs
+  that are generated due to errors in code.
+</Aside>
+
+---
+
 # CCIP Service Responsibility - Shared Accountability Model
 Source: https://docs.chain.link/ccip/service-responsibility
 Last Updated: 2025-06-27

--- a/src/content/ccip/service-limits/ton.mdx
+++ b/src/content/ccip/service-limits/ton.mdx
@@ -1,0 +1,42 @@
+---
+section: ccip
+date: Last Modified
+title: "CCIP Service Limits (TON)"
+metadata:
+  description: "Explore Chainlink CCIP service limits for the TON blockchain, including message size, gas limits, and execution parameters for EVM-TON lanes."
+  excerpt: "Chainlink CCIP, TON service limits, TON constraints, Message size limits, Cross-chain execution, TON parameters, EVM to TON, TON to EVM"
+  datePublished: "2026-04-13"
+  lastModified: "2026-04-13"
+---
+
+import { Aside } from "@components"
+import CcipCommon from "@features/ccip/CcipCommon.astro"
+
+<Aside type="note" title="Contact for Exception Requests">
+  If you consistently need more gas for your use case, please reach out to your Chainlink Labs point of contact or
+  contact us via this [contact form](https://chain.link/ccip-contact).
+</Aside>
+
+## EVM to TON
+
+These limits apply to messages sent from an EVM-compatible chain to the TON blockchain.
+
+| Item                        | Description                                                                                                                | Limit                 |
+| :-------------------------- | :------------------------------------------------------------------------------------------------------------------------- | :-------------------- |
+| Maximum message data length | The data payload sent within the CCIP message.                                                                             | 30,000 bytes          |
+| Message execution gas limit | The user-specified `gasLimit` (in nanoTON) in `extraArgs` for the execution of the `ccipReceive` function on TON.          | 4,200,000,000 nanoTON |
+| Smart Execution time window | The maximum duration that CCIP will attempt to automatically execute a message on TON before manual execution is required. | 8 hours               |
+| Out of Order execution      | The `allowOutOfOrderExecution` parameter in the `extraArgs` of a CCIP message from an EVM chain.                           | Must be `true`        |
+
+## TON to EVM
+
+These limits apply to messages sent from the TON blockchain to an EVM-compatible chain.
+
+| Item                        | Description                                                                                                                | Limit          |
+| :-------------------------- | :------------------------------------------------------------------------------------------------------------------------- | :------------- |
+| Maximum message data length | The data payload sent within the CCIP message.                                                                             | 30,000 bytes   |
+| Message execution gas limit | The user-specified `gasLimit` in `extraArgs` for the execution of the `ccipReceive` function on the destination EVM chain. | 3,000,000 gas  |
+| Smart Execution time window | The maximum duration for the execution of a CCIP message on the destination EVM chain before manual execution is required. | 8 hours        |
+| Out of Order execution      | The `allowOutOfOrderExecution` parameter in the `extraArgs` of a CCIP message from TON.                                    | Must be `true` |
+
+<CcipCommon callout="educationalDisclaimer" />


### PR DESCRIPTION
Adds `ccip/service-limits/ton.mdx` with EVM→TON and TON→EVM service limits tables