### PR TITLE
Remove directory rest api from index and sitemap. clarify contacts/programs/modules api refs

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -93,6 +93,11 @@ export default defineConfig({
           return false
         }
 
+        // CCIP directory API v1 interactive page: noindex + omit from sitemap to avoid competing with CCIP Tools REST (v2)
+        if (cleanPath === "/api/ccip/v1/docs") {
+          return false
+        }
+
         return !redirectSources.has(cleanPath)
       },
       serialize(item) {

--- a/postman/ccip-chains-api.json
+++ b/postman/ccip-chains-api.json
@@ -1,7 +1,7 @@
 {
   "info": {
-    "name": "CCIP API",
-    "description": "Collection for testing the Cross-Chain Interoperability Protocol (CCIP) API",
+    "name": "CCIP directory and configuration REST API (v1)",
+    "description": "**Deprecation:** CCIP Directory REST API (v1) is **planned for deprecation soon**; see https://docs.chain.link/ccip/tools/. For CCIP Tools REST API (v2), see https://docs.chain.link/ccip/tools/api/",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [

--- a/public/api/ccip/v1/openapi.json
+++ b/public/api/ccip/v1/openapi.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "CCIP Docs config API",
-    "description": "API for retrieving CCIP chain, token, and lane information.\n\nTo get started quickly, you can download our [Postman Collection](/api/ccip/v1/postman-collection.json) which includes all endpoints and example requests.",
+    "title": "CCIP directory and configuration REST API (v1)",
+    "description": "**Deprecation:** This CCIP Directory and configuration REST API (v1), including `/api/ccip/v1/*` on docs.chain.link, is **planned for deprecation soon**. Timelines and migration guidance will be published in the [CCIP Tools documentation](https://docs.chain.link/ccip/tools/). For new integrations, prefer the [CCIP Tools REST API (v2)](https://docs.chain.link/ccip/tools/api/) where it meets your needs.\n\nREST API for CCIP supported chains, tokens, lanes, and related configuration on docs.chain.link. This is distinct from the CCIP Tools REST API (v2), which covers messages, lane latency, intents, and related tooling (https://docs.chain.link/ccip/tools/api/). For on-chain Solidity, Move, SVM, and TON interfaces, see https://docs.chain.link/ccip/api-reference.\n\nTo get started quickly, you can download our [Postman Collection](/api/ccip/v1/postman-collection.json) which includes all endpoints and example requests.",
     "version": "1.6.0",
     "contact": {
       "name": "File issues",

--- a/public/api/ccip/v1/postman-collection.json
+++ b/public/api/ccip/v1/postman-collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
-    "name": "CCIP API",
-    "description": "Collection for testing the Cross-Chain Interoperability Protocol (CCIP) API. Includes examples for chains, tokens, and lanes across EVM, Solana, and Aptos networks.",
+    "name": "CCIP directory and configuration REST API (v1)",
+    "description": "**Deprecation:** This CCIP Directory and configuration REST API (v1) is **planned for deprecation soon**; see https://docs.chain.link/ccip/tools/ for timelines and migration. Prefer CCIP Tools REST API (v2) for new work where applicable.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [

--- a/public/ccip/llms.txt
+++ b/public/ccip/llms.txt
@@ -49,10 +49,17 @@ Use directory pages only when retrieving current chain, lane, token, or contract
 
 ## Tools and Reference
 
-- [EVM API Reference](https://docs.chain.link/ccip/api-reference.md)
-- [SVM API Reference](https://docs.chain.link/ccip/api-reference/svm.md)
-- [Aptos API Reference](https://docs.chain.link/ccip/api-reference/aptos.md)
-- [TON API Reference](https://docs.chain.link/ccip/api-reference/ton.md)
+On-chain contracts and interfaces:
+
+- [EVM contracts and interfaces reference](https://docs.chain.link/ccip/api-reference.md)
+- [Solana program interfaces reference](https://docs.chain.link/ccip/api-reference/svm.md)
+- [Aptos Move module interfaces reference](https://docs.chain.link/ccip/api-reference/aptos.md)
+- [TON contract interfaces reference](https://docs.chain.link/ccip/api-reference/ton.md)
+
+### CCIP HTTP REST APIs
+
+- **Directory and configuration (v1)** — supported chains, tokens, and lanes: OpenAPI UI at `https://docs.chain.link/api/ccip/v1/docs` and spec at `https://docs.chain.link/api/ccip/v1/openapi.json`. **Planned for deprecation soon**; follow [CCIP Tools](https://docs.chain.link/ccip/tools/) for timelines and migration. Prefer [CCIP Tools API (v2)](https://docs.chain.link/ccip/tools/api/) for new work where applicable.
+- **CCIP Tools (v2)** — messages, lane latency, intents: [CCIP Tools API](https://docs.chain.link/ccip/tools/api/).
 
 ## Live Data
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -88,10 +88,10 @@ Operational Considerations
 - [Service Limits](https://docs.chain.link/ccip/service-limits.md)
 
 Reference
-- [EVM API Reference](https://docs.chain.link/ccip/api-reference/evm.md)
-- [SVM API Reference](https://docs.chain.link/ccip/api-reference/svm.md)
-- [Aptos API Reference](https://docs.chain.link/ccip/api-reference/aptos.md)
-- [TON API Reference](https://docs.chain.link/ccip/api-reference/ton.md)
+- [EVM contracts and interfaces reference](https://docs.chain.link/ccip/api-reference/evm.md)
+- [Solana program interfaces reference](https://docs.chain.link/ccip/api-reference/svm.md)
+- [Aptos Move module interfaces reference](https://docs.chain.link/ccip/api-reference/aptos.md)
+- [TON contract interfaces reference](https://docs.chain.link/ccip/api-reference/ton.md)
 
 
 ## Data Feeds

--- a/src/content/ccip/api-reference/aptos/index.mdx
+++ b/src/content/ccip/api-reference/aptos/index.mdx
@@ -1,9 +1,9 @@
 ---
 section: ccip
 date: Last Modified
-title: "Move Module Interfaces Reference Documentation (Aptos)"
+title: "CCIP Move Module Interfaces Reference Documentation (Aptos)"
 metadata:
-  description: "Complete API reference documentation for Chainlink Cross-Chain Interoperability Protocol (CCIP) on the Aptos blockchain. Includes message structures, router functionality, events, and error handling."
+  description: "On-chain Move module interfaces for Chainlink CCIP on Aptos: messages, router, events, and errors."
 isIndex: true
 ---
 

--- a/src/content/ccip/api-reference/evm/index.mdx
+++ b/src/content/ccip/api-reference/evm/index.mdx
@@ -1,9 +1,9 @@
 ---
 section: ccip
 date: Last Modified
-title: "Solidity Interfaces & Contracts Reference Documentation (EVM)"
+title: "CCIP Solidity Interfaces & Contracts Reference Documentation (EVM)"
 metadata:
-  description: "Complete API reference documentation for Chainlink Cross-Chain Interoperability Protocol (CCIP) on EVM-based blockchains. Includes smart contracts, libraries, and interfaces for cross-chain messaging and token transfers."
+  description: "On-chain Solidity interfaces and contracts for Chainlink CCIP on EVM chains: routers, pools, receivers, and related contracts."
 isIndex: true
 ---
 

--- a/src/content/ccip/api-reference/index.mdx
+++ b/src/content/ccip/api-reference/index.mdx
@@ -1,14 +1,22 @@
 ---
 section: ccip
 date: Last Modified
-title: "CCIP API Reference"
+title: "CCIP contracts and interfaces reference"
 metadata:
-  description: "Complete API reference documentation for Chainlink Cross-Chain Interoperability Protocol (CCIP). Access developer resources for EVM, Solana, and Aptos blockchains."
+  description: "On-chain reference for Chainlink CCIP: EVM, Solana, Aptos, and TON contracts and interfaces for cross-chain messaging and token transfers."
 isIndex: true
 ---
 
 Chainlink Cross-Chain Interoperability Protocol (CCIP) provides secure cross-chain messaging and token transfers between blockchain networks.
 
-- **[EVM-based Blockchains](/ccip/api-reference/evm)**: Complete API reference for CCIP on Ethereum Virtual Machine (EVM) compatible blockchains.
-- **[Solana](/ccip/api-reference/svm)**: Complete API reference for CCIP on Solana.
-- **[Aptos Blockchain](/ccip/api-reference/aptos)**: Complete API reference for CCIP on the Aptos blockchain.
+**This section is for on-chain integration** (contracts, interfaces, and program modules). CCIP also exposes HTTP APIs for different jobs:
+
+- **Directory and configuration REST API (v1)** — JSON for supported chains, tokens, and lanes served from `docs.chain.link`. **Planned for deprecation soon**; timelines and migration steps will be published with the [CCIP Tools documentation](https://docs.chain.link/ccip/tools/). Until then: interactive reference [/api/ccip/v1/docs](/api/ccip/v1/docs); machine-readable spec [/api/ccip/v1/openapi.json](/api/ccip/v1/openapi.json). Prefer the [CCIP Tools REST API (v2)](https://docs.chain.link/ccip/tools/api/) for new integrations where it meets your needs.
+- **CCIP Tools REST API (v2)** — messages, lane latency, intents, and related tooling. See the [CCIP Tools API documentation](https://docs.chain.link/ccip/tools/api/) and [CCIP Tools overview](https://docs.chain.link/ccip/tools/).
+
+Platform-specific **contracts and interfaces** on this site:
+
+- **[EVM-based blockchains](/ccip/api-reference/evm)**: Solidity interfaces and contracts for CCIP on Ethereum Virtual Machine (EVM) compatible chains.
+- **[Solana](/ccip/api-reference/svm)**: SVM program interfaces for CCIP on Solana.
+- **[Aptos](/ccip/api-reference/aptos)**: Move module interfaces for CCIP on Aptos.
+- **[TON](/ccip/api-reference/ton)**: TON contract interfaces for CCIP on TON.

--- a/src/content/ccip/api-reference/svm/index.mdx
+++ b/src/content/ccip/api-reference/svm/index.mdx
@@ -1,9 +1,9 @@
 ---
 section: ccip
 date: Last Modified
-title: "SVM Program Interfaces Reference Documentation (SVM)"
+title: "CCIP Program Interfaces Reference Documentation (Solana)"
 metadata:
-  description: "Complete API reference documentation for Chainlink CCIP on Solana. Includes message structures, router functionality, events, and error handling."
+  description: "Onchain SVM program interfaces for Chainlink CCIP on Solana: message structures, router, pools, events, and errors."
 isIndex: true
 ---
 

--- a/src/content/ccip/api-reference/ton/index.mdx
+++ b/src/content/ccip/api-reference/ton/index.mdx
@@ -1,9 +1,9 @@
 ---
 section: ccip
 date: Last Modified
-title: "TON Contract Interface Reference Documentation"
+title: "CCIP Contract Interface Reference Documentation (TON)"
 metadata:
-  description: "Complete API reference documentation for Chainlink CCIP on the TON blockchain. Includes message structures, router interface, receiver interface, events, and error codes."
+  description: "Onchain TON contract interfaces for Chainlink CCIP: messages, router, receiver, events, and error codes."
 isIndex: true
 ---
 

--- a/src/content/ccip/llms-full.txt
+++ b/src/content/ccip/llms-full.txt
@@ -7375,13 +7375,13 @@ Locate the CCIP-BnM contract address in the [CCIP Directory](/ccip/directory/tes
 
 ---
 
-# CCIP API, SDK & CLI
+# CCIP Tools API, SDK & CLI
 Source: https://docs.chain.link/ccip/tutorials/offchain
 Last Updated: 2026-03-02
 
 Chainlink CCIP provides three tools for interacting with CCIP programmatically:
 
-- **[CCIP API](https://docs.chain.link/ccip/tools/api/)**: REST API with endpoints for querying messages and their details, lane latency, and intents.
+- **[CCIP Tools REST API (v2)](https://docs.chain.link/ccip/tools/api/)**: REST API with endpoints for querying messages and their details, lane latency, and intents.
 - **[CCIP SDK](https://docs.chain.link/ccip/tools/sdk/)** ([`@chainlink/ccip-sdk`](https://www.npmjs.com/package/@chainlink/ccip-sdk)): A TypeScript library for sending messages, transferring tokens, estimating fees, and querying CCIP activity.
 - **[CCIP CLI](https://docs.chain.link/ccip/tools/cli/)** ([`@chainlink/ccip-cli`](https://www.npmjs.com/package/@chainlink/ccip-cli)): A command-line interface built on top of the SDK.
 
@@ -26710,7 +26710,7 @@ Once testing is complete, please share your CCIP transaction hashes with the tea
 
 ---
 
-# Solidity Interfaces & Contracts Reference Documentation (EVM)
+# CCIP Solidity Interfaces & Contracts Reference Documentation (EVM)
 Source: https://docs.chain.link/ccip/api-reference/evm
 
 ## Available Versions
@@ -48853,7 +48853,7 @@ These events are emitted when a cross-chain message is executed on the destinati
 
 ---
 
-# SVM Program Interfaces Reference Documentation (SVM)
+# CCIP Program Interfaces Reference Documentation (Solana)
 Source: https://docs.chain.link/ccip/api-reference/svm
 
 ## Available Versions
@@ -52196,7 +52196,7 @@ pub struct ExecutionStateChanged {
 
 ---
 
-# Move Module Interfaces Reference Documentation (Aptos)
+# CCIP Move Module Interfaces Reference Documentation (Aptos)
 Source: https://docs.chain.link/ccip/api-reference/aptos
 
 ## Available Versions
@@ -52844,7 +52844,7 @@ struct ExecutionStateChanged has store, drop {
 
 ---
 
-# TON Contract Interface Reference Documentation
+# CCIP Contract Interface Reference Documentation (TON)
 Source: https://docs.chain.link/ccip/api-reference/ton
 
 <Aside>TON currently supports arbitrary message passing only. Token transfers are not yet supported.</Aside>
@@ -67542,14 +67542,22 @@ function supportsInterface(bytes4 interfaceId) public pure virtual override retu
 
 ---
 
-# CCIP API Reference
+# CCIP contracts and interfaces reference
 Source: https://docs.chain.link/ccip/api-reference
 
 Chainlink Cross-Chain Interoperability Protocol (CCIP) provides secure cross-chain messaging and token transfers between blockchain networks.
 
-- **[EVM-based Blockchains](/ccip/api-reference/evm)**: Complete API reference for CCIP on Ethereum Virtual Machine (EVM) compatible blockchains.
-- **[Solana](/ccip/api-reference/svm)**: Complete API reference for CCIP on Solana.
-- **[Aptos Blockchain](/ccip/api-reference/aptos)**: Complete API reference for CCIP on the Aptos blockchain.
+**This section is for on-chain integration** (contracts, interfaces, and program modules). CCIP also exposes HTTP APIs for different jobs:
+
+- **Directory and configuration REST API (v1)** — JSON for supported chains, tokens, and lanes served from `docs.chain.link`. **Planned for deprecation soon**; timelines and migration steps will be published with the [CCIP Tools documentation](https://docs.chain.link/ccip/tools/). Until then: interactive reference [/api/ccip/v1/docs](/api/ccip/v1/docs); machine-readable spec [/api/ccip/v1/openapi.json](/api/ccip/v1/openapi.json). Prefer the [CCIP Tools REST API (v2)](https://docs.chain.link/ccip/tools/api/) for new integrations where it meets your needs.
+- **CCIP Tools REST API (v2)** — messages, lane latency, intents, and related tooling. See the [CCIP Tools API documentation](https://docs.chain.link/ccip/tools/api/) and [CCIP Tools overview](https://docs.chain.link/ccip/tools/).
+
+Platform-specific **contracts and interfaces** on this site:
+
+- **[EVM-based blockchains](/ccip/api-reference/evm)**: Solidity interfaces and contracts for CCIP on Ethereum Virtual Machine (EVM) compatible chains.
+- **[Solana](/ccip/api-reference/svm)**: SVM program interfaces for CCIP on Solana.
+- **[Aptos](/ccip/api-reference/aptos)**: Move module interfaces for CCIP on Aptos.
+- **[TON](/ccip/api-reference/ton)**: TON contract interfaces for CCIP on TON.
 
 ---
 

--- a/src/content/ccip/llms.txt
+++ b/src/content/ccip/llms.txt
@@ -12,7 +12,7 @@ Use directory pages only when retrieving current chain, lane, token, or contract
 - [Getting Started](https://docs.chain.link/ccip/getting-started.md)
 - [Getting Started (EVM)](https://docs.chain.link/ccip/getting-started/evm.md)
 - [Getting Started (Aptos)](https://docs.chain.link/ccip/getting-started/aptos.md)
-- [Getting Started (SVM)](https://docs.chain.link/ccip/getting-started/svm.md)
+- [Getting Started (Solana)](https://docs.chain.link/ccip/getting-started/svm.md)
 
 ## Concepts and Architecture
 
@@ -49,10 +49,17 @@ Use directory pages only when retrieving current chain, lane, token, or contract
 
 ## Tools and Reference
 
-- [EVM API Reference](https://docs.chain.link/ccip/api-reference.md)
-- [SVM API Reference](https://docs.chain.link/ccip/api-reference/svm.md)
-- [Aptos API Reference](https://docs.chain.link/ccip/api-reference/aptos.md)
-- [TON API Reference](https://docs.chain.link/ccip/api-reference/ton.md)
+On-chain contracts and interfaces:
+
+- [EVM contracts and interfaces reference](https://docs.chain.link/ccip/api-reference.md)
+- [SVM program interfaces reference](https://docs.chain.link/ccip/api-reference/svm.md)
+- [Aptos Move module interfaces reference](https://docs.chain.link/ccip/api-reference/aptos.md)
+- [TON contract interfaces reference](https://docs.chain.link/ccip/api-reference/ton.md)
+
+### CCIP HTTP REST APIs
+
+- **Directory and configuration (v1)** — supported chains, tokens, and lanes: OpenAPI UI at `https://docs.chain.link/api/ccip/v1/docs` and spec at `https://docs.chain.link/api/ccip/v1/openapi.json`. **Planned for deprecation soon**; follow [CCIP Tools](https://docs.chain.link/ccip/tools/) for timelines and migration. Prefer [CCIP Tools API (v2)](https://docs.chain.link/ccip/tools/api/) for new work where applicable.
+- **CCIP Tools (v2)** — messages, lane latency, intents: [CCIP Tools API](https://docs.chain.link/ccip/tools/api/).
 
 ## Live Data
 

--- a/src/content/ccip/tutorials/offchain/index.mdx
+++ b/src/content/ccip/tutorials/offchain/index.mdx
@@ -1,9 +1,9 @@
 ---
 section: ccip
 date: Last Modified
-title: "CCIP API, SDK & CLI"
+title: "CCIP Tools API, SDK & CLI"
 metadata:
-  description: "REST API, TypeScript SDK, and CLI for interacting with Chainlink CCIP. Query messages, send transfers, estimate fees, and inspect lane configurations."
+  description: "CCIP Tools REST API (v2), TypeScript SDK, and CLI for Chainlink CCIP. Query messages, send transfers, estimate fees, and inspect activity."
   excerpt: "CCIP API, CCIP SDK, CCIP CLI, TypeScript, cross-chain messaging, token transfers, gas estimation, REST API"
   datePublished: "2026-02-19"
   lastModified: "2026-03-02"
@@ -11,7 +11,7 @@ metadata:
 
 Chainlink CCIP provides three tools for interacting with CCIP programmatically:
 
-- **[CCIP API](https://docs.chain.link/ccip/tools/api/)**: REST API with endpoints for querying messages and their details, lane latency, and intents.
+- **[CCIP Tools REST API (v2)](https://docs.chain.link/ccip/tools/api/)**: REST API with endpoints for querying messages and their details, lane latency, and intents.
 - **[CCIP SDK](https://docs.chain.link/ccip/tools/sdk/)** ([`@chainlink/ccip-sdk`](https://www.npmjs.com/package/@chainlink/ccip-sdk)): A TypeScript library for sending messages, transferring tokens, estimating fees, and querying CCIP activity.
 - **[CCIP CLI](https://docs.chain.link/ccip/tools/cli/)** ([`@chainlink/ccip-cli`](https://www.npmjs.com/package/@chainlink/ccip-cli)): A command-line interface built on top of the SDK.
 

--- a/src/pages/api/ccip/README.md
+++ b/src/pages/api/ccip/README.md
@@ -1,6 +1,21 @@
-# CCIP API
+# CCIP directory and configuration REST API (v1)
 
-The CCIP API provides information about supported chains and tokens in the Cross-Chain Interoperability Protocol (CCIP). This API allows you to query chain details, token information, supported fee tokens, and contract addresses needed for cross-chain operations.
+This folder documents the **CCIP directory REST API** hosted on Chainlink Documentation (`/api/ccip/v1/*`): supported chains, tokens, and lanes.
+
+## Deprecation
+
+The **CCIP Directory and configuration REST API (v1)** (`/api/ccip/v1/*` on docs.chain.link) is **planned for deprecation soon**. Official timelines and migration guidance will be published in the [CCIP Tools documentation](https://docs.chain.link/ccip/tools/). For new integrations, prefer the [CCIP Tools REST API (v2)](https://docs.chain.link/ccip/tools/api/) and the SDK/CLI where they cover your use case.
+
+## Related documentation (different products)
+
+| Surface                               | Use when you need                        | Where                                                                                                |
+| ------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **CCIP Tools REST API (v2)**          | Messages, lane latency, intents, tooling | [CCIP Tools API](https://docs.chain.link/ccip/tools/api/) (maintained with the CCIP Tools docs site) |
+| **On-chain contracts and interfaces** | Solidity, Move, SVM, TON integration     | [CCIP contracts and interfaces reference](https://docs.chain.link/ccip/api-reference)                |
+
+The CCIP Tools docs repository should cross-link back here for directory/configuration (v1) and keep page titles distinct (e.g. include "Tools" and "v2" in REST API page metadata) so search engines do not merge intents with this v1 surface.
+
+This HTTP API returns information about supported chains and tokens in CCIP. You can query chain details, token information, supported fee tokens, and contract addresses used for cross-chain operations.
 
 ## Quick Start
 

--- a/src/pages/api/ccip/v1/docs.astro
+++ b/src/pages/api/ccip/v1/docs.astro
@@ -67,25 +67,26 @@ Astro.response.headers.set("Cache-Control", "s-max-age=300, stale-while-revalida
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>CCIP API Documentation</title>
+    <title>CCIP directory and configuration REST API (v1) | Chainlink Documentation</title>
 
     <!-- SEO Metadata -->
     <meta
       name="description"
-      content="Official documentation for the Cross-Chain Interoperability Protocol (CCIP) API. Explore chains and tokens endpoints, parameters, and response schemas."
+      content="Deprecation: CCIP Directory and configuration REST API (v1) is planned for deprecation soon. OpenAPI reference for chains, tokens, and lanes. Use CCIP Tools REST API (v2) for new work where applicable."
     />
     <meta
       name="keywords"
-      content="CCIP, Chain API, Token API, Blockchain, Cross-Chain, API Documentation, Chainlink, EVM, Solana, Aptos"
+      content="CCIP, directory API, chains API, tokens API, lanes, REST, OpenAPI, Chainlink, EVM, Solana, Aptos"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, follow" />
     <link rel="canonical" href="https://docs.chain.link/api/ccip/v1/docs" />
 
     <!-- Open Graph tags -->
-    <meta property="og:title" content="CCIP API Documentation" />
+    <meta property="og:title" content="CCIP directory and configuration REST API (v1)" />
     <meta
       property="og:description"
-      content="Explore the Cross-Chain Interoperability Protocol (CCIP) API. Find chains and tokens endpoints, examples, and integration guidelines."
+      content="Deprecation: this directory REST API (v1) is planned for deprecation soon. Timelines on CCIP Tools docs. For messages and intents use CCIP Tools REST API (v2)."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://docs.chain.link/api/ccip/v1/docs" />
@@ -93,8 +94,11 @@ Astro.response.headers.set("Cache-Control", "s-max-age=300, stale-while-revalida
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="CCIP API Documentation" />
-    <meta name="twitter:description" content="Documentation for the Chainlink CCIP Configuration API." />
+    <meta name="twitter:title" content="CCIP directory and configuration REST API (v1)" />
+    <meta
+      name="twitter:description"
+      content="Deprecation: CCIP Directory REST API (v1) planned for deprecation soon. See CCIP Tools docs for migration. v2 covers messages and intents."
+    />
     <meta name="twitter:image" content="https://docs.chain.link/_astro/ccip-logo.Dbxa2KeA.svg" />
 
     <!-- Resource hints -->
@@ -109,8 +113,8 @@ Astro.response.headers.set("Cache-Control", "s-max-age=300, stale-while-revalida
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "headline": "CCIP Configuration API Documentation",
-        "description": "Documentation for the Chainlink CCIP Configuration API",
+        "headline": "CCIP directory and configuration REST API (v1)",
+        "description": "Deprecation: CCIP Directory and configuration REST API (v1) is planned for deprecation soon. OpenAPI docs for chains, tokens, and lanes; use CCIP Tools REST API (v2) for messages and intents.",
         "author": {
           "@type": "Organization",
           "name": "Chainlink"
@@ -128,11 +132,52 @@ Astro.response.headers.set("Cache-Control", "s-max-age=300, stale-while-revalida
           "@id": "https://docs.chain.link/api/ccip/v1/docs"
         },
         "datePublished": "2025-03-06T00:00:00+00:00",
-        "dateModified": "2025-03-06T00:00:00+00:00"
+        "dateModified": "2026-05-13T00:00:00+00:00"
       }
     </script>
 
     <style>
+      .api-deprecation-banner {
+        background-color: #fff8e6;
+        border-bottom: 1px solid #e8c96b;
+        border-left: 6px solid #b45309;
+        padding: 16px 20px 16px 18px;
+        font-size: 1rem;
+        line-height: 1.55;
+      }
+
+      .api-deprecation-banner strong {
+        color: #92400e;
+      }
+
+      .api-deprecation-banner a {
+        color: #375bd2;
+        font-weight: 600;
+      }
+
+      .api-deprecation-banner .container {
+        max-width: 1400px;
+        margin: 0 auto;
+      }
+
+      .api-disambiguation-banner {
+        background-color: #e7f0ff;
+        border-bottom: 1px solid #c5d4f5;
+        padding: 14px 20px;
+        font-size: 0.95rem;
+        line-height: 1.5;
+      }
+
+      .api-disambiguation-banner a {
+        color: #375bd2;
+        font-weight: 600;
+      }
+
+      .api-disambiguation-banner .container {
+        max-width: 1400px;
+        margin: 0 auto;
+      }
+
       body {
         margin: 0;
         padding: 0;
@@ -382,19 +427,44 @@ Astro.response.headers.set("Cache-Control", "s-max-age=300, stale-while-revalida
     </style>
   </head>
   <body>
+    <div class="api-deprecation-banner" role="alert">
+      <div class="container">
+        <p>
+          <strong>Deprecation:</strong> The CCIP Directory and configuration REST API (v1), including the
+          <code>/api/ccip/v1/*</code> endpoints on this site, is <strong>planned for deprecation soon</strong>.
+          Timelines and migration steps will be published in the
+          <a href="https://docs.chain.link/ccip/tools/">CCIP Tools documentation</a>. For new integrations, prefer the
+          <a href="https://docs.chain.link/ccip/tools/api/">CCIP Tools REST API (v2)</a> and the SDK/CLI where they cover
+          your use case.
+        </p>
+      </div>
+    </div>
+
+    <div class="api-disambiguation-banner" role="note">
+      <div class="container">
+        <p>
+          <strong>CCIP Tools REST API (v2):</strong> for messages, lane latency, and intents, see the
+          <a href="https://docs.chain.link/ccip/tools/api/">CCIP Tools API documentation</a>.
+          <strong>On-chain contracts:</strong> see the
+          <a href="https://docs.chain.link/ccip/api-reference">CCIP contracts and interfaces reference</a>.
+        </p>
+      </div>
+    </div>
+
     <!-- SEO-friendly introduction section -->
     <header class="api-doc-header">
       <div class="container">
-        <h1>CCIP API Documentation <span class="version-badge">v1</span></h1>
+        <h1>CCIP directory and configuration REST API <span class="version-badge">v1</span></h1>
         <p class="lead">
-          The Cross-Chain Interoperability Protocol (CCIP) API provides comprehensive information about supported
-          blockchain networks, tokens, and their configurations across multiple blockchain families including EVM,
-          Solana, and Aptos.
+          This HTTP API returns supported blockchain networks, tokens, lanes, and related configuration for CCIP across
+          EVM, Solana, and Aptos. It is <strong>planned for deprecation soon</strong> (see the notice above). The CCIP Tools
+          REST API (v2) covers execution-time data such as messages and intents and is the preferred surface for new work
+          where applicable.
         </p>
 
         <div class="api-overview">
-          <h2>API Overview</h2>
-          <p>This documentation provides details about:</p>
+          <h2>API overview</h2>
+          <p>This reference describes:</p>
           <ul>
             <li>Available endpoints for retrieving chain and token information</li>
             <li>Chain details including IDs, selectors, and contract addresses</li>

--- a/src/tests/openapi.test.ts
+++ b/src/tests/openapi.test.ts
@@ -19,7 +19,7 @@ describe("OpenAPI Specification", () => {
 
   it("should have required info fields", () => {
     expect(openApiDoc.info).toBeDefined()
-    expect(openApiDoc.info.title).toBe("CCIP Docs config API")
+    expect(openApiDoc.info.title).toBe("CCIP directory and configuration REST API (v1)")
     expect(openApiDoc.info.version).toBeDefined()
     expect(openApiDoc.info.description).toBeDefined()
   })


### PR DESCRIPTION
This pull request updates the CCIP documentation to clarify the distinction between on-chain contract/program interfaces and HTTP REST APIs, and to communicate the planned deprecation of the CCIP Directory REST API (v1) in favor of the newer CCIP Tools REST API (v2). It also improves naming consistency, platform references, and the organization of API reference materials throughout the documentation.

The most important changes are:

**Deprecation and API Guidance Updates:**
* Added clear deprecation notices for the CCIP Directory REST API (v1) in OpenAPI specs, Postman collections, and documentation, and directed users to the CCIP Tools REST API (v2) for new integrations. [[1]](diffhunk://#diff-89927b458697cef57fd902de2056f60617d2314cf1e514dc3e3974fd888edf63L4-R5) [[2]](diffhunk://#diff-18bca94009483953b9e19dce2fd2dda2d23aba13cb75de1330f9a4aea71fe324L3-R4) [[3]](diffhunk://#diff-048d40601bce0fe593a9d36ef8991ce2be4aa90092606c361a62399a06408676L3-R4) [[4]](diffhunk://#diff-1dd7e52d8216e57662601a7410af0479daec7f5f8a79fde89c49f73143b83fe8L4-R22) [[5]](diffhunk://#diff-57122ef322b5ee7e3a4742f96f391e4cfd6566c7d0cbc52a17ab98ffaa5504cfL52-R62) [[6]](diffhunk://#diff-5fc41005ceabca8265f7813f494fe3229a7cf7f87e68738a6c24858467697d12L52-R62)
* Updated the sitemap generation logic in `astro.config.ts` to exclude the v1 interactive docs page, preventing it from competing with the v2 API in search and sitemaps.

**Documentation Structure and Naming:**
* Renamed and clarified section titles and descriptions for the on-chain API reference pages (EVM, Solana/SVM, Aptos, TON) to emphasize they are for contracts and program interfaces, not HTTP APIs. [[1]](diffhunk://#diff-1dd7e52d8216e57662601a7410af0479daec7f5f8a79fde89c49f73143b83fe8L4-R22) [[2]](diffhunk://#diff-b7900ae0045c219de09ae1704075a2992443cb8d6bfe34e63fead924a05fe364L4-R6) [[3]](diffhunk://#diff-8b127bfd1106069cf8a815a9cf74ceccebfa8bfe32444702151ceccd13ad89fcL4-R6) [[4]](diffhunk://#diff-fd47147f2b162e3a0eae3a121cb1651cf39e1181a9dd2b9e407a1b76675ccabfL4-R6) [[5]](diffhunk://#diff-4476d182566a1c63a208bd53a96472291ccae659c828227f23a4d2f2ddb688f6L4-R6)
* Updated links and references throughout the docs and LLM prompt files to use consistent, platform-specific naming (e.g., "Solana" instead of "SVM", "Move module interfaces" for Aptos, etc.). [[1]](diffhunk://#diff-5fc41005ceabca8265f7813f494fe3229a7cf7f87e68738a6c24858467697d12L15-R15) [[2]](diffhunk://#diff-ed4d106f89c9df8a4a70d275aa87d33904784c5107b3018519abd34086e3b101L26713-R26713) [[3]](diffhunk://#diff-52e9ef6b126524351161179a059fec08d4d303d3aaa52f5dd6fe26e8eff389e3L91-R94)

**CCIP Tools Documentation Improvements:**
* Renamed "CCIP API, SDK & CLI" sections and references to "CCIP Tools API, SDK & CLI" for clarity and consistency with the v2 API branding. [[1]](diffhunk://#diff-8c0b6828054dbc13c5dd0a016775f1dc5968e7607d9ac8f7d590baab63e55beeL4-R14) [[2]](diffhunk://#diff-ed4d106f89c9df8a4a70d275aa87d33904784c5107b3018519abd34086e3b101L7378-R7384)

**Content and Reference Updates:**
* Improved descriptions and organization of reference sections, making a clear separation between on-chain interfaces and off-chain HTTP APIs, and updating all relevant links and section headers. [[1]](diffhunk://#diff-1dd7e52d8216e57662601a7410af0479daec7f5f8a79fde89c49f73143b83fe8L4-R22) [[2]](diffhunk://#diff-ed4d106f89c9df8a4a70d275aa87d33904784c5107b3018519abd34086e3b101L67545-R67560)

These changes make the documentation clearer for users, reduce confusion between v1/v2 APIs, and help guide developers toward the recommended integration paths.