### PR TITLE
Data Feeds: ink mainnet + testnet support

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -405,6 +405,14 @@
     {
       "category": "integration",
       "date": "2026-05-12",
+      "description": "Chainlink Data Feeds is available on Ink Mainnet and Ink Sepolia Testnet. View the available price feed information on the [Price Feed Addresses](https://docs.chain.link/data-feeds/price-feeds/addresses?network=ink&page=1) page.",
+      "relatedNetworks": ["ink"],
+      "title": "Data Feeds Expands to Ink Mainnet and Ink Sepolia Testnet",
+      "topic": "Data Feeds"
+    },
+    {
+      "category": "integration",
+      "date": "2026-05-12",
       "description": "Newly supported tokens: BGBTC",
       "relatedTokens": [
         {

--- a/src/features/data/chains.ts
+++ b/src/features/data/chains.ts
@@ -340,6 +340,31 @@ export const CHAINS: Chain[] = [
     ],
   },
   {
+    page: "ink",
+    label: "Ink",
+    title: "Ink Data Feeds",
+    img: "/assets/chains/ink.svg",
+    networkStatusUrl: "https://status.inkonchain.com/",
+    tags: ["default"],
+    supportedFeatures: ["feeds"],
+    networks: [
+      {
+        name: "Ink Mainnet",
+        explorerUrl: "https://explorer.inkonchain.com/address/%s",
+        networkType: "mainnet",
+        rddUrl: "https://reference-data-directory.vercel.app/feeds-ethereum-mainnet-ink-1.json",
+        queryString: "ink-mainnet",
+      },
+      {
+        name: "Ink Sepolia testnet",
+        explorerUrl: "https://explorer-sepolia.inkonchain.com/address/%s",
+        networkType: "testnet",
+        rddUrl: "https://reference-data-directory.vercel.app/feeds-ink-testnet-sepolia.json",
+        queryString: "ink-sepolia",
+      },
+    ],
+  },
+  {
     page: "katana",
     label: "Katana",
     title: "Katana Data Feeds",


### PR DESCRIPTION
This pull request adds support for the Ink blockchain network to the data feeds application. The changes include updating the list of supported chains and networks, as well as adding a new changelog entry to announce the availability of Chainlink Data Feeds on Ink Mainnet and Ink Sepolia Testnet.

**Support for Ink blockchain:**

* Added a new entry for the Ink blockchain in the `CHAINS` array, including configuration for both Ink Mainnet and Ink Sepolia Testnet, with relevant explorer URLs, RDD URLs, and metadata. (`src/features/data/chains.ts`)

**Changelog update:**

* Added a changelog entry announcing that Chainlink Data Feeds are now available on Ink Mainnet and Ink Sepolia Testnet, with a link to the price feed addresses. (`public/changelog.json`)