### PR TITLE
CRE: release notes for cli 1.18.0

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -403,6 +403,13 @@
   },
   "data": [
     {
+      "category": "release",
+      "date": "2026-06-04",
+      "description": "CRE CLI version 1.18.0 is now available. This release includes internal reliability improvements across context propagation, secret handling, and registry type management.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.17.0...v1.18.0)",
+      "title": "CRE CLI v1.18.0 — Internal Improvements",
+      "topic": "CRE"
+    },
+    {
       "category": "deprecation",
       "date": "2026-05-29",
       "description": "Chainlink is deprecating support for the legacy Webhook job type.\n\nAfter version 2.49, this job type will no longer be supported in Chainlink node releases. Node operators and developers that continue to rely on this job type can choose to remain on the last compatible release, but should not expect ongoing development support, including maintenance, bug fixes, security patches, or compatibility with future releases.\n\nTeams using this legacy job type should begin planning to upgrade to the [Chainlink Runtime Environment (CRE)](https://docs.chain.link/cre) as an alternative.",

--- a/src/config/versions/index.ts
+++ b/src/config/versions/index.ts
@@ -77,8 +77,9 @@ export const VERSIONS = {
   },
   // CRE CLI Versions — update LATEST here for each new release
   "cre-cli": {
-    LATEST: "v1.17.0",
+    LATEST: "v1.18.0",
     ALL: [
+      "v1.18.0",
       "v1.17.0",
       "v1.16.0",
       "v1.15.0",
@@ -91,6 +92,7 @@ export const VERSIONS = {
       "v1.8.0",
     ] as const,
     RELEASE_DATES: {
+      "v1.18.0": "2026-06-04T00:00:00Z",
       "v1.17.0": "2026-05-28T00:00:00Z",
       "v1.16.0": "2026-05-22T00:00:00Z",
       "v1.15.0": "2026-05-14T00:00:00Z",

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -507,9 +507,22 @@ To help us assist you faster, please include:
 
 # Release Notes
 Source: https://docs.chain.link/cre/release-notes
-Last Updated: 2026-05-28
+Last Updated: 2026-06-04
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.18.0 - June 4, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.18.0" target="_blank">CRE CLI version 1.18.0</a> is now available.**
+
+- **Internal improvements**: Reliability fixes across context propagation, secret handling, and registry type management.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.17.0...v1.18.0)
 
 ## CLI v1.17.0 - May 28, 2026
 

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -507,9 +507,22 @@ To help us assist you faster, please include:
 
 # Release Notes
 Source: https://docs.chain.link/cre/release-notes
-Last Updated: 2026-05-28
+Last Updated: 2026-06-04
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.18.0 - June 4, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.18.0" target="_blank">CRE CLI version 1.18.0</a> is now available.**
+
+- **Internal improvements**: Reliability fixes across context propagation, secret handling, and registry type management.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.17.0...v1.18.0)
 
 ## CLI v1.17.0 - May 28, 2026
 

--- a/src/content/cre/release-notes.mdx
+++ b/src/content/cre/release-notes.mdx
@@ -5,12 +5,25 @@ date: Last Modified
 metadata:
   description: "Discover what's new in CRE: latest features, changes, and improvements in each release of the Chainlink Runtime Environment."
   datePublished: "2025-11-04"
-  lastModified: "2026-05-28"
+  lastModified: "2026-06-04"
 ---
 
 import { Aside } from "@components"
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.18.0 - June 4, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.18.0" target="_blank">CRE CLI version 1.18.0</a> is now available.**
+
+- **Internal improvements**: Reliability fixes across context propagation, secret handling, and registry type management.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.17.0...v1.18.0)
 
 ## CLI v1.17.0 - May 28, 2026
 


### PR DESCRIPTION
This pull request documents the release of CRE CLI version 1.18.0, updates all relevant version tracking, and adds release notes across the documentation. The update highlights internal reliability improvements and provides users with update instructions.

Release documentation and notes:

* Added release notes for CRE CLI v1.18.0, detailing internal reliability improvements in context propagation, secret handling, and registry type management, along with update instructions and a GitHub changelog link in `src/content/cre/release-notes.mdx`, `src/content/cre/llms-full-ts.txt`, and `src/content/cre/llms-full-go.txt`. [[1]](diffhunk://#diff-8f255833e502c901bafae6bf2a2dc1c1e3b950451989d8c88c006351d8ddf444L8-R27) [[2]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L510-R526) [[3]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL510-R526)
* Added a new entry for the v1.18.0 release in the public changelog (`public/changelog.json`).

Version tracking updates:

* Updated the latest CRE CLI version to v1.18.0 and added its release date in `src/config/versions/index.ts`. [[1]](diffhunk://#diff-11892e6b40841ca0f483f57267775d1ae2ccf579daa451f843c66de7f1558b3aL80-R82) [[2]](diffhunk://#diff-11892e6b40841ca0f483f57267775d1ae2ccf579daa451f843c66de7f1558b3aR95)