### PR TITLE
Data Feeds: added missing tags for various categorical feed displays

### DIFF
--- a/src/features/data/chains.ts
+++ b/src/features/data/chains.ts
@@ -94,7 +94,7 @@ export const CHAINS: Chain[] = [
         rddBundleUrl:
           "https://reference-data-directory.vercel.app/bundle-proxies-ethereum-testnet-sepolia-arbitrum-1.json",
         queryString: "arbitrum-sepolia",
-        tags: ["rates", "streams", "smartData"],
+        tags: ["rates", "streams", "smartData", "usGovernmentMacroeconomicData"],
       },
     ],
   },
@@ -121,7 +121,7 @@ export const CHAINS: Chain[] = [
         networkType: "testnet",
         rddUrl: "https://reference-data-directory.vercel.app/feeds-avalanche-fuji-testnet.json",
         queryString: "avalanche-fuji",
-        tags: ["rates", "streams"],
+        tags: ["rates", "streams", "smartData"],
       },
     ],
     label: "Avalanche",
@@ -273,7 +273,7 @@ export const CHAINS: Chain[] = [
         rddUrl: "https://reference-data-directory.vercel.app/feeds-ethereum-testnet-sepolia.json",
         rddBundleUrl: "https://reference-data-directory.vercel.app/bundle-proxies-ethereum-testnet-sepolia.json",
         queryString: "ethereum-sepolia",
-        tags: ["rates"],
+        tags: ["rates", "smartData"],
       },
     ],
     label: "Ethereum",
@@ -327,7 +327,7 @@ export const CHAINS: Chain[] = [
     title: "HyperEVM Data Feeds",
     img: "/assets/chains/hyperevm.svg",
     networkStatusUrl: "https://hyperevmscan.statuspage.io/",
-    tags: ["default"],
+    tags: ["default", "smartData"],
     supportedFeatures: ["feeds"],
     networks: [
       {
@@ -336,6 +336,7 @@ export const CHAINS: Chain[] = [
         networkType: "mainnet",
         rddUrl: "https://reference-data-directory.vercel.app/feeds-hyperliquid-mainnet.json",
         queryString: "hyperliquid-mainnet",
+        tags: ["smartData"],
       },
     ],
   },


### PR DESCRIPTION
This pull request updates the chain configuration in `src/features/data/chains.ts` to improve and standardize the tagging of supported features for various blockchain networks. The main focus is on expanding the use of the `smartData` tag and introducing a new tag for macroeconomic data.

Tagging updates by theme:

**Expansion of the `smartData` tag:**

* Added the `smartData` tag to the Avalanche Fuji testnet, Ethereum Sepolia testnet, and Ethereum Sepolia networks to indicate support for smart data features. [[1]](diffhunk://#diff-8ed0d393a36e93381036afcd284cc8c5a57d64c32555ce19f8487e7f46614899L124-R124) [[2]](diffhunk://#diff-8ed0d393a36e93381036afcd284cc8c5a57d64c32555ce19f8487e7f46614899L276-R276)
* Added the `smartData` tag to the HyperEVM network and its Hyperliquid mainnet network entry, ensuring consistent tagging for smart data support. [[1]](diffhunk://#diff-8ed0d393a36e93381036afcd284cc8c5a57d64c32555ce19f8487e7f46614899L330-R330) [[2]](diffhunk://#diff-8ed0d393a36e93381036afcd284cc8c5a57d64c32555ce19f8487e7f46614899R339)

**Introduction of new data tag:**

* Added the `usGovernmentMacroeconomicData` tag to the Arbitrum Sepolia testnet to represent support for U.S. government macroeconomic data.