### PR TITLE
Data Streams: clarify delayed quote availability at reg-hours open for less liquid stocks

### DIFF
--- a/src/content/data-streams/llms-full.txt
+++ b/src/content/data-streams/llms-full.txt
@@ -5802,9 +5802,9 @@ Phase-specific feeds can introduce unique behavior due to venue-specific operati
 
 ##### Regular Hours Session: Delayed Quote Availability at Market Open
 
-During the first 10–20 seconds after regular hours open (9:30am ET), bid/ask quotes may not yet be available from the regular hours venue. In those cases, the reported price may still reflect the previous regular hours close rather than live market data.
+Right after the open of the regular trading hours (starting at 9:30 a.m. ET), bid/ask quotes from the regular-hours venue may not yet be available. For highly liquid stocks, this typically lasts only a few seconds (around 10–20 seconds), while for less liquid stocks it can take several minutes. Until live quotes become available, the reported price may continue to reflect the previous regular-hours close rather than current market activity.
 
-Users should factor this transition period into their switching logic and consider alternative strategies during the first \~20 seconds of regular hours, such as:
+Users should factor this transition period into their switching logic and consider alternative strategies until live regular-hours quotes are available, such as:
 
 - Pause or lock market activity
 - Continue using the pre-market (Extended Hours) stream until fresh regular hours quotes are available

--- a/src/content/data-streams/rwa-streams/24-5-us-equities-user-guide.mdx
+++ b/src/content/data-streams/rwa-streams/24-5-us-equities-user-guide.mdx
@@ -140,9 +140,9 @@ Phase-specific feeds can introduce unique behavior due to venue-specific operati
 
 ##### Regular Hours Session: Delayed Quote Availability at Market Open
 
-During the first 10–20 seconds after regular hours open (9:30am ET), bid/ask quotes may not yet be available from the regular hours venue. In those cases, the reported price may still reflect the previous regular hours close rather than live market data.
+Right after the open of the regular trading hours (starting at 9:30 a.m. ET), bid/ask quotes from the regular-hours venue may not yet be available. For highly liquid stocks, this typically lasts only a few seconds (around 10–20 seconds), while for less liquid stocks it can take several minutes. Until live quotes become available, the reported price may continue to reflect the previous regular-hours close rather than current market activity.
 
-Users should factor this transition period into their switching logic and consider alternative strategies during the first ~20 seconds of regular hours, such as:
+Users should factor this transition period into their switching logic and consider alternative strategies until live regular-hours quotes are available, such as:
 
 - Pause or lock market activity
 - Continue using the pre-market (Extended Hours) stream until fresh regular hours quotes are available


### PR DESCRIPTION
This pull request improves the documentation regarding delayed quote availability at the open of regular trading hours for US equities. The updates provide more accurate and detailed guidance on how long quotes may be unavailable and how users should handle this transition period.

Documentation improvements to quote availability at market open:

* Clarified that the unavailability of bid/ask quotes from the regular-hours venue after 9:30 a.m. ET can last only a few seconds for highly liquid stocks, but may take several minutes for less liquid stocks, and that reported prices may continue to reflect the previous close until live quotes are available. [[1]](diffhunk://#diff-010d6ec73559d39dbac789893010a22165c77468a04bab2cc55e61fc7c1e1dc6L143-R145) [[2]](diffhunk://#diff-6869f893776e3f74955fcb97bfd3cfbf038f1e1a57e2e20ce948594b36678145L5805-R5807)
* Updated user guidance to recommend considering alternative strategies until live regular-hours quotes are available, rather than just during the first ~20 seconds after the open. [[1]](diffhunk://#diff-010d6ec73559d39dbac789893010a22165c77468a04bab2cc55e61fc7c1e1dc6L143-R145) [[2]](diffhunk://#diff-6869f893776e3f74955fcb97bfd3cfbf038f1e1a57e2e20ce948594b36678145L5805-R5807)