### PR TITLE
adding content for permissioned chains

### DIFF
--- a/src/components/CCIP/Tooltip/chainTooltips.tsx
+++ b/src/components/CCIP/Tooltip/chainTooltips.tsx
@@ -56,6 +56,26 @@ export const CHAIN_TOOLTIPS: Record<string, ChainTooltipConfig> = {
     hoverable: true,
     hideDelay: 300,
   },
+  "memento-mainnet": {
+    content: (
+      <>
+        Memento is a private/permissioned network. Please make sure to understand the implications before proceeding.{" "}
+        <a href="/ccip/service-limits/evm#private--permissioned-network-limitations">Learn More</a>.
+      </>
+    ),
+    hoverable: true,
+    hideDelay: 300,
+  },
+  "nexon-mainnet-henesys": {
+    content: (
+      <>
+        Henesys is a private/permissioned network. Please make sure to understand the implications before proceeding.{" "}
+        <a href="/ccip/service-limits/evm#private--permissioned-network-limitations">Learn More</a>.
+      </>
+    ),
+    hoverable: true,
+    hideDelay: 300,
+  },
 
   // Example: Add more chains as needed
   // "abstract-mainnet": {

--- a/src/content/ccip/concepts/rate-limit-management/overview.mdx
+++ b/src/content/ccip/concepts/rate-limit-management/overview.mdx
@@ -4,11 +4,18 @@ date: Last Modified
 title: "Rate Limit Management Overview"
 ---
 
+import { Aside } from "@components"
+
 CCIP rate limits are an **operator-level control** that apply to token pools used for cross-chain transfers. They are designed to limit the volume of tokens that can move across a specific CCIP lane over time, reducing the blast radius of unexpected behavior and helping manage operational risk.
 
 This documentation is intended for **CCIP operators, token issuers, and administrators** who have been granted permission to manage rate limits on their token pool contracts. Most CCIP users do **not** need to interact with rate limits as part of a standard integration.
 
 Rate limit changes are applied on-chain, take effect immediately, and directly affect user-facing transfer availability.
+
+<Aside type="note" title="Private/Permissioned Networks">
+  When configuring Token Pool Rate Limits (TPRLs) on a private / permissioned network, please make sure to understand
+  the implications before proceeding. [Learn More](/ccip/service-limits/evm#private--permissioned-network-limitations).
+</Aside>
 
 ## What rate limits are
 

--- a/src/content/ccip/llms-full.txt
+++ b/src/content/ccip/llms-full.txt
@@ -696,6 +696,21 @@ Some EVM networks have additional constraints beyond the standard limits above:
 | -------- | ------------------------------------------------- | ------------------------------------------------------------ |
 | HyperEVM | Data availability limitations during RPC downtime | [HyperEVM Service Limits](/ccip/service-limits/evm/hyperevm) |
 
+## Private / Permissioned Network Limitations
+
+Some CCIP integrations are with private / permissioned networks (see list below). CCIP's integration with these networks depends on a single centralized RPC provider rather than a distinct set of local nodes or RPCs utililized by node operators. As a result:
+
+- Transaction data sourced from these networks cannot be independently verified across multiple nodes in the same way as public chains.
+- A compromised RPC provider could manipulate transaction data, up to and including theft of bridged funds.
+- Anomalous or malicious activity on these networks may be harder to detect and alert on, as monitoring infrastructure relies on the same private RPC layer.
+
+Developers and integrators building CCIP integrations on private / permissioned networks should review these constraints carefully and implement additional safeguards appropriate to their application's use case. These include, but not limited to: more conservative token pool rate limits, monitoring of messages and token transfers, and emergency preparedness.
+
+Private / permissioned networks:
+
+- [Memento](/ccip/directory/mainnet/chain/memento-mainnet)
+- [Henesys](/ccip/directory/mainnet/chain/nexon-mainnet-henesys)
+
 ---
 
 # CCIP Service Limits (SVM)
@@ -5226,6 +5241,11 @@ CCIP rate limits are an **operator-level control** that apply to token pools use
 This documentation is intended for **CCIP operators, token issuers, and administrators** who have been granted permission to manage rate limits on their token pool contracts. Most CCIP users do **not** need to interact with rate limits as part of a standard integration.
 
 Rate limit changes are applied on-chain, take effect immediately, and directly affect user-facing transfer availability.
+
+<Aside type="note" title="Private/Permissioned Networks">
+  When configuring Token Pool Rate Limits (TPRLs) on a private / permissioned network, please make sure to understand
+  the implications before proceeding. [Learn More](/ccip/service-limits/evm#private--permissioned-network-limitations).
+</Aside>
 
 ## What rate limits are
 

--- a/src/content/ccip/service-limits/evm.mdx
+++ b/src/content/ccip/service-limits/evm.mdx
@@ -49,3 +49,18 @@ Some EVM networks have additional constraints beyond the standard limits above:
 | Network  | Special Considerations                            | Documentation                                                |
 | -------- | ------------------------------------------------- | ------------------------------------------------------------ |
 | HyperEVM | Data availability limitations during RPC downtime | [HyperEVM Service Limits](/ccip/service-limits/evm/hyperevm) |
+
+## Private / Permissioned Network Limitations
+
+Some CCIP integrations are with private / permissioned networks (see list below). CCIP's integration with these networks depends on a single centralized RPC provider rather than a distinct set of local nodes or RPCs utililized by node operators. As a result:
+
+- Transaction data sourced from these networks cannot be independently verified across multiple nodes in the same way as public chains.
+- A compromised RPC provider could manipulate transaction data, up to and including theft of bridged funds.
+- Anomalous or malicious activity on these networks may be harder to detect and alert on, as monitoring infrastructure relies on the same private RPC layer.
+
+Developers and integrators building CCIP integrations on private / permissioned networks should review these constraints carefully and implement additional safeguards appropriate to their application's use case. These include, but not limited to: more conservative token pool rate limits, monitoring of messages and token transfers, and emergency preparedness.
+
+Private / permissioned networks:
+
+- [Memento](/ccip/directory/mainnet/chain/memento-mainnet)
+- [Henesys](/ccip/directory/mainnet/chain/nexon-mainnet-henesys)


### PR DESCRIPTION
This pull request introduces explicit documentation and UI support for private/permissioned network limitations within CCIP. It adds warnings, tooltips, and detailed documentation to ensure users are aware of the risks and special considerations when interacting with such networks, specifically Memento and Henesys. The changes are grouped into documentation enhancements and UI improvements.

**Documentation enhancements:**

* Added a new section on "Private / Permissioned Network Limitations" to both `service-limits/evm.mdx` and `llms-full.txt`, detailing the risks (such as centralized RPC provider trust, potential for data manipulation, and monitoring limitations) and listing the affected networks (Memento and Henesys). [[1]](diffhunk://#diff-551ef8b2a8c0f8b394e1335009f509d9939683be29e1c52887c48a88fb0a9d69R52-R66) [[2]](diffhunk://#diff-ed4d106f89c9df8a4a70d275aa87d33904784c5107b3018519abd34086e3b101R699-R713)
* Inserted an "Aside" warning in the rate limit management overview documentation (`overview.mdx` and `llms-full.txt`) to alert users about the implications of configuring Token Pool Rate Limits on private/permissioned networks, with a link to the new limitations section. [[1]](diffhunk://#diff-0dd78b130c0aa12ce90aa72aae8518a1140d1fa46c9fb4e000a04799b3970df5R7-R19) [[2]](diffhunk://#diff-ed4d106f89c9df8a4a70d275aa87d33904784c5107b3018519abd34086e3b101R5245-R5249)

**UI improvements:**

* Added new tooltip entries in `chainTooltips.tsx` for the "memento-mainnet" and "nexon-mainnet-henesys" chains, warning users about the private/permissioned nature of these networks and linking to the documentation for further information.