### PR TITLE
CRE: add info for finding the org id in the ui, onchain write permission guidance

### DIFF
--- a/src/content/cre/guides/operations/deploying-to-private-registry-go.mdx
+++ b/src/content/cre/guides/operations/deploying-to-private-registry-go.mdx
@@ -7,7 +7,7 @@ pageId: "operations-deploying-to-private-registry"
 metadata:
   description: "Deploy and manage CRE workflows using the Chainlink-hosted private registry — no linked wallet, no gas, and no Ethereum Mainnet RPC required for registry operations."
   datePublished: "2026-05-06"
-  lastModified: "2026-05-14"
+  lastModified: "2026-05-27"
 ---
 
 import { Aside } from "@components"
@@ -124,7 +124,7 @@ Details:
    Owner:            <your-organization-owner>
 ```
 
-The workflow is registered and active immediately. Notice there is no transaction hash, no gas cost, and the `Owner` is your CRE organization rather than a wallet address.
+The workflow is registered and active immediately. Notice there is no transaction hash, no gas cost, and the `Owner` is your [organization owner address](#organization-owner-address) rather than a linked wallet address.
 
 ## Step 3: Verify the deployment
 
@@ -141,6 +141,19 @@ cre workflow list --registry private
 ```
 
 You can also view the workflow in the [CRE platform](https://app.chain.link/cre/discover) under **Workflows**.
+
+## Organization owner address
+
+For workflows managed on the private registry, the workflow owner is your organization's owner address, not a linked wallet key.
+
+To find it in the CRE platform UI:
+
+1. Open the [CRE platform](https://app.chain.link/cre/discover) and navigate to **Organization** in the sidebar
+1. Copy the **Organization address** shown on the page
+
+## Onchain write permissions
+
+If your workflow performs [onchain writes](/cre/guides/workflow/using-evm-client/onchain-write/overview-go) and you did not [link your own wallet key](/cre/organization/linking-keys), use your [organization owner address](#organization-owner-address) when configuring consumer contract permissions (for example, with `setExpectedAuthor()` in [Building Consumer Contracts](/cre/guides/workflow/using-evm-client/onchain-write/building-consumer-contracts#34-configuring-permissions)).
 
 ## Managing a private registry workflow
 

--- a/src/content/cre/guides/operations/deploying-to-private-registry-go.mdx
+++ b/src/content/cre/guides/operations/deploying-to-private-registry-go.mdx
@@ -7,7 +7,7 @@ pageId: "operations-deploying-to-private-registry"
 metadata:
   description: "Deploy and manage CRE workflows using the Chainlink-hosted private registry — no linked wallet, no gas, and no Ethereum Mainnet RPC required for registry operations."
   datePublished: "2026-05-06"
-  lastModified: "2026-05-27"
+  lastModified: "2026-05-28"
 ---
 
 import { Aside } from "@components"
@@ -98,29 +98,33 @@ The CLI compiles your workflow, uploads the artifacts to the CRE Storage Service
 **Example output:**
 
 ```
-Deploying Workflow :     my-workflow
-Target :                 staging-settings
-Owner Address :          <your-organization-owner>
+Deploying Workflow: my-workflow-staging
+  Registry:      private
+  Target:        staging-settings
+  Owner Address: <your-organization-owner> (derived)
 
 Compiling workflow...
-Workflow compiled successfully
+✓ Workflow compiled successfully
+  Binary hash:   <binary-hash>
+  Config hash:   <config-hash>
+  Workflow hash: <workflow-id>
 
 Uploading files...
 ✔ Loaded binary from: ./binary.wasm.br.b64
-✔ Uploaded binary to: https://storage.cre.example.com/artifacts/<workflow-id>/binary.wasm
+✔ Uploaded binary to: https://storage.cre.chain.link/artifacts/<workflow-id>/binary.wasm
 ✔ Loaded config from: ./config.staging.json
-✔ Uploaded config to: https://storage.cre.example.com/artifacts/<workflow-id>/config
+✔ Uploaded config to: https://storage.cre.chain.link/artifacts/<workflow-id>/config
 
-Registering workflow in private registry (workflowID: <your-workflow-id>)...
+Registering workflow in private registry (workflowID: <workflow-id>)...
 ✓ Workflow registered in private registry
 
 Details:
    Registry:         private
    Workflow Name:    my-workflow
-   Workflow ID:      <your-workflow-id>
+   Workflow ID:      <workflow-id>
    Status:           Active
-   Binary URL:       https://storage.cre.example.com/artifacts/<workflow-id>/binary.wasm
-   Config URL:       https://storage.cre.example.com/artifacts/<workflow-id>/config
+   Binary URL:       https://storage.cre.chain.link/artifacts/<workflow-id>/binary.wasm
+   Config URL:       https://storage.cre.chain.link/artifacts/<workflow-id>/config
    Owner:            <your-organization-owner>
 ```
 
@@ -144,12 +148,32 @@ You can also view the workflow in the [CRE platform](https://app.chain.link/cre/
 
 ## Organization owner address
 
-For workflows managed on the private registry, the workflow owner is your organization's owner address, not a linked wallet key.
+For workflows managed on the private registry, the workflow owner is your organization's owner address — not a linked wallet key. CRE derives this address from your organization; it matches the **Organization address** in the CRE platform UI.
 
-To find it in the CRE platform UI:
+### In the CRE platform UI
 
 1. Open the [CRE platform](https://app.chain.link/cre/discover) and navigate to **Organization** in the sidebar
 1. Copy the **Organization address** shown on the page
+
+You can also find the same address on a workflow's detail page under **Workflow Owner**.
+
+### From the CLI
+
+You can retrieve the organization owner address with:
+
+- **`cre workflow deploy`** — prints `Owner Address: … (derived)` at the start of the command output (before compilation finishes), even if registration later fails
+- **`cre workflow list --registry private --output json`** — each workflow includes an `ownerAddress` field
+- **`cre workflow get`** — prints the owner address for a workflow configured in `workflow.yaml`
+
+```bash
+# Example: list owner addresses for private registry workflows
+cre workflow list --registry private --output json
+
+# Example: owner address for a specific workflow
+cre workflow get ./my-workflow --target staging-settings
+```
+
+The `Owner Address (derived)` value from deploy matches the **Organization address** in the UI.
 
 ## Onchain write permissions
 

--- a/src/content/cre/guides/operations/deploying-to-private-registry-ts.mdx
+++ b/src/content/cre/guides/operations/deploying-to-private-registry-ts.mdx
@@ -7,7 +7,7 @@ pageId: "operations-deploying-to-private-registry"
 metadata:
   description: "Deploy and manage CRE workflows using the Chainlink-hosted private registry — no linked wallet, no gas, and no Ethereum Mainnet RPC required for registry operations."
   datePublished: "2026-05-06"
-  lastModified: "2026-05-14"
+  lastModified: "2026-05-27"
 ---
 
 import { Aside } from "@components"
@@ -124,7 +124,7 @@ Details:
    Owner:            <your-organization-owner>
 ```
 
-The workflow is registered and active immediately. Notice there is no transaction hash, no gas cost, and the `Owner` is your CRE organization rather than a wallet address.
+The workflow is registered and active immediately. Notice there is no transaction hash, no gas cost, and the `Owner` is your [organization owner address](#organization-owner-address) rather than a linked wallet address.
 
 ## Step 3: Verify the deployment
 
@@ -141,6 +141,19 @@ cre workflow list --registry private
 ```
 
 You can also view the workflow in the [CRE platform](https://app.chain.link/cre/discover) under **Workflows**.
+
+## Organization owner address
+
+For workflows managed on the private registry, the workflow owner is your organization's owner address, not a linked wallet key.
+
+To find it in the CRE platform UI:
+
+1. Open the [CRE platform](https://app.chain.link/cre/discover) and navigate to **Organization** in the sidebar
+1. Copy the **Organization address** shown on the page
+
+## Onchain write permissions
+
+If your workflow performs [onchain writes](/cre/guides/workflow/using-evm-client/onchain-write/overview-ts) and you did not [link your own wallet key](/cre/organization/linking-keys), use your [organization owner address](#organization-owner-address) when configuring consumer contract permissions (for example, with `setExpectedAuthor()` in [Building Consumer Contracts](/cre/guides/workflow/using-evm-client/onchain-write/building-consumer-contracts#34-configuring-permissions)).
 
 ## Managing a private registry workflow
 

--- a/src/content/cre/guides/operations/deploying-to-private-registry-ts.mdx
+++ b/src/content/cre/guides/operations/deploying-to-private-registry-ts.mdx
@@ -7,7 +7,7 @@ pageId: "operations-deploying-to-private-registry"
 metadata:
   description: "Deploy and manage CRE workflows using the Chainlink-hosted private registry — no linked wallet, no gas, and no Ethereum Mainnet RPC required for registry operations."
   datePublished: "2026-05-06"
-  lastModified: "2026-05-27"
+  lastModified: "2026-05-28"
 ---
 
 import { Aside } from "@components"
@@ -98,29 +98,33 @@ The CLI compiles your workflow, uploads the artifacts to the CRE Storage Service
 **Example output:**
 
 ```
-Deploying Workflow :     my-workflow
-Target :                 staging-settings
-Owner Address :          <your-organization-owner>
+Deploying Workflow: my-workflow-staging
+  Registry:      private
+  Target:        staging-settings
+  Owner Address: <your-organization-owner> (derived)
 
 Compiling workflow...
-Workflow compiled successfully
+✓ Workflow compiled successfully
+  Binary hash:   <binary-hash>
+  Config hash:   <config-hash>
+  Workflow hash: <workflow-id>
 
 Uploading files...
 ✔ Loaded binary from: ./binary.wasm.br.b64
-✔ Uploaded binary to: https://storage.cre.example.com/artifacts/<workflow-id>/binary.wasm
+✔ Uploaded binary to: https://storage.cre.chain.link/artifacts/<workflow-id>/binary.wasm
 ✔ Loaded config from: ./config.staging.json
-✔ Uploaded config to: https://storage.cre.example.com/artifacts/<workflow-id>/config
+✔ Uploaded config to: https://storage.cre.chain.link/artifacts/<workflow-id>/config
 
-Registering workflow in private registry (workflowID: <your-workflow-id>)...
+Registering workflow in private registry (workflowID: <workflow-id>)...
 ✓ Workflow registered in private registry
 
 Details:
    Registry:         private
    Workflow Name:    my-workflow
-   Workflow ID:      <your-workflow-id>
+   Workflow ID:      <workflow-id>
    Status:           Active
-   Binary URL:       https://storage.cre.example.com/artifacts/<workflow-id>/binary.wasm
-   Config URL:       https://storage.cre.example.com/artifacts/<workflow-id>/config
+   Binary URL:       https://storage.cre.chain.link/artifacts/<workflow-id>/binary.wasm
+   Config URL:       https://storage.cre.chain.link/artifacts/<workflow-id>/config
    Owner:            <your-organization-owner>
 ```
 
@@ -144,12 +148,32 @@ You can also view the workflow in the [CRE platform](https://app.chain.link/cre/
 
 ## Organization owner address
 
-For workflows managed on the private registry, the workflow owner is your organization's owner address, not a linked wallet key.
+For workflows managed on the private registry, the workflow owner is your organization's owner address — not a linked wallet key. CRE derives this address from your organization; it matches the **Organization address** in the CRE platform UI.
 
-To find it in the CRE platform UI:
+### In the CRE platform UI
 
 1. Open the [CRE platform](https://app.chain.link/cre/discover) and navigate to **Organization** in the sidebar
 1. Copy the **Organization address** shown on the page
+
+You can also find the same address on a workflow's detail page under **Workflow Owner**.
+
+### From the CLI
+
+You can retrieve the organization owner address with:
+
+- **`cre workflow deploy`** — prints `Owner Address: … (derived)` at the start of the command output (before compilation finishes), even if registration later fails
+- **`cre workflow list --registry private --output json`** — each workflow includes an `ownerAddress` field
+- **`cre workflow get`** — prints the owner address for a workflow configured in `workflow.yaml`
+
+```bash
+# Example: list owner addresses for private registry workflows
+cre workflow list --registry private --output json
+
+# Example: owner address for a specific workflow
+cre workflow get ./my-workflow --target staging-settings
+```
+
+The `Owner Address (derived)` value from deploy matches the **Organization address** in the UI.
 
 ## Onchain write permissions
 

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -12092,7 +12092,7 @@ For complete setup instructions, configuration requirements, and step-by-step gu
 
 # Deploying to the Private Registry
 Source: https://docs.chain.link/cre/guides/operations/deploying-to-private-registry-go
-Last Updated: 2026-05-14
+Last Updated: 2026-05-27
 
 <Aside type="note" title="Go">
   This page covers deployment to the private registry for Go workflows. For TypeScript workflows, see [Deploying to the Private Registry (TypeScript)](/cre/guides/operations/deploying-to-private-registry-ts).
@@ -12205,7 +12205,7 @@ Details:
    Owner:            <your-organization-owner>
 ```
 
-The workflow is registered and active immediately. Notice there is no transaction hash, no gas cost, and the `Owner` is your CRE organization rather than a wallet address.
+The workflow is registered and active immediately. Notice there is no transaction hash, no gas cost, and the `Owner` is your [organization owner address](#organization-owner-address) rather than a linked wallet address.
 
 ## Step 3: Verify the deployment
 
@@ -12222,6 +12222,19 @@ cre workflow list --registry private
 ```
 
 You can also view the workflow in the [CRE platform](https://app.chain.link/cre/discover) under **Workflows**.
+
+## Organization owner address
+
+For workflows managed on the private registry, the workflow owner is your organization's owner address, not a linked wallet key.
+
+To find it in the CRE platform UI:
+
+1. Open the [CRE platform](https://app.chain.link/cre/discover) and navigate to **Organization** in the sidebar
+2. Copy the **Organization address** shown on the page
+
+## Onchain write permissions
+
+If your workflow performs [onchain writes](/cre/guides/workflow/using-evm-client/onchain-write/overview-go) and you did not [link your own wallet key](/cre/organization/linking-keys), use your [organization owner address](#organization-owner-address) when configuring consumer contract permissions (for example, with `setExpectedAuthor()` in [Building Consumer Contracts](/cre/guides/workflow/using-evm-client/onchain-write/building-consumer-contracts#34-configuring-permissions)).
 
 ## Managing a private registry workflow
 

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -329,7 +329,7 @@ These quotas apply to each individual workflow.
 | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ------ |
 | <a href="#perworkflow-wasmbinarysizelimit" id="perworkflow-wasmbinarysizelimit">`PerWorkflow.WASMBinarySizeLimit`</a>                               | Maximum size of the compiled WASM binary   | 100 MB |
 | <a href="#perworkflow-wasmcompressedbinarysizelimit" id="perworkflow-wasmcompressedbinarysizelimit">`PerWorkflow.WASMCompressedBinarySizeLimit`</a> | Maximum size of the compressed WASM binary | 20 MB  |
-| <a href="#perworkflow-wasmconfigsizelimit" id="perworkflow-wasmconfigsizelimit">`PerWorkflow.WASMConfigSizeLimit`</a>                               | Maximum size of the workflow configuration | 1 MB   |
+| <a href="#perworkflow-wasmconfigsizelimit" id="perworkflow-wasmconfigsizelimit">`PerWorkflow.WASMConfigSizeLimit`</a>                               | Maximum size of the workflow configuration | 50 KB  |
 
 ### Trigger quotas
 
@@ -357,9 +357,10 @@ These quotas apply to each individual workflow.
 
 | Quota Key                                                                                                                         | Description                                                                                                                      | Value |
 | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| <a href="#perworkflow-wasmsecretssizelimit" id="perworkflow-wasmsecretssizelimit">`PerWorkflow.WASMSecretsSizeLimit`</a>          | Maximum total size of secrets accessible to a workflow                                                                           | 1 MB  |
+| <a href="#perworkflow-wasmsecretssizelimit" id="perworkflow-wasmsecretssizelimit">`PerWorkflow.WASMSecretsSizeLimit`</a>          | Maximum total size of secrets accessible to a workflow                                                                           | 27 KB |
 | <a href="#perworkflow-secretsconcurrencylimit" id="perworkflow-secretsconcurrencylimit">`PerWorkflow.SecretsConcurrencyLimit`</a> | Maximum number of secrets that can be fetched concurrently. [Learn how to fetch multiple secrets](/cre/guides/workflow/secrets). | 5     |
 | <a href="#perworkflow-secrets-calllimit" id="perworkflow-secrets-calllimit">`PerWorkflow.Secrets.CallLimit`</a>                   | Maximum number of secrets fetch calls per workflow execution                                                                     | 5     |
+| <a href="#persecret-ciphertextsize" id="persecret-ciphertextsize">`PerSecret.CipherTextSize`</a>                                  | Maximum size of a single encrypted secret value                                                                                  | 2 KB  |
 
 ### Consensus quotas
 

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -12092,7 +12092,7 @@ For complete setup instructions, configuration requirements, and step-by-step gu
 
 # Deploying to the Private Registry
 Source: https://docs.chain.link/cre/guides/operations/deploying-to-private-registry-go
-Last Updated: 2026-05-27
+Last Updated: 2026-05-28
 
 <Aside type="note" title="Go">
   This page covers deployment to the private registry for Go workflows. For TypeScript workflows, see [Deploying to the Private Registry (TypeScript)](/cre/guides/operations/deploying-to-private-registry-ts).
@@ -12179,29 +12179,33 @@ The CLI compiles your workflow, uploads the artifacts to the CRE Storage Service
 **Example output:**
 
 ```
-Deploying Workflow :     my-workflow
-Target :                 staging-settings
-Owner Address :          <your-organization-owner>
+Deploying Workflow: my-workflow-staging
+  Registry:      private
+  Target:        staging-settings
+  Owner Address: <your-organization-owner> (derived)
 
 Compiling workflow...
-Workflow compiled successfully
+✓ Workflow compiled successfully
+  Binary hash:   <binary-hash>
+  Config hash:   <config-hash>
+  Workflow hash: <workflow-id>
 
 Uploading files...
 ✔ Loaded binary from: ./binary.wasm.br.b64
-✔ Uploaded binary to: https://storage.cre.example.com/artifacts/<workflow-id>/binary.wasm
+✔ Uploaded binary to: https://storage.cre.chain.link/artifacts/<workflow-id>/binary.wasm
 ✔ Loaded config from: ./config.staging.json
-✔ Uploaded config to: https://storage.cre.example.com/artifacts/<workflow-id>/config
+✔ Uploaded config to: https://storage.cre.chain.link/artifacts/<workflow-id>/config
 
-Registering workflow in private registry (workflowID: <your-workflow-id>)...
+Registering workflow in private registry (workflowID: <workflow-id>)...
 ✓ Workflow registered in private registry
 
 Details:
    Registry:         private
    Workflow Name:    my-workflow
-   Workflow ID:      <your-workflow-id>
+   Workflow ID:      <workflow-id>
    Status:           Active
-   Binary URL:       https://storage.cre.example.com/artifacts/<workflow-id>/binary.wasm
-   Config URL:       https://storage.cre.example.com/artifacts/<workflow-id>/config
+   Binary URL:       https://storage.cre.chain.link/artifacts/<workflow-id>/binary.wasm
+   Config URL:       https://storage.cre.chain.link/artifacts/<workflow-id>/config
    Owner:            <your-organization-owner>
 ```
 
@@ -12225,12 +12229,32 @@ You can also view the workflow in the [CRE platform](https://app.chain.link/cre/
 
 ## Organization owner address
 
-For workflows managed on the private registry, the workflow owner is your organization's owner address, not a linked wallet key.
+For workflows managed on the private registry, the workflow owner is your organization's owner address — not a linked wallet key. CRE derives this address from your organization; it matches the **Organization address** in the CRE platform UI.
 
-To find it in the CRE platform UI:
+### In the CRE platform UI
 
 1. Open the [CRE platform](https://app.chain.link/cre/discover) and navigate to **Organization** in the sidebar
 2. Copy the **Organization address** shown on the page
+
+You can also find the same address on a workflow's detail page under **Workflow Owner**.
+
+### From the CLI
+
+You can retrieve the organization owner address with:
+
+- **`cre workflow deploy`** — prints `Owner Address: … (derived)` at the start of the command output (before compilation finishes), even if registration later fails
+- **`cre workflow list --registry private --output json`** — each workflow includes an `ownerAddress` field
+- **`cre workflow get`** — prints the owner address for a workflow configured in `workflow.yaml`
+
+```bash
+# Example: list owner addresses for private registry workflows
+cre workflow list --registry private --output json
+
+# Example: owner address for a specific workflow
+cre workflow get ./my-workflow --target staging-settings
+```
+
+The `Owner Address (derived)` value from deploy matches the **Organization address** in the UI.
 
 ## Onchain write permissions
 

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -12041,7 +12041,7 @@ For complete setup instructions, configuration requirements, and step-by-step gu
 
 # Deploying to the Private Registry
 Source: https://docs.chain.link/cre/guides/operations/deploying-to-private-registry-ts
-Last Updated: 2026-05-27
+Last Updated: 2026-05-28
 
 <Aside type="note" title="TypeScript">
   This page covers deployment to the private registry for TypeScript workflows. For Go workflows, see [Deploying to the Private Registry (Go)](/cre/guides/operations/deploying-to-private-registry-go).
@@ -12128,29 +12128,33 @@ The CLI compiles your workflow, uploads the artifacts to the CRE Storage Service
 **Example output:**
 
 ```
-Deploying Workflow :     my-workflow
-Target :                 staging-settings
-Owner Address :          <your-organization-owner>
+Deploying Workflow: my-workflow-staging
+  Registry:      private
+  Target:        staging-settings
+  Owner Address: <your-organization-owner> (derived)
 
 Compiling workflow...
-Workflow compiled successfully
+✓ Workflow compiled successfully
+  Binary hash:   <binary-hash>
+  Config hash:   <config-hash>
+  Workflow hash: <workflow-id>
 
 Uploading files...
 ✔ Loaded binary from: ./binary.wasm.br.b64
-✔ Uploaded binary to: https://storage.cre.example.com/artifacts/<workflow-id>/binary.wasm
+✔ Uploaded binary to: https://storage.cre.chain.link/artifacts/<workflow-id>/binary.wasm
 ✔ Loaded config from: ./config.staging.json
-✔ Uploaded config to: https://storage.cre.example.com/artifacts/<workflow-id>/config
+✔ Uploaded config to: https://storage.cre.chain.link/artifacts/<workflow-id>/config
 
-Registering workflow in private registry (workflowID: <your-workflow-id>)...
+Registering workflow in private registry (workflowID: <workflow-id>)...
 ✓ Workflow registered in private registry
 
 Details:
    Registry:         private
    Workflow Name:    my-workflow
-   Workflow ID:      <your-workflow-id>
+   Workflow ID:      <workflow-id>
    Status:           Active
-   Binary URL:       https://storage.cre.example.com/artifacts/<workflow-id>/binary.wasm
-   Config URL:       https://storage.cre.example.com/artifacts/<workflow-id>/config
+   Binary URL:       https://storage.cre.chain.link/artifacts/<workflow-id>/binary.wasm
+   Config URL:       https://storage.cre.chain.link/artifacts/<workflow-id>/config
    Owner:            <your-organization-owner>
 ```
 
@@ -12174,12 +12178,32 @@ You can also view the workflow in the [CRE platform](https://app.chain.link/cre/
 
 ## Organization owner address
 
-For workflows managed on the private registry, the workflow owner is your organization's owner address, not a linked wallet key.
+For workflows managed on the private registry, the workflow owner is your organization's owner address — not a linked wallet key. CRE derives this address from your organization; it matches the **Organization address** in the CRE platform UI.
 
-To find it in the CRE platform UI:
+### In the CRE platform UI
 
 1. Open the [CRE platform](https://app.chain.link/cre/discover) and navigate to **Organization** in the sidebar
 2. Copy the **Organization address** shown on the page
+
+You can also find the same address on a workflow's detail page under **Workflow Owner**.
+
+### From the CLI
+
+You can retrieve the organization owner address with:
+
+- **`cre workflow deploy`** — prints `Owner Address: … (derived)` at the start of the command output (before compilation finishes), even if registration later fails
+- **`cre workflow list --registry private --output json`** — each workflow includes an `ownerAddress` field
+- **`cre workflow get`** — prints the owner address for a workflow configured in `workflow.yaml`
+
+```bash
+# Example: list owner addresses for private registry workflows
+cre workflow list --registry private --output json
+
+# Example: owner address for a specific workflow
+cre workflow get ./my-workflow --target staging-settings
+```
+
+The `Owner Address (derived)` value from deploy matches the **Organization address** in the UI.
 
 ## Onchain write permissions
 

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -329,7 +329,7 @@ These quotas apply to each individual workflow.
 | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ------ |
 | <a href="#perworkflow-wasmbinarysizelimit" id="perworkflow-wasmbinarysizelimit">`PerWorkflow.WASMBinarySizeLimit`</a>                               | Maximum size of the compiled WASM binary   | 100 MB |
 | <a href="#perworkflow-wasmcompressedbinarysizelimit" id="perworkflow-wasmcompressedbinarysizelimit">`PerWorkflow.WASMCompressedBinarySizeLimit`</a> | Maximum size of the compressed WASM binary | 20 MB  |
-| <a href="#perworkflow-wasmconfigsizelimit" id="perworkflow-wasmconfigsizelimit">`PerWorkflow.WASMConfigSizeLimit`</a>                               | Maximum size of the workflow configuration | 1 MB   |
+| <a href="#perworkflow-wasmconfigsizelimit" id="perworkflow-wasmconfigsizelimit">`PerWorkflow.WASMConfigSizeLimit`</a>                               | Maximum size of the workflow configuration | 50 KB  |
 
 ### Trigger quotas
 
@@ -357,9 +357,10 @@ These quotas apply to each individual workflow.
 
 | Quota Key                                                                                                                         | Description                                                                                                                      | Value |
 | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| <a href="#perworkflow-wasmsecretssizelimit" id="perworkflow-wasmsecretssizelimit">`PerWorkflow.WASMSecretsSizeLimit`</a>          | Maximum total size of secrets accessible to a workflow                                                                           | 1 MB  |
+| <a href="#perworkflow-wasmsecretssizelimit" id="perworkflow-wasmsecretssizelimit">`PerWorkflow.WASMSecretsSizeLimit`</a>          | Maximum total size of secrets accessible to a workflow                                                                           | 27 KB |
 | <a href="#perworkflow-secretsconcurrencylimit" id="perworkflow-secretsconcurrencylimit">`PerWorkflow.SecretsConcurrencyLimit`</a> | Maximum number of secrets that can be fetched concurrently. [Learn how to fetch multiple secrets](/cre/guides/workflow/secrets). | 5     |
 | <a href="#perworkflow-secrets-calllimit" id="perworkflow-secrets-calllimit">`PerWorkflow.Secrets.CallLimit`</a>                   | Maximum number of secrets fetch calls per workflow execution                                                                     | 5     |
+| <a href="#persecret-ciphertextsize" id="persecret-ciphertextsize">`PerSecret.CipherTextSize`</a>                                  | Maximum size of a single encrypted secret value                                                                                  | 2 KB  |
 
 ### Consensus quotas
 

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -12041,7 +12041,7 @@ For complete setup instructions, configuration requirements, and step-by-step gu
 
 # Deploying to the Private Registry
 Source: https://docs.chain.link/cre/guides/operations/deploying-to-private-registry-ts
-Last Updated: 2026-05-14
+Last Updated: 2026-05-27
 
 <Aside type="note" title="TypeScript">
   This page covers deployment to the private registry for TypeScript workflows. For Go workflows, see [Deploying to the Private Registry (Go)](/cre/guides/operations/deploying-to-private-registry-go).
@@ -12154,7 +12154,7 @@ Details:
    Owner:            <your-organization-owner>
 ```
 
-The workflow is registered and active immediately. Notice there is no transaction hash, no gas cost, and the `Owner` is your CRE organization rather than a wallet address.
+The workflow is registered and active immediately. Notice there is no transaction hash, no gas cost, and the `Owner` is your [organization owner address](#organization-owner-address) rather than a linked wallet address.
 
 ## Step 3: Verify the deployment
 
@@ -12171,6 +12171,19 @@ cre workflow list --registry private
 ```
 
 You can also view the workflow in the [CRE platform](https://app.chain.link/cre/discover) under **Workflows**.
+
+## Organization owner address
+
+For workflows managed on the private registry, the workflow owner is your organization's owner address, not a linked wallet key.
+
+To find it in the CRE platform UI:
+
+1. Open the [CRE platform](https://app.chain.link/cre/discover) and navigate to **Organization** in the sidebar
+2. Copy the **Organization address** shown on the page
+
+## Onchain write permissions
+
+If your workflow performs [onchain writes](/cre/guides/workflow/using-evm-client/onchain-write/overview-ts) and you did not [link your own wallet key](/cre/organization/linking-keys), use your [organization owner address](#organization-owner-address) when configuring consumer contract permissions (for example, with `setExpectedAuthor()` in [Building Consumer Contracts](/cre/guides/workflow/using-evm-client/onchain-write/building-consumer-contracts#34-configuring-permissions)).
 
 ## Managing a private registry workflow
 

--- a/src/content/cre/service-quotas.mdx
+++ b/src/content/cre/service-quotas.mdx
@@ -65,7 +65,7 @@ These quotas apply to each individual workflow.
 | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ------ |
 | <a href="#perworkflow-wasmbinarysizelimit" id="perworkflow-wasmbinarysizelimit">`PerWorkflow.WASMBinarySizeLimit`</a>                               | Maximum size of the compiled WASM binary   | 100 MB |
 | <a href="#perworkflow-wasmcompressedbinarysizelimit" id="perworkflow-wasmcompressedbinarysizelimit">`PerWorkflow.WASMCompressedBinarySizeLimit`</a> | Maximum size of the compressed WASM binary | 20 MB  |
-| <a href="#perworkflow-wasmconfigsizelimit" id="perworkflow-wasmconfigsizelimit">`PerWorkflow.WASMConfigSizeLimit`</a>                               | Maximum size of the workflow configuration | 1 MB   |
+| <a href="#perworkflow-wasmconfigsizelimit" id="perworkflow-wasmconfigsizelimit">`PerWorkflow.WASMConfigSizeLimit`</a>                               | Maximum size of the workflow configuration | 50 KB  |
 
 ### Trigger quotas
 
@@ -93,9 +93,10 @@ These quotas apply to each individual workflow.
 
 | Quota Key                                                                                                                         | Description                                                                                                                      | Value |
 | --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| <a href="#perworkflow-wasmsecretssizelimit" id="perworkflow-wasmsecretssizelimit">`PerWorkflow.WASMSecretsSizeLimit`</a>          | Maximum total size of secrets accessible to a workflow                                                                           | 1 MB  |
+| <a href="#perworkflow-wasmsecretssizelimit" id="perworkflow-wasmsecretssizelimit">`PerWorkflow.WASMSecretsSizeLimit`</a>          | Maximum total size of secrets accessible to a workflow                                                                           | 27 KB |
 | <a href="#perworkflow-secretsconcurrencylimit" id="perworkflow-secretsconcurrencylimit">`PerWorkflow.SecretsConcurrencyLimit`</a> | Maximum number of secrets that can be fetched concurrently. [Learn how to fetch multiple secrets](/cre/guides/workflow/secrets). | 5     |
 | <a href="#perworkflow-secrets-calllimit" id="perworkflow-secrets-calllimit">`PerWorkflow.Secrets.CallLimit`</a>                   | Maximum number of secrets fetch calls per workflow execution                                                                     | 5     |
+| <a href="#persecret-ciphertextsize" id="persecret-ciphertextsize">`PerSecret.CipherTextSize`</a>                                  | Maximum size of a single encrypted secret value                                                                                  | 2 KB  |
 
 ### Consensus quotas
 


### PR DESCRIPTION
This pull request updates the documentation for deploying and managing workflows on the Chainlink-hosted private registry, with improvements to clarity around organization ownership, CLI output, and updated resource quotas for workflows in both Go and TypeScript guides.

Key changes include:

**Documentation improvements for private registry workflows:**

* Added a new section explaining the "organization owner address," including how to find it in both the CRE platform UI and CLI, and clarified its use for onchain write permissions instead of a linked wallet address. This section is now present in both the Go and TypeScript deployment guides. [[1]](diffhunk://#diff-9f2cce07a6409b227df465e302245585a0bf0bea5b07e6587bc5c00050ad75feR149-R181) [[2]](diffhunk://#diff-9d382dfde2ef5fe273ca8a4f7ee1054ccafd475b3672f48c1d18b7c5eadfeb0dR149-R181) [[3]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeR12231-R12263)
* Updated CLI example output in deployment guides to reflect the derived organization owner address, new registry field, updated URLs (now using `cre.chain.link`), and improved formatting for clarity and accuracy. [[1]](diffhunk://#diff-9f2cce07a6409b227df465e302245585a0bf0bea5b07e6587bc5c00050ad75feL101-R131) [[2]](diffhunk://#diff-9d382dfde2ef5fe273ca8a4f7ee1054ccafd475b3672f48c1d18b7c5eadfeb0dL101-R131) [[3]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL12182-R12213)
* Clarified that the owner address shown in CLI output matches the organization address in the UI, and improved language to emphasize that a linked wallet is not required for registry operations. [[1]](diffhunk://#diff-9f2cce07a6409b227df465e302245585a0bf0bea5b07e6587bc5c00050ad75feL101-R131) [[2]](diffhunk://#diff-9d382dfde2ef5fe273ca8a4f7ee1054ccafd475b3672f48c1d18b7c5eadfeb0dL101-R131) [[3]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL12182-R12213)

**Resource quota updates:**

* Reduced the maximum allowed workflow configuration size from 1 MB to 50 KB, and the maximum total secrets size per workflow from 1 MB to 27 KB. [[1]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL332-R332) [[2]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L332-R332) [[3]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL360-R363) [[4]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L360-R363)
* Added a new quota for the maximum size of a single encrypted secret value (`PerSecret.CipherTextSize`), set at 2 KB. [[1]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL360-R363) [[2]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L360-R363)

**General maintenance:**

* Updated the `lastModified` metadata in all affected files to reflect the latest changes. [[1]](diffhunk://#diff-9f2cce07a6409b227df465e302245585a0bf0bea5b07e6587bc5c00050ad75feL10-R10) [[2]](diffhunk://#diff-9d382dfde2ef5fe273ca8a4f7ee1054ccafd475b3672f48c1d18b7c5eadfeb0dL10-R10) [[3]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL12095-R12096) [[4]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L12044-R12045)

These updates ensure the documentation accurately reflects the current platform behavior and resource limits, and provide clearer guidance for users deploying workflows to the private registry.