### PR TITLE
Data Streams: update ha mode behavior for rust

### DIFF
--- a/src/content/data-streams/llms-full.txt
+++ b/src/content/data-streams/llms-full.txt
@@ -4555,11 +4555,27 @@ Security best practices:
 
 ### High Availability Mode
 
+The Data Streams SDK supports High Availability mode for WebSocket connections. When enabled with `WebSocketHighAvailability::Enabled`, the SDK maintains concurrent connections to different instances to ensure high availability, fault tolerance, and minimize the risk of report gaps.
+
+#### HA Mode Behavior
+
+When high availability mode is enabled:
+
+- The client queries the server for available origins using the `X-Cll-Available-Origins` header
+- Multiple WebSocket connections are established to different server instances
+- Reports are deduplicated when received across connections
+- Partial reconnects occur when some connections fail while others remain active
+- Full reconnects occur when all connections fail
+
+#### HA Configuration
+
+Pass a single WebSocket URL. When HA mode is enabled, the SDK discovers additional origin endpoints behind that URL and opens a connection to each origin.
+
 ```rust
 use chainlink_data_streams_sdk::config::{Config, WebSocketHighAvailability};
 
-let ws_urls = "wss://ws1.dataengine.chain.link,wss://ws2.dataengine.chain.link";
-let config = Config::new(api_key, api_secret, rest_url, ws_urls)
+let ws_url = "wss://ws.dataengine.chain.link";
+let config = Config::new(api_key, api_secret, rest_url, ws_url)
     // Enable WebSocket HA mode
     .with_ws_ha(WebSocketHighAvailability::Enabled)
     // Increase the max reconnection attempts (optional, default is 5)
@@ -4567,7 +4583,9 @@ let config = Config::new(api_key, api_secret, rest_url, ws_urls)
     .build()?;
 ```
 
-- Multiple WebSocket endpoints
+**Note:** High Availability mode is only available on mainnet endpoints, not testnet.
+
+- Automatic origin discovery from a single WebSocket URL
 - Automatic failover on connection loss
 - Parallel connections to reduce gaps in data
 
@@ -4576,7 +4594,7 @@ let config = Config::new(api_key, api_secret, rest_url, ws_urls)
 The SDK allows you to:
 
 - Set `ws_max_reconnect`: The maximum number of reconnection attempts (default: 5)
-- Enable HA for multiple WebSocket endpoints
+- Enable HA for automatic multi-origin WebSocket connections
 - Optional `insecure_skip_verify` for TLS
 
 Example:
@@ -4584,9 +4602,9 @@ Example:
 ```rust
 use chainlink_data_streams_sdk::config::{Config, InsecureSkipVerify, WebSocketHighAvailability};
 
-let ws_urls = "wss://ws.testnet-dataengine.chain.link";
+let ws_url = "wss://ws.testnet-dataengine.chain.link";
 
-let config = Config::new(api_key, api_secret, rest_url, ws_urls)
+let config = Config::new(api_key, api_secret, rest_url, ws_url)
     .with_ws_ha(WebSocketHighAvailability::Enabled)
     .with_ws_max_reconnect(5)
     .with_insecure_skip_verify(InsecureSkipVerify::Enabled)
@@ -4638,7 +4656,7 @@ The [SDK repository](https://github.com/smartcontractkit/data-streams-sdk/blob/m
 - Fetching a single report, bulk reports, or paginated reports
 - Compressing report data
 - Simple WebSocket streaming
-- Multiple WebSocket endpoints (HA)
+- WebSocket streaming with HA mode
 
 ## Performance Considerations
 
@@ -4674,14 +4692,14 @@ pub struct ConfigBuilder {
 
 - Purpose: Enables or disables HA mode for WebSocket streaming.
 - Values:
-  - `WebSocketHighAvailability::Enabled`: Maintains multiple WebSocket connections to different endpoints simultaneously.
+  - `WebSocketHighAvailability::Enabled`: Discovers available origins from the configured WebSocket URL and maintains multiple connections simultaneously.
   - `WebSocketHighAvailability::Disabled`: Maintains a single connection.
 - Default: `Disabled`.
 - Example Use Case:
 
   ```rust
-  // When you want uninterrupted streaming even if one server goes down:
-  let config = Config::new(api_key, api_secret, rest_url, "wss://ws1,...,wss://wsN")
+  // When you want uninterrupted streaming even if one origin goes down:
+  let config = Config::new(api_key, api_secret, rest_url, "wss://ws.dataengine.chain.link")
       .with_ws_ha(WebSocketHighAvailability::Enabled)
       .build()?;
   ```
@@ -8953,7 +8971,7 @@ let config = Config::new(
     api_key,
     api_secret,
     "https://api.dataengine.chain.link".to_string(), // Mainnet endpoint
-    "wss://ws.dataengine.chain.link,wss://ws.dataengine.chain.link".to_string(), // Multiple WebSocket endpoints
+    "wss://ws.dataengine.chain.link".to_string(), // Mainnet WebSocket endpoint
 )
 .with_ws_ha(WebSocketHighAvailability::Enabled) // Enable WebSocket High Availability Mode
 .build()?;
@@ -8961,6 +8979,8 @@ let config = Config::new(
 
 // ... existing code ...
 ```
+
+When `WebSocketHighAvailability::Enabled` is set, the SDK automatically discovers multiple origin endpoints behind the single URL and establishes separate connections to each origin.
 
 See more details about HA mode in the [SDK Reference](/data-streams/reference/data-streams-api/rust-sdk#high-availability-mode).
 

--- a/src/content/data-streams/reference/data-streams-api/rust-sdk.mdx
+++ b/src/content/data-streams/reference/data-streams-api/rust-sdk.mdx
@@ -149,11 +149,27 @@ Security best practices:
 
 ### High Availability Mode
 
+The Data Streams SDK supports High Availability mode for WebSocket connections. When enabled with `WebSocketHighAvailability::Enabled`, the SDK maintains concurrent connections to different instances to ensure high availability, fault tolerance, and minimize the risk of report gaps.
+
+#### HA Mode Behavior
+
+When high availability mode is enabled:
+
+- The client queries the server for available origins using the `X-Cll-Available-Origins` header
+- Multiple WebSocket connections are established to different server instances
+- Reports are deduplicated when received across connections
+- Partial reconnects occur when some connections fail while others remain active
+- Full reconnects occur when all connections fail
+
+#### HA Configuration
+
+Pass a single WebSocket URL. When HA mode is enabled, the SDK discovers additional origin endpoints behind that URL and opens a connection to each origin.
+
 ```rust
 use chainlink_data_streams_sdk::config::{Config, WebSocketHighAvailability};
 
-let ws_urls = "wss://ws1.dataengine.chain.link,wss://ws2.dataengine.chain.link";
-let config = Config::new(api_key, api_secret, rest_url, ws_urls)
+let ws_url = "wss://ws.dataengine.chain.link";
+let config = Config::new(api_key, api_secret, rest_url, ws_url)
     // Enable WebSocket HA mode
     .with_ws_ha(WebSocketHighAvailability::Enabled)
     // Increase the max reconnection attempts (optional, default is 5)
@@ -161,7 +177,9 @@ let config = Config::new(api_key, api_secret, rest_url, ws_urls)
     .build()?;
 ```
 
-- Multiple WebSocket endpoints
+**Note:** High Availability mode is only available on mainnet endpoints, not testnet.
+
+- Automatic origin discovery from a single WebSocket URL
 - Automatic failover on connection loss
 - Parallel connections to reduce gaps in data
 
@@ -170,7 +188,7 @@ let config = Config::new(api_key, api_secret, rest_url, ws_urls)
 The SDK allows you to:
 
 - Set `ws_max_reconnect`: The maximum number of reconnection attempts (default: 5)
-- Enable HA for multiple WebSocket endpoints
+- Enable HA for automatic multi-origin WebSocket connections
 - Optional `insecure_skip_verify` for TLS
 
 Example:
@@ -178,9 +196,9 @@ Example:
 ```rust
 use chainlink_data_streams_sdk::config::{Config, InsecureSkipVerify, WebSocketHighAvailability};
 
-let ws_urls = "wss://ws.testnet-dataengine.chain.link";
+let ws_url = "wss://ws.testnet-dataengine.chain.link";
 
-let config = Config::new(api_key, api_secret, rest_url, ws_urls)
+let config = Config::new(api_key, api_secret, rest_url, ws_url)
     .with_ws_ha(WebSocketHighAvailability::Enabled)
     .with_ws_max_reconnect(5)
     .with_insecure_skip_verify(InsecureSkipVerify::Enabled)
@@ -232,7 +250,7 @@ The [SDK repository](https://github.com/smartcontractkit/data-streams-sdk/blob/m
 - Fetching a single report, bulk reports, or paginated reports
 - Compressing report data
 - Simple WebSocket streaming
-- Multiple WebSocket endpoints (HA)
+- WebSocket streaming with HA mode
 
 ## Performance Considerations
 
@@ -268,14 +286,14 @@ pub struct ConfigBuilder {
 
 - Purpose: Enables or disables HA mode for WebSocket streaming.
 - Values:
-  - `WebSocketHighAvailability::Enabled`: Maintains multiple WebSocket connections to different endpoints simultaneously.
+  - `WebSocketHighAvailability::Enabled`: Discovers available origins from the configured WebSocket URL and maintains multiple connections simultaneously.
   - `WebSocketHighAvailability::Disabled`: Maintains a single connection.
 - Default: `Disabled`.
 - Example Use Case:
 
   ```rust
-  // When you want uninterrupted streaming even if one server goes down:
-  let config = Config::new(api_key, api_secret, rest_url, "wss://ws1,...,wss://wsN")
+  // When you want uninterrupted streaming even if one origin goes down:
+  let config = Config::new(api_key, api_secret, rest_url, "wss://ws.dataengine.chain.link")
       .with_ws_ha(WebSocketHighAvailability::Enabled)
       .build()?;
   ```

--- a/src/content/data-streams/tutorials/rust-sdk-stream.mdx
+++ b/src/content/data-streams/tutorials/rust-sdk-stream.mdx
@@ -348,7 +348,7 @@ let config = Config::new(
     api_key,
     api_secret,
     "https://api.dataengine.chain.link".to_string(), // Mainnet endpoint
-    "wss://ws.dataengine.chain.link,wss://ws.dataengine.chain.link".to_string(), // Multiple WebSocket endpoints
+    "wss://ws.dataengine.chain.link".to_string(), // Mainnet WebSocket endpoint
 )
 .with_ws_ha(WebSocketHighAvailability::Enabled) // Enable WebSocket High Availability Mode
 .build()?;
@@ -356,6 +356,8 @@ let config = Config::new(
 
 // ... existing code ...
 ```
+
+When `WebSocketHighAvailability::Enabled` is set, the SDK automatically discovers multiple origin endpoints behind the single URL and establishes separate connections to each origin.
 
 See more details about HA mode in the [SDK Reference](/data-streams/reference/data-streams-api/rust-sdk#high-availability-mode).
 

--- a/src/content/datalink/llms-full.txt
+++ b/src/content/datalink/llms-full.txt
@@ -2359,22 +2359,22 @@ In this example, we're using report schema `v4` for the EUR/USD feed, but your i
    [...]
    ```
 
-The example above demonstrates streaming data from a single crypto stream. For production environments, especially when subscribing to multiple streams, it's recommended to enable [High Availability (HA) mode](https://github.com/smartcontractkit/data-streams-sdk/blob/main/rust/docs/examples/wss_multiple.md). This can be achieved by:
+The example above demonstrates streaming data from a single crypto stream. For production environments, especially when subscribing to multiple streams, it's recommended to enable [High Availability (HA) mode](/data-streams/reference/data-streams-api/rust-sdk#high-availability-mode). Use a mainnet WebSocket URL and enable HA mode in the configuration:
 
-1. Adding multiple WebSocket endpoints in the configuration:
+```rust
+use chainlink_data_streams_sdk::config::WebSocketHighAvailability;
 
-   ```rust
-   "wss://ws.testnet-dataengine.chain.link,wss://ws.testnet-dataengine.chain.link"
-   ```
+let config = Config::new(
+    api_key,
+    api_secret,
+    "https://api.dataengine.chain.link",
+    "wss://ws.dataengine.chain.link",
+)
+.with_ws_ha(WebSocketHighAvailability::Enabled)
+.build()?;
+```
 
-2. Enabling HA mode in the configuration:
-   ```rust
-   use chainlink_data_streams_sdk::config::WebSocketHighAvailability;
-   // ...
-   .with_ws_ha(WebSocketHighAvailability::Enabled)
-   ```
-
-When HA mode is enabled and multiple WebSocket origins are provided, the Stream will maintain concurrent connections to different instances. This ensures high availability, fault tolerance, and minimizes the risk of report gaps.
+When HA mode is enabled, the SDK discovers available origins from the configured WebSocket URL and maintains concurrent connections to different instances. This ensures high availability, fault tolerance, and minimizes the risk of report gaps.
 
 #### Decoded report details
 

--- a/src/content/datalink/pull-delivery/tutorials/stream-decode/ws-rust.mdx
+++ b/src/content/datalink/pull-delivery/tutorials/stream-decode/ws-rust.mdx
@@ -271,22 +271,22 @@ In this example, we're using report schema `v4` for the EUR/USD feed, but your i
    [...]
    ```
 
-The example above demonstrates streaming data from a single crypto stream. For production environments, especially when subscribing to multiple streams, it's recommended to enable [High Availability (HA) mode](https://github.com/smartcontractkit/data-streams-sdk/blob/main/rust/docs/examples/wss_multiple.md). This can be achieved by:
+The example above demonstrates streaming data from a single crypto stream. For production environments, especially when subscribing to multiple streams, it's recommended to enable [High Availability (HA) mode](/data-streams/reference/data-streams-api/rust-sdk#high-availability-mode). Use a mainnet WebSocket URL and enable HA mode in the configuration:
 
-1. Adding multiple WebSocket endpoints in the configuration:
+```rust
+use chainlink_data_streams_sdk::config::WebSocketHighAvailability;
 
-   ```rust
-   "wss://ws.testnet-dataengine.chain.link,wss://ws.testnet-dataengine.chain.link"
-   ```
+let config = Config::new(
+    api_key,
+    api_secret,
+    "https://api.dataengine.chain.link",
+    "wss://ws.dataengine.chain.link",
+)
+.with_ws_ha(WebSocketHighAvailability::Enabled)
+.build()?;
+```
 
-1. Enabling HA mode in the configuration:
-   ```rust
-   use chainlink_data_streams_sdk::config::WebSocketHighAvailability;
-   // ...
-   .with_ws_ha(WebSocketHighAvailability::Enabled)
-   ```
-
-When HA mode is enabled and multiple WebSocket origins are provided, the Stream will maintain concurrent connections to different instances. This ensures high availability, fault tolerance, and minimizes the risk of report gaps.
+When HA mode is enabled, the SDK discovers available origins from the configured WebSocket URL and maintains concurrent connections to different instances. This ensures high availability, fault tolerance, and minimizes the risk of report gaps.
 
 #### Decoded report details
 


### PR DESCRIPTION
This pull request updates the Data Streams SDK documentation to clarify and improve guidance on enabling High Availability (HA) mode for WebSocket connections. The changes focus on simplifying HA configuration, emphasizing automatic origin discovery from a single endpoint, and updating example code and explanations throughout the documentation.

Key documentation improvements:

**High Availability Mode Clarification & Usage:**

- Updated HA mode documentation to explain that enabling `WebSocketHighAvailability::Enabled` with a single WebSocket URL allows the SDK to automatically discover and connect to multiple origins for improved reliability. This replaces the previous method of manually specifying multiple endpoints. [[1]](diffhunk://#diff-6869f893776e3f74955fcb97bfd3cfbf038f1e1a57e2e20ce948594b36678145R4558-R4588) [[2]](diffhunk://#diff-1b0b54413d989a0282d12e6e402e4ff3376d59dc84a655007462be03d34bfb8fR152-R182)
- Added detailed descriptions of HA mode behavior, including origin discovery, deduplication of reports, partial and full reconnects, and the requirement that HA mode is only available on mainnet endpoints. [[1]](diffhunk://#diff-6869f893776e3f74955fcb97bfd3cfbf038f1e1a57e2e20ce948594b36678145R4558-R4588) [[2]](diffhunk://#diff-1b0b54413d989a0282d12e6e402e4ff3376d59dc84a655007462be03d34bfb8fR152-R182)

**Code Example & API Reference Updates:**

- Revised all Rust code samples to use a single WebSocket URL when enabling HA mode, and updated method descriptions to reflect the new automatic origin discovery mechanism. [[1]](diffhunk://#diff-6869f893776e3f74955fcb97bfd3cfbf038f1e1a57e2e20ce948594b36678145L4579-R4607) [[2]](diffhunk://#diff-1b0b54413d989a0282d12e6e402e4ff3376d59dc84a655007462be03d34bfb8fL173-R201) [[3]](diffhunk://#diff-6869f893776e3f74955fcb97bfd3cfbf038f1e1a57e2e20ce948594b36678145L4677-R4702) [[4]](diffhunk://#diff-1b0b54413d989a0282d12e6e402e4ff3376d59dc84a655007462be03d34bfb8fL271-R296)
- Updated tutorials and usage examples to demonstrate the new HA configuration pattern, including explanatory notes on automatic origin discovery. [[1]](diffhunk://#diff-c49a00f693980dcaf9e55173efc7d2596b26e78c28253c746abc23d2f1064037L351-R351) [[2]](diffhunk://#diff-c49a00f693980dcaf9e55173efc7d2596b26e78c28253c746abc23d2f1064037R360-R361) [[3]](diffhunk://#diff-6869f893776e3f74955fcb97bfd3cfbf038f1e1a57e2e20ce948594b36678145L8956-R8974) [[4]](diffhunk://#diff-6869f893776e3f74955fcb97bfd3cfbf038f1e1a57e2e20ce948594b36678145R8983-R8984)

**General Documentation Consistency:**

- Replaced outdated references to manual multi-endpoint configuration with links to the improved HA mode documentation and clarified language throughout. [[1]](diffhunk://#diff-a4ed59299f9656e3d5ae803a0674ffe4438c9f61e24ad8430f11760885c6dc22L2362-R2377) [[2]](diffhunk://#diff-fcfec6aa38d6b7d9fbc8fc2f55d39d9305e594bf9c1fdcad2b463457766a11ecL274-R289)
- Updated feature lists and overviews to refer to "WebSocket streaming with HA mode" instead of "Multiple WebSocket endpoints (HA)" for clarity. [[1]](diffhunk://#diff-6869f893776e3f74955fcb97bfd3cfbf038f1e1a57e2e20ce948594b36678145L4641-R4659) [[2]](diffhunk://#diff-1b0b54413d989a0282d12e6e402e4ff3376d59dc84a655007462be03d34bfb8fL235-R253)

These changes make it easier for developers to enable and understand HA mode in the Data Streams SDK, reducing configuration complexity and improving reliability in production environments.