### PR TITLE
ACE Beta mainnet networks

### DIFF
--- a/src/content/ace/beta-scope.mdx
+++ b/src/content/ace/beta-scope.mdx
@@ -15,11 +15,11 @@ import { Aside } from "@components"
   us](https://chain.link/contact).
 </Aside>
 
-ACE Beta is an early-access release for testing and integration on testnet networks. The limitations listed below are all areas of active development. Each will be addressed as ACE progresses toward general availability.
+ACE Beta is an early-access release for testing and integration on supported mainnet and testnet networks. The limitations listed below are all areas of active development. Each will be addressed as ACE progresses toward general availability.
 
-## Testnet only
+## Supported networks
 
-ACE Beta is currently available on testnet networks only.
+ACE Beta is available on selected [mainnet and testnet networks](/ace/supported-networks). Additional networks may be added before general availability (GA).
 
 ## No custom policies, extractors, or mappers
 

--- a/src/content/ace/llms-full.txt
+++ b/src/content/ace/llms-full.txt
@@ -101,11 +101,11 @@ Last Updated: 2026-04-20
   us](https://chain.link/contact).
 </Aside>
 
-ACE Beta is an early-access release for testing and integration on testnet networks. The limitations listed below are all areas of active development. Each will be addressed as ACE progresses toward general availability.
+ACE Beta is an early-access release for testing and integration on supported mainnet and testnet networks. The limitations listed below are all areas of active development. Each will be addressed as ACE progresses toward general availability.
 
-## Testnet only
+## Supported networks
 
-ACE Beta is currently available on testnet networks only.
+ACE Beta is available on selected [mainnet and testnet networks](/ace/supported-networks). Additional networks may be added before general availability (GA).
 
 ## No custom policies, extractors, or mappers
 
@@ -139,9 +139,13 @@ For Beta, model compliance checks as attestations. For example, have the Credent
 
 # Supported Networks
 Source: https://docs.chain.link/ace/supported-networks
-Last Updated: 2026-04-20
+Last Updated: 2026-05-26
 
-ACE Beta is available on the following testnet networks. Mainnet support will be available soon.
+ACE Beta is available on the following networks.
+
+## Mainnet networks
+
+## Testnet networks
 
 <Aside type="note" title="About chain selectors">
   A **chain selector** is Chainlink's unique numeric identifier for each blockchain network. Unlike chain IDs, chain
@@ -154,6 +158,10 @@ ACE Beta is available on the following testnet networks. Mainnet support will be
 # Release Notes
 Source: https://docs.chain.link/ace/release-notes
 Last Updated: 2026-04-20
+
+## May 26, 2026 — Mainnet support
+
+ACE Beta is now live on the following mainnet networks: Ethereum, Arbitrum, Avalanche, Base, and Polygon, in addition to existing testnets. See [Supported Networks](/ace/supported-networks) for chain IDs and chain selectors.
 
 ## April 15, 2026 — ACE Beta (Private Release)
 

--- a/src/content/ace/release-notes.mdx
+++ b/src/content/ace/release-notes.mdx
@@ -8,6 +8,10 @@ metadata:
   lastModified: "2026-04-20"
 ---
 
+## May 26, 2026 — Mainnet support
+
+ACE Beta is now live on the following mainnet networks: Ethereum, Arbitrum, Avalanche, Base, and Polygon, in addition to existing testnets. See [Supported Networks](/ace/supported-networks) for chain IDs and chain selectors.
+
 ## April 15, 2026 — ACE Beta (Private Release)
 
 Chainlink ACE Beta is now available to a first set of selected participants as a **private release**. This initial release provides early access to the ACE platform.

--- a/src/content/ace/supported-networks.mdx
+++ b/src/content/ace/supported-networks.mdx
@@ -4,13 +4,15 @@ title: "Supported Networks"
 date: Last Modified
 metadata:
   description: "EVM networks supported by Chainlink ACE Beta, including chain names, chain IDs, and network type."
-  datePublished: "2026-04-20"
-  lastModified: "2026-04-20"
+  datePublished: "2026-03-31"
+  lastModified: "2026-05-26"
 ---
 
-import { Aside, CopyText } from "@components"
+import { Aside } from "@components"
 
-ACE Beta is available on the following testnet networks. Mainnet support will be available soon.
+ACE Beta is available on the following networks.
+
+## Mainnet networks
 
 <div style="overflow-x: auto;">
   <table style="width: 100%; border-collapse: collapse;">
@@ -19,7 +21,92 @@ ACE Beta is available on the following testnet networks. Mainnet support will be
         <th style="text-align: left; padding: 12px 16px;">Network</th>
         <th style="text-align: left; padding: 12px 16px;">Chain ID</th>
         <th style="text-align: left; padding: 12px 16px;">Chain Selector</th>
-        <th style="text-align: left; padding: 12px 16px;">Type</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="padding: 12px 16px;">
+          <span style="display: inline-flex; align-items: center; gap: 8px;">
+            <img src="/assets/chains/ethereum.svg" alt="" width="24" height="24" style="vertical-align: middle;" />
+            Ethereum Mainnet
+          </span>
+        </td>
+        <td style="padding: 12px 16px;">
+          <code>1</code>
+        </td>
+        <td style="padding: 12px 16px;">
+          <code>5009297550715157269</code>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding: 12px 16px;">
+          <span style="display: inline-flex; align-items: center; gap: 8px;">
+            <img src="/assets/chains/arbitrum.svg" alt="" width="24" height="24" style="vertical-align: middle;" />
+            Arbitrum Mainnet
+          </span>
+        </td>
+        <td style="padding: 12px 16px;">
+          <code>42161</code>
+        </td>
+        <td style="padding: 12px 16px;">
+          <code>4949039107694359620</code>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding: 12px 16px;">
+          <span style="display: inline-flex; align-items: center; gap: 8px;">
+            <img src="/assets/chains/avalanche.svg" alt="" width="24" height="24" style="vertical-align: middle;" />
+            Avalanche Mainnet
+          </span>
+        </td>
+        <td style="padding: 12px 16px;">
+          <code>43114</code>
+        </td>
+        <td style="padding: 12px 16px;">
+          <code>6433500567565415381</code>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding: 12px 16px;">
+          <span style="display: inline-flex; align-items: center; gap: 8px;">
+            <img src="/assets/chains/base.svg" alt="" width="24" height="24" style="vertical-align: middle;" />
+            Base Mainnet
+          </span>
+        </td>
+        <td style="padding: 12px 16px;">
+          <code>8453</code>
+        </td>
+        <td style="padding: 12px 16px;">
+          <code>15971525489660198786</code>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding: 12px 16px;">
+          <span style="display: inline-flex; align-items: center; gap: 8px;">
+            <img src="/assets/chains/polygon.svg" alt="" width="24" height="24" style="vertical-align: middle;" />
+            Polygon Mainnet
+          </span>
+        </td>
+        <td style="padding: 12px 16px;">
+          <code>137</code>
+        </td>
+        <td style="padding: 12px 16px;">
+          <code>4051577828743386545</code>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+## Testnet networks
+
+<div style="overflow-x: auto;">
+  <table style="width: 100%; border-collapse: collapse;">
+    <thead>
+      <tr>
+        <th style="text-align: left; padding: 12px 16px;">Network</th>
+        <th style="text-align: left; padding: 12px 16px;">Chain ID</th>
+        <th style="text-align: left; padding: 12px 16px;">Chain Selector</th>
       </tr>
     </thead>
     <tbody>
@@ -34,9 +121,8 @@ ACE Beta is available on the following testnet networks. Mainnet support will be
           <code>11155111</code>
         </td>
         <td style="padding: 12px 16px;">
-          <CopyText text="16015286601757825753" code />
+          <code>16015286601757825753</code>
         </td>
-        <td style="padding: 12px 16px;">Testnet</td>
       </tr>
       <tr>
         <td style="padding: 12px 16px;">
@@ -49,9 +135,8 @@ ACE Beta is available on the following testnet networks. Mainnet support will be
           <code>421614</code>
         </td>
         <td style="padding: 12px 16px;">
-          <CopyText text="3478487238524512106" code />
+          <code>3478487238524512106</code>
         </td>
-        <td style="padding: 12px 16px;">Testnet</td>
       </tr>
       <tr>
         <td style="padding: 12px 16px;">
@@ -64,24 +149,8 @@ ACE Beta is available on the following testnet networks. Mainnet support will be
           <code>43113</code>
         </td>
         <td style="padding: 12px 16px;">
-          <CopyText text="14767482510784806043" code />
+          <code>14767482510784806043</code>
         </td>
-        <td style="padding: 12px 16px;">Testnet</td>
-      </tr>
-      <tr>
-        <td style="padding: 12px 16px;">
-          <span style="display: inline-flex; align-items: center; gap: 8px;">
-            <img src="/assets/chains/polygon.svg" alt="" width="24" height="24" style="vertical-align: middle;" />
-            Polygon Amoy
-          </span>
-        </td>
-        <td style="padding: 12px 16px;">
-          <code>80002</code>
-        </td>
-        <td style="padding: 12px 16px;">
-          <CopyText text="16281711391670634445" code />
-        </td>
-        <td style="padding: 12px 16px;">Testnet</td>
       </tr>
       <tr>
         <td style="padding: 12px 16px;">
@@ -94,9 +163,22 @@ ACE Beta is available on the following testnet networks. Mainnet support will be
           <code>84532</code>
         </td>
         <td style="padding: 12px 16px;">
-          <CopyText text="10344971235874465080" code />
+          <code>10344971235874465080</code>
         </td>
-        <td style="padding: 12px 16px;">Testnet</td>
+      </tr>
+      <tr>
+        <td style="padding: 12px 16px;">
+          <span style="display: inline-flex; align-items: center; gap: 8px;">
+            <img src="/assets/chains/polygon.svg" alt="" width="24" height="24" style="vertical-align: middle;" />
+            Polygon Amoy
+          </span>
+        </td>
+        <td style="padding: 12px 16px;">
+          <code>80002</code>
+        </td>
+        <td style="padding: 12px 16px;">
+          <code>16281711391670634445</code>
+        </td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
This pull request updates ACE Beta documentation to announce and detail mainnet support, revises the list of supported networks, and improves the presentation of supported network data. The changes clarify that ACE Beta is now available on selected mainnet and testnet networks, update release notes, and enhance the formatting and accuracy of the supported networks tables.

**Mainnet Support Announcement and Documentation Updates:**

* Announced that ACE Beta is now live on mainnet networks (Ethereum, Arbitrum, Avalanche, Base, and Polygon) in addition to existing testnets, updating all relevant introductory and release note sections to reflect this change. [[1]](diffhunk://#diff-fd26238ce8c673ae5f1765e7c2cff9e70466d49859f99afb811289ac4ec8be75L18-R22) [[2]](diffhunk://#diff-96ac43b0a639366f49abeabc51ed20707b6e6417106ecb27a7f1ec2451a8ea03L104-R108) [[3]](diffhunk://#diff-96ac43b0a639366f49abeabc51ed20707b6e6417106ecb27a7f1ec2451a8ea03R162-R165) [[4]](diffhunk://#diff-ff2b261fd26065c225c38e060e996111ba68efd0059b948a6480563d0e736d3dR11-R14)

**Supported Networks Table Enhancements:**

* Updated the `supported-networks.mdx` file to include a new mainnet networks table with network names, chain IDs, and chain selectors, and revised the testnet table for improved clarity and formatting (e.g., removed the "Type" column, replaced `CopyText` with `<code>`, and corrected the order and details for Base Sepolia and Polygon Amoy). [[1]](diffhunk://#diff-78e9150b4542e1561d265f19b9514b65103def03480b404cae485acfad6f3186L7-R101) [[2]](diffhunk://#diff-78e9150b4542e1561d265f19b9514b65103def03480b404cae485acfad6f3186L22) [[3]](diffhunk://#diff-78e9150b4542e1561d265f19b9514b65103def03480b404cae485acfad6f3186L37-L39) [[4]](diffhunk://#diff-78e9150b4542e1561d265f19b9514b65103def03480b404cae485acfad6f3186L52-L54) [[5]](diffhunk://#diff-78e9150b4542e1561d265f19b9514b65103def03480b404cae485acfad6f3186L67-L99)

**Metadata and Date Updates:**

* Updated metadata fields such as `datePublished` and `lastModified` to reflect the latest documentation changes and mainnet support release date. [[1]](diffhunk://#diff-78e9150b4542e1561d265f19b9514b65103def03480b404cae485acfad6f3186L7-R101) [[2]](diffhunk://#diff-96ac43b0a639366f49abeabc51ed20707b6e6417106ecb27a7f1ec2451a8ea03L142-R148)

These changes ensure that the documentation accurately reflects ACE Beta's expanded network support and presents network information in a clearer, more user-friendly format.