### PR TITLE
Data Feeds: fix missing null check for solana feed display

### DIFF
--- a/src/features/feeds/utils/feedVisibility.ts
+++ b/src/features/feeds/utils/feedVisibility.ts
@@ -32,8 +32,8 @@ export const CONTACT_EMAIL_PROXY_ADDRESSES = new Set<string>([
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function shouldHideAddress(feed: any): boolean {
   if (feed.docs?.productSubType === "calculatedPrice") return true
-  const proxy: string | undefined = feed.proxyAddress
-  return proxy !== undefined && CONTACT_EMAIL_PROXY_ADDRESSES.has(proxy.toLowerCase())
+  const proxy: string | null | undefined = feed.proxyAddress
+  return proxy != null && CONTACT_EMAIL_PROXY_ADDRESSES.has(proxy.toLowerCase())
 }
 
 /**


### PR DESCRIPTION
This pull request makes a small update to the address visibility logic in `feedVisibility.ts` to improve type safety and correctness when checking for proxy addresses. 

- The `shouldHideAddress` function now checks if `feed.proxyAddress` is not `null` or `undefined` (instead of only `undefined`), ensuring that all falsy values are handled correctly.