### PR TITLE
Data Streams: v9 schema fix

### DIFF
--- a/src/content/data-streams/llms-full.txt
+++ b/src/content/data-streams/llms-full.txt
@@ -5685,7 +5685,7 @@ Chainlink SmartData streams adhere to the report schema outlined below.
 | `linkFee`               | `uint192` | Cost to verify report onchain (LINK)                                     |
 | `expiresAt`             | `uint32`  | Expiration date of the report (seconds)                                  |
 | `navPerShare`           | `int192`  | DON consensus NAV Per Share value as reported by the Fund Manager        |
-| `navDate`               | `uint64`  | Timestamp for the NAV Report publication date (nanoseconds)              |
+| `navDate`               | `uint64`  | Timestamp for the NAV Report publication date (milliseconds)             |
 | `aum`                   | `int192`  | DON consensus total USD value of Assets Under Management                 |
 | `ripcord`               | `uint32`  | Data provider pause status: 0 (normal), 1 (paused — do not consume data) |
 

--- a/src/features/feeds/components/reportSchemaData.ts
+++ b/src/features/feeds/components/reportSchemaData.ts
@@ -100,7 +100,7 @@ export const REPORT_SCHEMA_DEFINITIONS: Record<string, SchemaDefinition> = {
         type: "int192",
         description: "DON consensus NAV Per Share value as reported by the Fund Manager",
       },
-      { field: "navDate", type: "uint64", description: "Timestamp for the NAV Report publication date (nanoseconds)" },
+      { field: "navDate", type: "uint64", description: "Timestamp for the NAV Report publication date (milliseconds)" },
       { field: "aum", type: "int192", description: "DON consensus total USD value of Assets Under Management" },
       {
         field: "ripcord",


### PR DESCRIPTION
This pull request updates the documentation and schema definitions to clarify the time unit used for the `navDate` field in NAV reports, changing it from nanoseconds to milliseconds. This ensures consistency and accuracy in how timestamps are interpreted throughout the codebase.

Schema and documentation updates:

* Updated the `navDate` field description in the report schema documentation to specify that the timestamp is in milliseconds instead of nanoseconds (`src/content/data-streams/llms-full.txt`).
* Updated the `navDate` field description in the `REPORT_SCHEMA_DEFINITIONS` object to reflect the change to milliseconds (`src/features/feeds/components/reportSchemaData.ts`).