### PR TITLE
Agent improvements

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -80,20 +80,23 @@ export default defineConfig({
         // Exclude redirect source URLs from sitemap to prevent duplicates
         const pathname = new URL(page).pathname
         const cleanPath = pathname.endsWith("/") && pathname !== "/" ? pathname.slice(0, -1) : pathname
-
+        // Keep machine-readable markdown twin URLs in the sitemap
+        // These are explicit crawlable endpoints generated from docs routes
+        const isMarkdownTwin = cleanPath.endsWith(".md")
         // Exclude short format API reference URLs (e.g., /api-reference/v150, /ccip/api-reference/evm/v150)
         // These are aliases for versioned content - we keep only the canonical long format URLs
         const shortVersionPattern = /\/api-reference\/(?:.*\/)?v\d{3,4}(?:\/|$)/
         if (shortVersionPattern.test(cleanPath)) {
           return false
         }
-
         // Exclude canonical URLs that have language-specific variants (from sidebar config)
-        if (canonicalUrlsWithLanguageVariants.has(cleanPath)) {
+        if (!isMarkdownTwin && canonicalUrlsWithLanguageVariants.has(cleanPath)) {
           return false
         }
-
-        return !redirectSources.has(cleanPath)
+        if (!isMarkdownTwin && redirectSources.has(cleanPath)) {
+          return false
+        }
+        return true
       },
       serialize(item) {
         // Remove trailing slash from URLs (except for root)

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,8 @@
         "swagger-ui-dist": "^5.32.5",
         "swagger-ui-react": "^5.32.5",
         "tweetnacl": "^1.0.3",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "@apidevtools/swagger-parser": "^10.1.1",
@@ -37995,9 +37996,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
     "swagger-ui-dist": "^5.32.5",
     "swagger-ui-react": "^5.32.5",
     "tweetnacl": "^1.0.3",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^10.1.1",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,173 +1,200 @@
 # Chainlink Documentation
 
-> Chainlink is the industry-standard oracle platform bringing the capital markets onchain and powering the majority of decentralized finance (DeFi). The Chainlink stack provides the essential data, interoperability, compliance, and privacy standards needed to power advanced blockchain use cases for institutional tokenized assets, lending, payments, stablecoins, and more. Since inventing decentralized oracle networks, Chainlink has enabled tens of trillions in transaction value and now secures the vast majority of DeFi.
-Many of the world’s largest financial services institutions have also adopted Chainlink’s standards and infrastructure, including Swift, Euroclear, Mastercard, Fidelity International, UBS, S&P Dow Jones Indices, FTSE Russell, WisdomTree, ANZ, and top protocols such as Aave, Lido, GMX and many others. Chainlink leverages a novel fee model where offchain and onchain revenue from enterprise adoption is converted to LINK tokens and stored in a strategic [Chainlink Reserve](https://blog.chain.link/chainlink-reserve-strategic-link-reserve/). Learn more at [chain.link](https://chain.link/).
+Use this file as the root navigation index for Chainlink docs.
 
-This document offers simple, clean, and comprehensive resources for developers to learn, experiment, and build with Chainlink.
+For each task:
+
+1. Retrieve the smallest relevant `.md` page first.
+2. Prefer reference, supported networks, directory, billing, service limits, and address pages when they provide complete content. Otherwise use the closest fully rendered documentation page.
+3. Do not rely on memorized addresses, supported networks, router addresses, feed addresses, chain selectors, quotas, or billing details.
+4. Use product-level `llms-full.txt` files only when broad product context is required.
+
+Current defaults:
+
+* Prefer CRE for new multi-step or offchain workflow use cases unless another product is explicitly required.
+* Prefer VRF v2.5 for new randomness integrations.
+* Treat Any API and `/chainlink-nodes/v1/` as legacy unless maintaining an existing integration.
+
 
 ## Core Documentation
-- [Chainlink Docs](https://docs.chain.link/): Main documentation hub for all Chainlink products and services.
+
+* https://docs.chain.link/getting-started/conceptual-overview.md
+* https://docs.chain.link/builders-quick-links.md
+* https://docs.chain.link/oracle-platform/overview.md
+* https://docs.chain.link/oracle-platform/data-standard.md
+* https://docs.chain.link/oracle-platform/interoperability-standard.md
+* https://docs.chain.link/oracle-platform/compliance-standard.md
+* https://docs.chain.link/oracle-platform/privacy-standard.md
+
 
 ## Chainlink Runtime Environment (CRE)
-- [About CRE](https://docs.chain.link/cre/about): Overview of the Chainlink Runtime Environment and its capabilities.
-- [Key Terms and Concepts](https://docs.chain.link/cre/key-terms-and-concepts): Glossary of foundational terms used in CRE.
-- [Service Quotas](https://docs.chain.link/cre/service-quotas): Information about usage limits and quotas.
-- [Support & Feedback](https://docs.chain.link/cre/support-feedback): How to get help and provide feedback.
-- [Release Notes](https://docs.chain.link/cre/release-notes): Version history and updates for CRE.
-- [Overview](https://docs.chain.link/cre/getting-started/overview): Introduction to the CRE development workflow.
-- [Triggers](https://docs.chain.link/cre/workflow-guides/triggers): Configuring and using triggers.
-- [EVM Chain Interactions](https://docs.chain.link/cre/workflow-guides/evm-chain-interactions): Interacting with EVM-compatible chains.
-- [API Interactions](https://docs.chain.link/cre/workflow-guides/api-interactions): Using APIs within CRE workflows.
-- [Secrets](https://docs.chain.link/cre/workflow-guides/secrets): Managing secrets securely within CRE workflows.
-- [Simulating Workflows](https://docs.chain.link/cre/workflow-operations/simulating-workflows): Running simulations of workflows.
-- [Deploying Workflows](https://docs.chain.link/cre/workflow-operations/deploying-workflows): Deploying workflows to the CRE environment.
-- [Activating & Pausing Workflows](https://docs.chain.link/cre/workflow-operations/activating-pausing-workflows): Managing workflow lifecycle states.
-- [Updating Deployed Workflows](https://docs.chain.link/cre/workflow-operations/updating-deployed-workflows): Modifying live workflows.
-- [Deleting Workflows](https://docs.chain.link/cre/workflow-operations/deleting-workflows): Removing workflows from CRE.
-- [Using Multi-sig Wallets](https://docs.chain.link/cre/workflow-operations/using-multisig-wallets): Managing workflow ownership via multi-signature wallets.
-- [Monitoring & Debugging Workflows](https://docs.chain.link/cre/workflow-operations/monitoring-debugging-workflows): Observing and troubleshooting workflows.
-- [Account](https://docs.chain.link/cre/account-organization/account): Managing your CRE account.
-- [Organization](https://docs.chain.link/cre/account-organization/organization): Managing organization-level settings.
-- [Overview](https://docs.chain.link/cre/capabilities/overview): Overview of available capabilities.
-- [Consensus Computing](https://docs.chain.link/cre/concepts/consensus-computing): How consensus computing operates in CRE.
-- [Non-Determinism in Workflows](https://docs.chain.link/cre/concepts/non-determinism-in-workflows): Handling non-deterministic operations.
-- [Time in CRE](https://docs.chain.link/cre/concepts/time): Managing time and scheduling.
-- [Random in CRE](https://docs.chain.link/cre/concepts/random): Using randomness within workflows.
-- [Running a Demo Workflow](https://docs.chain.link/cre/templates/running-a-demo-workflow): Example workflow template for testing and learning.
-- [Project Configuration](https://docs.chain.link/cre/reference/project-configuration): Configuration reference for CRE projects.
-- [CLI Reference](https://docs.chain.link/cre/reference/cli): Full CLI command reference.
-- [SDK Reference](https://docs.chain.link/cre/reference/sdk): SDK reference documentation.
 
+* https://docs.chain.link/cre.md
+* https://docs.chain.link/cre/key-terms.md
+* https://docs.chain.link/cre/service-quotas.md
+* https://docs.chain.link/cre/supported-networks-go.md
+* https://docs.chain.link/cre/supported-networks-ts.md
+* https://docs.chain.link/cre/support-feedback.md
+* https://docs.chain.link/cre/release-notes.md
+
+### Getting Started
+
+* https://docs.chain.link/cre/getting-started/overview.md
+* https://docs.chain.link/cre/getting-started/cli-installation.md
+* https://docs.chain.link/cre/getting-started/before-you-build-go.md
+* https://docs.chain.link/cre/getting-started/before-you-build-ts.md
+* https://docs.chain.link/cre/getting-started/build-with-ai-go.md
+* https://docs.chain.link/cre/getting-started/build-with-ai-ts.md
+
+### Capabilities
+
+* https://docs.chain.link/cre/capabilities.md
+* https://docs.chain.link/cre/capabilities/triggers.md
+* https://docs.chain.link/cre/capabilities/http.md
+* https://docs.chain.link/cre/capabilities/evm-read-write.md
+* https://docs.chain.link/cre/capabilities/confidential-http-go.md
+* https://docs.chain.link/cre/capabilities/confidential-http-ts.md
+
+### Workflow Guides
+
+* https://docs.chain.link/cre/guides/workflow/using-triggers/overview.md
+* https://docs.chain.link/cre/guides/workflow/using-http-client.md
+* https://docs.chain.link/cre/guides/workflow/using-confidential-http-client.md
+* https://docs.chain.link/cre/guides/workflow/using-evm-client/overview-go.md
+* https://docs.chain.link/cre/guides/workflow/using-evm-client/overview-ts.md
+* https://docs.chain.link/cre/guides/workflow/secrets.md
+* https://docs.chain.link/cre/guides/workflow/using-randomness.md
+
+### Operations
+
+* https://docs.chain.link/cre/guides/operations/simulating-workflows.md
+* https://docs.chain.link/cre/guides/operations/deploying-workflows.md
+* https://docs.chain.link/cre/guides/operations/activating-pausing-workflows.md
+* https://docs.chain.link/cre/guides/operations/updating-deployed-workflows.md
+* https://docs.chain.link/cre/guides/operations/deleting-workflows.md
+* https://docs.chain.link/cre/guides/operations/using-multisig-wallets.md
+* https://docs.chain.link/cre/guides/operations/monitoring-workflows.md
+
+### Account & Templates
+
+* https://docs.chain.link/cre/account.md
+* https://docs.chain.link/cre/organization.md
+* https://docs.chain.link/cre/templates.md
+* https://docs.chain.link/cre/templates/running-demo-workflow-go.md
+* https://docs.chain.link/cre/templates/running-demo-workflow-ts.md
+
+### Reference
+
+* https://docs.chain.link/cre/reference/cli.md
+* https://docs.chain.link/cre/reference/project-configuration-go.md
+* https://docs.chain.link/cre/reference/project-configuration-ts.md
+* https://docs.chain.link/cre/reference/sdk/overview-go.md
+* https://docs.chain.link/cre/reference/sdk/overview-ts.md
 
 
 ## Cross-Chain Interoperability Protocol (CCIP)
-- [CCIP Overview](https://docs.chain.link/ccip): Introduction to CCIP and its functionalities.
-- [Getting Started with CCIP](https://docs.chain.link/ccip/getting-started): Step-by-step guide to begin using CCIP.
-- [CCIP API Reference](https://docs.chain.link/ccip/api-reference): Detailed API documentation for CCIP.
-- [CCIP Architecture](https://docs.chain.link/ccip/architecture): Technical architecture and design of CCIP.
-- [CCIP Best Practices](https://docs.chain.link/ccip/best-practices): Recommended practices for implementing CCIP.
-- [CCIP Billing](https://docs.chain.link/ccip/billing): Information on billing and pricing for CCIP services.
-- [CCIP Concepts](https://docs.chain.link/ccip/concepts): Fundamental concepts and components of CCIP.
-- [Cross-Chain Tokens](https://docs.chain.link/ccip/concepts/cross-chain-tokens): Guide on handling cross-chain tokens with CCIP.
-- [CCIP Mainnet Directory](https://docs.chain.link/ccip/directory/mainnet): List of supported networks on mainnet.
-- [CCIP Testnet Directory](https://docs.chain.link/ccip/directory/testnet): List of supported networks on testnet.
-- [CCIP Examples](https://docs.chain.link/ccip/examples): Practical examples demonstrating CCIP usage.
-- [CCIP Release Notes](https://docs.chain.link/ccip/release-notes): Updates and changes in CCIP versions.
-- [Supported Networks - Mainnet](https://docs.chain.link/ccip/supported-networks/v1_2_0/mainnet): Detailed information on mainnet support.
-- [Supported Networks - Testnet](https://docs.chain.link/ccip/supported-networks/v1_2_0/testnet): Detailed information on testnet support.
-- [CCIP Test Tokens](https://docs.chain.link/ccip/test-tokens): Information on test tokens for CCIP.
-- [CCIP Tutorials](https://docs.chain.link/ccip/tutorials): Tutorials for implementing CCIP.
-- [Cross-Chain Tokens Tutorial](https://docs.chain.link/ccip/tutorials/cross-chain-tokens): Tutorial on using cross-chain tokens.
-- [Programmable Token Transfers](https://docs.chain.link/ccip/tutorials/programmable-token-transfers): Guide on programmable token transfers.
-- [Defensive Token Transfers](https://docs.chain.link/ccip/tutorials/programmable-token-transfers-defensive): Implementing defensive token transfers.
-- [Send Arbitrary Data](https://docs.chain.link/ccip/tutorials/send-arbitrary-data): Tutorial on sending arbitrary data across chains.
-- [Transfer Tokens from Contract](https://docs.chain.link/ccip/tutorials/transfer-tokens-from-contract): Guide on transferring tokens from a contract.
-- [USDC Transfer Tutorial](https://docs.chain.link/ccip/tutorials/usdc): Tutorial on transferring USDC using CCIP.
+
+* https://docs.chain.link/ccip.md
+* https://docs.chain.link/ccip/getting-started.md
+* https://docs.chain.link/ccip/getting-started/evm.md
+* https://docs.chain.link/ccip/getting-started/aptos.md
+* https://docs.chain.link/ccip/getting-started/svm.md
+* https://docs.chain.link/ccip/api-reference.md
+* https://docs.chain.link/ccip/concepts.md
+* https://docs.chain.link/ccip/concepts/architecture.md
+
+### Service Data
+
+* https://docs.chain.link/ccip/billing.md
+* https://docs.chain.link/ccip/service-limits.md
+
+### Directories
+
+* https://docs.chain.link/ccip/directory/mainnet.md
+* https://docs.chain.link/ccip/directory/testnet.md
+
+### Tutorials
+
+* https://docs.chain.link/ccip/tutorials.md
+* https://docs.chain.link/ccip/tutorials/evm.md
+* https://docs.chain.link/ccip/tutorials/aptos.md
+* https://docs.chain.link/ccip/tutorials/svm.md
+* https://docs.chain.link/ccip/tutorials/ton.md
 
 ## Data Feeds
-- [Data Feeds Overview](https://docs.chain.link/data-feeds): Introduction to Chainlink Data Feeds.
-- [Data Feeds API Reference](https://docs.chain.link/data-feeds/api-reference): API documentation for Data Feeds.
-- [Developer Responsibilities](https://docs.chain.link/data-feeds/developer-responsibilities): Guidelines for developers using Data Feeds.
-- [Feed Registry](https://docs.chain.link/data-feeds/feed-registry): Information on the Feed Registry.
-- [Feed Registry Functions](https://docs.chain.link/data-feeds/feed-registry/feed-registry-functions): Detailed functions of the Feed Registry.
-- [Getting Started with Data Feeds](https://docs.chain.link/data-feeds/getting-started): Beginner's guide to Data Feeds.
-- [Historical Data](https://docs.chain.link/data-feeds/historical-data): Accessing historical data from Data Feeds.
-- [L2 Sequencer Feeds](https://docs.chain.link/data-feeds/l2-sequencer-feeds): Information on Layer 2 sequencer feeds.
-- [Price Feeds](https://docs.chain.link/data-feeds/price-feeds): Overview of price feeds.
-- [Price Feeds Addresses](https://docs.chain.link/data-feeds/price-feeds/addresses): Addresses for various price feeds.
-- [Proof of Reserve](https://docs.chain.link/data-feeds/proof-of-reserve): Ensuring asset reserves with Chainlink.
-- [Proof of Reserve Addresses](https://docs.chain.link/data-feeds/proof-of-reserve/addresses): Addresses related to Proof of Reserve.
-- [Rates Feeds](https://docs.chain.link/data-feeds/rates-feeds): Information on rates feeds.
-- [Rates Feeds Addresses](https://docs.chain.link/data-feeds/rates-feeds/addresses): Addresses for rates feeds.
-- [Selecting Data Feeds](https://docs.chain.link/data-feeds/selecting-data-feeds): Guide to choosing appropriate data feeds.
-- [SmartData](https://docs.chain.link/data-feeds/smartdata): Introduction to SmartData feeds.
-- [SmartData Addresses](https://docs.chain.link/data-feeds/smartdata/addresses): Addresses for SmartData feeds.
-- [Solana Data Feeds](https://docs.chain.link/data-feeds/solana): Data feeds specific to the Solana blockchain.
-- [Using Data Feeds](https://docs.chain.link/data-feeds/using-data-feeds): Instructions on integrating data feeds.
+
+* https://docs.chain.link/data-feeds.md
+* https://docs.chain.link/data-feeds/getting-started.md
+* https://docs.chain.link/data-feeds/api-reference.md
+* https://docs.chain.link/data-feeds/contract-registry.md
+
+### Addresses
+
+* https://docs.chain.link/data-feeds/price-feeds/addresses.md
+* https://docs.chain.link/data-feeds/rates-feeds/addresses.md
+* https://docs.chain.link/data-feeds/smartdata/addresses.md
+
 
 ## Data Streams
-- [Data Streams Overview](https://docs.chain.link/data-streams): Introduction to Chainlink Data Streams.
-- [Getting Started with Data Streams](https://docs.chain.link/data-streams/getting-started): Beginner's guide to Data Streams.
-- [Data Streams Billing](https://docs.chain.link/data-streams/billing): Billing information for Data Streams.
-- [Stream IDs](https://docs.chain.link/data-streams/stream-ids): Understanding Stream IDs in Data Streams.
+
+* https://docs.chain.link/data-streams.md
+* https://docs.chain.link/data-streams/architecture.md
+* https://docs.chain.link/data-streams/billing.md
+* https://docs.chain.link/data-streams/supported-networks.md
+* https://docs.chain.link/data-streams/reference/data-streams-api.md
+
+
+## DataLink
+
+* https://docs.chain.link/datalink.md
+* https://docs.chain.link/datalink/billing.md
+* https://docs.chain.link/datalink/pull-delivery/overview.md
+* https://docs.chain.link/datalink/pull-delivery/verifier-proxy-addresses.md
+
 
 ## Chainlink Automation
-- [Automation Overview](https://docs.chain.link/chainlink-automation): Introduction to Chainlink Automation.
-- [Getting Started with Automation](https://docs.chain.link/chainlink-automation/overview/getting-started): Guide to begin using Automation.
-- [Automation Economics](https://docs.chain.link/chainlink-automation/overview/automation-economics): Economic aspects of Automation.
-- [Supported Networks for Automation](https://docs.chain.link/chainlink-automation/overview/supported-networks): Networks supported by Automation.
-- [Compatible Contracts](https://docs.chain.link/chainlink-automation/guides/compatible-contracts): Contracts compatible with Automation.
-- [Job Scheduler Guide](https://docs.chain.link/chainlink-automation/guides/job-scheduler): Guide on scheduling jobs with Chainlink Automation.
+
+* https://docs.chain.link/chainlink-automation.md
+* https://docs.chain.link/chainlink-automation/overview/getting-started.md
+* https://docs.chain.link/chainlink-automation/overview/service-limits.md
+* https://docs.chain.link/chainlink-automation/overview/supported-networks.md
+
 
 ## Chainlink Functions
-- [Functions Overview](https://docs.chain.link/chainlink-functions): Introduction to Chainlink Functions.
-- [Getting Started with Functions](https://docs.chain.link/chainlink-functions/getting-started): Beginner's guide to Functions.
-- [Functions Architecture](https://docs.chain.link/chainlink-functions/resources/architecture): Technical architecture of Functions.
-- [Functions Billing](https://docs.chain.link/chainlink-functions/resources/billing): Billing information for Functions.
-- [Supported Networks for Functions](https://docs.chain.link/chainlink-functions/supported-networks): Networks supported by Functions.
-- [API Query Parameters Tutorial](https://docs.chain.link/chainlink-functions/tutorials/api-query-parameters): Tutorial on using API query parameters.
-- [Simple Computation Tutorial](https://docs.chain.link/chainlink-functions/tutorials/simple-computation): Guide on performing simple computations using Chainlink Functions.
+
+* https://docs.chain.link/chainlink-functions.md
+* https://docs.chain.link/chainlink-functions/getting-started.md
+* https://docs.chain.link/chainlink-functions/resources/service-limits.md
+* https://docs.chain.link/chainlink-functions/supported-networks.md
+
 
 ## Verifiable Random Function (VRF)
-- [VRF Overview](https://docs.chain.link/vrf): Introduction to Chainlink VRF.
-- [Getting Started with VRF v2.5](https://docs.chain.link/vrf/v2-5/getting-started): Guide to begin using VRF v2.5.
-- [VRF Billing](https://docs.chain.link/vrf/v2-5/billing): Billing details for VRF.
-- [Migration from VRF v2](https://docs.chain.link/vrf/v2-5/migration-from-v2): Steps to migrate from VRF v2.
-- [VRF Subscription Overview](https://docs.chain.link/vrf/v2-5/overview/subscription): Understanding VRF subscriptions.
-- [Create and Manage Subscriptions](https://docs.chain.link/vrf/v2-5/subscription/create-manage): Managing VRF subscriptions.
-- [Get a Random Number](https://docs.chain.link/vrf/v2-5/subscription/get-a-random-number): Guide to obtaining random numbers.
-- [Supported Networks for VRF](https://docs.chain.link/vrf/v2-5/supported-networks): Networks supported by VRF.
 
-## Architecture
-- [Decentralized Model Architecture](https://docs.chain.link/architecture-overview/architecture-decentralized-model): Overview of the decentralized architecture.
-- [Architecture Overview](https://docs.chain.link/architecture-overview/architecture-overview): General architecture of Chainlink.
-- [Request Model Architecture](https://docs.chain.link/architecture-overview/architecture-request-model): Understanding the request model.
-- [Off-Chain Reporting](https://docs.chain.link/architecture-overview/off-chain-reporting): Details on off-chain reporting mechanisms.
-
-## Chainlink Nodes
-- [Chainlink Nodes Overview](https://docs.chain.link/chainlink-nodes): Introduction to Chainlink nodes and their role.
-- [Configuring Chainlink Nodes](https://docs.chain.link/chainlink-nodes/configuring-nodes): Guide to setting up and configuring a Chainlink node.
-- [All Oracle Jobs](https://docs.chain.link/chainlink-nodes/oracle-jobs/all-jobs): Full list of supported oracle jobs.
-- [All Oracle Tasks](https://docs.chain.link/chainlink-nodes/oracle-jobs/all-tasks): Detailed information on all available oracle tasks.
-- [Node Requirements](https://docs.chain.link/chainlink-nodes/resources/requirements): Hardware and software requirements for running a Chainlink node.
-- [Fulfilling Requests (v1)](https://docs.chain.link/chainlink-nodes/v1/fulfilling-requests): How to fulfill data requests with Chainlink v1 nodes.
-- [Node Configuration (v1)](https://docs.chain.link/chainlink-nodes/v1/node-config): Best practices for configuring v1 nodes.
-- [Running a Chainlink Node (v1)](https://docs.chain.link/chainlink-nodes/v1/running-a-chainlink-node): Step-by-step instructions for operating a v1 Chainlink node.
+* https://docs.chain.link/vrf.md
+* https://docs.chain.link/vrf/v2-5/getting-started.md
+* https://docs.chain.link/vrf/v2-5/billing.md
+* https://docs.chain.link/vrf/v2-5/supported-networks.md
 
 ## Quickstarts
-- [Deploy Your First Contract](https://docs.chain.link/quickstarts/deploy-your-first-contract): Beginner tutorial for deploying your first smart contract.
-- [Foundry Chainlink Toolkit](https://docs.chain.link/quickstarts/foundry-chainlink-toolkit): Quickstart for using Foundry with Chainlink.
-- [Historical Price Feeds API](https://docs.chain.link/quickstarts/historical-price-feeds-api): Using Chainlink APIs for historical price data.
-- [Other Tutorials](https://docs.chain.link/getting-started/other-tutorials): Additional beginner-friendly tutorials.
 
-## Any API
-- [Getting Started with Any API](https://docs.chain.link/any-api/getting-started): Guide to connecting any external API to smart contracts.
-- [Any API Introduction](https://docs.chain.link/any-api/introduction): Overview of Chainlink Any API functionality.
-- [Any API Reference](https://docs.chain.link/any-api/api-reference): Complete API reference for Any API connections.
-- [GET Request Introduction](https://docs.chain.link/any-api/get-request/introduction): Basics of making GET requests.
-- [Single Word Response Examples](https://docs.chain.link/any-api/get-request/examples/single-word-response): Example requests for fetching a single-word API response.
-- [Testnet Oracles](https://docs.chain.link/any-api/testnet-oracles): Available testnet oracles for Any API usage.
+* https://docs.chain.link/quickstarts/deploy-your-first-contract.md
+* https://docs.chain.link/quickstarts/chainlink-hardhat-starter-kit.md
+* https://docs.chain.link/quickstarts/foundry-chainlink-toolkit.md
 
-## Developer Resources
-- [Chainlink Developer Certification](https://dev.chain.link/certification): Earn a certification as a Chainlink developer.
-- [Conceptual Overview](https://docs.chain.link/getting-started/conceptual-overview): High-level introduction to Chainlink.
-- [Acquire LINK Tokens](https://docs.chain.link/resources/acquire-link): How to obtain LINK tokens.
-- [Bridge Risks](https://docs.chain.link/resources/bridge-risks): Risks associated with blockchain bridges.
-- [Create a Chainlinked Project](https://docs.chain.link/resources/create-a-chainlinked-project): Building your first project using Chainlink services.
-- [Developer Communications](https://docs.chain.link/resources/developer-communications): How developers can stay informed and connected.
-- [Fund Your Smart Contract](https://docs.chain.link/resources/fund-your-contract): Guide to funding a contract with LINK.
-- [Hackathon Resources](https://docs.chain.link/resources/hackathon-resources): Resources for participating in Chainlink hackathons.
-- [LINK Token Contracts](https://docs.chain.link/resources/link-token-contracts): Contract addresses for LINK across blockchains.
-- [Network Integration Resources](https://docs.chain.link/resources/network-integration): Tools and information for integrating Chainlink into various networks.
+## Resources
 
-## Utilities
-- [Chainlink Faucets](https://faucets.chain.link/): Get testnet LINK, ETH and other network tokens for development.
-- [PegSwap](https://pegswap.chain.link/): Convert Chainlink tokens (LINK) to be ERC-677 compatible so you can use it with Chainlink oracles.
-- [Chainlink Metrics](https://metrics.chain.link/): Explore key Chainlink metrics, including network usage and ecosystem adoption.
-## Economics
-- [Chainlink Staking](https://staking.chain.link/): Earn rewards and support network security by staking LINK.
+* https://docs.chain.link/resources/getting-help.md
+* https://docs.chain.link/resources/glossary.md
+* https://docs.chain.link/resources/link-token-contracts.md
 
-## Tools
-- [Chainlink Local Development Environment](https://docs.chain.link/chainlink-local): Set up a local Chainlink node environment.
-- [Chainlink Functions Toolkit (NPM)](https://www.npmjs.com/package/@chainlink/functions-toolkit): NPM package for working with Chainlink Functions.
-- [CCIP Tools (GitHub)](https://github.com/smartcontractkit/ccip-tools-ts): TypeScript SDK and CLI for interacting with CCIP.
+## Full Documentation Bundles
+
+* https://docs.chain.link/cre/llms-full-go.txt
+* https://docs.chain.link/cre/llms-full-ts.txt
+* https://docs.chain.link/ccip/llms-full.txt
+* https://docs.chain.link/data-feeds/llms-full.txt
+* https://docs.chain.link/data-streams/llms-full.txt
+* https://docs.chain.link/datalink/llms-full.txt
+* https://docs.chain.link/chainlink-automation/llms-full.txt
+* https://docs.chain.link/chainlink-functions/llms-full.txt
+* https://docs.chain.link/vrf/llms-full.txt

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -19,6 +19,7 @@ interface Props {
   frontmatter: BaseFrontmatter
   headings?: MarkdownHeading[]
 }
+
 const { frontmatter, headings } = Astro.props
 
 const titleHeading: MarkdownHeading = {
@@ -33,9 +34,9 @@ const initialHeadings = [titleHeading].concat(filteredHeadings ?? [])
 const whatsNext = frontmatter.whatsnext
 
 const currentPage = new URL(Astro.request.url).pathname
+const markdownUrl = `${currentPage.replace(/\/$/, "")}.md`
 
 const fileExtension = frontmatter.fileExtension || "mdx"
-
 const baseDirectory = fileExtension === "astro" ? "src/pages" : "src/content"
 
 const currentFile = `${baseDirectory}${currentPage.replace(/\/$/, "")}${
@@ -65,7 +66,11 @@ const howToSteps = initialHeadings
   pageTitle={frontmatter.title}
   howToSteps={howToSteps}
 >
-  <slot name="head-scripts" slot="head-scripts" />
+  <Fragment slot="head-scripts">
+    <link rel="alternate" type="text/markdown" href={markdownUrl} />
+    <slot name="head-scripts" />
+  </Fragment>
+
   <StickyHeader client:media="(max-width: 50em)" {initialHeadings} />
   <DocsNavigation client:load pathname={currentPage} />
   <main>

--- a/src/pages/ace/[...id].md.ts
+++ b/src/pages/ace/[...id].md.ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import yaml from "yaml"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"ace">>>[number]
+}
+
+function normalizeFrontmatterValue(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeFrontmatterValue)
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, normalizeFrontmatterValue(nestedValue)])
+    )
+  }
+
+  return value
+}
+
+function serializeFrontmatter(data: Record<string, unknown>) {
+  const normalized = normalizeFrontmatterValue(data)
+
+  if (!normalized || typeof normalized !== "object" || Object.keys(normalized).length === 0) {
+    return ""
+  }
+
+  return `---\n${yaml.stringify(normalized).trimEnd()}\n---\n\n`
+}
+
+export async function getStaticPaths() {
+  const aceEntries = await getCollection("ace")
+
+  return aceEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/architecture-overview/[...id].md.ts
+++ b/src/pages/architecture-overview/[...id].md.ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import yaml from "yaml"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"architecture-overview">>>[number]
+}
+
+function normalizeFrontmatterValue(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeFrontmatterValue)
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, normalizeFrontmatterValue(nestedValue)])
+    )
+  }
+
+  return value
+}
+
+function serializeFrontmatter(data: Record<string, unknown>) {
+  const normalized = normalizeFrontmatterValue(data)
+
+  if (!normalized || typeof normalized !== "object" || Object.keys(normalized).length === 0) {
+    return ""
+  }
+
+  return `---\n${yaml.stringify(normalized).trimEnd()}\n---\n\n`
+}
+
+export async function getStaticPaths() {
+  const architectureOverviewEntries = await getCollection("architecture-overview")
+
+  return architectureOverviewEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/ccip/[...id].md.ts
+++ b/src/pages/ccip/[...id].md.ts
@@ -1,0 +1,87 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import yaml from "yaml"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"ccip">>>[number]
+}
+
+function normalizeFrontmatterValue(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeFrontmatterValue)
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, normalizeFrontmatterValue(nestedValue)])
+    )
+  }
+
+  return value
+}
+
+function serializeFrontmatter(data: Record<string, unknown>) {
+  const normalized = normalizeFrontmatterValue(data)
+
+  if (!normalized || typeof normalized !== "object" || Object.keys(normalized).length === 0) {
+    return ""
+  }
+
+  return `---\n${yaml.stringify(normalized).trimEnd()}\n---\n\n`
+}
+
+export async function getStaticPaths() {
+  const ccipEntries = await getCollection("ccip")
+  const pathMap = new Map()
+
+  for (const entry of ccipEntries) {
+    const urlPath = entry.id.replace(/\.(md|mdx)$/, "")
+
+    if (urlPath.startsWith("directory/") || urlPath.startsWith("tutorials/")) {
+      continue
+    }
+
+    if (urlPath.includes("/api-reference/") && urlPath.includes("/v")) {
+      const parts = urlPath.split("/")
+      const versionIndex = parts.findIndex((part) => part.startsWith("v") && /^v\d+$/.test(part))
+
+      if (versionIndex !== -1) {
+        const versionPart = parts[versionIndex]
+
+        if (versionPart.length === 4) {
+          const formattedVersion = `v${versionPart[1]}.${versionPart[2]}.${versionPart[3]}`
+          parts[versionIndex] = formattedVersion
+          pathMap.set(parts.join("/"), entry)
+        } else {
+          pathMap.set(urlPath, entry)
+        }
+      } else {
+        pathMap.set(urlPath, entry)
+      }
+    } else {
+      pathMap.set(urlPath, entry)
+    }
+  }
+
+  return Array.from(pathMap.entries()).map(([urlPath, entry]) => ({
+    params: { id: urlPath },
+    props: { entry },
+  }))
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/chainlink-automation/[...id].md.ts
+++ b/src/pages/chainlink-automation/[...id].md.ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import yaml from "yaml"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"chainlink-automation">>>[number]
+}
+
+function normalizeFrontmatterValue(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeFrontmatterValue)
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, normalizeFrontmatterValue(nestedValue)])
+    )
+  }
+
+  return value
+}
+
+function serializeFrontmatter(data: Record<string, unknown>) {
+  const normalized = normalizeFrontmatterValue(data)
+
+  if (!normalized || typeof normalized !== "object" || Object.keys(normalized).length === 0) {
+    return ""
+  }
+
+  return `---\n${yaml.stringify(normalized).trimEnd()}\n---\n\n`
+}
+
+export async function getStaticPaths() {
+  const chainlinkAutomationEntries = await getCollection("chainlink-automation")
+
+  return chainlinkAutomationEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/chainlink-functions/[...id].md.ts
+++ b/src/pages/chainlink-functions/[...id].md.ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import yaml from "yaml"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"chainlink-functions">>>[number]
+}
+
+function normalizeFrontmatterValue(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeFrontmatterValue)
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, normalizeFrontmatterValue(nestedValue)])
+    )
+  }
+
+  return value
+}
+
+function serializeFrontmatter(data: Record<string, unknown>) {
+  const normalized = normalizeFrontmatterValue(data)
+
+  if (!normalized || typeof normalized !== "object" || Object.keys(normalized).length === 0) {
+    return ""
+  }
+
+  return `---\n${yaml.stringify(normalized).trimEnd()}\n---\n\n`
+}
+
+export async function getStaticPaths() {
+  const chainlinkFunctionsEntries = await getCollection("chainlink-functions")
+
+  return chainlinkFunctionsEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/chainlink-local/[...id].md.ts
+++ b/src/pages/chainlink-local/[...id].md.ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import yaml from "yaml"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"chainlink-local">>>[number]
+}
+
+function normalizeFrontmatterValue(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeFrontmatterValue)
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, normalizeFrontmatterValue(nestedValue)])
+    )
+  }
+
+  return value
+}
+
+function serializeFrontmatter(data: Record<string, unknown>) {
+  const normalized = normalizeFrontmatterValue(data)
+
+  if (!normalized || typeof normalized !== "object" || Object.keys(normalized).length === 0) {
+    return ""
+  }
+
+  return `---\n${yaml.stringify(normalized).trimEnd()}\n---\n\n`
+}
+
+export async function getStaticPaths() {
+  const chainlinkLocalEntries = await getCollection("chainlink-local")
+
+  return chainlinkLocalEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/chainlink-nodes/[...id].md.ts
+++ b/src/pages/chainlink-nodes/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "~/utils/markdown" // use shared util if you created it
+import { serializeFrontmatter } from "@utils/markdown" // use shared util if you created it
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"chainlink-nodes">>>[number]

--- a/src/pages/chainlink-nodes/[...id].md.ts
+++ b/src/pages/chainlink-nodes/[...id].md.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import { serializeFrontmatter } from "~/utils/markdown" // use shared util if you created it
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"chainlink-nodes">>>[number]
+}
+
+export async function getStaticPaths() {
+  const chainlinkNodesEntries = await getCollection("chainlink-nodes")
+
+  return chainlinkNodesEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/chainlink-nodes/[...id].md.ts
+++ b/src/pages/chainlink-nodes/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "@utils/markdown" // use shared util if you created it
+import { serializeFrontmatter } from "../../utils/markdown" // use shared util if you created it
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"chainlink-nodes">>>[number]

--- a/src/pages/chainlink-nodes/[...id].md.ts
+++ b/src/pages/chainlink-nodes/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "../../utils/markdown" // use shared util if you created it
+import { serializeFrontmatter } from "../../utils/markdown.js" // use shared util if you created it
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"chainlink-nodes">>>[number]

--- a/src/pages/cre-templates/[...id].md.ts
+++ b/src/pages/cre-templates/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "@utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"cre-templates">>>[number]

--- a/src/pages/cre-templates/[...id].md.ts
+++ b/src/pages/cre-templates/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "~/utils/markdown"
+import { serializeFrontmatter } from "@utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"cre-templates">>>[number]

--- a/src/pages/cre-templates/[...id].md.ts
+++ b/src/pages/cre-templates/[...id].md.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import { serializeFrontmatter } from "~/utils/markdown"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"cre-templates">>>[number]
+}
+
+export async function getStaticPaths() {
+  const creTemplatesEntries = await getCollection("cre-templates")
+
+  return creTemplatesEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "").replace(/\/index$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/cre-templates/[...id].md.ts
+++ b/src/pages/cre-templates/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "../../utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown.js"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"cre-templates">>>[number]

--- a/src/pages/cre/[...id].md.ts
+++ b/src/pages/cre/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "~/utils/markdown"
+import { serializeFrontmatter } from "@utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"cre">>>[number]

--- a/src/pages/cre/[...id].md.ts
+++ b/src/pages/cre/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "@utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"cre">>>[number]

--- a/src/pages/cre/[...id].md.ts
+++ b/src/pages/cre/[...id].md.ts
@@ -1,0 +1,74 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import { serializeFrontmatter } from "~/utils/markdown"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"cre">>>[number]
+}
+
+export async function getStaticPaths() {
+  const allEntries = await getCollection("cre")
+  const pagesByPageId = new Map<string, any[]>()
+  const standalonePages: any[] = []
+
+  // Group entries by pageId or treat as standalone
+  for (const entry of allEntries) {
+    if (entry.data.pageId && entry.data.sdkLang) {
+      if (!pagesByPageId.has(entry.data.pageId)) {
+        pagesByPageId.set(entry.data.pageId, [])
+      }
+      pagesByPageId.get(entry.data.pageId)!.push(entry)
+    } else {
+      standalonePages.push(entry)
+    }
+  }
+
+  const paths: Array<{
+    params: { id: string }
+    props: { entry: Awaited<ReturnType<typeof getCollection<"cre">>>[number] }
+  }> = []
+
+  // Create routes only for language-specific pages
+  for (const entries of pagesByPageId.values()) {
+    const goEntry = entries.find((e) => e.data.sdkLang === "go")
+    const tsEntry = entries.find((e) => e.data.sdkLang === "ts")
+
+    if (goEntry) {
+      paths.push({
+        params: { id: goEntry.id.replace(/\.(md|mdx)$/, "") },
+        props: { entry: goEntry },
+      })
+    }
+
+    if (tsEntry) {
+      paths.push({
+        params: { id: tsEntry.id.replace(/\.(md|mdx)$/, "") },
+        props: { entry: tsEntry },
+      })
+    }
+  }
+
+  // Standalone pages
+  standalonePages.forEach((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+    paths.push({
+      params: { id: routeId },
+      props: { entry },
+    })
+  })
+
+  return paths
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/cre/[...id].md.ts
+++ b/src/pages/cre/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "../../utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown.js"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"cre">>>[number]

--- a/src/pages/data-feeds/[...id].md.ts
+++ b/src/pages/data-feeds/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "~/utils/markdown"
+import { serializeFrontmatter } from "@utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"data-feeds">>>[number]

--- a/src/pages/data-feeds/[...id].md.ts
+++ b/src/pages/data-feeds/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "../../utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown.js"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"data-feeds">>>[number]

--- a/src/pages/data-feeds/[...id].md.ts
+++ b/src/pages/data-feeds/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "@utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"data-feeds">>>[number]

--- a/src/pages/data-feeds/[...id].md.ts
+++ b/src/pages/data-feeds/[...id].md.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import { serializeFrontmatter } from "~/utils/markdown"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"data-feeds">>>[number]
+}
+
+export async function getStaticPaths() {
+  const dataFeedsEntries = await getCollection("data-feeds")
+
+  return dataFeedsEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/data-streams/[...id].md.ts
+++ b/src/pages/data-streams/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "../../utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown.js"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"data-streams">>>[number]

--- a/src/pages/data-streams/[...id].md.ts
+++ b/src/pages/data-streams/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "@utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"data-streams">>>[number]

--- a/src/pages/data-streams/[...id].md.ts
+++ b/src/pages/data-streams/[...id].md.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import { serializeFrontmatter } from "~/utils/markdown"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"data-streams">>>[number]
+}
+
+export async function getStaticPaths() {
+  const dataStreamsEntries = await getCollection("data-streams")
+
+  return dataStreamsEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/data-streams/[...id].md.ts
+++ b/src/pages/data-streams/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "~/utils/markdown"
+import { serializeFrontmatter } from "@utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"data-streams">>>[number]

--- a/src/pages/datalink/[...id].md.ts
+++ b/src/pages/datalink/[...id].md.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import { serializeFrontmatter } from "~/utils/markdown"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"datalink">>>[number]
+}
+
+export async function getStaticPaths() {
+  const dataLinkEntries = await getCollection("datalink")
+
+  return dataLinkEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/datalink/[...id].md.ts
+++ b/src/pages/datalink/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "@utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"datalink">>>[number]

--- a/src/pages/datalink/[...id].md.ts
+++ b/src/pages/datalink/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "../../utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown.js"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"datalink">>>[number]

--- a/src/pages/datalink/[...id].md.ts
+++ b/src/pages/datalink/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "~/utils/markdown"
+import { serializeFrontmatter } from "@utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"datalink">>>[number]

--- a/src/pages/dta-technical-standard/[...id].md.ts
+++ b/src/pages/dta-technical-standard/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "../../utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown.js"
 
 type Props = {
   entry: Awaited<ReturnType<typeof getCollection<"dta-technical-standard">>>[number]

--- a/src/pages/dta-technical-standard/[...id].md.ts
+++ b/src/pages/dta-technical-standard/[...id].md.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import { serializeFrontmatter } from "~/utils/markdown"
+
+type Props = {
+  entry: Awaited<ReturnType<typeof getCollection<"dta-technical-standard">>>[number]
+}
+
+export async function getStaticPaths() {
+  const dtaEntries = await getCollection("dta-technical-standard")
+
+  return dtaEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/dta-technical-standard/[...id].md.ts
+++ b/src/pages/dta-technical-standard/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "@utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown"
 
 type Props = {
   entry: Awaited<ReturnType<typeof getCollection<"dta-technical-standard">>>[number]

--- a/src/pages/dta-technical-standard/[...id].md.ts
+++ b/src/pages/dta-technical-standard/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "~/utils/markdown"
+import { serializeFrontmatter } from "@utils/markdown"
 
 type Props = {
   entry: Awaited<ReturnType<typeof getCollection<"dta-technical-standard">>>[number]

--- a/src/pages/getting-started/[...id].md.ts
+++ b/src/pages/getting-started/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "../../utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown.js"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"getting-started">>>[number]

--- a/src/pages/getting-started/[...id].md.ts
+++ b/src/pages/getting-started/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "@utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"getting-started">>>[number]

--- a/src/pages/getting-started/[...id].md.ts
+++ b/src/pages/getting-started/[...id].md.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import { serializeFrontmatter } from "~/utils/markdown"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"getting-started">>>[number]
+}
+
+export async function getStaticPaths() {
+  const gettingStartedEntries = await getCollection("getting-started")
+
+  return gettingStartedEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/getting-started/[...id].md.ts
+++ b/src/pages/getting-started/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "~/utils/markdown"
+import { serializeFrontmatter } from "@utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"getting-started">>>[number]

--- a/src/pages/oracle-platform/[...id].md.ts
+++ b/src/pages/oracle-platform/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "../../utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown.js"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"oracle-platform">>>[number]

--- a/src/pages/oracle-platform/[...id].md.ts
+++ b/src/pages/oracle-platform/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "~/utils/markdown"
+import { serializeFrontmatter } from "@utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"oracle-platform">>>[number]

--- a/src/pages/oracle-platform/[...id].md.ts
+++ b/src/pages/oracle-platform/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "@utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"oracle-platform">>>[number]

--- a/src/pages/oracle-platform/[...id].md.ts
+++ b/src/pages/oracle-platform/[...id].md.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import { serializeFrontmatter } from "~/utils/markdown"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"oracle-platform">>>[number]
+}
+
+export async function getStaticPaths() {
+  const oraclePlatformEntries = await getCollection("oracle-platform")
+
+  return oraclePlatformEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/quickstarts/[...id].md.ts
+++ b/src/pages/quickstarts/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "~/utils/markdown"
+import { serializeFrontmatter } from "@utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"quickstarts">>>[number]

--- a/src/pages/quickstarts/[...id].md.ts
+++ b/src/pages/quickstarts/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "../../utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown.js"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"quickstarts">>>[number]

--- a/src/pages/quickstarts/[...id].md.ts
+++ b/src/pages/quickstarts/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "@utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"quickstarts">>>[number]

--- a/src/pages/quickstarts/[...id].md.ts
+++ b/src/pages/quickstarts/[...id].md.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import { serializeFrontmatter } from "~/utils/markdown"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"quickstarts">>>[number]
+}
+
+export async function getStaticPaths() {
+  const quickstartsEntries = await getCollection("quickstarts")
+
+  return quickstartsEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/resources/[...id].md.ts
+++ b/src/pages/resources/[...id].md.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import { serializeFrontmatter } from "~/utils/markdown"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"resources">>>[number]
+}
+
+export async function getStaticPaths() {
+  const resourcesEntries = await getCollection("resources")
+
+  return resourcesEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/pages/resources/[...id].md.ts
+++ b/src/pages/resources/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "../../utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown.js"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"resources">>>[number]

--- a/src/pages/resources/[...id].md.ts
+++ b/src/pages/resources/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "@utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"resources">>>[number]

--- a/src/pages/resources/[...id].md.ts
+++ b/src/pages/resources/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "~/utils/markdown"
+import { serializeFrontmatter } from "@utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"resources">>>[number]

--- a/src/pages/vrf/[...id].md.ts
+++ b/src/pages/vrf/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "@utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"vrf">>>[number]

--- a/src/pages/vrf/[...id].md.ts
+++ b/src/pages/vrf/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "../../utils/markdown"
+import { serializeFrontmatter } from "../../utils/markdown.js"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"vrf">>>[number]

--- a/src/pages/vrf/[...id].md.ts
+++ b/src/pages/vrf/[...id].md.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro"
 import { getCollection } from "astro:content"
-import { serializeFrontmatter } from "~/utils/markdown"
+import { serializeFrontmatter } from "@utils/markdown"
 
 interface Props {
   entry: Awaited<ReturnType<typeof getCollection<"vrf">>>[number]

--- a/src/pages/vrf/[...id].md.ts
+++ b/src/pages/vrf/[...id].md.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+import { serializeFrontmatter } from "~/utils/markdown"
+
+interface Props {
+  entry: Awaited<ReturnType<typeof getCollection<"vrf">>>[number]
+}
+
+export async function getStaticPaths() {
+  const vrfEntries = await getCollection("vrf")
+
+  return vrfEntries.map((entry) => {
+    const routeId = entry.id.replace(/\.(md|mdx)$/, "")
+
+    return {
+      params: { id: routeId },
+      props: { entry },
+    }
+  })
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { entry } = props as Props
+
+  const frontmatter = serializeFrontmatter(entry.data)
+
+  return new Response(`${frontmatter}${entry.body ?? ""}`, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  })
+}

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,29 @@
+import yaml from "yaml"
+
+export function normalizeFrontmatterValue(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeFrontmatterValue)
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, normalizeFrontmatterValue(nestedValue)])
+    )
+  }
+
+  return value
+}
+
+export function serializeFrontmatter(data: Record<string, unknown>) {
+  const normalized = normalizeFrontmatterValue(data)
+
+  if (!normalized || typeof normalized !== "object" || Object.keys(normalized).length === 0) {
+    return ""
+  }
+
+  return `---\n${yaml.stringify(normalized).trimEnd()}\n---\n\n`
+}


### PR DESCRIPTION
This pull request makes significant improvements to both the sitemap generation logic and the structure and content of the `llms.txt` documentation navigation file. The changes focus on enhancing the accuracy and usability of documentation indexing for both machine and human readers, ensuring that the most relevant, canonical, and up-to-date documentation endpoints are prioritized and that sitemap entries are more precise.

**Sitemap and Documentation Indexing Improvements:**

*Filtering and Inclusion Logic:*
- The sitemap generation in `astro.config.ts` now explicitly includes machine-readable markdown twin URLs (those ending in `.md`), ensuring these important crawlable documentation endpoints are not excluded. It also refines the exclusion logic to avoid filtering out canonical URLs and redirect sources when the page is a markdown twin, improving the accuracy of the sitemap.

**Documentation Navigation Overhaul:**

*Structural and Content Updates:*
- The `llms.txt` file has been completely restructured to serve as a machine-friendly root navigation index for Chainlink documentation. It now provides explicit instructions for task prioritization, default product preferences, and directs both humans and LLMs to the smallest relevant `.md` page first, with a strong preference for canonical, reference, and directory pages.
- The navigation has been reorganized into clear, product-based sections (e.g., CRE, CCIP, Data Feeds, Data Streams, Automation, Functions, VRF), each listing direct `.md` endpoints for core docs, guides, references, and directories. This replaces the previous prose-based, human-oriented link list with a structured, machine-readable format.
- Additional sections for resources, utilities, and full documentation bundles have been added, making it easier for automated systems to locate comprehensive or product-level documentation when needed.
- The file now includes explicit guidance to treat legacy products (such as Any API and `/chainlink-nodes/v1/`) as legacy unless maintaining an existing integration, and to prefer newer products like CRE and VRF v2.5 for new use cases.

These changes collectively improve the reliability and utility of both the sitemap and documentation navigation for developers, automated