### PR TITLE
Migrate Solana CCT tutorials to bs58-generator, Hardhat, and ccip-cli

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -429,12 +429,6 @@
           "baseAsset": "reUSD",
           "url": "https://docs.chain.link/ccip/directory/mainnet/token/reUSD",
           "iconUrl": "https://d2f70xi62kby8n.cloudfront.net/tokens/reusd.webp?auto=compress%2Cformat&q=60&w=40&h=40&fit=cover"
-        },
-        {
-          "assetName": "Zest",
-          "baseAsset": "ZEST",
-          "url": "https://docs.chain.link/ccip/directory/mainnet/token/ZEST",
-          "iconUrl": "https://d2f70xi62kby8n.cloudfront.net/tokens/zest.webp?auto=compress%2Cformat&q=60&w=40&h=40&fit=cover"
         }
       ],
       "title": "Cross-chain token (CCT) standard: Added support for new tokens",

--- a/src/content/ccip/llms-full.txt
+++ b/src/content/ccip/llms-full.txt
@@ -19418,7 +19418,7 @@ Understanding these encoding details becomes especially important when working w
 
 # Cross-Chain Token (CCT) Tutorials
 Source: https://docs.chain.link/ccip/tutorials/svm/cross-chain-tokens
-Last Updated: 2025-08-13
+Last Updated: 2026-06-15
 
 Learn how to implement cross-chain tokens using Chainlink's Cross-Chain Interoperability Protocol (CCIP) on SVM-based blockchains like Solana.
 
@@ -19442,7 +19442,7 @@ This tutorial demonstrates the Lock and Mint token handling mechanism using Lock
 
 # Cross-Chain Token Setup: BurnMint with Direct Mint Authority Transfer
 Source: https://docs.chain.link/ccip/tutorials/svm/cross-chain-tokens/direct-mint-authority
-Last Updated: 2025-08-13
+Last Updated: 2026-06-15
 
 This comprehensive tutorial demonstrates how to create and configure cross-chain tokens using Chainlink's Cross-Chain Interoperability Protocol (CCIP) between Solana Devnet and Ethereum Sepolia. You will implement the **direct mint authority transfer** approach within **Path A** from the [CCIP Cross-Chain Token Integration Guide](/ccip/concepts/cross-chain-token/svm/integration-guide).
 
@@ -19490,76 +19490,86 @@ For complete details on token handling mechanisms, see [Token Handling Mechanism
 
 ## Prerequisites
 
-This tutorial requires setting up two different repositories in separate terminal windows. Follow the setup instructions for both environments before proceeding.
+This tutorial uses a **two-terminal workflow** across two repositories. Install the system tools below, clone both repos, then complete environment setup before starting Phase 1.
 
-### Development Environment Requirements
+### System Requirements
 
-**System Requirements:**
-
-- **Anchor and Solana CLI Tools**: Install following the [installation guide](https://www.anchor-lang.com/docs/installation). Requires Rust to be installed.
-- **Node.js v20 or higher**: Use the [nvm package](https://www.npmjs.com/package/nvm) to install and manage versions. Verify with `node -v`
-- **Yarn**: For dependency management
+- **Node.js v22 or higher**: Verify with `node -v` ([nvm](https://www.npmjs.com/package/nvm) recommended)
+- **pnpm**: Required for the BS58 generator (`npm install -g pnpm`)
+- **Solana CLI**: [Installation guide](https://docs.solana.com/cli/install-solana-cli-tools) (includes `spl-token`)
 - **Git**: For cloning repositories
+- **CCIP CLI**: For cross-chain transfer testing in the final phase
 
-### Terminal 1: Solana Starter Kit Setup
-
-**Clone and setup the Solana Starter Kit:**
+Install the [CCIP CLI](https://github.com/smartcontractkit/ccip-tools-ts) globally:
 
 ```bash
-git clone https://github.com/smartcontractkit/solana-starter-kit.git && cd solana-starter-kit
+npm install -g @chainlink/ccip-cli
+ccip-cli --help
 ```
 
-**Install dependencies:**
+See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for RPC and wallet configuration.
+
+### Tutorial Workflow
+
+| Terminal       | Repository                                                                                                                  | Purpose                              | Commands        |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | --------------- |
+| **Terminal 1** | [CCIP Solana BS58 Generator](https://github.com/smartcontractkit/ccip-solana-bs58-generator)                                | Solana setup and configuration       | `pnpm bs58`     |
+| **Terminal 2** | [Smart Contract Examples (Hardhat)](https://github.com/smartcontractkit/smart-contract-examples/tree/main/ccip/cct/hardhat) | EVM deploy and configuration         | `npx hardhat`   |
+| **Either**     | Global `@chainlink/ccip-cli`                                                                                                | Cross-chain transfer testing (final) | `ccip-cli send` |
+
+### Terminal 1: CCIP Solana BS58 Generator
+
+**Clone and install** (skip `git clone` if you already have the repo):
 
 ```bash
-yarn install
+git clone https://github.com/smartcontractkit/ccip-solana-bs58-generator.git
+cd ccip-solana-bs58-generator
+pnpm install
 ```
 
-**Configure your Solana environment:**
+**Configure Solana CLI for devnet:**
+
+First, check whether your environment is already set up:
 
 ```bash
-# Set Solana CLI to use devnet
+solana config get
+solana address
+solana balance
+```
+
+If the RPC URL is already `https://api.devnet.solana.com`, your keypair path is correct, and you have sufficient SOL, skip to [Terminal 2 setup](#terminal-2-smart-contract-examples-hardhat) below.
+
+Otherwise, run only the steps you need:
+
+```bash
+# Set devnet (skip if config get already shows devnet)
 solana config set --url https://api.devnet.solana.com
 
-# Set your keypair (create one if needed)
+# Point to your keypair (skip if config get already shows the path you want)
 solana config set --keypair ~/.config/solana/id.json
 
-# If you do not have a keypair, create one:
+# Create a keypair only if the file does not exist yet
 solana-keygen new --outfile ~/.config/solana/id.json
-```
 
-**Fund your Solana wallet:**
-
-```bash
-# Get your wallet address
-solana address
-
-# Request SOL from the devnet faucet
+# Fund your wallet if balance is low
 solana airdrop 2
-```
-
-**Verify your setup:**
-
-```bash
-# Check your SOL balance
 solana balance
-
-# Verify you are on devnet
-solana config get
 ```
 
-### Terminal 2: Smart Contract Examples Setup
+<Aside type="note" title="Direct Execution">
+  Append `--execute` to **mutating** `pnpm bs58` commands in Terminal 1 so your local wallet signs and sends
+  transactions. **Read-only** commands (`get-state`, `get-chain-config`, `derive-accounts`) omit `--execute`. See the
+  [CCIP Solana BS58 Generator
+  README](https://github.com/smartcontractkit/ccip-solana-bs58-generator/blob/main/README.md) for command syntax.
+</Aside>
 
-**Clone the repository and navigate to the Hardhat project:**
+### Terminal 2: Smart Contract Examples (Hardhat)
+
+**Clone, install, and compile** (skip `git clone` if you already have the repo):
 
 ```bash
 git clone https://github.com/smartcontractkit/smart-contract-examples.git
 cd smart-contract-examples/ccip/cct/hardhat
-```
-
-**Install and compile dependencies:**
-
-```bash
 npm install
 npm run compile
 ```
@@ -19567,38 +19577,70 @@ npm run compile
 **Set up encrypted environment variables:**
 
 ```bash
-# Set encryption password
+# Required at the start of each session
 npx env-enc set-pw
 
-# Configure environment variables
+# Verify existing variables (skip npx env-enc set if all required vars are already configured)
+npx env-enc view
+
+# Add or update variables only if missing
 npx env-enc set
 ```
 
-**Required environment variables for Ethereum Sepolia:**
+**Required variables for Ethereum Sepolia:**
 
 - `ETHEREUM_SEPOLIA_RPC_URL`: RPC endpoint from [Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/)
 - `PRIVATE_KEY`: Your testnet wallet private key ([MetaMask export guide](https://support.metamask.io/managing-my-wallet/secret-recovery-phrase-and-private-keys/how-to-export-an-accounts-private-key/))
 - `ETHERSCAN_API_KEY`: API key from [Etherscan](https://docs.etherscan.io/getting-started/viewing-api-usage-statistics)
 
-**Fund your wallet:**
+**Fund your EVM wallet:**
 
-- Acquire LINK and ETH on Ethereum Sepolia using [Chainlink faucets](https://faucets.chain.link/)
+- Acquire **ETH** on Ethereum Sepolia for transaction gas and CCIP fees ([Chainlink faucet](https://faucets.chain.link/) or [Google Cloud Faucet](https://cloud.google.com/application/web3/faucet/ethereum/sepolia))
+- **LINK** is optional — use `--fee-token LINK` on EVM → Solana sends if you prefer paying CCIP fees in LINK
+
+### Cross-Chain Transfers (CCIP CLI)
+
+The final tutorial phase uses globally installed `ccip-cli` (not the BS58 generator):
+
+- **Solana → EVM**: Run from Terminal 1 with `--wallet ~/.config/solana/id.json`
+- **EVM → Solana**: Run from Terminal 2 (Hardhat directory). Prefer `--wallet hardhat:<name>` ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)) so the signing key stays encrypted. Hardhat tasks load env-enc automatically; `ccip-cli` does not. As an alternative, view the same key with `npx env-enc view` and export `PRIVATE_KEY` manually for the send command.
+
+**RPC endpoints** (required for source and destination chains). You can provide them any of these ways — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration):
+
+- **Command line:** pass `--rpc` on each command (repeat for multiple networks), or `--rpcs` with comma-separated URLs
+- **Environment variables:** export `RPC_*` variables (e.g., `RPC_SEPOLIA`, `RPC_SOLANA_DEVNET`) or the tutorial's `SOLANA_DEVNET_RPC` and `ETHEREUM_SEPOLIA_RPC_URL` exports
+- **File:** create a `.env` file in the directory where you run `ccip-cli` (default `--rpcs-file`, one URL per line)
+
+See the tutorial's **Configure CCIP CLI** section for the recommended `--rpc` examples.
+
+### Environment Variables
+
+Variables use prefixes to prevent confusion across repositories and tools:
+
+| Prefix       | Usage                   | Examples                                                                  |
+| ------------ | ----------------------- | ------------------------------------------------------------------------- |
+| `ETH_*`      | Ethereum addresses      | `ETH_TOKEN_ADDRESS`, `ETH_POOL_ADDRESS`                                   |
+| `SOL_*`      | Solana addresses        | `SOL_TOKEN_MINT`, `SOL_POOL_ADDRESS`, `SOL_WALLET_ADDRESS`                |
+| `SOL_CCIP_*` | Solana CCIP program IDs | `SOL_CCIP_POOL_PROGRAM`, `SOL_CCIP_ROUTER`, `SOL_CCIP_FEE_QUOTER_PROGRAM` |
 
 <Aside type="note" title="Two-Terminal Workflow">
-  Keep both terminal windows open throughout the tutorial. You will switch between the Solana Starter Kit (Terminal 1)
-  and Hardhat project (Terminal 2) as you progress through the phases.
+  Keep both terminal windows open throughout the tutorial. Switch between the CCIP Solana BS58 Generator (Terminal 1)
+  and the Hardhat project (Terminal 2) as each phase indicates. Cross-chain transfer commands use `ccip-cli` from the
+  terminal that matches the source chain.
 </Aside>
 
 ## Tutorial Approach
 
-This tutorial provides step-by-step instructions with detailed explanations of what each command does and why. You'll work primarily in Terminal 1 (Solana) with occasional switches to Terminal 2 (EVM).
+This tutorial provides step-by-step instructions with detailed explanations of what each command does and why. You'll work primarily in Terminal 1 (CCIP Solana BS58 Generator) with occasional switches to Terminal 2 (EVM).
 
 **Environment Variable Management**: This tutorial uses phase-based variable files (e.g., `~/.phase1_vars`, `~/.ccip_complete_vars`) to eliminate manual variable re-entry when switching between terminals. Each phase saves its variables to files that subsequent phases can load automatically.
 
 For deeper technical implementation details, refer to:
 
-- **[Solana Starter Kit README](https://github.com/smartcontractkit/solana-starter-kit/blob/main/README.md)**: SVM command details
+- **[CCIP Solana BS58 Generator README](https://github.com/smartcontractkit/ccip-solana-bs58-generator/blob/main/README.md)**: Solana CLI command details, `--execute` EOA workflow, and options
 - **[Smart Contract Examples README](https://github.com/smartcontractkit/smart-contract-examples/blob/main/ccip/cct/hardhat/README.md)**: EVM implementation guide
+
+**EOA execution**: In Terminal 1, append `--execute` to each `pnpm bs58` command so your local Solana wallet signs and sends transactions directly. Set `--authority` to your wallet address (`$SOL_WALLET_ADDRESS`). Read-only commands (`get-state`, `get-chain-config`, `derive-accounts`) do not use `--execute`.
 
 ## Phase 1: Ethereum Sepolia Token Setup
 
@@ -19646,31 +19688,37 @@ Save your EVM configuration for use in later phases:
 Now we'll create and configure the Solana side of your cross-chain token system.
 
 <Aside type="note" title="Terminal Context">
-  **Switch to Terminal 1** (Solana Starter Kit) Verify your location:
+  **Switch to Terminal 1** (CCIP Solana BS58 Generator) Verify your location:
 
   ```bash
   pwd
-  # Should show: .../solana-starter-kit
+  # Should show: .../ccip-solana-bs58-generator
   ```
 </Aside>
 
-### Step 1: Create SPL Token
+### Step 1: Prepare Environment
 
-Create an SPL token with metadata support:
+Load EVM variables from Phase 1 and set Solana CCIP constants:
+
+### Step 2: Create SPL Token
+
+Create an SPL token with metadata and initial supply using direct EOA execution:
 
 Set the token mint variable:
 
-### Step 2: Initialize CCIP Token Pool
+### Step 3: Initialize CCIP Token Pool
 
 Initialize the token pool configuration on Solana:
 
-Save the Pool Signer PDA and Pool Config PDA from the output:
+Save the Pool Signer PDA and Pool Config PDA. Derive them from the onchain pool configuration:
 
-### Step 3: Create Pool Token Account
+Copy the **Pool Signer PDA** and **Pool State PDA** addresses from the output, then export them:
+
+### Step 4: Create Pool Token Account
 
 In this step, you will create an Associated Token Account (ATA) for the Pool Signer PDA. This ATA is required for the pool to hold and manage tokens during cross-chain transfer operations.
 
-### Step 4: Register as CCIP Administrator
+### Step 5: Register as CCIP Administrator
 
 #### Propose Admin
 
@@ -19680,7 +19728,7 @@ In this step, you will propose yourself as the CCIP administrator for the Solana
 
 In this step, you will accept the administrator role for the Solana token. This process establishes your control over the token's CCIP configuration on Solana.
 
-### Step 5: Transfer Mint Authority to Pool Signer PDA
+### Step 6: Transfer Mint Authority to Pool Signer PDA
 
 <Aside type="caution" title="Critical Step: Mint Authority Transfer">
   **This is the defining step** of the direct mint authority approach. You're transferring complete mint authority to the Pool Signer PDA, which:
@@ -19692,7 +19740,9 @@ In this step, you will accept the administrator role for the Solana token. This 
   **Important**: Ensure you have sufficient tokens for testing before proceeding. The SPL token creation in Step 1 already minted tokens to your wallet, so you're ready to continue.
 </Aside>
 
-### Step 6: Save Phase 2 Variables
+Verify the authority transfer:
+
+### Step 7: Save Phase 2 Variables
 
 Save your Solana configuration for use in cross-chain setup:
 
@@ -19702,7 +19752,7 @@ Configure bidirectional connectivity between your token pools on both chains.
 
 ### Step 1: Configure Solana Pool
 
-**Stay in Terminal 1 (Solana Starter Kit)**
+**Stay in Terminal 1** (CCIP Solana BS58 Generator)
 
 Load the Ethereum addresses from Phase 1:
 
@@ -19748,16 +19798,23 @@ Register the BurnMint token pool with your token in the TokenAdminRegistry:
 
 ### Step 2: Register Solana Pool
 
-**Switch to Terminal 1 (Solana Starter Kit)**
+**Switch to Terminal 1** (CCIP Solana BS58 Generator)
 
 ```bash
 pwd
-# Should show ../solana-starter-kit
+# Should show: .../ccip-solana-bs58-generator
+```
+
+Load variables from previous phases:
+
+```bash
+source ~/.phase1_vars
+source ~/.phase2_vars
 ```
 
 #### Create Address Lookup Table
 
-Address Lookup Tables (ALT) optimize Solana transactions by compressing addresses.
+Address Lookup Tables (ALT) optimize Solana transactions by compressing addresses. With EOA execution, create and populate the ALT in one step:
 
 Save the ALT address:
 
@@ -19771,52 +19828,94 @@ Save all variables for the testing phase:
 
 ## Phase 5: Pre-Transfer Setup
 
-Before testing transfers, complete final setup steps.
+Before validating your configuration, complete final setup steps.
 
-### Step 1: Get Pool Signer PDA
+### Step 1: Verify Pool Signer PDA
 
-Extract the Pool Signer PDA for reference:
+Confirm the Pool Signer PDA matches your saved configuration:
 
-Confirm this matches your previously saved PDA:
-
-```bash
-echo "Saved Pool Signer PDA: $SOL_POOL_SIGNER_PDA"
-echo "Current Pool Signer PDA: BwzTc3R77vf1dS4kj3JX8YGpCvjsg91vBDgyKJfeBkue"
-```
+Compare the onchain **Pool Signer** with your saved variable:
 
 ### Step 2: Delegate Token Authority
 
-In this step, you will delegate token approval to the fee-billing signer PDA, which is what enables CCIP to transfer tokens on your behalf when sending cross-chain messages.
+In this step, you will delegate token approval to the CCIP fee-billing signer PDA, which enables CCIP to transfer tokens on your behalf when sending cross-chain messages.
 
-### Step 3: Verify Delegate
+Approve the fee-billing signer to transfer tokens from your ATA:
 
-Check the previous step to verify the token is delegated to the Pool Signer PDA:
+### Step 3: Verify Delegation
 
-## Phase 6: Testing Cross-Chain Transfers
+Check that your token account is delegated to the fee-billing signer:
 
-In this step, you will test bidirectional token transfers to verify your setup.
+Display token account and delegation status:
+
+## Phase 6: Test Cross-Chain Transfers
+
+Validate your configuration, then execute bidirectional token transfers using the CCIP CLI.
+
+<Aside type="note" title="Cross-Chain Transfers with CCIP CLI">
+  Use [`@chainlink/ccip-cli`](https://github.com/smartcontractkit/ccip-tools-ts) for bidirectional token transfers. Run Solana → EVM sends from Terminal 1 and EVM → Solana sends from Terminal 2. See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for full options.
+</Aside>
 
 Confirm you are in the correct directory (Terminal 1):
 
 ```bash
 pwd
-# Should output: ../solana-starter-kit
+# Should show: .../ccip-solana-bs58-generator
 ```
 
 ### Step 1: Load Complete Configuration
 
-Before testing, ensure all variables are available in your current terminal:
+### Step 2: Verify Solana Pool and Chain Config
 
-### Step 2: Transfer Solana → Ethereum
+### Step 3: Verify Ethereum Pool (Terminal 2)
 
-**In Terminal 1 (Solana Starter Kit)**
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
 
-### Step 3: Transfer Ethereum → Solana
+```bash
+npx hardhat getPoolConfig \
+  --pooladdress $ETH_POOL_ADDRESS \
+  --network ethereumSepolia
+```
 
-<Aside type="note" title="EVM Credentials Required">
-  For this direction, ensure your `.env` file in Terminal 1 contains your EVM credentials as set up in the
-  prerequisites.
+Confirm the Ethereum pool recognizes Solana Devnet with your `$SOL_POOL_CONFIG_PDA` and `$SOL_TOKEN_MINT`.
+
+### Configure CCIP CLI
+
+Export these RPC URLs once before your first transfer:
+
+```bash
+export SOLANA_DEVNET_RPC="https://api.devnet.solana.com"
+export ETHEREUM_SEPOLIA_RPC_URL="<YOUR_ETHEREUM_SEPOLIA_RPC_URL>"
+
+export ETH_CCIP_ROUTER="0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59"
+```
+
+Use the same `ETHEREUM_SEPOLIA_RPC_URL` from your env-enc setup in Terminal 2 (`npx env-enc view`). On `ccip-cli send`, the source chain RPC quotes fees and submits the transaction; for token-only transfers in this tutorial, that is the only RPC strictly required to send. Pass both RPCs on cross-chain commands anyway: the destination RPC is required for `ccip-cli show --wait` and for optional send features such as `--estimate-gas-limit` or `send --wait`.
+
+<Aside type="note" title="RPC and wallet configuration">
+  Repeat `--rpc` for multiple networks, or use `--rpcs` with comma-separated URLs. Alternatively, set `RPC_*` environment variables or a `.env` file — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration). Solana sends use `--wallet ~/.config/solana/id.json`. EVM sends: prefer `--wallet hardhat:<name>` from the Hardhat project directory ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)); alternatively export `PRIVATE_KEY` manually after `npx env-enc view` (Hardhat tasks load env-enc automatically, but `ccip-cli` does not). See [CCIP CLI wallet configuration](https://docs.chain.link/ccip/tools/cli/configuration#wallet-configuration).
 </Aside>
+
+### Transfer Solana → Ethereum
+
+**Terminal 1** (CCIP Solana BS58 Generator):
+
+The `-t` flag uses human-readable amounts (0.001 tokens with 9 decimals = 1,000,000 smallest units).
+
+### Transfer Ethereum → Solana
+
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
+
+`ccip-cli` does not load Hardhat env-enc automatically. Run these commands from the Hardhat project directory. Prefer [Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore) over exporting a private key in plain text.
+
+For token-only transfers to Solana, `--to` is the destination wallet that receives minted tokens. CCIP fees are paid in native Sepolia ETH by default — ensure your wallet has sufficient ETH for gas and fees.
+
+<Aside type="note" title="Pay fees in LINK (optional)">
+  Add `--fee-token LINK` to pay CCIP fees in LINK instead of ETH (Sepolia LINK:
+  `0x779877A7B0D9E8603169DdbD7836e478b4624789`).
+</Aside>
+
+**Congratulations!** Your cross-chain token infrastructure is fully configured on both chains.
 
 ## Reference: Verification Commands
 
@@ -19824,13 +19923,14 @@ Use these commands to verify your setup at any point during the tutorial. Each s
 
 ### Solana Pool Verification
 
-**Terminal 1 (Solana Starter Kit)**
+**Terminal 1** (CCIP Solana BS58 Generator)
 
 ```bash
 # Verify pool configuration and status
-yarn svm:pool:get-info \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-state \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT
 ```
 
 **What this shows:**
@@ -19842,14 +19942,15 @@ yarn svm:pool:get-info \
 
 ### Solana Chain Configuration
 
-**Terminal 1 (Solana Starter Kit)**
+**Terminal 1** (CCIP Solana BS58 Generator)
 
 ```bash
-# Verify cross-chain configuration with Ethereum
-yarn svm:pool:get-chain-config \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM \
-  --remote-chain ethereum-sepolia
+# Verify cross-chain configuration with Ethereum Sepolia
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-chain-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --remote-chain-selector $ETH_SEPOLIA_CHAIN_SELECTOR
 ```
 
 **What this shows:**
@@ -19861,7 +19962,7 @@ yarn svm:pool:get-chain-config \
 
 ### Solana Token Balance
 
-**Terminal 1 (Solana Starter Kit)**
+**Terminal 1** (CCIP Solana BS58 Generator)
 
 ```bash
 # Check your token balance
@@ -19882,7 +19983,7 @@ spl-token balance $SOL_TOKEN_MINT
 # Verify Ethereum pool configuration
 npx hardhat getPoolConfig \
   --pooladdress $ETH_POOL_ADDRESS \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 **What this shows:**
@@ -19923,7 +20024,7 @@ npx hardhat getPoolConfig \
 
 # Cross-Chain Token Setup: BurnMint with SPL Token Multisig Tutorial
 Source: https://docs.chain.link/ccip/tutorials/svm/cross-chain-tokens/spl-token-multisig-tutorial
-Last Updated: 2025-08-13
+Last Updated: 2026-06-15
 
 This educational tutorial demonstrates how to create and configure cross-chain tokens using Chainlink's Cross-Chain Interoperability Protocol (CCIP) between Solana Devnet and Ethereum Sepolia using **SPL token multisig concepts**. You will learn to implement the **SPL token multisig** approach within **Path A** from the [CCIP Cross-Chain Token Integration Guide](/ccip/concepts/cross-chain-token/svm/integration-guide#path-a-full-self-service-mint-authority-controlled).
 
@@ -19981,76 +20082,86 @@ This tutorial implements the **[Burn and Mint](/ccip/concepts/cross-chain-token/
 
 ## Prerequisites
 
-This tutorial requires setting up two different repositories in separate terminal windows. Follow the setup instructions for both environments before proceeding.
+This tutorial uses a **two-terminal workflow** across two repositories. Install the system tools below, clone both repos, then complete environment setup before starting Phase 1.
 
-### Development Environment Requirements
+### System Requirements
 
-**System Requirements:**
-
-- **Anchor and Solana CLI Tools**: Install following the [installation guide](https://www.anchor-lang.com/docs/installation). Requires Rust to be installed.
-- **Node.js v20 or higher**: Use the [nvm package](https://www.npmjs.com/package/nvm) to install and manage versions. Verify with `node -v`
-- **Yarn**: For dependency management
+- **Node.js v22 or higher**: Verify with `node -v` ([nvm](https://www.npmjs.com/package/nvm) recommended)
+- **pnpm**: Required for the BS58 generator (`npm install -g pnpm`)
+- **Solana CLI**: [Installation guide](https://docs.solana.com/cli/install-solana-cli-tools) (includes `spl-token`)
 - **Git**: For cloning repositories
+- **CCIP CLI**: For cross-chain transfer testing in the final phase
 
-### Terminal 1: Solana Starter Kit Setup
-
-**Clone and setup the Solana Starter Kit:**
+Install the [CCIP CLI](https://github.com/smartcontractkit/ccip-tools-ts) globally:
 
 ```bash
-git clone https://github.com/smartcontractkit/solana-starter-kit.git && cd solana-starter-kit
+npm install -g @chainlink/ccip-cli
+ccip-cli --help
 ```
 
-**Install dependencies:**
+See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for RPC and wallet configuration.
+
+### Tutorial Workflow
+
+| Terminal       | Repository                                                                                                                  | Purpose                              | Commands        |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | --------------- |
+| **Terminal 1** | [CCIP Solana BS58 Generator](https://github.com/smartcontractkit/ccip-solana-bs58-generator)                                | Solana setup and configuration       | `pnpm bs58`     |
+| **Terminal 2** | [Smart Contract Examples (Hardhat)](https://github.com/smartcontractkit/smart-contract-examples/tree/main/ccip/cct/hardhat) | EVM deploy and configuration         | `npx hardhat`   |
+| **Either**     | Global `@chainlink/ccip-cli`                                                                                                | Cross-chain transfer testing (final) | `ccip-cli send` |
+
+### Terminal 1: CCIP Solana BS58 Generator
+
+**Clone and install** (skip `git clone` if you already have the repo):
 
 ```bash
-yarn install
+git clone https://github.com/smartcontractkit/ccip-solana-bs58-generator.git
+cd ccip-solana-bs58-generator
+pnpm install
 ```
 
-**Configure your Solana environment:**
+**Configure Solana CLI for devnet:**
+
+First, check whether your environment is already set up:
 
 ```bash
-# Set Solana CLI to use devnet
+solana config get
+solana address
+solana balance
+```
+
+If the RPC URL is already `https://api.devnet.solana.com`, your keypair path is correct, and you have sufficient SOL, skip to [Terminal 2 setup](#terminal-2-smart-contract-examples-hardhat) below.
+
+Otherwise, run only the steps you need:
+
+```bash
+# Set devnet (skip if config get already shows devnet)
 solana config set --url https://api.devnet.solana.com
 
-# Set your keypair (create one if needed)
+# Point to your keypair (skip if config get already shows the path you want)
 solana config set --keypair ~/.config/solana/id.json
 
-# If you do not have a keypair, create one:
+# Create a keypair only if the file does not exist yet
 solana-keygen new --outfile ~/.config/solana/id.json
-```
 
-**Fund your Solana wallet:**
-
-```bash
-# Get your wallet address
-solana address
-
-# Request SOL from the devnet faucet
+# Fund your wallet if balance is low
 solana airdrop 2
-```
-
-**Verify your setup:**
-
-```bash
-# Check your SOL balance
 solana balance
-
-# Verify you are on devnet
-solana config get
 ```
 
-### Terminal 2: Smart Contract Examples Setup
+<Aside type="note" title="Direct Execution">
+  Append `--execute` to **mutating** `pnpm bs58` commands in Terminal 1 so your local wallet signs and sends
+  transactions. **Read-only** commands (`get-state`, `get-chain-config`, `derive-accounts`) omit `--execute`. See the
+  [CCIP Solana BS58 Generator
+  README](https://github.com/smartcontractkit/ccip-solana-bs58-generator/blob/main/README.md) for command syntax.
+</Aside>
 
-**Clone the repository and navigate to the Hardhat project:**
+### Terminal 2: Smart Contract Examples (Hardhat)
+
+**Clone, install, and compile** (skip `git clone` if you already have the repo):
 
 ```bash
 git clone https://github.com/smartcontractkit/smart-contract-examples.git
 cd smart-contract-examples/ccip/cct/hardhat
-```
-
-**Install and compile dependencies:**
-
-```bash
 npm install
 npm run compile
 ```
@@ -20058,40 +20169,70 @@ npm run compile
 **Set up encrypted environment variables:**
 
 ```bash
-# Set encryption password
+# Required at the start of each session
 npx env-enc set-pw
 
-# Configure environment variables
+# Verify existing variables (skip npx env-enc set if all required vars are already configured)
+npx env-enc view
+
+# Add or update variables only if missing
 npx env-enc set
 ```
 
-**Required environment variables for Ethereum Sepolia:**
+**Required variables for Ethereum Sepolia:**
 
 - `ETHEREUM_SEPOLIA_RPC_URL`: RPC endpoint from [Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/)
 - `PRIVATE_KEY`: Your testnet wallet private key ([MetaMask export guide](https://support.metamask.io/managing-my-wallet/secret-recovery-phrase-and-private-keys/how-to-export-an-accounts-private-key/))
 - `ETHERSCAN_API_KEY`: API key from [Etherscan](https://docs.etherscan.io/getting-started/viewing-api-usage-statistics)
 
-**Fund your wallet:**
+**Fund your EVM wallet:**
 
-- Acquire LINK and ETH on Ethereum Sepolia using [Chainlink faucets](https://faucets.chain.link/)
+- Acquire **ETH** on Ethereum Sepolia for transaction gas and CCIP fees ([Chainlink faucet](https://faucets.chain.link/) or [Google Cloud Faucet](https://cloud.google.com/application/web3/faucet/ethereum/sepolia))
+- **LINK** is optional — use `--fee-token LINK` on EVM → Solana sends if you prefer paying CCIP fees in LINK
+
+### Cross-Chain Transfers (CCIP CLI)
+
+The final tutorial phase uses globally installed `ccip-cli` (not the BS58 generator):
+
+- **Solana → EVM**: Run from Terminal 1 with `--wallet ~/.config/solana/id.json`
+- **EVM → Solana**: Run from Terminal 2 (Hardhat directory). Prefer `--wallet hardhat:<name>` ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)) so the signing key stays encrypted. Hardhat tasks load env-enc automatically; `ccip-cli` does not. As an alternative, view the same key with `npx env-enc view` and export `PRIVATE_KEY` manually for the send command.
+
+**RPC endpoints** (required for source and destination chains). You can provide them any of these ways — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration):
+
+- **Command line:** pass `--rpc` on each command (repeat for multiple networks), or `--rpcs` with comma-separated URLs
+- **Environment variables:** export `RPC_*` variables (e.g., `RPC_SEPOLIA`, `RPC_SOLANA_DEVNET`) or the tutorial's `SOLANA_DEVNET_RPC` and `ETHEREUM_SEPOLIA_RPC_URL` exports
+- **File:** create a `.env` file in the directory where you run `ccip-cli` (default `--rpcs-file`, one URL per line)
+
+See the tutorial's **Configure CCIP CLI** section for the recommended `--rpc` examples.
+
+### Environment Variables
+
+Variables use prefixes to prevent confusion across repositories and tools:
+
+| Prefix       | Usage                   | Examples                                                                  |
+| ------------ | ----------------------- | ------------------------------------------------------------------------- |
+| `ETH_*`      | Ethereum addresses      | `ETH_TOKEN_ADDRESS`, `ETH_POOL_ADDRESS`                                   |
+| `SOL_*`      | Solana addresses        | `SOL_TOKEN_MINT`, `SOL_POOL_ADDRESS`, `SOL_WALLET_ADDRESS`                |
+| `SOL_CCIP_*` | Solana CCIP program IDs | `SOL_CCIP_POOL_PROGRAM`, `SOL_CCIP_ROUTER`, `SOL_CCIP_FEE_QUOTER_PROGRAM` |
 
 <Aside type="note" title="Two-Terminal Workflow">
-  Keep both terminal windows open throughout the tutorial. You will switch between the Solana Starter Kit (Terminal 1)
-  and Hardhat project (Terminal 2) as you progress through the phases.
+  Keep both terminal windows open throughout the tutorial. Switch between the CCIP Solana BS58 Generator (Terminal 1)
+  and the Hardhat project (Terminal 2) as each phase indicates. Cross-chain transfer commands use `ccip-cli` from the
+  terminal that matches the source chain.
 </Aside>
 
 ## Tutorial Approach
 
-This tutorial provides step-by-step instructions with detailed explanations of what each command does and why. You'll work primarily in Terminal 1 (Solana) with occasional switches to Terminal 2 (EVM).
+This tutorial provides step-by-step instructions with detailed explanations of what each command does and why. You'll work primarily in Terminal 1 (CCIP Solana BS58 Generator) with occasional switches to Terminal 2 (EVM).
 
 **Environment Variable Management**: This tutorial uses phase-based variable files (e.g., `~/.phase1_vars`, `~/.ccip_complete_vars`) to eliminate manual variable re-entry when switching between terminals. Each phase saves its variables to files that subsequent phases can load automatically.
 
-For detailed implementation code explanations, refer to the comprehensive READMEs in both repositories:
+For detailed implementation code explanations, refer to:
 
-- **[Solana Starter Kit README](https://github.com/smartcontractkit/solana-starter-kit/blob/main/README.md)**: Detailed explanations of all SVM commands and implementation
-- **[Smart Contract Examples README](https://github.com/smartcontractkit/smart-contract-examples/blob/main/ccip/cct/hardhat/README.md)**: Comprehensive EVM implementation guide
+- **[CCIP Solana BS58 Generator README](https://github.com/smartcontractkit/ccip-solana-bs58-generator/blob/main/README.md)**: Solana CLI command details, `--execute` EOA workflow, and options
+- **[Smart Contract Examples README](https://github.com/smartcontractkit/smart-contract-examples/blob/main/ccip/cct/hardhat/README.md)**: EVM implementation guide
 
-The READMEs contain detailed technical explanations, troubleshooting guides, and advanced configuration options.
+**EOA execution**: In Terminal 1, append `--execute` to each `pnpm bs58` command so your local Solana wallet signs and sends transactions directly. Set `--authority` to your wallet address (`$SOL_ADMIN_WALLET`). Read-only commands (`get-state`, `get-chain-config`, `derive-accounts`) do not use `--execute`.
 
 ## Phase 1: Ethereum Sepolia Token Setup
 
@@ -20134,101 +20275,76 @@ Save the Phase 1 variables for cross-terminal access:
 
 In this phase, you will create an SPL token, initialize the CCIP token pool, and complete CCIP registration **before\*\*** setting up the SPL token multisig. This sequence is critical because the self-service registration requires you to hold the mint authority.
 
-**Switch to Terminal 1** (Solana Starter Kit) Verify your location:
+**Switch to Terminal 1** (CCIP Solana BS58 Generator) Verify your location:
 
 ```bash
 pwd
-# Should show: .../solana-starter-kit
+# Should show: .../ccip-solana-bs58-generator
 ```
 
-Load the Ethereum addresses from Phase 1:
-
-```bash
-source ~/.phase1_vars
-echo "Loaded Phase 1 variables: ETH_TOKEN_ADDRESS=$ETH_TOKEN_ADDRESS, ETH_POOL_ADDRESS=$ETH_POOL_ADDRESS"
-```
+Load the Ethereum addresses from Phase 1 and set CCIP constants:
 
 ### Step 1: Create SPL Token
 
-In this step, you will use the `svm:token:create` script to create an SPL token with Metaplex metadata support on Solana Devnet. This script leverages the TokenManager library to create a comprehensive token with metadata, initial supply, and proper configuration for CCIP integration.
+Create an SPL token with Metaplex metadata and initial supply using direct EOA execution:
 
-### Set Environment Variables
-
-Set up environment variables for easier reference throughout the tutorial:
+Set the token mint variable:
 
 ### Step 2: Initialize CCIP Token Pool
 
-In this step, you will use the `svm:pool:initialize` script to initialize a CCIP token pool for your SPL token. This process creates the necessary on-chain state for cross-chain operations and establishes the Pool Signer PDA that will manage token operations.
+Initialize a CCIP token pool for your SPL token. This creates the on-chain state for cross-chain operations and establishes the Pool Signer PDA that will become a multisig member.
 
 ### Step 3: Verify Pool Creation
 
-In this step, you will use the `svm:pool:get-info` script to verify that your token pool was initialized correctly. This command queries the on-chain state and displays comprehensive information about your pool configuration, including the Pool Signer PDA and current ownership.
+Derive pool accounts using the read-only `derive-accounts` command:
+
+Copy the **Pool Signer PDA** and **Pool State PDA** from the output, then export them:
 
 ### Step 4: Create Pool Token Account
 
-In this step, you will use the `svm:pool:create-token-account` script to create an Associated Token Account (ATA) for the Pool Signer PDA. This ATA is required for the pool to hold and manage tokens during cross-chain transfer operations.
+Create an Associated Token Account (ATA) for the Pool Signer PDA. This ATA is required for the pool to hold and manage tokens during cross-chain transfer operations.
 
-### Step 5: Set Pool Environment Variables
+### Step 5: Claim Admin
 
-Set the Pool Signer PDA and Pool Config PDA from the Step 3 output above:
+Register yourself as the CCIP administrator for the Solana token. This must be completed while you still hold the mint authority.
 
-### Step 6: Claim Admin
+### Step 6: Accept Admin Role
 
-In this step, you will use the `svm:admin:propose-administrator` and `svm:admin:accept-admin-role` scripts to register yourself as the CCIP administrator for the Solana token. This process establishes your control over the token's CCIP configuration on Solana.
+Accept the proposed administrator role to establish CCIP admin control:
 
-### Step 7: Accept Admin Role
-
-In this step, you will use the `svm:admin:accept-admin-role` script to accept the proposed administrator role. This process establishes your control over the token's CCIP configuration on Solana.
-
-### Step 8: Create SPL Token Multisig
+### Step 7: Create SPL Token Multisig
 
 Now that CCIP registration is complete, create the SPL token multisig that will serve as the mint authority:
 
 **Set the multisig address environment variable:**
 
-### Step 9: Transfer Mint Authority to Multisig
+### Step 8: Transfer Mint Authority to Multisig
 
 Now transfer the mint authority from your wallet to the multisig:
 
-### Step 10: Verify Multisig Configuration
+### Step 9: Verify Multisig Configuration
 
 Verify that the multisig has been properly configured and the mint authority has been transferred:
 
 Save the Phase 2 variables for cross-terminal access:
 
-```bash
-# Save all variables from Phases 1 and 2 to complete vars file
-cat > ~/.ccip_complete_vars << EOF
-export ETH_TOKEN_ADDRESS="$ETH_TOKEN_ADDRESS"
-export ETH_POOL_ADDRESS="$ETH_POOL_ADDRESS"
-export SOL_TOKEN_MINT="$SOL_TOKEN_MINT"
-export SOL_ADMIN_WALLET="$SOL_ADMIN_WALLET"
-export CCIP_POOL_PROGRAM="$CCIP_POOL_PROGRAM"
-export SOL_POOL_SIGNER_PDA="$SOL_POOL_SIGNER_PDA"
-export SOL_POOL_CONFIG_PDA="$SOL_POOL_CONFIG_PDA"
-export SOL_MULTISIG_ADDRESS="$SOL_MULTISIG_ADDRESS"
-EOF
-
-echo "All variables saved to ~/.ccip_complete_vars for cross-terminal access"
-```
-
 ## Phase 3: Cross-Chain Configuration
 
-In this step, you will configure bidirectional connectivity between the token pools on both chains. Each chain uses different tools: **Solana** uses Starter Kit scripts to configure its pool to recognize Ethereum tokens and pools, while **Ethereum** uses Hardhat tasks to configure its pool to recognize Solana tokens and pools.
+In this step, you will configure bidirectional connectivity between the token pools on both chains. Each chain uses different tools: **Solana** uses [CCIP Solana BS58 Generator](https://github.com/smartcontractkit/ccip-solana-bs58-generator) commands to configure its pool to recognize Ethereum tokens and pools, while **Ethereum** uses Hardhat tasks to configure its pool to recognize Solana tokens and pools.
 
 ### Step 1: Configure Solana -> Ethereum
 
 #### Initialize Chain Remote Configuration
 
-In this step, you will use the `svm:pool:init-chain-remote-config` script to initialize the configuration for Ethereum Sepolia as a remote chain. This creates the basic chain configuration with token information but without pool addresses (those will be added in the next step).
+In this step, you will initialize the configuration for Ethereum Sepolia as a remote chain. This creates the basic chain configuration with token information but without pool addresses (those will be added in the next step).
 
 #### Add Ethereum Pool Address
 
-In this step, you will use the `svm:pool:edit-chain-remote-config` script to update the previously created chain configuration with the Ethereum pool address. This completes the configuration by telling the Solana pool which Ethereum pool it should interact with for cross-chain transfers.
+In this step, you will update the previously created chain configuration with the Ethereum pool address.
 
 #### Verify Configuration
 
-In this step, you will use the `svm:pool:get-chain-config` script to verify that the Solana pool configuration for Ethereum Sepolia has been set up correctly with both the token address and pool address.
+In this step, you will verify that the Solana pool configuration for Ethereum Sepolia has been set up correctly.
 
 ### Step 2: Configure Ethereum → Solana
 
@@ -20271,16 +20387,16 @@ In this step, you will use the `setPool` Hardhat task to register the BurnMint t
 
 ### Step 2: Solana Devnet Pool Registration
 
-**Switch to Terminal 1 (Solana Starter Kit)**
+**Switch to Terminal 1** (CCIP Solana BS58 Generator)
 
 ```bash
 pwd
-# Should show: .../solana-starter-kit
+# Should show: .../ccip-solana-bs58-generator
 ```
 
 #### Create Address Lookup Table
 
-Create an Address Lookup Table (ALT) containing all required accounts for CCIP operations:
+Create an Address Lookup Table (ALT) containing all required CCIP accounts plus your multisig address:
 
 **Set ALT environment variable:**
 
@@ -20288,94 +20404,117 @@ Create an Address Lookup Table (ALT) containing all required accounts for CCIP o
 
 Register your token pool with the CCIP Router using the Address Lookup Table:
 
-## Phase 5: Testing Cross-Chain Transfers
+Save the complete configuration including the ALT address:
 
-Test the complete cross-chain token transfer functionality in both directions.
+## Phase 5: Pre-Transfer Setup
 
-### Step 1: Transfer Solana → Ethereum
+Before validating your configuration, complete final setup steps.
 
-**Stay in Terminal 1 (Solana Starter Kit)**
-
-Confirm you are in the correct directory:
+**Stay in Terminal 1** (CCIP Solana BS58 Generator)
 
 ```bash
 pwd
-# Should show: .../solana-starter-kit
+# Should show: .../ccip-solana-bs58-generator
 ```
 
-#### Prepare for Testing
+### Step 1: Delegate Token Authority
 
-Your Associated Token Account (ATA) was already created during token creation in Phase 1. Now verify your token balance and prepare for cross-chain transfers:
+Delegate token approval to the CCIP fee-billing signer PDA, which enables CCIP to transfer tokens on your behalf when sending cross-chain messages.
 
-#### Execute Transfer
+Approve the fee-billing signer to transfer tokens from your ATA:
 
-#### Monitor and Verify Transaction
+### Step 2: Verify Delegation
 
-Upon successful execution, the system generates critical tracking identifiers for transaction monitoring and verification.
+Check that your token account is delegated to the fee-billing signer:
 
-**Transaction Identifiers:**
+Display token account and delegation status:
 
-- **Transaction Signature**: `sb2kHXW3M4P56WNNH74LviWcPmeYXjNA4f6opmt8iPrYF1cu5FC9grLhyu2XTEwkABQUrTdaJoDWc5CHe2gQL2u`
-- **CCIP Message ID**: `0x9c486ce15650d0bbff3f9cd8ead0510aadd854f7247bf9b775918a1296408aaa`
+## Phase 6: Test Cross-Chain Transfers
 
-**CCIP Explorer** (Primary monitoring interface):
+Validate your configuration, then execute bidirectional token transfers using the CCIP CLI.
 
-```
-https://ccip.chain.link/msg/0x9c486ce15650d0bbff3f9cd8ead0510aadd854f7247bf9b775918a1296408aaa
-```
+<Aside type="note" title="Cross-Chain Transfers with CCIP CLI">
+  Use [`@chainlink/ccip-cli`](https://github.com/smartcontractkit/ccip-tools-ts) for bidirectional token transfers. Run Solana → EVM sends from Terminal 1 and EVM → Solana sends from Terminal 2. See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for full options.
+</Aside>
 
-The CCIP Explorer provides comprehensive transaction visibility:
+### Step 1: Load Complete Configuration
 
-- Source chain (Solana) transaction confirmation
-- CCIP message processing and routing
-- Destination chain (Ethereum) message delivery
-- Token minting completion on Ethereum
+### Step 2: Verify Solana Pool and Chain Config
 
-**Solana Explorer** (Source chain verification):
+### Step 3: Verify Ethereum Pool (Terminal 2)
 
-```
-https://explorer.solana.com/tx/sb2kHXW3M4P56WNNH74LviWcPmeYXjNA4f6opmt8iPrYF1cu5FC9grLhyu2XTEwkABQUrTdaJoDWc5CHe2gQL2u?cluster=devnet
-```
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
 
-### Step 2: Transfer Ethereum → Solana
-
-**In Terminal 1 (Solana Starter Kit)**
-
-#### Execute Transfer
-
-#### Monitor and Verify Transaction
-
-Upon successful execution, the system generates distinct tracking identifiers for comprehensive monitoring across both blockchain networks.
-
-**Transaction Identifiers:**
-
-- **Ethereum Transaction Hash**: `0xb2d48398a4d57dde2aaf0551209abad448b092602ca5087e0d108eadd8a8c319`
-- **CCIP Message ID**: `0x567f4cdb2e1c52f6aef6354bd9acbeac6761aa4b1a5e74a356785c2e67197d88`
-
-**CCIP Explorer** (Primary monitoring interface):
-
-```
-https://ccip.chain.link/msg/0x567f4cdb2e1c52f6aef6354bd9acbeac6761aa4b1a5e74a356785c2e67197d88
+```bash
+npx hardhat getPoolConfig \
+  --pooladdress $ETH_POOL_ADDRESS \
+  --network ethereumSepolia
 ```
 
-The CCIP Explorer provides comprehensive transaction visibility:
+Confirm the Ethereum pool recognizes Solana Devnet with your `$SOL_POOL_CONFIG_PDA` and `$SOL_TOKEN_MINT`.
 
-- Source chain (Ethereum) transaction confirmation
-- CCIP message processing and routing
-- Destination chain (Solana) message delivery
-- Token minting completion on Solana network
+### Configure CCIP CLI
 
-**Ethereum Sepolia Explorer** (Source chain verification):
+Export these RPC URLs once before your first transfer:
 
+```bash
+export SOLANA_DEVNET_RPC="https://api.devnet.solana.com"
+export ETHEREUM_SEPOLIA_RPC_URL="<YOUR_ETHEREUM_SEPOLIA_RPC_URL>"
+
+export ETH_CCIP_ROUTER="0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59"
 ```
-https://sepolia.etherscan.io/tx/0xb2d48398a4d57dde2aaf0551209abad448b092602ca5087e0d108eadd8a8c319
-```
+
+Use the same `ETHEREUM_SEPOLIA_RPC_URL` from your env-enc setup in Terminal 2 (`npx env-enc view`). On `ccip-cli send`, the source chain RPC quotes fees and submits the transaction; for token-only transfers in this tutorial, that is the only RPC strictly required to send. Pass both RPCs on cross-chain commands anyway: the destination RPC is required for `ccip-cli show --wait` and for optional send features such as `--estimate-gas-limit` or `send --wait`.
+
+<Aside type="note" title="RPC and wallet configuration">
+  Repeat `--rpc` for multiple networks, or use `--rpcs` with comma-separated URLs. Alternatively, set `RPC_*` environment variables or a `.env` file — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration). Solana sends use `--wallet ~/.config/solana/id.json`. EVM sends: prefer `--wallet hardhat:<name>` from the Hardhat project directory ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)); alternatively export `PRIVATE_KEY` manually after `npx env-enc view` (Hardhat tasks load env-enc automatically, but `ccip-cli` does not). See [CCIP CLI wallet configuration](https://docs.chain.link/ccip/tools/cli/configuration#wallet-configuration).
+</Aside>
+
+### Transfer Solana → Ethereum
+
+**Terminal 1** (CCIP Solana BS58 Generator):
+
+The `-t` flag uses human-readable amounts (0.001 tokens with 9 decimals = 1,000,000 smallest units).
+
+### Transfer Ethereum → Solana
+
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
+
+`ccip-cli` does not load Hardhat env-enc automatically. Run these commands from the Hardhat project directory. Prefer [Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore) over exporting a private key in plain text.
+
+For token-only transfers to Solana, `--to` is the destination wallet that receives minted tokens. CCIP fees are paid in native Sepolia ETH by default — ensure your wallet has sufficient ETH for gas and fees.
+
+<Aside type="note" title="Pay fees in LINK (optional)">
+  Add `--fee-token LINK` to pay CCIP fees in LINK instead of ETH (Sepolia LINK:
+  `0x779877A7B0D9E8603169DdbD7836e478b4624789`).
+</Aside>
+
+**Congratulations!** Your cross-chain token infrastructure with SPL token multisig governance is fully configured on both chains.
 
 ## Optional: Verify Mint Authority Control
 
 ### Demonstrate Manual Minting Through Multisig
 
 This optional section demonstrates that transferring mint authority to the multisig doesn't mean "losing control" - you can still mint tokens manually through the **Admin Wallet** (the non-PDA signer in your multisig). This proves the multisig setup is working correctly and that you retain administrative capabilities.
+
+<Aside type="tip" title="Understanding This Demonstration">
+  **What This Proves**: Successfully minting tokens through the multisig confirms that:
+
+  - Mint authority transfer was successful
+  - The multisig is properly configured (1-of-2 with Pool Signer PDA + Admin Wallet)
+  - You retain administrative control through your Admin Wallet
+  - The Pool Signer PDA can autonomously handle CCIP operations
+
+  **Key Insight**: Since you're one of the multisig signers, you can still perform administrative mints. The Pool Signer PDA handles CCIP burns/mints automatically, while you handle manual operations.
+</Aside>
+
+<Aside type="caution" title="Production Considerations">
+  **Tutorial vs Production**: This tutorial uses your single wallet as the admin signer for simplicity. In production, replace the admin wallet with a proper governance multisig (Such as [Squads](https://squads.so/)) for enhanced security.
+
+  **Scope Limitation**: This SPL token multisig only controls mint authority. For comprehensive governance (CCIP admin roles, pool ownership), implement separate governance infrastructure.
+
+  To learn more, see the [Production Multisig Tutorial](/ccip/tutorials/svm/cross-chain-tokens/production-multisig-tutorial).
+</Aside>
 
 <Aside type="caution" title="Educational Example Disclaimer">
   This page includes an educational example to use a Chainlink system, product, or service and is provided to
@@ -20391,7 +20530,7 @@ This optional section demonstrates that transferring mint authority to the multi
 
 # Cross-Chain Token Setup: BurnMint with Production Multisig Governance
 Source: https://docs.chain.link/ccip/tutorials/svm/cross-chain-tokens/production-multisig-tutorial
-Last Updated: 2025-08-13
+Last Updated: 2026-06-15
 
 This tutorial implements **production-grade cross-chain tokens** using Chainlink CCIP with **dual-layer multisig governance** between Solana Devnet and Ethereum Sepolia. You'll build a **production-ready governance architecture** following **Path A** from the [CCIP Cross-Chain Token Integration Guide](/ccip/concepts/cross-chain-token/svm/integration-guide#path-a-full-self-service-mint-authority-controlled).
 
@@ -20441,30 +20580,34 @@ This tutorial implements **dual-layer multisig governance** that separates conce
 
 ## Prerequisites
 
+This tutorial uses a **two-terminal workflow** with **Squads multisig governance** on Solana. Install the system tools below, create your Squad on devnet, clone both repositories, then complete environment setup before starting Phase 1.
+
 ### System Requirements
 
-Install these tools before starting:
-
-**Package Managers:**
-
-- **Node.js v20+**: Required for all repositories
-- **pnpm**: Required for base58 Generator (`npm install -g pnpm`)
-- **yarn**: Required for Solana Starter Kit (`npm install -g yarn`)
-
-**Solana Development:**
-
-- **Solana CLI**: [Installation guide](https://docs.solana.com/cli/install-solana-cli-tools)
+- **Node.js v22 or higher**: Required for all tools. Verify with `node -v`
+- **pnpm**: Required for the BS58 generator (`npm install -g pnpm`)
+- **npm**: Required for the Hardhat project (bundled with Node.js)
+- **Solana CLI**: [Installation guide](https://docs.solana.com/cli/install-solana-cli-tools) (includes `spl-token`)
+- **Git**: For cloning repositories
+- **CCIP CLI**: For cross-chain transfer testing in the final phase
 
 **Wallets:**
 
-- **Solana wallet**: [Phantom](https://phantom.app/) or [Backpack](https://backpack.app/) for Devnet operations
-- **Ethereum wallet**: [MetaMask](https://metamask.io/) for Sepolia testnet operations
+- **Solana**: [Phantom](https://phantom.app/) or [Backpack](https://backpack.app/) for Devnet and Squads operations
+- **Ethereum**: [MetaMask](https://metamask.io/) for Sepolia testnet operations
+
+Install the [CCIP CLI](https://github.com/smartcontractkit/ccip-tools-ts) globally:
+
+```bash
+npm install -g @chainlink/ccip-cli
+ccip-cli --help
+```
+
+See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for RPC and wallet configuration.
 
 ### Repository Setup
 
-Clone and install dependencies for all three repositories:
-
-**Terminal 1: base58 Generator**
+**Terminal 1: CCIP Solana BS58 Generator** (skip `git clone` if you already have the repo)
 
 ```bash
 git clone https://github.com/smartcontractkit/ccip-solana-bs58-generator.git
@@ -20472,7 +20615,7 @@ cd ccip-solana-bs58-generator
 pnpm install
 ```
 
-**Terminal 2: EVM Hardhat**
+**Terminal 2: Smart Contract Examples (Hardhat)** (skip `git clone` if you already have the repo)
 
 ```bash
 git clone https://github.com/smartcontractkit/smart-contract-examples.git
@@ -20481,76 +20624,77 @@ npm install
 npm run compile
 ```
 
-**Terminal 3: Solana Starter Kit**
-
-```bash
-git clone https://github.com/smartcontractkit/solana-starter-kit.git
-cd solana-starter-kit
-yarn install
-```
-
-**Create and configure the .env file:**
-
-```bash
-# Create .env file in the project root
-cat > .env << 'EOF'
-EVM_PRIVATE_KEY=your_private_key_here
-EVM_RPC_URL=your_rpc_url_here
-EOF
-```
-
-Replace the placeholder values with:
-
-- `EVM_PRIVATE_KEY`: Your Ethereum wallet private key (for Sepolia testnet operations)
-- `EVM_RPC_URL`: Your Ethereum RPC URL (from [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/), or another provider)
-
 ### Environment Configuration
 
-**Solana Configuration:**
+#### Solana (Terminal 1)
+
+First, check whether your environment is already set up:
 
 ```bash
-# Set Solana CLI to devnet
-solana config set --url https://api.devnet.solana.com
-
-# Create keypair (ONLY IF NEEDED)
-solana-keygen new --outfile ~/.config/solana/id.json
-
-# Check Config
 solana config get
-
-# Fund wallet
-solana airdrop 3
+solana address
+solana balance
 ```
 
-**Ethereum Sepolia Configuration:**
+If the RPC URL is already `https://api.devnet.solana.com`, your keypair path is correct, and you have sufficient SOL, skip to [Ethereum Sepolia setup](#ethereum-sepolia-terminal-2) below.
+
+Otherwise, run only the steps you need:
 
 ```bash
-# In Terminal 2 (Hardhat directory)
+# Set devnet (skip if config get already shows devnet)
+solana config set --url https://api.devnet.solana.com
+
+# Point to your keypair (skip if config get already shows the path you want)
+solana config set --keypair ~/.config/solana/id.json
+
+# Create a keypair only if the file does not exist yet
+solana-keygen new --outfile ~/.config/solana/id.json
+
+# Fund your wallet if balance is low
+solana airdrop 3
+solana balance
+```
+
+#### Ethereum Sepolia (Terminal 2)
+
+```bash
+# Required at the start of each session
 npx env-enc set-pw
+
+# Verify existing variables (skip npx env-enc set if all required vars are already configured)
+npx env-enc view
+
+# Add or update variables only if missing
 npx env-enc set
 ```
 
-Required environment variables:
+Required variables:
 
 - `ETHEREUM_SEPOLIA_RPC_URL`: RPC endpoint ([Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/))
 - `PRIVATE_KEY`: Testnet wallet private key
 - `ETHERSCAN_API_KEY`: API key from [Etherscan](https://etherscan.io/apis)
 
-**Testnet Tokens:**
+**Testnet tokens:**
 
-- **Solana Devnet**: Use `solana airdrop 3` for SOL
-- **Ethereum Sepolia**: Use [Chainlink faucets](https://faucets.chain.link/) for LINK and ETH
+- **Solana Devnet**: `solana airdrop 3` for SOL
+- **Ethereum Sepolia**: ETH for gas and CCIP fees ([Chainlink faucet](https://faucets.chain.link/) or [Google Cloud Faucet](https://cloud.google.com/application/web3/faucet/ethereum/sepolia)). LINK is optional for `--fee-token LINK` on EVM sends.
+
+<Aside type="note" title="When to Use --execute">
+  **Governance steps** generate base58-encoded transactions in Terminal 1 **without** `--execute`. Import the output
+  into Squads and sign there. **Pre-transfer steps** (token delegation, pool ATA creation) use your local Solana wallet
+  with `--execute` on `pnpm bs58` commands. **Read-only** commands (`get-state`, `get-chain-config`) omit `--execute`.
+  See the [CCIP Solana BS58 Generator
+  README](https://github.com/smartcontractkit/ccip-solana-bs58-generator/blob/main/README.md).
+</Aside>
 
 ### Squads Multisig Setup
 
 <Aside type="caution" title="Required: Create Squads Multisig">
-  **Before starting this tutorial**, you must create a Squads multisig on Solana Devnet. This will serve as your
-  governance mechanism for all CCIP administrative operations.
+  **Before starting this tutorial**, create a Squads multisig on Solana Devnet. It serves as your governance mechanism
+  for CCIP administrative operations.
 </Aside>
 
-**Step 1: Prepare Signers**
-
-Create multiple wallet addresses for your multisig signers:
+**Step 1: Prepare signers**
 
 ```bash
 # Create additional signers using Solana CLI
@@ -20567,121 +20711,107 @@ solana transfer <SIGNER2_ADDRESS> 0.1 --allow-unfunded-recipient
 solana transfer <SIGNER3_ADDRESS> 0.1 --allow-unfunded-recipient
 ```
 
-Alternatively, create signers in Phantom wallet and fund them:
+Alternatively, create signers in Phantom and fund them:
 
 ```bash
-# Transfer SOL to Phantom-created addresses
 solana transfer <PHANTOM_SIGNER_ADDRESS> 0.5 --allow-unfunded-recipient
 ```
 
-**Step 2: Create Your Squad**
+**Step 2: Create your Squad**
 
 1. Visit [devnet.squads.so](https://devnet.squads.so)
-2. Connect your Solana wallet (e.g., Phantom/Backpack)
-3. Click "Create New Squad"
-4. Configure your multisig:
-   - **Squad Name**: Choose a descriptive name (e.g., "CCIP Token Governance")
-   - **Members**: Add wallet addresses of all signers
-   - **Threshold**: Set approval threshold (recommended: 2/3 or 3/5)
+2. Connect your Solana wallet (Phantom or Backpack)
+3. Click **Create New Squad**
+4. Configure members and threshold (recommended: 2/3 or 3/5)
 
 <Aside type="note" title="Threshold Best Practices">
   - **Avoid 1/n thresholds** (single point of failure)
   - **Avoid maximum thresholds** (e.g., 3/3 prevents recovery if one key is lost)
 </Aside>
 
-**Step 3: Record Critical Addresses**
+**Step 3: Record the vault address**
 
-After Squad creation, navigate to Settings tab and record these addresses.
+After Squad creation, open the Settings tab and copy the **vault address** (not the multisig address).
 
-**In Terminal 1 (base58 Generator), export the vault address:**
+**In Terminal 1:**
 
 ```bash
 # CRITICAL: Use the VAULT address, NOT the multisig address
 export SOL_SQUAD_VAULT_MULTISIG="YOUR_VAULT_ADDRESS_HERE"
-```
-
-Verify the export:
-
-```bash
 echo "Squads Vault Address: $SOL_SQUAD_VAULT_MULTISIG"
 ```
 
 <Aside type="caution" title="Vault vs Multisig Address">
-  **IMPORTANT**: Only use the **Vault address** for setting authorities and receiving funds. The **Multisig address** is
-  used only for CLI detection - sending assets to it causes **irreversible loss**.
+  Use the **vault address** for authorities and receiving funds. The **multisig address** is for CLI detection only —
+  sending assets to it causes **irreversible loss**.
 </Aside>
 
-**Step 4: Test Your Squad**
-
-Perform a small test transaction to verify setup:
+**Step 4: Test your Squad**
 
 1. Send a small amount of SOL to your Squad vault
 2. Create a test transaction in Squads UI (e.g., SOL transfer to your wallet)
-3. Confirm all signers can approve transactions
-4. Execute the transaction
+3. Confirm signers can approve and execute
 
-For detailed setup guidance, see the [Squads Documentation](https://docs.squads.so/).
+See [Squads Documentation](https://docs.squads.so/) for detailed setup guidance.
 
 ### Token Creation Option
 
 <Aside type="note" title="Existing Token Requirements">
-  **Important**: You can only skip token creation if you have an existing SPL token where the **mint authority is already controlled by your Squad vault**.
+  You can skip token creation only if you have an existing SPL token where **mint authority is already controlled by your
+  Squad vault**.
 
   **Two scenarios:**
 
-  1. **Mint authority = Squad vault**: Skip to Step 3 (pool initialization) and export your existing mint address
-  2. **Mint authority ≠ Squad vault**: You must first transfer mint authority to your Squad vault, OR create a fresh token in Step 2
+  1. **Mint authority = Squad vault**: Skip to pool initialization and export your existing mint address
+  2. **Mint authority ≠ Squad vault**: Transfer mint authority to your Squad vault first, or create a fresh token in the tutorial
 
-  **For fresh start**: Proceed with Step 2 to create a new token with Squad vault as mint authority from the beginning.
+  **For a fresh start**: Proceed with token creation so the Squad vault is mint authority from the beginning.
 </Aside>
 
 ## Tutorial Approach
 
-This tutorial implements production-grade cross-chain tokens using a three-terminal workflow across specialized repositories:
+| Terminal       | Repository                                                                                                                  | Purpose                                    | Commands        |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | --------------- |
+| **Terminal 1** | [CCIP Solana BS58 Generator](https://github.com/smartcontractkit/ccip-solana-bs58-generator)                                | Governance txs and pre-transfer setup      | `pnpm bs58`     |
+| **Terminal 2** | [Smart Contract Examples (Hardhat)](https://github.com/smartcontractkit/smart-contract-examples/tree/main/ccip/cct/hardhat) | Deploy and configure EVM components        | `npx hardhat`   |
+| **Either**     | Global `@chainlink/ccip-cli`                                                                                                | Cross-chain transfer testing (final phase) | `ccip-cli send` |
 
-| Terminal       | Repository                                                                                                                  | Purpose                          | Commands      |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------- |
-| **Terminal 1** | [CCIP Solana base58 Generator](https://github.com/smartcontractkit/ccip-solana-bs58-generator)                              | Generate governance transactions | `pnpm bs58`   |
-| **Terminal 2** | [Smart Contract Examples (Hardhat)](https://github.com/smartcontractkit/smart-contract-examples/tree/main/ccip/cct/hardhat) | Deploy EVM components            | `npx hardhat` |
-| **Terminal 3** | [Solana Starter Kit](https://github.com/smartcontractkit/solana-starter-kit)                                                | Test cross-chain transfers       | `yarn`        |
-
-**Note**: Each repository contains comprehensive READMEs with detailed technical explanations and troubleshooting guides.
+The [CCIP Solana BS58 Generator README](https://github.com/smartcontractkit/ccip-solana-bs58-generator/blob/main/README.md) contains command syntax, simulation behavior, and troubleshooting.
 
 ### Key Implementation Notes
 
-- **Terminal 1** generates base58-encoded transactions for Squads multisig governance
-- **Terminal 2** uses EOA for tutorial simplicity; production deployments should use multisig wallets (e.g., Safe)
-- **Terminal 3** validates end-to-end cross-chain functionality
+- **Terminal 1** generates base58 transactions for Squads governance (no `--execute`). Pre-transfer delegation steps use `--execute` with your local wallet.
+- **Terminal 2** uses an EOA for tutorial simplicity; production EVM deployments should use multisig wallets (e.g., Safe).
+- **Cross-chain transfers** use [`@chainlink/ccip-cli`](https://github.com/smartcontractkit/ccip-tools-ts): Terminal 1 for Solana → EVM, Terminal 2 for EVM → Solana. For EVM sends, prefer `--wallet hardhat:<name>` ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)) from the Hardhat directory; alternatively export `PRIVATE_KEY` manually after `npx env-enc view` (Hardhat tasks load env-enc automatically, but `ccip-cli` does not). Provide RPCs via `--rpc`/`--rpcs`, `RPC_*` environment variables, or a `.env` file — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration).
 
 ### base58 Transaction Execution Workflow
 
-**Transaction Generation and Validation:**
+**Transaction generation:**
 
-1. **CLI Simulation**: Each base58 transaction is automatically simulated during generation
-2. **Error Handling**: If simulation fails, error logs appear in terminal - do not upload failed transactions to Squads
-3. **Success Indicator**: Successful simulation shows transaction preview and base58 output
+1. **CLI simulation**: Each base58 transaction is simulated during generation
+2. **Error handling**: If simulation fails, do not upload the transaction to Squads
+3. **Success**: Terminal shows a transaction preview and base58 output
 
-**Squads Multisig Execution Process:**
+**Squads execution:**
 
-1. **Propose**: A signer imports the base58 transaction into Squads UI → "Add instruction" → "Import base58 encoded tx" → **Initiate Transaction**
-2. **Approve**: Required threshold (M) of signers review and approve the transaction
-3. **Simulate** (Recommended): Before execution, signers can simulate through Squads interface to preview onchain effects
-4. **Execute**: After threshold approval, any signer can execute the transaction
+1. **Propose**: Import base58 output in Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx** → **Initiate Transaction**
+2. **Approve**: Required threshold of signers approves
+3. **Simulate** (recommended): Preview onchain effects in Squads before execution
+4. **Execute**: Any approved signer executes after threshold is met
 
 <Aside type="note" title="Security Best Practice">
-  Always simulate before execution using Squads' built-in simulation feature. This shows exactly what will happen
-  onchain and is critical for validating complex governance operations before commitment.
+  Always simulate in Squads before execution. This validates complex governance operations before commitment.
 </Aside>
 
 ### Environment Variables
 
 Variables use prefixes to prevent confusion across repositories:
 
-| Prefix   | Usage              | Examples                                   |
-| -------- | ------------------ | ------------------------------------------ |
-| `ETH_*`  | Ethereum addresses | `ETH_TOKEN_ADDRESS`, `ETH_POOL_ADDRESS`    |
-| `SOL_*`  | Solana addresses   | `SOL_TOKEN_MINT`, `SOL_POOL_ADDRESS`       |
-| `CCIP_*` | Protocol constants | `CCIP_POOL_PROGRAM`, `CCIP_ROUTER_PROGRAM` |
+| Prefix       | Usage                   | Examples                                                                  |
+| ------------ | ----------------------- | ------------------------------------------------------------------------- |
+| `ETH_*`      | Ethereum addresses      | `ETH_TOKEN_ADDRESS`, `ETH_POOL_ADDRESS`                                   |
+| `SOL_*`      | Solana addresses        | `SOL_TOKEN_MINT`, `SOL_POOL_ADDRESS`                                      |
+| `SOL_CCIP_*` | Solana CCIP program IDs | `SOL_CCIP_POOL_PROGRAM`, `SOL_CCIP_ROUTER`, `SOL_CCIP_FEE_QUOTER_PROGRAM` |
 
 ## Phase 1: EVM Chain Setup (Ethereum Sepolia)
 
@@ -20743,6 +20873,8 @@ In this phase, you will implement the **production-grade dual-layer multisig gov
 
 ### Step 1: Prepare base58 Environment
 
+Set up CCIP constants on Solana Devnet (DO NOT CHANGE THESE)
+
 ### Step 2: Create SPL Token (Layer 2 Foundation)
 
 This command generates a transaction that creates a new SPL token mint with the following features:
@@ -20768,8 +20900,7 @@ Generate the SPL token creation transaction (customize parameters or reuse the e
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add
-    instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
   - **Review**: Verify transaction details, check authority and mint
 
@@ -20814,9 +20945,9 @@ Generate the pool initialization transaction:
 
 | Account | Address                                        | Purpose                                                     |
 | ------- | ---------------------------------------------- | ----------------------------------------------------------- |
-| **#1**  | `2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M` | **Pool State PDA** - Your main pool configuration           |
-| **#2**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | Token Mint (your token)                                     |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | Authority (your Squad vault)                                |
+| **#1**  | `2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu` | **Pool State PDA** - Your main pool configuration           |
+| **#2**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | Token Mint (your token)                                     |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | Authority (your Squad vault)                                |
 | **#4**  | `11111111111111111111111111111111`             | System Program                                              |
 | **#5**  | `41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB` | CCIP Pool Program                                           |
 | **#6**  | `4sVSCJqG9ZKEvnpN38qTzb7Kc8QdHakBgB87HN3FYRaz` | Program Data PDA                                            |
@@ -20830,8 +20961,7 @@ Generate the pool initialization transaction:
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add
-    instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
   - **Review**: Verify pool initialization parameters
 
@@ -20843,11 +20973,6 @@ Generate the pool initialization transaction:
 </Aside>
 
 After execution, set the pool state address from the transaction:
-
-```bash
-# Set the pool state address from Account #1 in the transaction above
-export SOL_POOL_ADDRESS="2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M"
-```
 
 ### Step 4: Derive Pool Signer PDA
 
@@ -20870,9 +20995,9 @@ The [owner_propose_administrator](/ccip/concepts/cross-chain-token/svm/registrat
 | Account | Address                                        | Description                                                           |
 | ------- | ---------------------------------------------- | --------------------------------------------------------------------- |
 | **#1**  | `3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3` | Router Config PDA (read-only)                                         |
-| **#2**  | `4maPuX2fcDmCkQv1Qa6RmQa2yGpeZLxiqKy9ybwazGft` | **🎯 Token Admin Registry PDA** - Gets created/updated for your token |
-| **#3**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | Token Mint (your token)                                               |
-| **#4**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | Authority/Payer (your Squad vault)                                    |
+| **#2**  | `6jWPxptvZKTiLFNdLT39uG1HHa1DXnUqFpi6VttNGrH3` | **🎯 Token Admin Registry PDA** - Gets created/updated for your token |
+| **#3**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | Token Mint (your token)                                               |
+| **#4**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | Authority/Payer (your Squad vault)                                    |
 | **#5**  | `11111111111111111111111111111111`             | System Program                                                        |
 
 **What This Transaction Does:**
@@ -20881,8 +21006,7 @@ This transaction proposes your Squad vault as the administrator for your token i
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add
-    instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
   - **Review**: Verify transaction details and parameters
 
@@ -20902,9 +21026,9 @@ The [accept_admin_role](/ccip/concepts/cross-chain-token/svm/registration-admini
 | Account | Address                                        | Description                                                  |
 | ------- | ---------------------------------------------- | ------------------------------------------------------------ |
 | **#1**  | `3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3` | Router Config PDA (read-only)                                |
-| **#2**  | `4maPuX2fcDmCkQv1Qa6RmQa2yGpeZLxiqKy9ybwazGft` | **🎯 Token Admin Registry PDA** - Updates status to "active" |
-| **#3**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | Token Mint (your token)                                      |
-| **#4**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | Authority (your Squad vault - must be pending admin)         |
+| **#2**  | `6jWPxptvZKTiLFNdLT39uG1HHa1DXnUqFpi6VttNGrH3` | **🎯 Token Admin Registry PDA** - Updates status to "active" |
+| **#3**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | Token Mint (your token)                                      |
+| **#4**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | Authority (your Squad vault - must be pending admin)         |
 
 **What This Transaction Does:**
 This is the **acceptance step** of the two-phase administrator registration. It updates the Token Admin Registry PDA (Account #2) from "pending administrator" to "active administrator" status. Your Squad vault explicitly accepts the administrator role, completing the secure registration process.
@@ -20914,8 +21038,7 @@ This is the **acceptance step** of the two-phase administrator registration. It 
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add
-    instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
   - **Review**: Verify transaction details and parameters
 
@@ -20945,15 +21068,15 @@ This command creates the second layer of your dual-multisig architecture by esta
 
 | Account | Address                                        | Description                               |
 | ------- | ---------------------------------------------- | ----------------------------------------- |
-| **#1**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Payer/Authority** (your Squad vault)    |
-| **#2**  | `6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK` | **🎯 SPL Token Multisig** (newly created) |
+| **#1**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Payer/Authority** (your Squad vault)    |
+| **#2**  | `3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX` | **🎯 SPL Token Multisig** (newly created) |
 
 **What This Transaction Does:**
 This creates an **SPL Token Multisig** account that will control your token's mint authority. The CLI automatically detected SPL Token v1 and created the appropriate multisig type.
 
 **Key Details:**
 
-- **Generated Multisig Address**: `6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK`
+- **Generated Multisig Address**: `3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX`
 - **Multisig Signers**: Pool Signer PDA + Squad vault
 - **Threshold**: 1 (either signer can authorize mint operations)
 - **Hybrid Control**: Enables both automated CCIP operations and human governance
@@ -20961,7 +21084,7 @@ This creates an **SPL Token Multisig** account that will control your token's mi
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify transaction details and parameters
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -20986,20 +21109,19 @@ Transfer mint authority from your Squad vault to the SPL Token Multisig, complet
 
 | Account | Address                                        | Description                                   |
 | ------- | ---------------------------------------------- | --------------------------------------------- |
-| **#1**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | **Token Mint** (writable - authority updated) |
-| **#2**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Current Authority** (signer - Squad vault)  |
+| **#1**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | **Token Mint** (writable - authority updated) |
+| **#2**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Current Authority** (signer - Squad vault)  |
 
 **Key Details:**
 
-- **Current Authority**: `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` (Squad vault)
-- **New Authority**: `6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK` (SPL Token Multisig)
-- **Token Mint**: `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` (authority field updated)
+- **Current Authority**: `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` (Squad vault)
+- **New Authority**: `3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX` (SPL Token Multisig)
+- **Token Mint**: `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub` (authority field updated)
 
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add
-    instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
   - **Review**: Verify transaction details and parameters
 
@@ -21029,10 +21151,10 @@ Verify that your Squad vault can still mint tokens after the authority transfer.
 
 | Account | Address                                        | Description                                         |
 | ------- | ---------------------------------------------- | --------------------------------------------------- |
-| **#1**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | **Token Mint** (writable - supply updated)          |
-| **#2**  | `84FvKxAQpHtSaFLguFygoPPEaRorZpTjs8rmMCxuwqUF` | **Recipient's ATA** (writable - receives tokens)    |
-| **#3**  | `6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK` | **SPL Token Multisig** (read-only - mint authority) |
-| **#4**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer - multisig member)          |
+| **#1**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | **Token Mint** (writable - supply updated)          |
+| **#2**  | `gKhGBvVGw62EdjfdNQFvVvvbg8CqdepTrdmSdVsEDBS`  | **Recipient's ATA** (writable - receives tokens)    |
+| **#3**  | `3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX` | **SPL Token Multisig** (read-only - mint authority) |
+| **#4**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer - multisig member)          |
 
 **What This Transaction Does:**
 This is an **SPL Token Multisig Mint** operation that proves your dual-layer governance is working correctly. The Squad vault acts as a signer for the SPL Token Multisig that now controls mint authority.
@@ -21040,9 +21162,9 @@ This is an **SPL Token Multisig Mint** operation that proves your dual-layer gov
 **Key Details:**
 
 - **Amount**: 1,000,000,000 smallest units = 1 token (with 9 decimals)
-- **Recipient**: Your wallet address (`EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB`)
-- **Mint Authority**: SPL Token Multisig (`6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK`)
-- **Multisig Signer**: Squad vault (`59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY`)
+- **Recipient**: Your wallet address (`GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN`)
+- **Mint Authority**: SPL Token Multisig (`3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX`)
+- **Multisig Signer**: Squad vault (`AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB`)
 - **Token Program**: SPL Token v1 (`TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 
 **Transaction Flow:**
@@ -21055,7 +21177,7 @@ This is an **SPL Token Multisig Mint** operation that proves your dual-layer gov
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify transaction details and parameters
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -21105,9 +21227,9 @@ Initialize the basic remote chain configuration for Ethereum Sepolia. Pool addre
 
 | Account | Address                                        | Description                                         |
 | ------- | ---------------------------------------------- | --------------------------------------------------- |
-| **#1**  | `2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M` | **Pool State PDA** (read-only - validation)         |
-| **#2**  | `8zdWLvsAgLQkRmBDATR3j8xVQzcdwrRNZtPZH5kU37jg` | **Chain Remote Config PDA** (writable - created)    |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer, writable - pool authority) |
+| **#1**  | `2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu` | **Pool State PDA** (read-only - validation)         |
+| **#2**  | `A3TEVLHYCbBzncbmVtiZAsK9R281n9oe4DZwMZyKy5p2` | **Chain Remote Config PDA** (writable - created)    |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer, writable - pool authority) |
 | **#4**  | `11111111111111111111111111111111`             | **System Program** (read-only - account creation)   |
 
 **What This Command Does:**
@@ -21116,7 +21238,7 @@ This initializes the **cross-chain configuration** for your Solana token to enab
 **Key Details:**
 
 - **Remote Chain**: Ethereum Sepolia (chain selector: `16015286601757825753`)
-- **Token Mapping**: Links to ERC20 token `0x7c57A9d966c3E6e344621C512d510f76575640ED`
+- **Token Mapping**: Links to ERC20 token `0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184`
 - **Decimal Precision**: 18 decimals (standard EVM token format)
 - **Basic Setup**: No rate limits or pool addresses configured at this stage
 - **Account Creation**: Creates a new Chain Remote Config PDA for this cross-chain relationship
@@ -21131,7 +21253,7 @@ This initializes the **cross-chain configuration** for your Solana token to enab
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify transaction details and parameters
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -21146,9 +21268,9 @@ After initializing the chain remote config, add the remote pool address to enabl
 
 | Account | Address                                        | Description                                                    |
 | ------- | ---------------------------------------------- | -------------------------------------------------------------- |
-| **#1**  | `2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M` | **Pool State PDA** (read-only - authority validation)          |
-| **#2**  | `8zdWLvsAgLQkRmBDATR3j8xVQzcdwrRNZtPZH5kU37jg` | **Chain Remote Config PDA** (writable - configuration updated) |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault Authority** (signer, writable - fee payer)       |
+| **#1**  | `2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu` | **Pool State PDA** (read-only - authority validation)          |
+| **#2**  | `A3TEVLHYCbBzncbmVtiZAsK9R281n9oe4DZwMZyKy5p2` | **Chain Remote Config PDA** (writable - configuration updated) |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault Authority** (signer, writable - fee payer)       |
 | **#4**  | `11111111111111111111111111111111`             | **System Program** (read-only - account operations)            |
 
 **Transaction Flow:**
@@ -21160,7 +21282,7 @@ After initializing the chain remote config, add the remote pool address to enabl
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify transaction details and parameters
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -21194,14 +21316,14 @@ This command configures inbound and outbound rate limiting for token transfers b
 
 | Account | Address                                        | Type                 | Purpose                                                           |
 | ------- | ---------------------------------------------- | -------------------- | ----------------------------------------------------------------- |
-| **#1**  | `2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M` | **Read-only**        | **Pool State PDA** - Main pool configuration account              |
-| **#2**  | `8zdWLvsAgLQkRmBDATR3j8xVQzcdwrRNZtPZH5kU37jg` | **Writable**         | **Chain Config PDA** - Chain-specific config (stores rate limits) |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Signer, Writable** | **Authority** - Your Squad vault that can modify rate limits      |
+| **#1**  | `2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu` | **Read-only**        | **Pool State PDA** - Main pool configuration account              |
+| **#2**  | `A3TEVLHYCbBzncbmVtiZAsK9R281n9oe4DZwMZyKy5p2` | **Writable**         | **Chain Config PDA** - Chain-specific config (stores rate limits) |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Signer, Writable** | **Authority** - Your Squad vault that can modify rate limits      |
 
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify transaction details and parameters
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -21220,9 +21342,9 @@ This command creates an **Address Lookup Table (ALT)** that stores frequently us
 
 | Account | Address                                        | Description                                               |
 | ------- | ---------------------------------------------- | --------------------------------------------------------- |
-| **#1**  | `2s6yx6xCBgEQBrv5h4dF7TQvvKUWTJBEsueqTnZZHLwY` | **ALT Account** (writable - being created)                |
-| **#2**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **ALT Authority** (signer - will own the table)           |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Fee Payer** (signer, writable - pays creation costs)    |
+| **#1**  | `DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv` | **ALT Account** (writable - being created)                |
+| **#2**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **ALT Authority** (signer - will own the table)           |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Fee Payer** (signer, writable - pays creation costs)    |
 | **#4**  | `11111111111111111111111111111111`             | **System Program** (read-only - handles account creation) |
 
 **What This Command Does:**
@@ -21231,7 +21353,7 @@ This command creates the ALT infrastructure needed for efficient CCIP operations
 
 **Transaction Flow:**
 
-1. **ALT Creation**: Creates lookup table account `2s6yx6x...` with Squad Vault as authority
+1. **ALT Creation**: Creates lookup table account `DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv` with Squad Vault as authority
 2. **Core Address Addition**: Adds essential CCIP accounts (programs, PDAs) to the table
 3. **SPL Multisig Addition**: Adds your SPL multisig `$SOL_SPL_MULTISIG` via `--additional-addresses`
 4. **Index Assignment**: Each address gets a unique 1-byte index for future reference
@@ -21246,17 +21368,17 @@ The created lookup table will contain indices for these accounts in this exact o
 
 | Index  | Account Address                                | Purpose                                               |
 | ------ | ---------------------------------------------- | ----------------------------------------------------- |
-| **0**  | `2s6yx6xCBgEQBrv5h4dF7TQvvKUWTJBEsueqTnZZHLwY` | **ALT Address (Self-Reference)**                      |
-| **1**  | `4maPuX2fcDmCkQv1Qa6RmQa2yGpeZLxiqKy9ybwazGft` | **Token Admin Registry PDA**                          |
+| **0**  | `DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv` | **ALT Address (Self-Reference)**                      |
+| **1**  | `6jWPxptvZKTiLFNdLT39uG1HHa1DXnUqFpi6VttNGrH3` | **Token Admin Registry PDA**                          |
 | **2**  | `41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB` | **Pool Program ID**                                   |
-| **3**  | `2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M` | **Pool State PDA**                                    |
-| **4**  | `BKkeydRQWKDc5dR7euwhYi47TDLV99o8pD83ncGA2LdZ` | **Pool Signer's Associated Token Account**            |
-| **5**  | `8NTqDH8dFj7aU5FBWeNMJwjsR1gZMR7criaEaDMEE24r` | **Pool Signer PDA**                                   |
+| **3**  | `2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu` | **Pool State PDA**                                    |
+| **4**  | `2Lzp4uRF6N2x65aMpKqFrajFukAbTCtQcG8thVgqcsEh` | **Pool Signer's Associated Token Account**            |
+| **5**  | `62So4PhmWWzMpVXKzsCXdNUfrrB4jGXTVda9BzS6HTeo` | **Pool Signer PDA**                                   |
 | **6**  | `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`  | **Token Program ID (SPL Token v1)**                   |
-| **7**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | **Token Mint**                                        |
+| **7**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | **Token Mint**                                        |
 | **8**  | `GTz54AfhMRkKzFVse8jX8rjAx21fA86ZmVBF1v5VUC3u` | **Fee Quoter Token Config PDA**                       |
 | **9**  | `H6ZviaabTYZqUPgiSoMDbeVthcNW9ULcAuUu3zRLFqDR` | **Router External Token Pools Signer PDA**            |
-| **10** | `6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK` | **SPL Token Multisig** ← **Your Additional Address!** |
+| **10** | `3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX` | **SPL Token Multisig** ← **Your Additional Address!** |
 
 **Transaction Efficiency Impact:**
 
@@ -21267,7 +21389,7 @@ The created lookup table will contain indices for these accounts in this exact o
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify transaction details and parameters
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -21293,10 +21415,10 @@ Register your token pool with the CCIP Router using [set_pool](/ccip/api-referen
 | Account | Address                                        | Description                                                 |
 | ------- | ---------------------------------------------- | ----------------------------------------------------------- |
 | **#1**  | `3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3` | **Router Config PDA** (read-only - configuration reference) |
-| **#2**  | `4maPuX2fcDmCkQv1Qa6RmQa2yGpeZLxiqKy9ybwazGft` | **Token Admin Registry PDA** (writable - pool registration) |
-| **#3**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | **Token Mint** (read-only - token identification)           |
-| **#4**  | `2s6yx6xCBgEQBrv5h4dF7TQvvKUWTJBEsueqTnZZHLwY` | **Address Lookup Table** (read-only - ALT registration)     |
-| **#5**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault Authority** (signer, writable - admin & fees) |
+| **#2**  | `6jWPxptvZKTiLFNdLT39uG1HHa1DXnUqFpi6VttNGrH3` | **Token Admin Registry PDA** (writable - pool registration) |
+| **#3**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | **Token Mint** (read-only - token identification)           |
+| **#4**  | `DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv` | **Address Lookup Table** (read-only - ALT registration)     |
+| **#5**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault Authority** (signer, writable - admin & fees) |
 
 **What This Command Does:**
 
@@ -21304,7 +21426,7 @@ This command **registers your token pool** with the CCIP Router. It configures t
 
 **Key Configuration:**
 
-- **ALT Integration**: Uses the lookup table `2s6yx6x...` you just created
+- **ALT Integration**: Uses the lookup table `DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv` you just created
 - **Writable Indexes**: `[3,4,7]` - Specific accounts from the ALTthat need write access during CCIP operations
 
 **Transaction Flow:**
@@ -21327,7 +21449,7 @@ Based on the ALT order established earlier:
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify transaction details and parameters
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -21367,141 +21489,120 @@ Configure the Ethereum pool to recognize the Solana chain and set production rat
     - 0.1 tokens/sec = `100000000000000000` wei (0.1 × 10^18)
 </Aside>
 
-## Phase 5: Testing and Validation
+## Phase 5: Pre-Transfer Setup, Validation, and Testing
 
 <Aside type="note" title="Terminal Context Check">
-  **Current Focus: Terminal 3 (Solana Testing)** Switch to the Solana Starter Kit repository for comprehensive testing.
+  **Current Focus: Terminal 1 (CCIP Solana BS58 Generator)** Complete pre-transfer setup and validate your
+  configuration. Governance steps use Squads; delegation and verification use your local wallet with `--execute`.
 </Aside>
 
-### Step 1: Load Phase 4 Variables
-
-Before testing cross-chain transfers, ensure your terminal environment is properly configured:
-
-### Transfer Direction 1: Solana → Ethereum
-
-Test the production multisig setup with a cross-chain transfer from Solana Devnet to Ethereum Sepolia:
-
-#### Prepare for Testing
-
-Before testing cross-chain transfers, you need to create the pool's Associated Token Account (ATA) and prepare your tokens:
-
-##### Check Token Balance
-
-##### Create Pool Associated Token Account
-
-##### Delegate Token Authority
-
-#### Transfer tokens from Solana Devnet to Ethereum Sepolia
-
-#### Monitor and Verify Transaction
-
-Upon successful execution, the system generates critical tracking identifiers for transaction monitoring and verification.
-
-**Transaction Identifiers:**
-
-- **Transaction Signature**: `4T6coWNspJ7TDhsUFVZ7S1huzVxy6dSjbPfrFw4THGRBEt8X9UYfFggrxYLD4Hnm11Hqdnzg9vJTbrNSjp7ycRvf`
-- **CCIP Message ID**: `0x21d6ca53d5ab59caa9d5a1d58a5f8040f9695043dcad5ddc0059710dff0113c3`
-
-**CCIP Explorer** (Primary monitoring interface):
-
-```
-https://ccip.chain.link/msg/0x21d6ca53d5ab59caa9d5a1d58a5f8040f9695043dcad5ddc0059710dff0113c3
-```
-
-The CCIP Explorer provides comprehensive transaction visibility:
-
-- Source chain (Solana) transaction confirmation
-- CCIP message processing and routing
-- Destination chain (Ethereum) message delivery
-- Token minting completion on Ethereum
-
-**Solana Explorer** (Source chain verification):
-
-```
-https://explorer.solana.com/tx/4T6coWNspJ7TDhsUFVZ7S1huzVxy6dSjbPfrFw4THGRBEt8X9UYfFggrxYLD4Hnm11Hqdnzg9vJTbrNSjp7ycRvf?cluster=devnet
-```
-
-### Transfer Direction 2: Ethereum → Solana
-
-<Aside type="note" title="Terminal Environment">
-  **Continue in Terminal 3** (Solana Starter Kit directory). No need to switch terminals - the Solana Starter Kit
-  handles Ethereum → Solana transfers as well.
+<Aside type="note" title="Cross-Chain Transfers with CCIP CLI">
+  Use [`@chainlink/ccip-cli`](https://github.com/smartcontractkit/ccip-tools-ts) for bidirectional token transfers. Run Solana → EVM sends from Terminal 1 and EVM → Solana sends from Terminal 2. See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for full options.
 </Aside>
 
-#### Transfer tokens from Ethereum Sepolia to Solana Devnet
+### Step 1: Load Configuration
 
-#### Monitor and Verify Transaction
+### Step 2: Pre-Transfer Setup
 
-Upon successful execution, the system generates distinct tracking identifiers for comprehensive monitoring across both blockchain networks.
+Before cross-chain transfers (when available), complete token delegation so CCIP can move tokens from your wallet.
 
-**Transaction Identifiers:**
+#### Check Token Balance
 
-- **Ethereum Transaction Hash**: `0x55e6e9c295c7d32bc0d708f3363e42aad37298f9f30b4db0889e06bfac761157`
-- **CCIP Message ID**: `0x11ef3640d8030bae75c2e4ca863a122bbf28fbbcd1dc83be0f77a25091442c72`
+#### Create Pool Associated Token Account
 
-**CCIP Explorer** (Primary monitoring interface):
+If not created during pool setup, create the pool's ATA:
 
+#### Delegate Token Authority
+
+Approve the fee-billing signer to transfer tokens from your ATA:
+
+#### Verify Delegation
+
+Check that your token account is delegated to the fee-billing signer:
+
+Display token account and delegation status:
+
+### Step 3: Verify Solana Pool and Chain Config
+
+### Step 4: Verify Ethereum Pool (Terminal 2)
+
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
+
+```bash
+npx hardhat getPoolConfig \
+  --pooladdress $ETH_POOL_ADDRESS \
+  --network ethereumSepolia
 ```
-https://ccip.chain.link/msg/0x11ef3640d8030bae75c2e4ca863a122bbf28fbbcd1dc83be0f77a25091442c72
+
+Confirm the Ethereum pool recognizes Solana Devnet with your `$SOL_POOL_ADDRESS` and `$SOL_TOKEN_MINT`.
+
+### Configure CCIP CLI
+
+Export these RPC URLs once before your first transfer:
+
+```bash
+export SOLANA_DEVNET_RPC="https://api.devnet.solana.com"
+export ETHEREUM_SEPOLIA_RPC_URL="<YOUR_ETHEREUM_SEPOLIA_RPC_URL>"
+
+export ETH_CCIP_ROUTER="0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59"
 ```
 
-The CCIP Explorer provides comprehensive transaction visibility:
+Use the same `ETHEREUM_SEPOLIA_RPC_URL` from your env-enc setup in Terminal 2 (`npx env-enc view`). On `ccip-cli send`, the source chain RPC quotes fees and submits the transaction; for token-only transfers in this tutorial, that is the only RPC strictly required to send. Pass both RPCs on cross-chain commands anyway: the destination RPC is required for `ccip-cli show --wait` and for optional send features such as `--estimate-gas-limit` or `send --wait`.
 
-- Source chain (Ethereum) transaction confirmation
-- CCIP message processing and routing
-- Destination chain (Solana) message delivery
-- Token minting completion on Solana network
-
-**Ethereum Sepolia Explorer** (Source chain verification):
-
-```
-https://sepolia.etherscan.io/tx/0x55e6e9c295c7d32bc0d708f3363e42aad37298f9f30b4db0889e06bfac761157
-```
-
-### Test Solana Rate Limit Enforcement (Optional)
-
-<Aside type="note" title="Rate Limit Configuration Reminder">
-  **Current Rate Limits**: If you followed Phase 3 with rate limits enabled:
-
-  - **Solana Outbound**: 18 tokens capacity, 0.1 tokens/second rate
-  - **Solana Inbound**: 20 tokens capacity, 0.1 tokens/second rate
-  - **Ethereum**: Similar limits (18-decimal equivalent: 18/20 ETH tokens)
-
-  **Testing Strategy**: Attempt to transfer 25 tokens (exceeds 20-token inbound capacity).
+<Aside type="note" title="RPC and wallet configuration">
+  Repeat `--rpc` for multiple networks, or use `--rpcs` with comma-separated URLs. Alternatively, set `RPC_*` environment variables or a `.env` file — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration). Solana sends use `--wallet ~/.config/solana/id.json`. EVM sends: prefer `--wallet hardhat:<name>` from the Hardhat project directory ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)); alternatively export `PRIVATE_KEY` manually after `npx env-enc view` (Hardhat tasks load env-enc automatically, but `ccip-cli` does not). See [CCIP CLI wallet configuration](https://docs.chain.link/ccip/tools/cli/configuration#wallet-configuration).
 </Aside>
 
-The transaction correctly failed with `RLMaxCapacityExceeded` error because:
+### Transfer Solana → Ethereum
 
-- **Attempted**: 25 tokens (`25000000000` in smallest units)
-- **Limit**: 20 tokens maximum capacity (`20000000000`)
-- **Result**: Rate limiter blocked the excessive transfer
+**Terminal 1** (CCIP Solana BS58 Generator):
 
-**Key Error Details:**
+The `-t` flag uses human-readable amounts (0.001 tokens with 9 decimals = 1,000,000 smallest units).
 
-- **Error Code**: `RLMaxCapacityExceeded` (Error Number: 6015)
-- **Source**: `programs/base-token-pool/src/rate_limiter.rs:48`
-- **Meaning**: The token bucket capacity was exceeded
+### Transfer Ethereum → Solana
 
-This demonstrates that your rate limits are properly configured and actively protecting against transfers that exceed the configured limits.
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
 
-### Test EVM Rate Limit Enforcement (Optional)
+`ccip-cli` does not load Hardhat env-enc automatically. Run these commands from the Hardhat project directory. Prefer [Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore) over exporting a private key in plain text.
 
-Test rate limits from the EVM side (Ethereum to Solana) using the same 25-token limit.
+For token-only transfers to Solana, `--to` is the destination wallet that receives minted tokens. CCIP fees are paid in native Sepolia ETH by default — ensure your wallet has sufficient ETH for gas and fees.
 
-The transaction correctly failed because:
+<Aside type="note" title="Pay fees in LINK (optional)">
+  Add `--fee-token LINK` to pay CCIP fees in LINK instead of ETH (Sepolia LINK:
+  `0x779877A7B0D9E8603169DdbD7836e478b4624789`).
+</Aside>
 
-- **Attempted**: 25 tokens (`25000000000000000000` wei - 18 decimals)
-- **Limit**: 18 tokens maximum capacity
-- **Error Selector**: [`0x1a76572a` (TokenMaxCapacityExceeded)](/ccip/api-reference/evm/v1.6.1/errors#rate-limiter-errors)
-- **Decoded Values**: Capacity: `18000000000000000000`, Attempted: `25000000000000000000`, Token: `0x9cE471d0a7bE21ee32276dde49104fe02c812906`
+### Optional: Test Rate Limit Enforcement
 
-This demonstrates that rate limits are enforced on both chains, protecting the cross-chain bridge from excessive transfers. The EVM error selector corresponds to the `TokenMaxCapacityExceeded` error in the [CCIP EVM v1.6.0 errors reference](/ccip/api-reference/evm/v1.6.1/errors).
+If you configured rate limits in Phase 3, attempt a transfer that exceeds capacity (25 tokens vs 20-token limit):
+
+### Optional: Verify Rate Limit Configuration
+
+If you configured rate limits in Phase 3, confirm they appear in your chain configuration:
+
+```bash
+# Terminal 1 — inspect Solana outbound/inbound rate limits
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-chain-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --remote-chain-selector $ETHEREUM_SEPOLIA_CHAIN_SELECTOR
+```
+
+```bash
+# Terminal 2 — inspect EVM rate limit settings
+npx hardhat getPoolConfig \
+  --pooladdress $ETH_POOL_ADDRESS \
+  --network ethereumSepolia
+```
+
+**Congratulations!** Your production cross-chain token infrastructure with Squads governance is fully configured on both chains.
 
 ---
 
 # Cross-Chain Token Setup: LockRelease Pool with Squads Governance
 Source: https://docs.chain.link/ccip/tutorials/svm/cross-chain-tokens/lock-release-multisig
-Last Updated: 2025-09-17
+Last Updated: 2026-06-15
 
 This tutorial demonstrates how to implement cross-chain tokens using the **[Lock and Mint](/ccip/concepts/cross-chain-token/overview#lock-and-mint)** mechanism with production-grade governance.
 
@@ -21550,30 +21651,34 @@ For complete details on token handling mechanisms, see [Token Handling Mechanism
 
 ## Prerequisites
 
+This tutorial uses a **two-terminal workflow** with **Squads multisig governance** on Solana. Install the system tools below, create your Squad on devnet, clone both repositories, then complete environment setup before starting Phase 1.
+
 ### System Requirements
 
-Install these tools before starting:
-
-**Package Managers:**
-
-- **Node.js v20+**: Required for all repositories
-- **pnpm**: Required for base58 Generator (`npm install -g pnpm`)
-- **yarn**: Required for Solana Starter Kit (`npm install -g yarn`)
-
-**Solana Development:**
-
-- **Solana CLI**: [Installation guide](https://docs.solana.com/cli/install-solana-cli-tools)
+- **Node.js v22 or higher**: Required for all tools. Verify with `node -v`
+- **pnpm**: Required for the BS58 generator (`npm install -g pnpm`)
+- **npm**: Required for the Hardhat project (bundled with Node.js)
+- **Solana CLI**: [Installation guide](https://docs.solana.com/cli/install-solana-cli-tools) (includes `spl-token`)
+- **Git**: For cloning repositories
+- **CCIP CLI**: For cross-chain transfer testing in the final phase
 
 **Wallets:**
 
-- **Solana wallet**: [Phantom](https://phantom.app/) or [Backpack](https://backpack.app/) for Devnet operations
-- **Ethereum wallet**: [MetaMask](https://metamask.io/) for Sepolia testnet operations
+- **Solana**: [Phantom](https://phantom.app/) or [Backpack](https://backpack.app/) for Devnet and Squads operations
+- **Ethereum**: [MetaMask](https://metamask.io/) for Sepolia testnet operations
+
+Install the [CCIP CLI](https://github.com/smartcontractkit/ccip-tools-ts) globally:
+
+```bash
+npm install -g @chainlink/ccip-cli
+ccip-cli --help
+```
+
+See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for RPC and wallet configuration.
 
 ### Repository Setup
 
-Clone and install dependencies for all three repositories:
-
-**Terminal 1: base58 Generator**
+**Terminal 1: CCIP Solana BS58 Generator** (skip `git clone` if you already have the repo)
 
 ```bash
 git clone https://github.com/smartcontractkit/ccip-solana-bs58-generator.git
@@ -21581,7 +21686,7 @@ cd ccip-solana-bs58-generator
 pnpm install
 ```
 
-**Terminal 2: EVM Hardhat**
+**Terminal 2: Smart Contract Examples (Hardhat)** (skip `git clone` if you already have the repo)
 
 ```bash
 git clone https://github.com/smartcontractkit/smart-contract-examples.git
@@ -21590,76 +21695,77 @@ npm install
 npm run compile
 ```
 
-**Terminal 3: Solana Starter Kit**
-
-```bash
-git clone https://github.com/smartcontractkit/solana-starter-kit.git
-cd solana-starter-kit
-yarn install
-```
-
-**Create and configure the .env file:**
-
-```bash
-# Create .env file in the project root
-cat > .env << 'EOF'
-EVM_PRIVATE_KEY=your_private_key_here
-EVM_RPC_URL=your_rpc_url_here
-EOF
-```
-
-Replace the placeholder values with:
-
-- `EVM_PRIVATE_KEY`: Your Ethereum wallet private key (for Sepolia testnet operations)
-- `EVM_RPC_URL`: Your Ethereum RPC URL (from [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/), or another provider)
-
 ### Environment Configuration
 
-**Solana Configuration:**
+#### Solana (Terminal 1)
+
+First, check whether your environment is already set up:
 
 ```bash
-# Set Solana CLI to devnet
-solana config set --url https://api.devnet.solana.com
-
-# Create keypair (ONLY IF NEEDED)
-solana-keygen new --outfile ~/.config/solana/id.json
-
-# Check Config
 solana config get
-
-# Fund wallet
-solana airdrop 3
+solana address
+solana balance
 ```
 
-**Ethereum Sepolia Configuration:**
+If the RPC URL is already `https://api.devnet.solana.com`, your keypair path is correct, and you have sufficient SOL, skip to [Ethereum Sepolia setup](#ethereum-sepolia-terminal-2) below.
+
+Otherwise, run only the steps you need:
 
 ```bash
-# In Terminal 2 (Hardhat directory)
+# Set devnet (skip if config get already shows devnet)
+solana config set --url https://api.devnet.solana.com
+
+# Point to your keypair (skip if config get already shows the path you want)
+solana config set --keypair ~/.config/solana/id.json
+
+# Create a keypair only if the file does not exist yet
+solana-keygen new --outfile ~/.config/solana/id.json
+
+# Fund your wallet if balance is low
+solana airdrop 3
+solana balance
+```
+
+#### Ethereum Sepolia (Terminal 2)
+
+```bash
+# Required at the start of each session
 npx env-enc set-pw
+
+# Verify existing variables (skip npx env-enc set if all required vars are already configured)
+npx env-enc view
+
+# Add or update variables only if missing
 npx env-enc set
 ```
 
-Required environment variables:
+Required variables:
 
 - `ETHEREUM_SEPOLIA_RPC_URL`: RPC endpoint ([Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/))
 - `PRIVATE_KEY`: Testnet wallet private key
 - `ETHERSCAN_API_KEY`: API key from [Etherscan](https://etherscan.io/apis)
 
-**Testnet Tokens:**
+**Testnet tokens:**
 
-- **Solana Devnet**: Use `solana airdrop 3` for SOL
-- **Ethereum Sepolia**: Use [Chainlink faucets](https://faucets.chain.link/) for LINK and ETH
+- **Solana Devnet**: `solana airdrop 3` for SOL
+- **Ethereum Sepolia**: ETH for gas and CCIP fees ([Chainlink faucet](https://faucets.chain.link/) or [Google Cloud Faucet](https://cloud.google.com/application/web3/faucet/ethereum/sepolia)). LINK is optional for `--fee-token LINK` on EVM sends.
+
+<Aside type="note" title="When to Use --execute">
+  **Governance steps** generate base58-encoded transactions in Terminal 1 **without** `--execute`. Import the output
+  into Squads and sign there. **Pre-transfer steps** (token delegation, pool ATA creation) use your local Solana wallet
+  with `--execute` on `pnpm bs58` commands. **Read-only** commands (`get-state`, `get-chain-config`) omit `--execute`.
+  See the [CCIP Solana BS58 Generator
+  README](https://github.com/smartcontractkit/ccip-solana-bs58-generator/blob/main/README.md).
+</Aside>
 
 ### Squads Multisig Setup
 
 <Aside type="caution" title="Required: Create Squads Multisig">
-  **Before starting this tutorial**, you must create a Squads multisig on Solana Devnet. This will serve as your
-  governance mechanism for all CCIP administrative operations.
+  **Before starting this tutorial**, create a Squads multisig on Solana Devnet. It serves as your governance mechanism
+  for CCIP administrative operations.
 </Aside>
 
-**Step 1: Prepare Signers**
-
-Create multiple wallet addresses for your multisig signers:
+**Step 1: Prepare signers**
 
 ```bash
 # Create additional signers using Solana CLI
@@ -21676,121 +21782,107 @@ solana transfer <SIGNER2_ADDRESS> 0.1 --allow-unfunded-recipient
 solana transfer <SIGNER3_ADDRESS> 0.1 --allow-unfunded-recipient
 ```
 
-Alternatively, create signers in Phantom wallet and fund them:
+Alternatively, create signers in Phantom and fund them:
 
 ```bash
-# Transfer SOL to Phantom-created addresses
 solana transfer <PHANTOM_SIGNER_ADDRESS> 0.5 --allow-unfunded-recipient
 ```
 
-**Step 2: Create Your Squad**
+**Step 2: Create your Squad**
 
 1. Visit [devnet.squads.so](https://devnet.squads.so)
-2. Connect your Solana wallet (e.g., Phantom/Backpack)
-3. Click "Create New Squad"
-4. Configure your multisig:
-   - **Squad Name**: Choose a descriptive name (e.g., "CCIP Token Governance")
-   - **Members**: Add wallet addresses of all signers
-   - **Threshold**: Set approval threshold (recommended: 2/3 or 3/5)
+2. Connect your Solana wallet (Phantom or Backpack)
+3. Click **Create New Squad**
+4. Configure members and threshold (recommended: 2/3 or 3/5)
 
 <Aside type="note" title="Threshold Best Practices">
   - **Avoid 1/n thresholds** (single point of failure)
   - **Avoid maximum thresholds** (e.g., 3/3 prevents recovery if one key is lost)
 </Aside>
 
-**Step 3: Record Critical Addresses**
+**Step 3: Record the vault address**
 
-After Squad creation, navigate to Settings tab and record these addresses.
+After Squad creation, open the Settings tab and copy the **vault address** (not the multisig address).
 
-**In Terminal 1 (base58 Generator), export the vault address:**
+**In Terminal 1:**
 
 ```bash
 # CRITICAL: Use the VAULT address, NOT the multisig address
 export SOL_SQUAD_VAULT_MULTISIG="YOUR_VAULT_ADDRESS_HERE"
-```
-
-Verify the export:
-
-```bash
 echo "Squads Vault Address: $SOL_SQUAD_VAULT_MULTISIG"
 ```
 
 <Aside type="caution" title="Vault vs Multisig Address">
-  **IMPORTANT**: Only use the **Vault address** for setting authorities and receiving funds. The **Multisig address** is
-  used only for CLI detection - sending assets to it causes **irreversible loss**.
+  Use the **vault address** for authorities and receiving funds. The **multisig address** is for CLI detection only —
+  sending assets to it causes **irreversible loss**.
 </Aside>
 
-**Step 4: Test Your Squad**
-
-Perform a small test transaction to verify setup:
+**Step 4: Test your Squad**
 
 1. Send a small amount of SOL to your Squad vault
 2. Create a test transaction in Squads UI (e.g., SOL transfer to your wallet)
-3. Confirm all signers can approve transactions
-4. Execute the transaction
+3. Confirm signers can approve and execute
 
-For detailed setup guidance, see the [Squads Documentation](https://docs.squads.so/).
+See [Squads Documentation](https://docs.squads.so/) for detailed setup guidance.
 
 ### Token Creation Option
 
 <Aside type="note" title="Existing Token Requirements">
-  **Important**: You can only skip token creation if you have an existing SPL token where the **mint authority is already controlled by your Squad vault**.
+  You can skip token creation only if you have an existing SPL token where **mint authority is already controlled by your
+  Squad vault**.
 
   **Two scenarios:**
 
-  1. **Mint authority = Squad vault**: Skip to Step 3 (pool initialization) and export your existing mint address
-  2. **Mint authority ≠ Squad vault**: You must first transfer mint authority to your Squad vault, OR create a fresh token in Step 2
+  1. **Mint authority = Squad vault**: Skip to pool initialization and export your existing mint address
+  2. **Mint authority ≠ Squad vault**: Transfer mint authority to your Squad vault first, or create a fresh token in the tutorial
 
-  **For fresh start**: Proceed with Step 2 to create a new token with Squad vault as mint authority from the beginning.
+  **For a fresh start**: Proceed with token creation so the Squad vault is mint authority from the beginning.
 </Aside>
 
 ## Tutorial Approach
 
-This tutorial implements production-grade cross-chain tokens using a three-terminal workflow across specialized repositories:
+| Terminal       | Repository                                                                                                                  | Purpose                                    | Commands        |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | --------------- |
+| **Terminal 1** | [CCIP Solana BS58 Generator](https://github.com/smartcontractkit/ccip-solana-bs58-generator)                                | Governance txs and pre-transfer setup      | `pnpm bs58`     |
+| **Terminal 2** | [Smart Contract Examples (Hardhat)](https://github.com/smartcontractkit/smart-contract-examples/tree/main/ccip/cct/hardhat) | Deploy and configure EVM components        | `npx hardhat`   |
+| **Either**     | Global `@chainlink/ccip-cli`                                                                                                | Cross-chain transfer testing (final phase) | `ccip-cli send` |
 
-| Terminal       | Repository                                                                                                                  | Purpose                          | Commands      |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------- |
-| **Terminal 1** | [CCIP Solana base58 Generator](https://github.com/smartcontractkit/ccip-solana-bs58-generator)                              | Generate governance transactions | `pnpm bs58`   |
-| **Terminal 2** | [Smart Contract Examples (Hardhat)](https://github.com/smartcontractkit/smart-contract-examples/tree/main/ccip/cct/hardhat) | Deploy EVM components            | `npx hardhat` |
-| **Terminal 3** | [Solana Starter Kit](https://github.com/smartcontractkit/solana-starter-kit)                                                | Test cross-chain transfers       | `yarn`        |
-
-**Note**: Each repository contains comprehensive READMEs with detailed technical explanations and troubleshooting guides.
+The [CCIP Solana BS58 Generator README](https://github.com/smartcontractkit/ccip-solana-bs58-generator/blob/main/README.md) contains command syntax, simulation behavior, and troubleshooting.
 
 ### Key Implementation Notes
 
-- **Terminal 1** generates base58-encoded transactions for Squads multisig governance
-- **Terminal 2** uses EOA for tutorial simplicity; production deployments should use multisig wallets (e.g., Safe)
-- **Terminal 3** validates end-to-end cross-chain functionality
+- **Terminal 1** generates base58 transactions for Squads governance (no `--execute`). Pre-transfer delegation steps use `--execute` with your local wallet.
+- **Terminal 2** uses an EOA for tutorial simplicity; production EVM deployments should use multisig wallets (e.g., Safe).
+- **Cross-chain transfers** use [`@chainlink/ccip-cli`](https://github.com/smartcontractkit/ccip-tools-ts): Terminal 1 for Solana → EVM, Terminal 2 for EVM → Solana. For EVM sends, prefer `--wallet hardhat:<name>` ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)) from the Hardhat directory; alternatively export `PRIVATE_KEY` manually after `npx env-enc view` (Hardhat tasks load env-enc automatically, but `ccip-cli` does not). Provide RPCs via `--rpc`/`--rpcs`, `RPC_*` environment variables, or a `.env` file — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration).
 
 ### base58 Transaction Execution Workflow
 
-**Transaction Generation and Validation:**
+**Transaction generation:**
 
-1. **CLI Simulation**: Each base58 transaction is automatically simulated during generation
-2. **Error Handling**: If simulation fails, error logs appear in terminal - do not upload failed transactions to Squads
-3. **Success Indicator**: Successful simulation shows transaction preview and base58 output
+1. **CLI simulation**: Each base58 transaction is simulated during generation
+2. **Error handling**: If simulation fails, do not upload the transaction to Squads
+3. **Success**: Terminal shows a transaction preview and base58 output
 
-**Squads Multisig Execution Process:**
+**Squads execution:**
 
-1. **Propose**: A signer imports the base58 transaction into Squads UI → "Add instruction" → "Import base58 encoded tx" → **Initiate Transaction**
-2. **Approve**: Required threshold (M) of signers review and approve the transaction
-3. **Simulate** (Recommended): Before execution, signers can simulate through Squads interface to preview onchain effects
-4. **Execute**: After threshold approval, any signer can execute the transaction
+1. **Propose**: Import base58 output in Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx** → **Initiate Transaction**
+2. **Approve**: Required threshold of signers approves
+3. **Simulate** (recommended): Preview onchain effects in Squads before execution
+4. **Execute**: Any approved signer executes after threshold is met
 
 <Aside type="note" title="Security Best Practice">
-  Always simulate before execution using Squads' built-in simulation feature. This shows exactly what will happen
-  onchain and is critical for validating complex governance operations before commitment.
+  Always simulate in Squads before execution. This validates complex governance operations before commitment.
 </Aside>
 
 ### Environment Variables
 
 Variables use prefixes to prevent confusion across repositories:
 
-| Prefix   | Usage              | Examples                                   |
-| -------- | ------------------ | ------------------------------------------ |
-| `ETH_*`  | Ethereum addresses | `ETH_TOKEN_ADDRESS`, `ETH_POOL_ADDRESS`    |
-| `SOL_*`  | Solana addresses   | `SOL_TOKEN_MINT`, `SOL_POOL_ADDRESS`       |
-| `CCIP_*` | Protocol constants | `CCIP_POOL_PROGRAM`, `CCIP_ROUTER_PROGRAM` |
+| Prefix       | Usage                   | Examples                                                                  |
+| ------------ | ----------------------- | ------------------------------------------------------------------------- |
+| `ETH_*`      | Ethereum addresses      | `ETH_TOKEN_ADDRESS`, `ETH_POOL_ADDRESS`                                   |
+| `SOL_*`      | Solana addresses        | `SOL_TOKEN_MINT`, `SOL_POOL_ADDRESS`                                      |
+| `SOL_CCIP_*` | Solana CCIP program IDs | `SOL_CCIP_POOL_PROGRAM`, `SOL_CCIP_ROUTER`, `SOL_CCIP_FEE_QUOTER_PROGRAM` |
 
 ## Phase 1: EVM Chain Setup (Ethereum Sepolia)
 
@@ -21838,12 +21930,12 @@ In this step, you will use the `setPool` task to register the BurnMint token poo
 
 <Aside type="note" title="Phase 1 Complete">
   **EVM Setup Complete**: You have successfully deployed and configured the EVM side. Next, you'll implement the
-  production-grade Solana side with dual-layer multisig governance.
+  production-grade Solana LockRelease setup with Squads governance.
 </Aside>
 
-## Phase 2: Solana Setup with Production Dual Multisig Governance
+## Phase 2: Solana LockRelease Setup with Squads Governance
 
-In this phase, you will implement the **production-grade multisig governance** architecture on Solana Devnet.
+In this phase, you will implement the **production-grade LockRelease pool** with Squads multisig governance on Solana Devnet.
 
 <Aside type="note" title="Terminal Context Check">
   **Current Focus: Terminal 1 (base58 Generator)** Switch to the base58 generator repository for transaction generation.
@@ -21852,7 +21944,9 @@ In this phase, you will implement the **production-grade multisig governance** a
 
 ### Step 1: Prepare base58 Environment
 
-### Step 2: Create SPL Token (Layer 2 Foundation)
+Set up CCIP constants on Solana Devnet (DO NOT CHANGE THESE)
+
+### Step 2: Create SPL Token
 
 This command generates a transaction that creates a new SPL token mint with the following features:
 
@@ -21877,8 +21971,7 @@ Generate the SPL token creation transaction (customize parameters or reuse the e
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add
-    instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
   - **Review**: Verify transaction details, check authority and mint
 
@@ -21893,8 +21986,8 @@ After execution, set the token mint:
 
 ### Step 3: Initialize LockRelease Token Pool
 
-<Aside type="caution" title="Why Initialize Pool Before Mint Authority Transfer">
-  Since your Squad multisig currently holds the mint authority, you can initialize the pool without Chainlink Labs intervention.
+<Aside type="note" title="Self-Service Pool Initialization">
+  Since your Squad vault currently holds the mint authority, you can initialize the LockRelease pool without Chainlink Labs intervention.
 
   If you have an existing token where the mint authority is held by a wallet or another multisig under your control, you can transfer the mint authority to your Squad vault first to follow the self-service path. Otherwise, if you cannot control the mint authority, you can submit a [registration request](https://chain.link/ccip-contact?v=Tokens:%20Token%20admin%20registration) to have Chainlink Labs initialize the pool for you.
 </Aside>
@@ -21919,9 +22012,9 @@ Generate the pool initialization transaction:
 
 | Account | Address                                        | Purpose                                                     |
 | ------- | ---------------------------------------------- | ----------------------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool State PDA** - Your main pool configuration           |
-| **#2**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | Token Mint (your token)                                     |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | Authority (your Squad vault)                                |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool State PDA** - Your main pool configuration           |
+| **#2**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | Token Mint (your token)                                     |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | Authority (your Squad vault)                                |
 | **#4**  | `11111111111111111111111111111111`             | System Program                                              |
 | **#5**  | `8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC` | CCIP Pool Program                                           |
 | **#6**  | `AeMEQshfd7w72oGt5cMn8196zod6gQPWskbf5BY83W1B` | Program Data PDA                                            |
@@ -21935,8 +22028,7 @@ Generate the pool initialization transaction:
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add
-    instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
   - **Review**: Verify pool initialization parameters
 
@@ -21948,11 +22040,6 @@ Generate the pool initialization transaction:
 </Aside>
 
 After execution, set the pool state address from the transaction:
-
-```bash
-# Set the pool state address from Account #1 in the transaction above
-export SOL_POOL_ADDRESS="9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1"
-```
 
 ### Step 4: Derive Pool Signer PDA
 
@@ -21975,9 +22062,9 @@ The [owner_propose_administrator](/ccip/concepts/cross-chain-token/svm/registrat
 | Account | Address                                        | Description                                                           |
 | ------- | ---------------------------------------------- | --------------------------------------------------------------------- |
 | **#1**  | `3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3` | Router Config PDA (read-only)                                         |
-| **#2**  | `89Jy2ZEz6LcvBPVQgR2YxPYVoF1sLugNRs3havQP8SvF` | **🎯 Token Admin Registry PDA** - Gets created/updated for your token |
-| **#3**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | Token Mint (your token)                                               |
-| **#4**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | Authority/Payer (your Squad vault)                                    |
+| **#2**  | `6gmKNyGtrSgB4gAH9yQyzXSPnDw1P5We9abZLEcuqdLY` | **🎯 Token Admin Registry PDA** - Gets created/updated for your token |
+| **#3**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | Token Mint (your token)                                               |
+| **#4**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | Authority/Payer (your Squad vault)                                    |
 | **#5**  | `11111111111111111111111111111111`             | System Program                                                        |
 
 **What This Transaction Does:**
@@ -21986,8 +22073,7 @@ This transaction proposes your Squad vault as the administrator for your token i
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add
-    instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
   - **Review**: Verify transaction details and parameters
 
@@ -22007,9 +22093,9 @@ The [accept_admin_role](/ccip/concepts/cross-chain-token/svm/registration-admini
 | Account | Address                                        | Description                                                  |
 | ------- | ---------------------------------------------- | ------------------------------------------------------------ |
 | **#1**  | `3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3` | Router Config PDA (read-only)                                |
-| **#2**  | `89Jy2ZEz6LcvBPVQgR2YxPYVoF1sLugNRs3havQP8SvF` | **🎯 Token Admin Registry PDA** - Updates status to "active" |
-| **#3**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | Token Mint (your token)                                      |
-| **#4**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | Authority (your Squad vault - must be pending admin)         |
+| **#2**  | `6gmKNyGtrSgB4gAH9yQyzXSPnDw1P5We9abZLEcuqdLY` | **🎯 Token Admin Registry PDA** - Updates status to "active" |
+| **#3**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | Token Mint (your token)                                      |
+| **#4**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | Authority (your Squad vault - must be pending admin)         |
 
 **What This Transaction Does:**
 This is the **acceptance step** of the two-phase administrator registration. It updates the Token Admin Registry PDA (Account #2) from "pending administrator" to "active administrator" status. Your Squad vault explicitly accepts the administrator role, completing the secure registration process.
@@ -22019,8 +22105,7 @@ This is the **acceptance step** of the two-phase administrator registration. It 
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add
-    instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
   - **Review**: Verify transaction details and parameters
 
@@ -22039,7 +22124,7 @@ Create the Associated Token Account (ATA) for the Squad vault. This account will
 
 **Transaction Details:**
 
-- **Squad Vault ATA**: `G7yVJJKDRBQDdbFttmA3G3oytFKBcsZH8VMdJWBXJKJB` (example)
+- **Squad Vault ATA**: `ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV` (example)
 - **Owner**: Squad vault PDA
 
 ### Step 7: Mint Tokens for Pool Liquidity
@@ -22056,9 +22141,9 @@ Mint tokens to your Squad vault to prepare for LockRelease pool liquidity provis
 
 | Account | Address                                        | Description                                        |
 | ------- | ---------------------------------------------- | -------------------------------------------------- |
-| **#1**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | **Token Mint** (writable - supply updated)         |
-| **#2**  | `G7yVJJKDRBQDdbFttmA3G3oytFKBcsZH8VMdJWBXJKJB` | **Squad vault's ATA** (writable - receives tokens) |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer)                           |
+| **#1**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | **Token Mint** (writable - supply updated)         |
+| **#2**  | `ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV` | **Squad vault's ATA** (writable - receives tokens) |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer)                           |
 
 **What This Transaction Does:**
 This is a standard SPL token mint operation that mints tokens for the Squad vault to use as liquidity for the LockRelease pool. Since the Squad vault retains mint authority, it can directly mint tokens without requiring multisig operations.
@@ -22080,7 +22165,7 @@ This is a standard SPL token mint operation that mints tokens for the Squad vaul
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify transaction details and parameters
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -22101,14 +22186,14 @@ Configure the Squad vault as the rebalancer for the LockRelease pool. The rebala
 
 | Account | Address                                        | Description                                  |
 | ------- | ---------------------------------------------- | -------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool state PDA** (writable)                |
-| **#2**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | **Token Mint** (read-only - your token mint) |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer)                     |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool state PDA** (writable)                |
+| **#2**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | **Token Mint** (read-only - your token mint) |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer)                     |
 
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify rebalancer address matches your Squad vault
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -22121,7 +22206,7 @@ Create the Associated Token Account (ATA) for the Pool Signer PDA. This account 
 
 **Transaction Details:**
 
-- **Pool ATA**: `A57bH91QkGuARh37JTN41fd3Vwcmf2bLzVHAVPB8Gaeg` (example)
+- **Pool ATA**: `GQ4md7wUKmU35m4munp8giYg9osXCTaGVCPvNYzz8Wnu` (example)
 - **Owner**: Pool Signer PDA
 
 ### Step 10: Set Can Accept Liquidity
@@ -22138,9 +22223,9 @@ Configure the LockRelease pool to accept liquidity from the rebalancer. This set
 
 | Account | Address                                        | Description                                           |
 | ------- | ---------------------------------------------- | ----------------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool State PDA** (writable - configuration updated) |
-| **#2**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | **Token Mint** (read-only)                            |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer - pool owner authority)       |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool State PDA** (writable - configuration updated) |
+| **#2**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | **Token Mint** (read-only)                            |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer - pool owner authority)       |
 
 **Transaction Flow:**
 
@@ -22151,7 +22236,7 @@ Configure the LockRelease pool to accept liquidity from the rebalancer. This set
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify the liquidity acceptance setting is enabled
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -22172,9 +22257,9 @@ Approve the Pool Signer PDA to spend tokens from the Squad vault's ATA. This del
 
 | Account | Address                                        | Description                                         |
 | ------- | ---------------------------------------------- | --------------------------------------------------- |
-| **#1**  | `G7yVJJKDRBQDdbFttmA3G3oytFKBcsZH8VMdJWBXJKJB` | **Squad Vault ATA** (writable - delegation updated) |
-| **#2**  | `E8odUv4V4DXy3RWvkNYF7H33X9J56RtsFp4ExVXB86UA` | **Pool Signer PDA** (read-only - delegate)          |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer - token account owner)      |
+| **#1**  | `ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV` | **Squad Vault ATA** (writable - delegation updated) |
+| **#2**  | `5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk` | **Pool Signer PDA** (read-only - delegate)          |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer - token account owner)      |
 
 **Transaction Flow:**
 
@@ -22184,7 +22269,7 @@ Approve the Pool Signer PDA to spend tokens from the Squad vault's ATA. This del
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify delegate address is the Pool Signer PDA
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -22205,13 +22290,13 @@ Provide initial liquidity to the LockRelease pool using the tokens minted in Ste
 
 | Account | Address                                        | Description                                         |
 | ------- | ---------------------------------------------- | --------------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool State PDA** (read-only)                      |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool State PDA** (read-only)                      |
 | **#2**  | `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`  | **Token Program** (read-only)                       |
-| **#3**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | **Token Mint** (writable)                           |
-| **#4**  | `E8odUv4V4DXy3RWvkNYF7H33X9J56RtsFp4ExVXB86UA` | **Pool Signer PDA** (read-only)                     |
-| **#5**  | `A57bH91QkGuARh37JTN41fd3Vwcmf2bLzVHAVPB8Gaeg` | **Pool Token ATA** (writable - receives liquidity)  |
-| **#6**  | `G7yVJJKDRBQDdbFttmA3G3oytFKBcsZH8VMdJWBXJKJB` | **Squad Vault ATA** (writable - provides liquidity) |
-| **#7**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer - rebalancer authority)     |
+| **#3**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | **Token Mint** (writable)                           |
+| **#4**  | `5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk` | **Pool Signer PDA** (read-only)                     |
+| **#5**  | `GQ4md7wUKmU35m4munp8giYg9osXCTaGVCPvNYzz8Wnu` | **Pool Token ATA** (writable - receives liquidity)  |
+| **#6**  | `ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV` | **Squad Vault ATA** (writable - provides liquidity) |
+| **#7**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer - rebalancer authority)     |
 
 **Transaction Flow:**
 
@@ -22223,7 +22308,7 @@ Provide initial liquidity to the LockRelease pool using the tokens minted in Ste
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify liquidity amount and token addresses
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -22255,8 +22340,8 @@ Load Phase 1 variables and set the Ethereum Sepolia chain selector for cross-cha
 
 Configure your token pool for cross-chain transfers to Ethereum Sepolia. This process involves two sequential operations:
 
-1. **Initialize Chain Remote Config**: Create the basic cross-chain configuration using [init_chain_remote_config](/ccip/api-reference/svm/v1.6.0/burn-mint-token-pool#init_chain_remote_config)
-2. **Edit Chain Remote Config**: Add the remote pool address using [edit_chain_remote_config](/ccip/api-reference/svm/v1.6.0/burn-mint-token-pool#edit_chain_remote_config)
+1. **Initialize Chain Remote Config**: Create the basic cross-chain configuration using [init_chain_remote_config](/ccip/api-reference/svm/v1.6.0/lock-release-token-pool#init_chain_remote_config)
+2. **Edit Chain Remote Config**: Add the remote pool address using [edit_chain_remote_config](/ccip/api-reference/svm/v1.6.0/lock-release-token-pool#edit_chain_remote_config)
 
 #### Step 2A: Initialize Chain Remote Config
 
@@ -22266,9 +22351,9 @@ Initialize the basic remote chain configuration for Ethereum Sepolia. Pool addre
 
 | Account | Address                                        | Description                                         |
 | ------- | ---------------------------------------------- | --------------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool State PDA** (read-only - validation)         |
-| **#2**  | `DzPjdCvEgJq6tyTvQtuh6i8WtPn6gWGmhaRM3DnCvwq9` | **Chain Remote Config PDA** (writable - created)    |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer, writable - pool authority) |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool State PDA** (read-only - validation)         |
+| **#2**  | `5ZctnHiRZyrtDirqfXxpo4aH6eNT7YTJZ3HZh5WJWMiX` | **Chain Remote Config PDA** (writable - created)    |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer, writable - pool authority) |
 | **#4**  | `11111111111111111111111111111111`             | **System Program** (read-only - account creation)   |
 
 **What This Command Does:**
@@ -22277,7 +22362,7 @@ This initializes the **cross-chain configuration** for your Solana token to enab
 **Key Details:**
 
 - **Remote Chain**: Ethereum Sepolia (chain selector: `16015286601757825753`)
-- **Token Mapping**: Links to ERC20 token `0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715`
+- **Token Mapping**: Links to ERC20 token `0x44490fee906a4cfd5e71a46c3ca2147287b018e7`
 - **Decimal Precision**: 18 decimals (standard EVM token format)
 - **Basic Setup**: No rate limits or pool addresses configured at this stage
 - **Account Creation**: Creates a new Chain Remote Config PDA for this cross-chain relationship
@@ -22292,7 +22377,7 @@ This initializes the **cross-chain configuration** for your Solana token to enab
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify transaction details and parameters
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -22301,15 +22386,15 @@ This initializes the **cross-chain configuration** for your Solana token to enab
 
 #### Step 2B: Edit Chain Remote Config (Add Remote Pool Address)
 
-After initializing the chain remote config, add the remote pool address to enable bidirectional cross-chain transfers. This uses [`edit_chain_remote_config`](/ccip/api-reference/svm/v1.6.0/burn-mint-token-pool#edit_chain_remote_config) to specify the Ethereum pool address.
+After initializing the chain remote config, add the remote pool address to enable bidirectional cross-chain transfers. This uses [`edit_chain_remote_config`](/ccip/api-reference/svm/v1.6.0/lock-release-token-pool#edit_chain_remote_config) to specify the Ethereum pool address.
 
 **Account Breakdown from the Transaction:**
 
 | Account | Address                                        | Description                                                    |
 | ------- | ---------------------------------------------- | -------------------------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool State PDA** (read-only - authority validation)          |
-| **#2**  | `DzPjdCvEgJq6tyTvQtuh6i8WtPn6gWGmhaRM3DnCvwq9` | **Chain Remote Config PDA** (writable - configuration updated) |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault Authority** (signer, writable - fee payer)       |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool State PDA** (read-only - authority validation)          |
+| **#2**  | `5ZctnHiRZyrtDirqfXxpo4aH6eNT7YTJZ3HZh5WJWMiX` | **Chain Remote Config PDA** (writable - configuration updated) |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault Authority** (signer, writable - fee payer)       |
 | **#4**  | `11111111111111111111111111111111`             | **System Program** (read-only - account operations)            |
 
 **Transaction Flow:**
@@ -22321,7 +22406,7 @@ After initializing the chain remote config, add the remote pool address to enabl
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify transaction details and parameters
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -22355,14 +22440,14 @@ This command configures inbound and outbound rate limiting for token transfers b
 
 | Account | Address                                        | Type                 | Purpose                                                           |
 | ------- | ---------------------------------------------- | -------------------- | ----------------------------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Read-only**        | **Pool State PDA** - Main pool configuration account              |
-| **#2**  | `DzPjdCvEgJq6tyTvQtuh6i8WtPn6gWGmhaRM3DnCvwq9` | **Writable**         | **Chain Config PDA** - Chain-specific config (stores rate limits) |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Signer, Writable** | **Authority** - Your Squad vault that can modify rate limits      |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Read-only**        | **Pool State PDA** - Main pool configuration account              |
+| **#2**  | `5ZctnHiRZyrtDirqfXxpo4aH6eNT7YTJZ3HZh5WJWMiX` | **Writable**         | **Chain Config PDA** - Chain-specific config (stores rate limits) |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Signer, Writable** | **Authority** - Your Squad vault that can modify rate limits      |
 
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify transaction details and parameters
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -22381,9 +22466,9 @@ This command creates an **Address Lookup Table (ALT)** that stores frequently us
 
 | Account | Address                                        | Description                                               |
 | ------- | ---------------------------------------------- | --------------------------------------------------------- |
-| **#1**  | `C3a5U5C4Sn8fywXmV4ZX6JAfYoQrEhAqF5daL39ScKSy` | **ALT Account** (writable - being created)                |
-| **#2**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **ALT Authority** (signer - will own the table)           |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Fee Payer** (signer, writable - pays creation costs)    |
+| **#1**  | `2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK` | **ALT Account** (writable - being created)                |
+| **#2**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **ALT Authority** (signer - will own the table)           |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Fee Payer** (signer, writable - pays creation costs)    |
 | **#4**  | `11111111111111111111111111111111`             | **System Program** (read-only - handles account creation) |
 
 **What This Command Does:**
@@ -22392,7 +22477,7 @@ This command creates the ALT infrastructure needed for efficient CCIP operations
 
 **Transaction Flow:**
 
-1. **ALT Creation**: Creates lookup table account `C3a5U...` with Squad Vault as authority
+1. **ALT Creation**: Creates lookup table account `2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK` with Squad Vault as authority
 2. **Core Address Addition**: Adds essential CCIP accounts (programs, PDAs) to the table
 3. **Index Assignment**: Each address gets a unique 1-byte index for future reference
 
@@ -22406,14 +22491,14 @@ The created lookup table will contain indices for these accounts in this exact o
 
 | Index | Account Address                                | Purpose                                    |
 | ----- | ---------------------------------------------- | ------------------------------------------ |
-| **0** | `C3a5U5C4Sn8fywXmV4ZX6JAfYoQrEhAqF5daL39ScKSy` | **ALT Address (Self-Reference)**           |
-| **1** | `89Jy2ZEz6LcvBPVQgR2YxPYVoF1sLugNRs3havQP8SvF` | **Token Admin Registry PDA**               |
+| **0** | `2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK` | **ALT Address (Self-Reference)**           |
+| **1** | `6gmKNyGtrSgB4gAH9yQyzXSPnDw1P5We9abZLEcuqdLY` | **Token Admin Registry PDA**               |
 | **2** | `8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC` | **Pool Program ID**                        |
-| **3** | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool State PDA**                         |
-| **4** | `A57bH91QkGuARh37JTN41fd3Vwcmf2bLzVHAVPB8Gaeg` | **Pool Signer's Associated Token Account** |
-| **5** | `E8odUv4V4DXy3RWvkNYF7H33X9J56RtsFp4ExVXB86UA` | **Pool Signer PDA**                        |
+| **3** | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool State PDA**                         |
+| **4** | `GQ4md7wUKmU35m4munp8giYg9osXCTaGVCPvNYzz8Wnu` | **Pool Signer's Associated Token Account** |
+| **5** | `5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk` | **Pool Signer PDA**                        |
 | **6** | `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`  | **Token Program ID (SPL Token v1)**        |
-| **7** | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | **Token Mint**                             |
+| **7** | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | **Token Mint**                             |
 | **8** | `84grjTssjNyuDsaxJGkpJB8t17Y9sQt1G81R5AQyZ1Rr` | **Fee Quoter Token Config PDA**            |
 | **9** | `DPyeT76APQQVQD7EJRVw8Y6gLYjGkC5CdbdHQTQkpoN2` | **Router External Token Pools Signer PDA** |
 
@@ -22426,7 +22511,7 @@ The created lookup table will contain indices for these accounts in this exact o
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify transaction details and parameters
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -22452,10 +22537,10 @@ Register your token pool with the CCIP Router using [set_pool](/ccip/api-referen
 | Account | Address                                        | Description                                                 |
 | ------- | ---------------------------------------------- | ----------------------------------------------------------- |
 | **#1**  | `3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3` | **Router Config PDA** (read-only - configuration reference) |
-| **#2**  | `89Jy2ZEz6LcvBPVQgR2YxPYVoF1sLugNRs3havQP8SvF` | **Token Admin Registry PDA** (writable - pool registration) |
-| **#3**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | **Token Mint** (read-only - token identification)           |
-| **#4**  | `C3a5U5C4Sn8fywXmV4ZX6JAfYoQrEhAqF5daL39ScKSy` | **Address Lookup Table** (read-only - ALT registration)     |
-| **#5**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault Authority** (signer, writable - admin & fees) |
+| **#2**  | `6gmKNyGtrSgB4gAH9yQyzXSPnDw1P5We9abZLEcuqdLY` | **Token Admin Registry PDA** (writable - pool registration) |
+| **#3**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | **Token Mint** (read-only - token identification)           |
+| **#4**  | `2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK` | **Address Lookup Table** (read-only - ALT registration)     |
+| **#5**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault Authority** (signer, writable - admin & fees) |
 
 **What This Command Does:**
 
@@ -22486,7 +22571,7 @@ Based on the ALT order established earlier:
 <Aside type="note" title="Squads Execution Required">
   **Execute this base58 transaction in Squads UI:**
 
-  - **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+  - **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
   - **Review**: Verify transaction details and parameters
   - **Simulate**: Simulate the transaction to ensure it will succeed
   - **Approve**: Obtain required threshold signatures
@@ -22526,94 +22611,118 @@ Configure the Ethereum pool to recognize the Solana chain and set production rat
     - 0.1 tokens/sec = `100000000000000000` wei (0.1 × 10^18)
 </Aside>
 
-## Phase 5: Testing and Validation
+## Phase 5: Pre-Transfer Setup, Validation, and Testing
 
 <Aside type="note" title="Terminal Context Check">
-  **Current Focus: Terminal 3 (Solana Testing)** Switch to the Solana Starter Kit repository for comprehensive testing.
+  **Current Focus: Terminal 1 (CCIP Solana BS58 Generator)** Complete pre-transfer setup and validate your
+  configuration. Governance steps use Squads; delegation and verification use your local wallet with `--execute`.
 </Aside>
 
-### Step 1: Load Phase 4 Variables
-
-Before testing cross-chain transfers, ensure your terminal environment is properly configured:
-
-### Transfer Direction 1: Solana → Ethereum
-
-Test the production multisig setup with a cross-chain transfer from Solana Devnet to Ethereum Sepolia:
-
-#### Prepare for Testing
-
-Before testing cross-chain transfers, you need to create the pool's Associated Token Account (ATA) and prepare your tokens:
-
-##### Check Token Balance
-
-##### Delegate Token Authority
-
-#### Transfer tokens from Solana Devnet to Ethereum Sepolia
-
-#### Monitor and Verify Transaction
-
-Upon successful execution, the system generates critical tracking identifiers for transaction monitoring and verification.
-
-**Transaction Identifiers:**
-
-- **Transaction Signature**: `4w81mpUozjJsEvHrkukCejbA9byMjkHacwtqM5cJD19XQu8MvXzoJ4YTqqkoEvBfP7HPvdivMA3Q1MePA16PdCXM`
-- **CCIP Message ID**: `0xd92433fea1fab2b9b2efa8d6091df0b5156bb159c883b94dada725539e5edace`
-
-**CCIP Explorer** (Primary monitoring interface):
-
-```
-https://ccip.chain.link/msg/0xd92433fea1fab2b9b2efa8d6091df0b5156bb159c883b94dada725539e5edace
-```
-
-The CCIP Explorer provides comprehensive transaction visibility:
-
-- Source chain (Solana) transaction confirmation
-- CCIP message processing and routing
-- Destination chain (Ethereum) message delivery
-- Token minting completion on Ethereum
-
-**Solana Explorer** (Source chain verification):
-
-```
-https://explorer.solana.com/tx/4w81mpUozjJsEvHrkukCejbA9byMjkHacwtqM5cJD19XQu8MvXzoJ4YTqqkoEvBfP7HPvdivMA3Q1MePA16PdCXM?cluster=devnet
-```
-
-### Transfer Direction 2: Ethereum → Solana
-
-<Aside type="note" title="Terminal Environment">
-  **Continue in Terminal 3** (Solana Starter Kit directory). No need to switch terminals - the Solana Starter Kit
-  handles Ethereum → Solana transfers as well.
+<Aside type="note" title="Cross-Chain Transfers with CCIP CLI">
+  Use [`@chainlink/ccip-cli`](https://github.com/smartcontractkit/ccip-tools-ts) for bidirectional token transfers. Run Solana → EVM sends from Terminal 1 and EVM → Solana sends from Terminal 2. See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for full options.
 </Aside>
 
-#### Transfer tokens from Ethereum Sepolia to Solana Devnet
+### Step 1: Load Configuration
 
-#### Monitor and Verify Transaction
+### Step 2: Pre-Transfer Setup
 
-Upon successful execution, the system generates distinct tracking identifiers for comprehensive monitoring across both blockchain networks.
+Before cross-chain transfers (when available), complete token delegation so CCIP can move tokens from your wallet.
 
-**Transaction Identifiers:**
+#### Check Token Balance
 
-- **Ethereum Transaction Hash**: `0xcacca1de44800d4e88544597b1b9f8190db93ae2f2144bb3b92aafd73b626c3d`
-- **CCIP Message ID**: `0xb8327a54fcf042f6fa9ca236372ea68835204802ca13ebfc34c7f839631ee567`
+#### Create Pool Associated Token Account
 
-**CCIP Explorer** (Primary monitoring interface):
+If not created during pool setup, create the pool's ATA:
 
+#### Delegate Token Authority
+
+Approve the fee-billing signer to transfer tokens from your ATA:
+
+#### Verify Delegation
+
+Check that your token account is delegated to the fee-billing signer:
+
+Display token account and delegation status:
+
+### Step 3: Verify Solana Pool and Chain Config
+
+### Step 4: Verify Ethereum Pool (Terminal 2)
+
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
+
+```bash
+npx hardhat getPoolConfig \
+  --pooladdress $ETH_POOL_ADDRESS \
+  --network ethereumSepolia
 ```
-https://ccip.chain.link/msg/0xb8327a54fcf042f6fa9ca236372ea68835204802ca13ebfc34c7f839631ee567
+
+Confirm the Ethereum pool recognizes Solana Devnet with your `$SOL_POOL_ADDRESS` and `$SOL_TOKEN_MINT`.
+
+### Configure CCIP CLI
+
+Export these RPC URLs once before your first transfer:
+
+```bash
+export SOLANA_DEVNET_RPC="https://api.devnet.solana.com"
+export ETHEREUM_SEPOLIA_RPC_URL="<YOUR_ETHEREUM_SEPOLIA_RPC_URL>"
+
+export ETH_CCIP_ROUTER="0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59"
 ```
 
-The CCIP Explorer provides comprehensive transaction visibility:
+Use the same `ETHEREUM_SEPOLIA_RPC_URL` from your env-enc setup in Terminal 2 (`npx env-enc view`). On `ccip-cli send`, the source chain RPC quotes fees and submits the transaction; for token-only transfers in this tutorial, that is the only RPC strictly required to send. Pass both RPCs on cross-chain commands anyway: the destination RPC is required for `ccip-cli show --wait` and for optional send features such as `--estimate-gas-limit` or `send --wait`.
 
-- Source chain (Ethereum) transaction confirmation
-- CCIP message processing and routing
-- Destination chain (Solana) message delivery
-- Token minting completion on Solana network
+<Aside type="note" title="RPC and wallet configuration">
+  Repeat `--rpc` for multiple networks, or use `--rpcs` with comma-separated URLs. Alternatively, set `RPC_*` environment variables or a `.env` file — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration). Solana sends use `--wallet ~/.config/solana/id.json`. EVM sends: prefer `--wallet hardhat:<name>` from the Hardhat project directory ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)); alternatively export `PRIVATE_KEY` manually after `npx env-enc view` (Hardhat tasks load env-enc automatically, but `ccip-cli` does not). See [CCIP CLI wallet configuration](https://docs.chain.link/ccip/tools/cli/configuration#wallet-configuration).
+</Aside>
 
-**Ethereum Sepolia Explorer** (Source chain verification):
+### Transfer Solana → Ethereum
 
+**Terminal 1** (CCIP Solana BS58 Generator):
+
+The `-t` flag uses human-readable amounts (0.001 tokens with 9 decimals = 1,000,000 smallest units).
+
+### Transfer Ethereum → Solana
+
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
+
+`ccip-cli` does not load Hardhat env-enc automatically. Run these commands from the Hardhat project directory. Prefer [Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore) over exporting a private key in plain text.
+
+For token-only transfers to Solana, `--to` is the destination wallet that receives minted tokens. CCIP fees are paid in native Sepolia ETH by default — ensure your wallet has sufficient ETH for gas and fees.
+
+<Aside type="note" title="Pay fees in LINK (optional)">
+  Add `--fee-token LINK` to pay CCIP fees in LINK instead of ETH (Sepolia LINK:
+  `0x779877A7B0D9E8603169DdbD7836e478b4624789`).
+</Aside>
+
+<Aside type="note" title="Your transfer identifiers will differ">
+  Use the Sepolia transaction hash from your `ccip-cli send` command with `ccip-cli show <TX_HASH> --wait`. Message IDs, timestamps, and Solana receipt signatures are unique per transfer. The example below shows the expected **completed** output shape once the message executes on Solana Devnet.
+</Aside>
+
+### Optional: Test Rate Limit Enforcement
+
+If you configured rate limits in Phase 3, attempt a transfer that exceeds capacity (25 tokens vs 20-token limit):
+
+### Optional: Verify Rate Limit Configuration
+
+If you configured rate limits in Phase 3, confirm they appear in your chain configuration:
+
+```bash
+# Terminal 1 — inspect Solana outbound/inbound rate limits
+pnpm bs58 --env devnet lockrelease-token-pool \
+  --instruction get-chain-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --remote-chain-selector $ETHEREUM_SEPOLIA_CHAIN_SELECTOR
 ```
-https://sepolia.etherscan.io/tx/0xcacca1de44800d4e88544597b1b9f8190db93ae2f2144bb3b92aafd73b626c3d
+
+```bash
+# Terminal 2 — inspect EVM rate limit settings
+npx hardhat getPoolConfig \
+  --pooladdress $ETH_POOL_ADDRESS \
+  --network ethereumSepolia
 ```
+
+**Congratulations!** Your production Lock/Release cross-chain token infrastructure with Squads governance is fully configured on both chains.
 
 ---
 

--- a/src/content/ccip/tutorials/svm/cross-chain-tokens/direct-mint-authority.mdx
+++ b/src/content/ccip/tutorials/svm/cross-chain-tokens/direct-mint-authority.mdx
@@ -10,7 +10,7 @@ metadata:
   description: "Quick-start guide for cross-chain SPL, Token-2022 tokens on Solana. Build bidirectional CCIP token bridges in 35 minutes using direct mint authority - perfect for developers."
   excerpt: "ccip cross-chain token tutorial solana ethereum burnmint pools path-a direct mint authority transfer self-service registration svm evm bidirectional token pools address lookup tables transaction monitoring development testing solana devnet ethereum sepolia pool signer pda token admin registry spl token token-2022"
   datePublished: "2025-08-13T00:53:46Z"
-  lastModified: "2025-08-13T00:53:46Z"
+  lastModified: "2026-06-15T00:53:46Z"
   estimatedTime: "35 minutes"
   difficulty: "intermediate"
 ---
@@ -69,14 +69,16 @@ designed for **development and testing environments only**.
 
 ## Tutorial Approach
 
-This tutorial provides step-by-step instructions with detailed explanations of what each command does and why. You'll work primarily in Terminal 1 (Solana) with occasional switches to Terminal 2 (EVM).
+This tutorial provides step-by-step instructions with detailed explanations of what each command does and why. You'll work primarily in Terminal 1 (CCIP Solana BS58 Generator) with occasional switches to Terminal 2 (EVM).
 
 **Environment Variable Management**: This tutorial uses phase-based variable files (e.g., `~/.phase1_vars`, `~/.ccip_complete_vars`) to eliminate manual variable re-entry when switching between terminals. Each phase saves its variables to files that subsequent phases can load automatically.
 
 For deeper technical implementation details, refer to:
 
-- **[Solana Starter Kit README](https://github.com/smartcontractkit/solana-starter-kit/blob/main/README.md)**: SVM command details
+- **[CCIP Solana BS58 Generator README](https://github.com/smartcontractkit/ccip-solana-bs58-generator/blob/main/README.md)**: Solana CLI command details, `--execute` EOA workflow, and options
 - **[Smart Contract Examples README](https://github.com/smartcontractkit/smart-contract-examples/blob/main/ccip/cct/hardhat/README.md)**: EVM implementation guide
+
+**EOA execution**: In Terminal 1, append `--execute` to each `pnpm bs58` command so your local Solana wallet signs and sends transactions directly. Set `--authority` to your wallet address (`$SOL_WALLET_ADDRESS`). Read-only commands (`get-state`, `get-chain-config`, `derive-accounts`) do not use `--execute`.
 
 ## Phase 1: Ethereum Sepolia Token Setup
 
@@ -109,10 +111,10 @@ Deploy a burnable and mintable ERC20 token that will serve as your cross-chain a
 
 npx hardhat deployToken \
   --name "BnM Cross-Chain Token" \
---symbol "BnMAEM" \
+  --symbol "BnMAEM" \
   --decimals 18 \
-  --verifycontract true \
-  --network sepolia
+  --verifycontract \
+  --network ethereumSepolia
 ```
 
 </Fragment>
@@ -120,15 +122,22 @@ npx hardhat deployToken \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-21T13:40:41.035Z info: Deploying BurnMintERC20 contract to sepolia
-2025-08-21T13:40:41.039Z info: Waiting 3 blocks for transaction 0xe114afdcb211b047ef6c835420dbdac99036d5c28e0fb4fcdad523ad3c8c7b68 to be confirmed...
-2025-08-21T13:41:12.857Z info: Token deployed to: 0x5D74645E854922009723a817fe4e417A80E7c709
-2025-08-21T13:41:12.923Z info: Granting mint and burn roles to 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-21T13:41:50.165Z info: Verifying contract...
-The contract 0x5D74645E854922009723a817fe4e417A80E7c709 has already been verified on the block explorer. If you're trying to verify a partially verified contract, please use the --force flag.
-https://sepolia.etherscan.io/address/0x5D74645E854922009723a817fe4e417A80E7c709#code
+2026-06-14T15:47:26.136Z info: 🚀 Deploying BurnMintERC20 to ethereumSepolia...
+2026-06-14T15:47:26.137Z info:    name: BnM Cross-Chain Token, symbol: BnMAEM
+2026-06-14T15:47:28.211Z info: ⏳ Deployment tx: 0xe3f88d62d59f8f6beb5bf8f505996da2861e973e13de0b797b01400c350113dc
+2026-06-14T15:47:28.211Z info:    Waiting for 3 confirmation(s)...
+2026-06-14T15:48:02.254Z info: ✅ Token deployed at: 0xc06d7a73ba115b592961290c8c49760b97247676
+2026-06-14T15:48:02.613Z info: Granting mint and burn roles to 0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA...
+2026-06-14T15:48:03.042Z info:    Waiting for 3 confirmation(s)...
+2026-06-14T15:48:41.403Z info: ✅ Mint/Burn roles granted.
+2026-06-14T15:48:41.403Z info: Verifying contract...
 
-2025-08-21T13:41:50.826Z info: Token contract deployed and verified
+The contract at 0xc06d7a73ba115b592961290c8c49760b97247676 has already been verified on Etherscan.
+
+If you need to verify a partially verified contract, please use the --force flag.
+
+Explorer: https://sepolia.etherscan.io/address/0xc06d7a73ba115b592961290c8c49760b97247676#code
+2026-06-14T15:48:44.420Z info: ✅ Token contract verified successfully
 ```
 
 </Fragment>
@@ -168,7 +177,7 @@ echo "Ethereum Token: $ETH_TOKEN_ADDRESS"
 <Fragment slot="panel.2">
 
 ```bash
-Ethereum Token: 0x5D74645E854922009723a817fe4e417A80E7c709
+Ethereum Token: 0xc06d7a73ba115b592961290c8c49760b97247676
 ```
 
 </Fragment>
@@ -191,8 +200,8 @@ npx hardhat deployTokenPool \
   --tokenaddress $ETH_TOKEN_ADDRESS \
   --localtokendecimals 18 \
   --pooltype burnMint \
-  --verifycontract true \
-  --network sepolia
+  --verifycontract \
+  --network ethereumSepolia
 ```
 
 </Fragment>
@@ -200,14 +209,24 @@ npx hardhat deployTokenPool \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-21T13:45:07.212Z info: Waiting 3 blocks for transaction 0xdeff8121275606b790d8b656ab8b2504d296cb732c2b4944107d2bdf9669897a to be confirmed...
-2025-08-21T13:45:36.491Z info: Token pool deployed to: 0x817FdAa9e7cd30C4838a82eEA7f09217C6d8c885
-2025-08-21T13:45:36.491Z info: Granting mint and burn roles to 0x817FdAa9e7cd30C4838a82eEA7f09217C6d8c885 on token 0x5D74645E854922009723a817fe4e417A80E7c709
-2025-08-21T13:46:13.019Z info: Verifying contract...
-The contract 0x817FdAa9e7cd30C4838a82eEA7f09217C6d8c885 has already been verified on the block explorer. If you're trying to verify a partially verified contract, please use the --force flag.
-https://sepolia.etherscan.io/address/0x817FdAa9e7cd30C4838a82eEA7f09217C6d8c885#code
+2026-06-14T15:55:33.429Z info: 🚀 Deploying burnMint pool on ethereumSepolia
+2026-06-14T15:55:33.430Z info:    Token: 0xc06d7a73ba115b592961290c8c49760b97247676
+2026-06-14T15:55:33.430Z info:    Decimals: 18
+2026-06-14T15:55:33.430Z info:    Allowlist: None
+2026-06-14T15:55:39.434Z info: ⏳ Deployment tx: 0xfca38c2532c5ef0441ca77e3def99c0cfa4959eee8b0bdc274d69e2255b440fb
+2026-06-14T15:55:39.434Z info:    Waiting for 3 confirmation(s)...
+2026-06-14T15:56:15.123Z info: ✅ Token pool deployed at: 0x835f9b923858aa5aca7ac1c7389361482fc32c45
+2026-06-14T15:56:15.123Z info: Granting mint and burn roles to 0x835f9b923858aa5aca7ac1c7389361482fc32c45 on token 0xc06d7a73ba115b592961290c8c49760b97247676
+2026-06-14T15:56:16.957Z info:    Waiting for 3 confirmation(s)...
+2026-06-14T15:56:53.039Z info: ✅ Mint/Burn roles granted
+2026-06-14T15:56:53.040Z info: Verifying contract...
 
-2025-08-21T13:46:13.573Z info: Token pool contract deployed and verified
+The contract at 0x835f9b923858aa5aca7ac1c7389361482fc32c45 has already been verified on Etherscan.
+
+If you need to verify a partially verified contract, please use the --force flag.
+
+Explorer: https://sepolia.etherscan.io/address/0x835f9b923858aa5aca7ac1c7389361482fc32c45#code
+2026-06-14T15:56:56.451Z info: ✅ Token pool contract verified successfully
 ```
 
 </Fragment>
@@ -248,8 +267,8 @@ echo "Ethereum Pool: $ETH_POOL_ADDRESS"
 <Fragment slot="panel.2">
 
 ```bash
-Ethereum Token: 0x5D74645E854922009723a817fe4e417A80E7c709
-Ethereum Pool: 0x817FdAa9e7cd30C4838a82eEA7f09217C6d8c885
+Ethereum Token: 0xc06d7a73ba115b592961290c8c49760b97247676
+Ethereum Pool: 0x835f9b923858aa5aca7ac1c7389361482fc32c45
 ```
 
 </Fragment>
@@ -270,7 +289,7 @@ Mint tokens to your wallet for testing cross-chain transfers:
 npx hardhat mintTokens \
   --tokenaddress $ETH_TOKEN_ADDRESS \
   --amount 1000000000000000000000 \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 </Fragment>
@@ -278,9 +297,11 @@ npx hardhat mintTokens \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-21T13:48:15.619Z info: Minting 1000000000000000000000 of BnMAEM tokens to 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-21T13:51:37.696Z info: Minted 1000000000000000000000 of BnMCC tokens to 0x9d087fC03ae39b088326b67fA3C788236645b717 - transaction hash: 0xde6ed9230d18c3b61f902ab9c7c00b46e1bac0f632f22141fd5f8ac05b87e449
-2025-08-21T13:51:37.834Z info: Current balance of 0x9d087fC03ae39b088326b67fA3C788236645b717 is 1000000000000000000000 BnMCC
+2026-06-14T15:58:32.181Z info: 🪙 Minting 1000000000000000000000 BnMAEM to 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca...
+2026-06-14T15:58:34.767Z info: ⏳ Mint tx: 0x9bc3e7018cbf89aac0c51717a39e2429692b45c2426511e8a3af9141e28b7a51
+2026-06-14T15:58:34.767Z info:    Waiting for 3 confirmation(s)...
+2026-06-14T15:59:15.269Z info: ✅ Minted 1000000000000000000000 BnMAEM to 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-14T15:59:15.271Z info:    Current balance of 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca: 1000000000000000000000 BnMAEM
 ```
 
 </Fragment>
@@ -303,7 +324,7 @@ Register yourself as the CCIP administrator for your token. This two-step proces
 # Claim admin role for your token
 npx hardhat claimAdmin \
   --tokenaddress $ETH_TOKEN_ADDRESS \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 </Fragment>
@@ -311,10 +332,10 @@ npx hardhat claimAdmin \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-21T13:52:17.017Z info: 🎯 Attempting to claim admin for token 0x5D74645E854922009723a817fe4e417A80E7c709 using getCCIPAdmin mode
-2025-08-21T13:52:17.835Z info: Current token CCIP admin: 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-21T13:52:17.835Z info: Claiming admin of 0x5D74645E854922009723a817fe4e417A80E7c709 via getCCIPAdmin() for CCIP admin 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-21T13:52:49.312Z info: ✅ Successfully claimed admin of 0x5D74645E854922009723a817fe4e417A80E7c709 using getCCIPAdmin mode. Transaction: 0x6b27be59b1f23d6e8388b517dc122323a7cc6dced2721dd164bc48921708d749
+2026-06-14T16:00:40.602Z info: 🎯 Claiming admin for 0xc06d7a73ba115b592961290c8c49760b97247676 using getCCIPAdmin mode
+2026-06-14T16:00:46.906Z info: ✅ Current wallet 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca is CCIP admin
+2026-06-14T16:00:50.179Z info: 📤 TX sent: 0x222e504cbb8a61715a03eb1cd18382ff856f8e79693856cc12d727a6b5f540e7. Waiting for 3 confirmations...
+2026-06-14T16:01:26.639Z info: ✅ Admin claimed for 0xc06d7a73ba115b592961290c8c49760b97247676 on ethereumSepolia (3 confirmations)
 ```
 
 </Fragment>
@@ -343,7 +364,7 @@ This command:
 # Accept the admin role to finalize
 npx hardhat acceptAdminRole \
   --tokenaddress $ETH_TOKEN_ADDRESS \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 </Fragment>
@@ -351,7 +372,12 @@ npx hardhat acceptAdminRole \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-21T13:54:00.703Z info: Accepted admin role for token 0x5D74645E854922009723a817fe4e417A80E7c709 tx: 0x8353306a31a6ab70f9c9fe3433956216b38239c7772436b9d779b4a52eb14080
+2026-06-14T16:03:19.318Z info: 🔄 Accepting admin role for 0xc06d7a73ba115b592961290c8c49760b97247676 on ethereumSepolia...
+2026-06-14T16:03:23.161Z info: Checking pending admin for 0xc06d7a73ba115b592961290c8c49760b97247676...
+2026-06-14T16:03:23.541Z info: ✅ Current wallet 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca is the pending admin
+2026-06-14T16:03:23.541Z info: Accepting admin role...
+2026-06-14T16:03:26.284Z info: 📤 TX sent: 0xeefe8ae8971bdcf66c1d30ee3d7eabefe29596575e191a8f9cc4fd6e5b751d12. Waiting for 3 confirmations...
+2026-06-14T16:04:03.547Z info: ✅ Admin role accepted for 0xc06d7a73ba115b592961290c8c49760b97247676 on ethereumSepolia (3 confirmations)
 ```
 
 </Fragment>
@@ -386,8 +412,8 @@ echo "✅ Variables saved to ~/.phase1_vars"
 
 ```bash
 === Phase 1 Complete - EVM Setup ===
-✅ ETH Token: 0x5D74645E854922009723a817fe4e417A80E7c709
-✅ ETH Pool: 0x817FdAa9e7cd30C4838a82eEA7f09217C6d8c885
+✅ ETH Token: 0xc06d7a73ba115b592961290c8c49760b97247676
+✅ ETH Pool: 0x835f9b923858aa5aca7ac1c7389361482fc32c45
 ✅ Variables saved to ~/.phase1_vars
 ```
 
@@ -400,18 +426,61 @@ Now we'll create and configure the Solana side of your cross-chain token system.
 
 <Aside type="note" title="Terminal Context">
   
-**Switch to Terminal 1** (Solana Starter Kit) Verify your location:
+**Switch to Terminal 1** (CCIP Solana BS58 Generator) Verify your location:
 
 ```bash
 pwd
-# Should show: .../solana-starter-kit
+# Should show: .../ccip-solana-bs58-generator
 ```
 
 </Aside>
 
-### Step 1: Create SPL Token
+### Step 1: Prepare Environment
 
-Create an SPL token with metadata support:
+Load EVM variables from Phase 1 and set Solana CCIP constants:
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Setup Command</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+# Load Phase 1 EVM variables
+source ~/.phase1_vars
+
+# Your Solana wallet (used as --authority for all EOA commands)
+export SOL_WALLET_ADDRESS=$(solana address)
+
+# CCIP program IDs on Solana Devnet (DO NOT CHANGE THESE)
+export SOL_CCIP_POOL_PROGRAM="41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
+export SOL_CCIP_ROUTER="Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C"
+export SOL_CCIP_FEE_QUOTER_PROGRAM="FeeQPGkKDeRV1MgoYfMH6L8o3KeuYjwUZrgn4LRKfjHi"
+
+# Ethereum Sepolia chain selector (used in remote chain config)
+export ETH_SEPOLIA_CHAIN_SELECTOR="16015286601757825753"
+
+echo "✅ Wallet: $SOL_WALLET_ADDRESS"
+echo "✅ Pool Program: $SOL_CCIP_POOL_PROGRAM"
+echo "✅ Router Program: $SOL_CCIP_ROUTER"
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+✅ Wallet: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+✅ Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
+✅ Router Program: Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
+```
+
+</Fragment>
+</Tabs>
+
+### Step 2: Create SPL Token
+
+Create an SPL token with metadata and initial supply using direct EOA execution:
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Create Command</Fragment>
@@ -420,22 +489,22 @@ Create an SPL token with metadata support:
 <Fragment slot="panel.1">
 
 ```bash
-# Create SPL token with default configuration
-yarn svm:token:create
+# Create SPL token with Metaplex metadata and initial supply
+pnpm bs58 --env devnet --execute spl-token \
+  --instruction create-mint \
+  --authority $SOL_WALLET_ADDRESS \
+  --decimals 9 \
+  --with-metaplex true \
+  --name "AEM" \
+  --symbol "CCIP-AEM" \
+  --uri "https://cyan-pleasant-anteater-613.mypinata.cloud/ipfs/bafkreieirlwjqbtzniqsgcjebzexlcspcmvd4woh3ajvf2p4fuivkenw6i" \
+  --initial-supply 1000000000000 \
+  --recipient $SOL_WALLET_ADDRESS
 ```
 
 <Aside type="note" title="Custom Configuration">
 
-You can customize the token:
-
-```bash
-yarn svm:token:create \
-  --name "Your Token Name" \
-  --symbol "SYMBOL" \
-  --uri "https://your-metadata-url.json"
-```
-
-Upload your metadata to IPFS or Arweave.
+You can customize the token name, symbol, and URI. Upload your metadata to IPFS or Arweave, then update the `--name`, `--symbol`, and `--uri` flags above.
 
 </Aside>
 
@@ -444,53 +513,54 @@ Upload your metadata to IPFS or Arweave.
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-21T13:57:16.600Z] 🏭 CREATING SPL TOKEN
-[2025-08-21T13:57:16.600Z] ===============================================
-[2025-08-21T13:57:16.600Z] Starting spl-token creation with metadata {
-  name: 'AEM',
-  symbol: 'CCIP-AEM',
-  decimals: 9,
-  uri: 'https://cyan-pleasant-anteater-613.mypinata.cloud/ipfs/bafkreieirlwjqbtzniqsgcjebzexlcspcmvd4woh3ajvf2p4fuivkenw6i',
-  initialSupply: '1000000000000',
-  sellerFeeBasisPoints: 0,
-  tokenProgram: 'spl-token'
-}
-[2025-08-21T13:57:30.740Z] spl-token token created successfully {
-  mint: 'GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A',
-  signature: '2JPuwB6i7gXLDvQNKVXbmgqyDe31yZuj5MGqHzze6QPXL1Hfbh6Tvdzk4pWTdtQd3UwFuCVYGjYUEMDfMrQrQSvu'
-}
-[2025-08-21T13:57:30.743Z] Starting token mint operation {
-  mint: 'GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A',
-  amount: '1000000000000',
-  recipient: 'EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB'
-}
-[2025-08-21T13:57:44.662Z] ATA created successfully {
-  tokenAccount: 'Cg9BDeWtC938iPfboCost6Fr9g5VnZcDdKsst94JtFV9',
-  signature: '48U4pVhquBL6m8qG6qsGs7cLpC3bSranZGdQKC5P9ucci6et2NPYuU8gRWPuSGATxDkXCNbieWLk9EMJLLdXNyUh'
-}
-[2025-08-21T13:57:58.375Z] Tokens minted successfully {
-  signature: '4N49ZxGDCwhfxAPXTWCVJhSYKoG3Cgq6jjJb8M4oCP6qhekCScdWkKJ5s2Qe8bovU2a8H3znWqpFuvJ5ZEsm3ArP',
-  amount: '1000000000000',
-  tokenAccount: 'Cg9BDeWtC938iPfboCost6Fr9g5VnZcDdKsst94JtFV9',
-  newBalance: '1000000000000'
-}
-[2025-08-21T13:57:58.376Z] Initial supply minted {
-  tokenAccount: 'Cg9BDeWtC938iPfboCost6Fr9g5VnZcDdKsst94JtFV9',
-  amount: '1000000000000'
-}
-[2025-08-21T13:57:58.377Z]
-[2025-08-21T13:57:58.377Z] ✅ SPL TOKEN CREATED SUCCESSFULLY
-[2025-08-21T13:57:58.377Z] ===============================================
-[2025-08-21T13:57:58.377Z] Mint Address: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T13:57:58.377Z] Transaction Signature: 2JPuwB6i7gXLDvQNKVXbmgqyDe31yZuj5MGqHzze6QPXL1Hfbh6Tvdzk4pWTdtQd3UwFuCVYGjYUEMDfMrQrQSvu
-[2025-08-21T13:57:58.377Z] Token Account: Cg9BDeWtC938iPfboCost6Fr9g5VnZcDdKsst94JtFV9
-[2025-08-21T13:57:58.377Z]
-[2025-08-21T13:57:58.377Z] 🔍 EXPLORER URLS
-[2025-08-21T13:57:58.377Z] ===============================================
-[2025-08-21T13:57:58.378Z] Mint: https://explorer.solana.com/address/GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A?cluster=devnet
-[2025-08-21T13:57:58.378Z] Transaction: https://explorer.solana.com/tx/2JPuwB6i7gXLDvQNKVXbmgqyDe31yZuj5MGqHzze6QPXL1Hfbh6Tvdzk4pWTdtQd3UwFuCVYGjYUEMDfMrQrQSvu?cluster=devnet
-[2025-08-21T13:57:58.378Z] Token Account: https://explorer.solana.com/address/Cg9BDeWtC938iPfboCost6Fr9g5VnZcDdKsst94JtFV9?cluster=devnet
-[2025-08-21T13:57:58.378Z]
+INFO [2026-06-14 21:38:11.724 +0530]: 🔍 Validating create mint parameters...
+INFO [2026-06-14 21:38:11.724 +0530]: 📋 Token Program: spl-token (TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA)
+INFO [2026-06-14 21:38:11.724 +0530]: 📋 Decimals: 9
+INFO [2026-06-14 21:38:11.724 +0530]: 📋 Metaplex metadata enabled
+INFO [2026-06-14 21:38:11.724 +0530]:    Name: "AEM"
+INFO [2026-06-14 21:38:11.724 +0530]:    Symbol: "CCIP-AEM"
+INFO [2026-06-14 21:38:11.724 +0530]:    URI: https://cyan-pleasant-anteater-613.mypinata.cloud/ipfs/bafkreieirlwjqbtzniqsgcjebzexlcspcmvd4woh3ajvf2p4fuivkenw6i
+INFO [2026-06-14 21:38:11.724 +0530]: 📋 Initial supply: 1000000000000 smallest units
+INFO [2026-06-14 21:38:11.724 +0530]: 📋 Recipient: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-14 21:38:11.724 +0530]: ✅ Parameter validation completed
+INFO [2026-06-14 21:38:11.724 +0530]: 🎨 Creating mint with Metaplex metadata...
+INFO [2026-06-14 21:38:11.726 +0530]: 📋 Generated mint address: 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
+INFO [2026-06-14 21:38:11.726 +0530]: 📋 Mint seed: mint_1781453291724_bq3i74
+INFO [2026-06-14 21:38:11.726 +0530]: 📋 Using token program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+INFO [2026-06-14 21:38:12.136 +0530]: 📋 Generated 3 instructions for mint + metadata creation
+INFO [2026-06-14 21:38:12.136 +0530]: 💰 Adding initial supply mint instructions...
+INFO [2026-06-14 21:38:12.136 +0530]: 📋 Creating ATA for recipient: 4PiwHZh1ZCcBCt6y1cDa7hvRWKmvzki4q9kQKYSvgHxK
+INFO [2026-06-14 21:38:12.136 +0530]: 📋 Will mint 1000000000000 smallest units to 4PiwHZh1ZCcBCt6y1cDa7hvRWKmvzki4q9kQKYSvgHxK
+INFO [2026-06-14 21:38:12.137 +0530]: 🔄 Building and simulating transaction...
+INFO [2026-06-14 21:38:12.137 +0530]: 📋 Metadata PDA: 5mvf5TcWa6L9xzVr4PebqEWxF6CCXteCa9DSFyg1HeSo
+INFO [2026-06-14 21:38:12.329 +0530]: Transaction built successfully
+    instructionName: "spl-token.create_mint_with_metaplex"
+    transactionSize: "778 bytes"
+    base58Length: "1062 characters"
+    hexLength: "1556 characters"
+    accountCount: 2
+    signerCount: 1
+    computeUnits: 62049
+INFO [2026-06-14 21:38:12.329 +0530]: Completed buildTransaction (spl-token.create_mint_with_metaplex)
+    durationMs: 192
+INFO [2026-06-14 21:38:12.517 +0530]:
+INFO [2026-06-14 21:38:12.517 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-14 21:38:12.517 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-14 21:38:12.517 +0530]:    Instruction: spl-token.create_mint_with_metaplex
+INFO [2026-06-14 21:38:12.517 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-14 21:38:12.517 +0530]:
+INFO [2026-06-14 21:38:13.351 +0530]: Transaction confirmed successfully
+    signature: "36JP4Mv2wwaCFTeXfZ4h4DeTfDgm2kANtSdWn776pmfu5jieLCLFWrLegBKP1LKVNkXPnVdZht9fHUsc6ecBw1Fd"
+    attempt: 1
+INFO [2026-06-14 21:38:13.351 +0530]:
+INFO [2026-06-14 21:38:13.352 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-14 21:38:13.352 +0530]:
+INFO [2026-06-14 21:38:13.352 +0530]: 📋 Execution Details:
+INFO [2026-06-14 21:38:13.352 +0530]:    Instruction: spl-token.create_mint_with_metaplex
+INFO [2026-06-14 21:38:13.352 +0530]:    Signature:   36JP4Mv2wwaCFTeXfZ4h4DeTfDgm2kANtSdWn776pmfu5jieLCLFWrLegBKP1LKVNkXPnVdZht9fHUsc6ecBw1Fd
+INFO [2026-06-14 21:38:13.352 +0530]:    Explorer:    https://explorer.solana.com/tx/36JP4Mv2wwaCFTeXfZ4h4DeTfDgm2kANtSdWn776pmfu5jieLCLFWrLegBKP1LKVNkXPnVdZht9fHUsc6ecBw1Fd?cluster=devnet
+INFO [2026-06-14 21:38:13.352 +0530]:
+INFO [2026-06-14 21:38:13.352 +0530]: ✅ Transaction simulation completed
 ```
 
 </Fragment>
@@ -505,27 +575,16 @@ Set the token mint variable:
 
 <Fragment slot="panel.1">
 
-<Aside type="note" title="CCIP BurnMint Pool Program">
-  The CCIP BurnMint pool program is a self-service pool program that allows you to create a pool for your token.
-  You can find the program ID in the CCIP Directory for:
-
-     - [Solana Devnet](/ccip/directory/testnet/chain/solana-devnet)
-     - [Solana Mainnet](/ccip/directory/mainnet/chain/solana-mainnet)
-
-</Aside>
-
 ```bash
-# REPLACE with your actual token mint address
+# Copy the mint address from the command output above
 export SOL_TOKEN_MINT="<INSERT_YOUR_MINT_ADDRESS_HERE>"
-export CCIP_POOL_PROGRAM="41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
 ```
 
 Verify the variables:
 
 ```bash
-# Verify variables
 echo "Solana Token Mint: $SOL_TOKEN_MINT"
-echo "CCIP Pool Program: $CCIP_POOL_PROGRAM"
+echo "Solana pool program: $SOL_CCIP_POOL_PROGRAM"
 ```
 
 </Fragment>
@@ -533,14 +592,14 @@ echo "CCIP Pool Program: $CCIP_POOL_PROGRAM"
 <Fragment slot="panel.2">
 
 ```bash
-Solana Token Mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
+Solana Token Mint: 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
 CCIP Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
 ```
 
 </Fragment>
 </Tabs>
 
-### Step 2: Initialize CCIP Token Pool
+### Step 3: Initialize CCIP Token Pool
 
 Initialize the token pool configuration on Solana:
 
@@ -553,9 +612,11 @@ Initialize the token pool configuration on Solana:
 
 ```bash
 # Initialize CCIP pool for your token
-yarn svm:pool:initialize \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM
+pnpm bs58 --env devnet --execute burnmint-token-pool \
+  --instruction initialize-pool \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_WALLET_ADDRESS
 ```
 
 </Fragment>
@@ -563,54 +624,36 @@ yarn svm:pool:initialize \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-21T14:00:08.849Z] ⚙️  POOL CONFIGURATION
-[2025-08-21T14:00:08.849Z] ===========================================
-[2025-08-21T14:00:08.849Z] Token Mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:00:08.849Z] Burn-Mint Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-21T14:00:08.850Z] Router Program: Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
-[2025-08-21T14:00:08.850Z] RMN Remote Program: RmnXLft1mSEwDgMKu2okYuHkiazxntFFcZFrrcXxYg7
-[2025-08-21T14:00:08.851Z]
-[2025-08-21T14:00:08.851Z] 🔍 POOL EXISTENCE CHECK
-[2025-08-21T14:00:08.852Z] ===========================================
-[2025-08-21T14:00:08.852Z] Checking if pool already exists...
-[2025-08-21T14:00:08.954Z]
-[2025-08-21T14:00:08.954Z] 🏗️  INITIALIZING POOL
-[2025-08-21T14:00:08.954Z] ===========================================
-[2025-08-21T14:00:08.954Z] Initializing token pool...
-[2025-08-21T14:00:08.955Z] Initializing burn-mint pool for mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:00:08.956Z] 📍 Pool State PDA: 7Ln8Y43dSdbNgC9bx5UgigaDRrwVi3WYnhRWoNKCcjV1
-[2025-08-21T14:00:22.685Z] Burn-mint pool initialized: 2Yh5ko2LxC4FkTRv4yZV98NTUQKVcSzs45wEGP9PK6n1Sfdr3RBZKYjQQSyncHV29YBHdDkWUvHopVE3mUTr2Wb7
-[2025-08-21T14:00:22.690Z]
-🎯 Pool Initialization Summary:
-[2025-08-21T14:00:22.692Z]    Token Mint:       GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:00:22.693Z]    Pool State PDA:   7Ln8Y43dSdbNgC9bx5UgigaDRrwVi3WYnhRWoNKCcjV1
-[2025-08-21T14:00:22.693Z]    Pool Signer PDA:  BwzTc3R77vf1dS4kj3JX8YGpCvjsg91vBDgyKJfeBkue
-[2025-08-21T14:00:22.693Z]    Program ID:       41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-21T14:00:22.693Z]    Transaction:      2Yh5ko2LxC4FkTRv4yZV98NTUQKVcSzs45wEGP9PK6n1Sfdr3RBZKYjQQSyncHV29YBHdDkWUvHopVE3mUTr2Wb7
-[2025-08-21T14:00:22.693Z]
-[2025-08-21T14:00:22.693Z] ✅ POOL INITIALIZED SUCCESSFULLY
-[2025-08-21T14:00:22.693Z] ===========================================
-[2025-08-21T14:00:22.693Z] Transaction Signature: 2Yh5ko2LxC4FkTRv4yZV98NTUQKVcSzs45wEGP9PK6n1Sfdr3RBZKYjQQSyncHV29YBHdDkWUvHopVE3mUTr2Wb7
-[2025-08-21T14:00:22.693Z] 📍 Pool State PDA: 7Ln8Y43dSdbNgC9bx5UgigaDRrwVi3WYnhRWoNKCcjV1
-[2025-08-21T14:00:22.693Z]
-[2025-08-21T14:00:22.693Z] 🔍 EXPLORER URLS
-[2025-08-21T14:00:22.696Z] ===========================================
-[2025-08-21T14:00:22.696Z] Transaction: https://explorer.solana.com/tx/2Yh5ko2LxC4FkTRv4yZV98NTUQKVcSzs45wEGP9PK6n1Sfdr3RBZKYjQQSyncHV29YBHdDkWUvHopVE3mUTr2Wb7?cluster=devnet
-[2025-08-21T14:00:22.696Z]
-[2025-08-21T14:00:22.696Z] 🔍 VERIFICATION
-[2025-08-21T14:00:22.696Z] ===========================================
-[2025-08-21T14:00:22.697Z] Verifying pool initialization...
-[2025-08-21T14:00:22.702Z] 📍 Pool Config PDA: 7Ln8Y43dSdbNgC9bx5UgigaDRrwVi3WYnhRWoNKCcjV1
-[2025-08-21T14:00:23.010Z] ✅ Pool initialization verified successfully!
-[2025-08-21T14:00:23.010Z] ✅ State PDA confirmed active: 7Ln8Y43dSdbNgC9bx5UgigaDRrwVi3WYnhRWoNKCcjV1
-[2025-08-21T14:00:23.011Z]
-[2025-08-21T14:00:23.012Z] 🎯 POOL CREATION SUMMARY
-[2025-08-21T14:00:23.012Z] ===============================================
-[2025-08-21T14:00:23.012Z] Token Mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:00:23.012Z] State PDA: 7Ln8Y43dSdbNgC9bx5UgigaDRrwVi3WYnhRWoNKCcjV1
-[2025-08-21T14:00:23.012Z] Owner: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-21T14:00:23.012Z] Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-21T14:00:23.017Z]
+🔄 Generating initialize (pool) transaction...
+🔄 Building and simulating transaction...
+INFO [2026-06-14 21:43:33.436 +0530]: Transaction built successfully
+    instructionName: "burnmint-token-pool.initialize"
+    transactionSize: "279 bytes"
+    base58Length: "380 characters"
+    hexLength: "558 characters"
+    accountCount: 7
+    signerCount: 1
+    computeUnits: 28818
+INFO [2026-06-14 21:43:33.437 +0530]: Completed buildTransaction (burnmint-token-pool.initialize)
+    durationMs: 374
+INFO [2026-06-14 21:43:33.600 +0530]:
+INFO [2026-06-14 21:43:33.600 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-14 21:43:33.600 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-14 21:43:33.600 +0530]:    Instruction: burnmint-token-pool.initialize
+INFO [2026-06-14 21:43:33.600 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-14 21:43:33.600 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-14 21:43:34.351 +0530]: Transaction confirmed successfully
+    signature: "4ts1pHPJ1gKTGhcZZLFTsVncQHxMCa3gArxCBsdXgKuuv1yZaYYNjTH3zG9YrgiFJopFKpyR8YqEnKxu89PLHNTy"
+    attempt: 1
+INFO [2026-06-14 21:43:34.351 +0530]:
+INFO [2026-06-14 21:43:34.351 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-14 21:43:34.351 +0530]:
+INFO [2026-06-14 21:43:34.351 +0530]: 📋 Execution Details:
+INFO [2026-06-14 21:43:34.351 +0530]:    Instruction: burnmint-token-pool.initialize
+INFO [2026-06-14 21:43:34.351 +0530]:    Signature:   4ts1pHPJ1gKTGhcZZLFTsVncQHxMCa3gArxCBsdXgKuuv1yZaYYNjTH3zG9YrgiFJopFKpyR8YqEnKxu89PLHNTy
+INFO [2026-06-14 21:43:34.352 +0530]:    Explorer:    https://explorer.solana.com/tx/4ts1pHPJ1gKTGhcZZLFTsVncQHxMCa3gArxCBsdXgKuuv1yZaYYNjTH3zG9YrgiFJopFKpyR8YqEnKxu89PLHNTy?cluster=devnet
+INFO [2026-06-14 21:43:34.352 +0530]:
 ```
 
 </Fragment>
@@ -630,20 +673,89 @@ Learn more about [Token Pool Architecture](/ccip/concepts/cross-chain-token/svm/
 </Fragment>
 </Tabs>
 
-Save the Pool Signer PDA and Pool Config PDA from the output:
+Save the Pool Signer PDA and Pool Config PDA. Derive them from the onchain pool configuration:
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Save Pool Signer PDA</Fragment>
+<Fragment slot="tab.1">Derive Pool Accounts</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# REPLACE with your Pool Signer PDA from the output
-export SOL_POOL_SIGNER_PDA="<INSERT_YOUR_POOL_SIGNER_PDA_HERE>"
+# Derive Pool Signer PDA and Pool State PDA
+pnpm bs58 --env devnet utils \
+  --instruction derive-accounts \
+  --program-type burnmint-token-pool \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT
+```
 
-# Also save the Pool Config PDA for later use
-export SOL_POOL_CONFIG_PDA="<INSERT_YOUR_POOL_CONFIG_PDA_HERE>"
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+🔍 Deriving burnmint-token-pool accounts...
+INFO [2026-06-14 21:45:01.843 +0530]: Starting deriveAccounts command
+    command: "derive-accounts"
+    programType: "burnmint-token-pool"
+    programId: "41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
+    mint: "6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
+
+📊 Derived Accounts:
+
+1. Pool State PDA
+   Address: HLRSx9TYk6Gaz9ZuWR9usmih5MyTpnKLjZg7aDCEk6nJ
+   Seeds: ["ccip_tokenpool_config", mint]
+   Bump: 253
+   Description: Main pool configuration account (created by initialize-pool)
+
+2. Pool Signer PDA
+   Address: F8QX4ZZqjV1gMwaC3erYjVXrcm9QBsSDLNiPLbFEVwH1
+   Seeds: ["ccip_tokenpool_signer", mint]
+   Bump: 254
+   Description: 🎯 CRITICAL: Autonomous mint/burn authority for cross-chain operations
+
+3. Global Config PDA
+   Address: E4Bsi43kX3iwXAFia2ebm1mS5Xkmmdv3minZDnfo7Zzf
+   Seeds: ["config"]
+   Bump: 255
+   Description: Program-wide configuration settings
+
+4. Pool Token ATA
+   Address: EP2Yhkc3yvRrxBK5dTNrcWivowYvaxGcrwi3dE1aPaYy
+   Seeds: [mint, pool_signer_pda, token_program]
+   Description: Pool's token account (owned by Pool Signer PDA)
+
+🎯 CRITICAL ADDRESS FOR CROSS-CHAIN OPERATIONS:
+   Pool Signer PDA: F8QX4ZZqjV1gMwaC3erYjVXrcm9QBsSDLNiPLbFEVwH1
+   ↳ This address signs all mint/burn transactions autonomously
+
+INFO [2026-06-14 21:45:02.294 +0530]: Detected SPL Token v1
+    mint: "6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+INFO [2026-06-14 21:45:02.296 +0530]: ✅ Account derivation completed successfully
+    command: "derive-accounts"
+```
+
+</Fragment>
+</Tabs>
+
+Copy the **Pool Signer PDA** and **Pool State PDA** addresses from the output, then export them:
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Set Pool Variables</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+export SOL_POOL_SIGNER_PDA="<INSERT_YOUR_POOL_SIGNER_PDA_HERE>"
+export SOL_POOL_CONFIG_PDA="<INSERT_YOUR_POOL_STATE_PDA_HERE>"
 ```
 
 Verify the variables:
@@ -658,14 +770,14 @@ echo "Pool Config PDA: $SOL_POOL_CONFIG_PDA"
 <Fragment slot="panel.2">
 
 ```bash
-Pool Signer PDA: BwzTc3R77vf1dS4kj3JX8YGpCvjsg91vBDgyKJfeBkue
-Pool Config PDA: 7Ln8Y43dSdbNgC9bx5UgigaDRrwVi3WYnhRWoNKCcjV1
+Pool Signer PDA: F8QX4ZZqjV1gMwaC3erYjVXrcm9QBsSDLNiPLbFEVwH1
+Pool Config PDA: HLRSx9TYk6Gaz9ZuWR9usmih5MyTpnKLjZg7aDCEk6nJ
 ```
 
 </Fragment>
 </Tabs>
 
-### Step 3: Create Pool Token Account
+### Step 4: Create Pool Token Account
 
 In this step, you will create an Associated Token Account (ATA) for the Pool Signer PDA. This ATA is required for the pool to hold and manage tokens during cross-chain transfer operations.
 
@@ -676,10 +788,11 @@ In this step, you will create an Associated Token Account (ATA) for the Pool Sig
 <Fragment slot="panel.1">
 
 ```bash
-# Create token account for Pool Signer PDA
-yarn svm:pool:create-token-account \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM
+# Create token account owned by the Pool Signer PDA
+# Your wallet (--fee-payer) pays rent; the Pool Signer PDA is the account owner
+spl-token create-account $SOL_TOKEN_MINT \
+  --owner $SOL_POOL_SIGNER_PDA \
+  --fee-payer $HOME/.config/solana/id.json
 ```
 
 </Fragment>
@@ -687,50 +800,15 @@ yarn svm:pool:create-token-account \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-21T14:06:00.729Z] 📋 ACCOUNT CREATION CONFIGURATION
-[2025-08-21T14:06:00.729Z] ==========================================
-[2025-08-21T14:06:00.729Z] Token Mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:06:00.729Z] Burn-Mint Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-21T14:06:00.730Z]
-[2025-08-21T14:06:00.731Z] 🔍 VERIFYING POOL EXISTENCE
-[2025-08-21T14:06:00.731Z] ==========================================
-[2025-08-21T14:06:00.733Z] 📍 Pool Config PDA: 7Ln8Y43dSdbNgC9bx5UgigaDRrwVi3WYnhRWoNKCcjV1
-[2025-08-21T14:06:00.834Z] ✅ Pool exists
-[2025-08-21T14:06:00.834Z] Current pool token account: EjTvTxhQ14sQAY9FXazrvV7rMH4cX7XGRgTAMK7G4dnF
-[2025-08-21T14:06:00.834Z] Getting mint account info for GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A to determine token program ID...
-[2025-08-21T14:06:00.940Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-21T14:06:00.940Z] Pool signer PDA: BwzTc3R77vf1dS4kj3JX8YGpCvjsg91vBDgyKJfeBkue
-[2025-08-21T14:06:00.941Z] Expected pool token account (ATA): EjTvTxhQ14sQAY9FXazrvV7rMH4cX7XGRgTAMK7G4dnF
-[2025-08-21T14:06:00.942Z]
-[2025-08-21T14:06:00.942Z] 🔍 CHECKING EXISTING ACCOUNT
-[2025-08-21T14:06:00.942Z] ==========================================
-[2025-08-21T14:06:01.064Z]
-[2025-08-21T14:06:01.064Z] 🔧 CREATING POOL TOKEN ACCOUNT
-[2025-08-21T14:06:01.064Z] ==========================================
-[2025-08-21T14:06:01.064Z] Creating pool token account (ATA)...
-[2025-08-21T14:06:02.433Z]
-[2025-08-21T14:06:02.434Z] ✅ POOL TOKEN ACCOUNT CREATED SUCCESSFULLY
-[2025-08-21T14:06:02.434Z] ==========================================
-[2025-08-21T14:06:02.434Z] Transaction Signature: V8JMNduSC8dQAhqxwGbN97fdkhHpW42DTrK1U3brhdNKG85uRGVFwzQGw8fkQVzTyVYL4Mqbzha42T27js95iZa
-[2025-08-21T14:06:02.434Z] Pool Token Account Address: EjTvTxhQ14sQAY9FXazrvV7rMH4cX7XGRgTAMK7G4dnF
-[2025-08-21T14:06:02.434Z]
-[2025-08-21T14:06:02.434Z] 🔍 EXPLORER URLS
-[2025-08-21T14:06:02.434Z] ==========================================
-[2025-08-21T14:06:02.434Z] Transaction: https://explorer.solana.com/tx/V8JMNduSC8dQAhqxwGbN97fdkhHpW42DTrK1U3brhdNKG85uRGVFwzQGw8fkQVzTyVYL4Mqbzha42T27js95iZa?cluster=devnet
-[2025-08-21T14:06:02.435Z]
-[2025-08-21T14:06:02.435Z] 🔍 VERIFYING ACCOUNT CREATION
-[2025-08-21T14:06:02.435Z] ==========================================
-[2025-08-21T14:06:02.732Z] ✅ Account creation verified!
-[2025-08-21T14:06:02.732Z]
-[2025-08-21T14:06:02.732Z] 🎉 Pool Token Account Setup Complete!
-[2025-08-21T14:06:02.732Z] ✅ ATA Address: EjTvTxhQ14sQAY9FXazrvV7rMH4cX7XGRgTAMK7G4dnF
-[2025-08-21T14:06:02.732Z] ✅ Owner: BwzTc3R77vf1dS4kj3JX8YGpCvjsg91vBDgyKJfeBkue (Pool Signer PDA)
+Creating account EP2Yhkc3yvRrxBK5dTNrcWivowYvaxGcrwi3dE1aPaYy
+
+Signature: 2Zt8FHAhYe9N4JLfY8jJMBwQduSdxokt6W2AfUQYb4fABTjrqpE2caWXUttDENGkqxFzY8gJijSQUaj1CvSAbqqd
 ```
 
 </Fragment>
 </Tabs>
 
-### Step 4: Register as CCIP Administrator
+### Step 5: Register as CCIP Administrator
 
 #### Propose Admin
 
@@ -744,8 +822,12 @@ In this step, you will propose yourself as the CCIP administrator for the Solana
 
 ```bash
 # Propose yourself as administrator
-yarn svm:admin:propose-administrator \
-  --token-mint $SOL_TOKEN_MINT
+pnpm bs58 --env devnet --execute router \
+  --instruction owner-propose-administrator \
+  --program-id $SOL_CCIP_ROUTER \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_WALLET_ADDRESS \
+  --token-admin-registry-admin $SOL_WALLET_ADDRESS
 ```
 
 </Fragment>
@@ -753,34 +835,36 @@ yarn svm:admin:propose-administrator \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-21T14:10:42.252Z] 🔗 CONNECTING TO TOKEN REGISTRY
-[2025-08-21T14:10:42.252Z] =========================================================
-[2025-08-21T14:10:42.253Z] 📋 Checking existing token admin registry...
-[2025-08-21T14:10:42.253Z] Fetching token admin registry for mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:10:42.420Z] 📝 No existing registry found - will create new one
-[2025-08-21T14:10:42.420Z]
-[2025-08-21T14:10:42.420Z] 🎯 PROPOSING ADMINISTRATOR
-[2025-08-21T14:10:42.420Z] =========================================================
-[2025-08-21T14:10:42.420Z] Preparing to propose administrator...
-[2025-08-21T14:10:42.420Z] Token: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:10:42.420Z] Proposed Administrator: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-21T14:10:42.421Z] Mint Authority (you): EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-21T14:10:42.421Z] Proposing administrator for token GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A: new admin EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-21T14:10:56.359Z] Administrator proposed successfully. Tx signature: 2q8gGBWVo7xffTeHHHJJsUp53GCYkadnd1fNJY6FRqe6E1zdbYbiLzdwQJnpJXRUuyP8R3KMrNpfbnud7sAHRmTE
-[2025-08-21T14:10:56.360Z]
-[2025-08-21T14:10:56.360Z] ✅ ADMINISTRATOR PROPOSAL SUCCESSFUL!
-[2025-08-21T14:10:56.360Z] =========================================================
-[2025-08-21T14:10:56.360Z] Transaction Signature: 2q8gGBWVo7xffTeHHHJJsUp53GCYkadnd1fNJY6FRqe6E1zdbYbiLzdwQJnpJXRUuyP8R3KMrNpfbnud7sAHRmTE
-[2025-08-21T14:10:56.360Z] Explorer URL: https://explorer.solana.com/tx/2q8gGBWVo7xffTeHHHJJsUp53GCYkadnd1fNJY6FRqe6E1zdbYbiLzdwQJnpJXRUuyP8R3KMrNpfbnud7sAHRmTE?cluster=devnet
-[2025-08-21T14:10:56.360Z]
-[2025-08-21T14:10:56.361Z] 📋 REGISTRY INFORMATION
-[2025-08-21T14:10:56.361Z] =========================================================
-[2025-08-21T14:10:56.361Z] Token Mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:10:56.361Z] Proposed Administrator: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-21T14:10:56.361Z] Registry Created/Updated By: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-21T14:10:56.361Z]
-[2025-08-21T14:10:56.361Z] 🎉 SUCCESS!
-[2025-08-21T14:10:56.361Z] Administrator proposal completed successfully!
+🔄 Generating owner_propose_administrator transaction...
+🔄 Building and simulating transaction...
+INFO [2026-06-14 21:58:49.697 +0530]: Transaction built successfully
+    instructionName: "router.owner_propose_administrator"
+    transactionSize: "277 bytes"
+    base58Length: "377 characters"
+    hexLength: "554 characters"
+    accountCount: 5
+    signerCount: 1
+    computeUnits: 21231
+INFO [2026-06-14 21:58:49.698 +0530]: Completed buildTransaction (router.owner_propose_administrator)
+    durationMs: 370
+INFO [2026-06-14 21:58:49.856 +0530]:
+INFO [2026-06-14 21:58:49.856 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-14 21:58:49.856 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-14 21:58:49.856 +0530]:    Instruction: router.owner_propose_administrator
+INFO [2026-06-14 21:58:49.856 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-14 21:58:49.856 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-14 21:58:50.639 +0530]: Transaction confirmed successfully
+    signature: "3TzhvTQytu3RmRSGf5XQ9cjsjXfAct4s4t2DLuGWHzHvxGU5R9BmvkQv64odZa8URsFwFTSv63AUSihhdzyDM5ng"
+    attempt: 1
+INFO [2026-06-14 21:58:50.639 +0530]:
+INFO [2026-06-14 21:58:50.639 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-14 21:58:50.639 +0530]:
+INFO [2026-06-14 21:58:50.639 +0530]: 📋 Execution Details:
+INFO [2026-06-14 21:58:50.639 +0530]:    Instruction: router.owner_propose_administrator
+INFO [2026-06-14 21:58:50.639 +0530]:    Signature:   3TzhvTQytu3RmRSGf5XQ9cjsjXfAct4s4t2DLuGWHzHvxGU5R9BmvkQv64odZa8URsFwFTSv63AUSihhdzyDM5ng
+INFO [2026-06-14 21:58:50.639 +0530]:    Explorer:    https://explorer.solana.com/tx/3TzhvTQytu3RmRSGf5XQ9cjsjXfAct4s4t2DLuGWHzHvxGU5R9BmvkQv64odZa8URsFwFTSv63AUSihhdzyDM5ng?cluster=devnet
+INFO [2026-06-14 21:58:50.639 +0530]:
 ```
 
 </Fragment>
@@ -797,8 +881,11 @@ In this step, you will accept the administrator role for the Solana token. This 
 
 ```bash
 # Accept the administrator role
-yarn svm:admin:accept-admin-role \
-  --token-mint $SOL_TOKEN_MINT
+pnpm bs58 --env devnet --execute router \
+  --instruction accept-admin-role \
+  --program-id $SOL_CCIP_ROUTER \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_WALLET_ADDRESS
 ```
 
 </Fragment>
@@ -806,34 +893,42 @@ yarn svm:admin:accept-admin-role \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-21T14:12:17.854Z] 🎯 ACCEPTING ADMINISTRATOR ROLE
-[2025-08-21T14:12:17.854Z] ======================================================
-[2025-08-21T14:12:17.854Z] Preparing to accept administrator role...
-[2025-08-21T14:12:17.854Z] Token: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:12:17.854Z] New Administrator (you): EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-21T14:12:17.854Z] Previous Administrator: 11111111111111111111111111111111
-[2025-08-21T14:12:17.854Z] Accepting admin role for token: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:12:30.940Z] Admin role accepted successfully. Tx signature: 4dRSKKzE6JVg3FZXNjGoG5Eu1DMF6Yu7VXjFtr8LHeMxkFFnaA1y4QrzSe7xWYtkK2Mgonqa2skMyH7QFtUkYHWD
-[2025-08-21T14:12:30.940Z]
-[2025-08-21T14:12:30.941Z] ✅ ROLE ACCEPTANCE SUCCESSFUL!
-[2025-08-21T14:12:30.941Z] ======================================================
-[2025-08-21T14:12:30.941Z] Transaction Signature: 4dRSKKzE6JVg3FZXNjGoG5Eu1DMF6Yu7VXjFtr8LHeMxkFFnaA1y4QrzSe7xWYtkK2Mgonqa2skMyH7QFtUkYHWD
-[2025-08-21T14:12:30.941Z] Explorer URL: https://explorer.solana.com/tx/4dRSKKzE6JVg3FZXNjGoG5Eu1DMF6Yu7VXjFtr8LHeMxkFFnaA1y4QrzSe7xWYtkK2Mgonqa2skMyH7QFtUkYHWD?cluster=devnet
-[2025-08-21T14:12:30.941Z]
-[2025-08-21T14:12:30.941Z] 📋 UPDATED REGISTRY INFORMATION
-[2025-08-21T14:12:30.941Z] ======================================================
-[2025-08-21T14:12:30.941Z] Token Mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:12:30.941Z] New Administrator: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-21T14:12:30.942Z] Previous Administrator: 11111111111111111111111111111111
-[2025-08-21T14:12:30.942Z]
-[2025-08-21T14:12:30.942Z] 🎉 SUCCESS!
-[2025-08-21T14:12:30.942Z] You are now the administrator for this token's CCIP registry.
+🔄 Generating accept_admin_role_token_admin_registry transaction...
+🔄 Building and simulating transaction...
+INFO [2026-06-14 21:59:51.627 +0530]: Transaction built successfully
+    instructionName: "router.accept_admin_role_token_admin_registry"
+    transactionSize: "212 bytes"
+    base58Length: "289 characters"
+    hexLength: "424 characters"
+    accountCount: 4
+    signerCount: 1
+    computeUnits: 16954
+INFO [2026-06-14 21:59:51.627 +0530]: Completed buildTransaction (router.accept_admin_role_token_admin_registry)
+    durationMs: 359
+INFO [2026-06-14 21:59:51.790 +0530]:
+INFO [2026-06-14 21:59:51.790 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-14 21:59:51.790 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-14 21:59:51.790 +0530]:    Instruction: router.accept_admin_role_token_admin_registry
+INFO [2026-06-14 21:59:51.790 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-14 21:59:51.790 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-14 21:59:52.533 +0530]: Transaction confirmed successfully
+    signature: "494bSaZQAf6tRxMApAmVLXubkNYSSiBwiZVwtFKNkfGeuAHysYg5CW79UzE8ptcchDN2duWr5ifks2x4pPLtmnHj"
+    attempt: 1
+INFO [2026-06-14 21:59:52.533 +0530]:
+INFO [2026-06-14 21:59:52.533 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-14 21:59:52.533 +0530]:
+INFO [2026-06-14 21:59:52.533 +0530]: 📋 Execution Details:
+INFO [2026-06-14 21:59:52.533 +0530]:    Instruction: router.accept_admin_role_token_admin_registry
+INFO [2026-06-14 21:59:52.533 +0530]:    Signature:   494bSaZQAf6tRxMApAmVLXubkNYSSiBwiZVwtFKNkfGeuAHysYg5CW79UzE8ptcchDN2duWr5ifks2x4pPLtmnHj
+INFO [2026-06-14 21:59:52.533 +0530]:    Explorer:    https://explorer.solana.com/tx/494bSaZQAf6tRxMApAmVLXubkNYSSiBwiZVwtFKNkfGeuAHysYg5CW79UzE8ptcchDN2duWr5ifks2x4pPLtmnHj?cluster=devnet
+INFO [2026-06-14 21:59:52.533 +0530]:
 ```
 
 </Fragment>
 </Tabs>
 
-### Step 5: Transfer Mint Authority to Pool Signer PDA
+### Step 6: Transfer Mint Authority to Pool Signer PDA
 
 <Aside type="caution" title="Critical Step: Mint Authority Transfer">
 
@@ -859,36 +954,16 @@ yarn svm:admin:accept-admin-role \
 spl-token authorize $SOL_TOKEN_MINT mint $SOL_POOL_SIGNER_PDA
 ```
 
-Verify the authority transfer
-
-```bash
-spl-token display $SOL_TOKEN_MINT
-```
-
 </Fragment>
 
 <Fragment slot="panel.2">
 
 ```bash
-# Transfer mint authority to Pool Signer PDA
-spl-token authorize $SOL_TOKEN_MINT mint $SOL_POOL_SIGNER_PDA
+Updating 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
+  Current mint: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+  New mint: F8QX4ZZqjV1gMwaC3erYjVXrcm9QBsSDLNiPLbFEVwH1
 
-Updating GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-  Current mint: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-  New mint: BwzTc3R77vf1dS4kj3JX8YGpCvjsg91vBDgyKJfeBkue
-
-Signature: 42CjMPQJK1MnyZn62mebPrYS7AQjgm2qkaDngdBVUq1aAXZcyBQ64QnAVXBGJjbJosvMgYbRatC5hdWhhj8aRyR9
-
-$ spl-token display $SOL_TOKEN_MINT
-
-
-SPL Token Mint
-  Address: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-  Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-  Supply: 1000000000000
-  Decimals: 9
-  Mint authority: BwzTc3R77vf1dS4kj3JX8YGpCvjsg91vBDgyKJfeBkue
-  Freeze authority: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
+Signature: 5zD2r6aMiijkQTuanvPQw9QSeJbqdTcT48ueafDEK1YcoNiQMrnbbdb5gZ8rZ6zGay12y6jyYmhMgRCABLtajyT7
 ```
 
 </Fragment>
@@ -912,7 +987,36 @@ SPL Token Mint
 </Fragment>
 </Tabs>
 
-### Step 6: Save Phase 2 Variables
+Verify the authority transfer:
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Verify Mint Authority</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+spl-token display $SOL_TOKEN_MINT
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+SPL Token Mint
+  Address: 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
+  Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+  Supply: 1000000000000
+  Decimals: 9
+  Mint authority: F8QX4ZZqjV1gMwaC3erYjVXrcm9QBsSDLNiPLbFEVwH1
+  Freeze authority: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+```
+
+</Fragment>
+</Tabs>
+
+### Step 7: Save Phase 2 Variables
 
 Save your Solana configuration for use in cross-chain setup:
 
@@ -928,7 +1032,11 @@ cat > ~/.phase2_vars << EOF
 export SOL_TOKEN_MINT="$SOL_TOKEN_MINT"
 export SOL_POOL_SIGNER_PDA="$SOL_POOL_SIGNER_PDA"
 export SOL_POOL_CONFIG_PDA="$SOL_POOL_CONFIG_PDA"
-export CCIP_POOL_PROGRAM="$CCIP_POOL_PROGRAM"
+export SOL_CCIP_POOL_PROGRAM="$SOL_CCIP_POOL_PROGRAM"
+export SOL_CCIP_ROUTER="$SOL_CCIP_ROUTER"
+export SOL_CCIP_FEE_QUOTER_PROGRAM="$SOL_CCIP_FEE_QUOTER_PROGRAM"
+export ETH_SEPOLIA_CHAIN_SELECTOR="$ETH_SEPOLIA_CHAIN_SELECTOR"
+export SOL_WALLET_ADDRESS="$SOL_WALLET_ADDRESS"
 EOF
 
 echo "=== Phase 2 Complete - Solana Setup ==="
@@ -944,9 +1052,9 @@ echo "✅ Variables saved to ~/.phase2_vars"
 
 ```bash
 === Phase 2 Complete - Solana Setup ===
-✅ SOL Token: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-✅ Pool Signer PDA: BwzTc3R77vf1dS4kj3JX8YGpCvjsg91vBDgyKJfeBkue
-✅ Pool Config PDA: 7Ln8Y43dSdbNgC9bx5UgigaDRrwVi3WYnhRWoNKCcjV1
+✅ SOL Token: 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
+✅ Pool Signer PDA: F8QX4ZZqjV1gMwaC3erYjVXrcm9QBsSDLNiPLbFEVwH1
+✅ Pool Config PDA: HLRSx9TYk6Gaz9ZuWR9usmih5MyTpnKLjZg7aDCEk6nJ
 ✅ Variables saved to ~/.phase2_vars
 ```
 
@@ -959,7 +1067,7 @@ Configure bidirectional connectivity between your token pools on both chains.
 
 ### Step 1: Configure Solana Pool
 
-**Stay in Terminal 1 (Solana Starter Kit)**
+**Stay in Terminal 1** (CCIP Solana BS58 Generator)
 
 Load the Ethereum addresses from Phase 1:
 
@@ -977,7 +1085,7 @@ source ~/.phase1_vars
 echo "✅ ETH Token: $ETH_TOKEN_ADDRESS"
 echo "✅ ETH Pool: $ETH_POOL_ADDRESS"
 echo "✅ SOL Token: $SOL_TOKEN_MINT"
-echo "✅ SOL Pool Program: $CCIP_POOL_PROGRAM"
+echo "✅ SOL Pool Program: $SOL_CCIP_POOL_PROGRAM"
 ```
 
 </Fragment>
@@ -985,9 +1093,9 @@ echo "✅ SOL Pool Program: $CCIP_POOL_PROGRAM"
 <Fragment slot="panel.2">
 
 ```bash
-✅ ETH Token: 0x5D74645E854922009723a817fe4e417A80E7c709
-✅ ETH Pool: 0x817FdAa9e7cd30C4838a82eEA7f09217C6d8c885
-✅ SOL Token: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
+✅ ETH Token: 0xc06d7a73ba115b592961290c8c49760b97247676
+✅ ETH Pool: 0x835f9b923858aa5aca7ac1c7389361482fc32c45
+✅ SOL Token: 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
 ✅ SOL Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
 ```
 
@@ -1006,33 +1114,103 @@ In this step, you will initialize the configuration for Ethereum Sepolia as a re
 
 ```bash
 # Initialize remote chain configuration
-yarn svm:pool:init-chain-remote-config \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM \
-  --remote-chain ethereum-sepolia \
+pnpm bs58 --env devnet --execute burnmint-token-pool \
+  --instruction init-chain-remote-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_WALLET_ADDRESS \
+  --remote-chain-selector $ETH_SEPOLIA_CHAIN_SELECTOR \
+  --pool-addresses '[]' \
   --token-address $ETH_TOKEN_ADDRESS \
   --decimals 9
 ```
-
-<Aside type="note" title="Expected Error Message">
-  You will see "Error: Chain config not found" in the output - this is **expected behavior** since we are creating the
-  configuration for the first time. The script will continue and successfully create the new configuration.
-</Aside>
 
 </Fragment>
 
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-21T14:26:32.723Z] Chain remote config initialized: 5cZnrgDcWw2jer2g8dTWw4hvjAGPkVfVXQBjZaRmxyXbbJTukrR8b9Pq5nJMcLGhvptMfkA3LvKVT1fsmi7kNyvi
-[2025-08-21T14:26:33.473Z]
-[2025-08-21T14:26:33.473Z] ✅ CHAIN CONFIG INITIALIZED SUCCESSFULLY
-[2025-08-21T14:26:33.473Z] ==========================================
-[2025-08-21T14:26:33.473Z] Transaction Signature: 5cZnrgDcWw2jer2g8dTWw4hvjAGPkVfVXQBjZaRmxyXbbJTukrR8b9Pq5nJMcLGhvptMfkA3LvKVT1fsmi7kNyvi
-[2025-08-21T14:26:33.473Z]
-[2025-08-21T14:26:33.473Z] 🔍 EXPLORER URLS
-[2025-08-21T14:26:33.473Z] ==========================================
-[2025-08-21T14:26:33.473Z] Transaction: https://explorer.solana.com/tx/5cZnrgDcWw2jer2g8dTWw4hvjAGPkVfVXQBjZaRmxyXbbJTukrR8b9Pq5nJMcLGhvptMfkA3LvKVT1fsmi7kNyvi?cluster=devnet
+🔄 Generating initChainRemoteConfig transaction...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
+   Mint: 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
+   Authority: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+   Remote Chain Selector: 16015286601757825753
+   Pool Addresses: 0 addresses (must be empty at init)
+   Token Address: c06d7a73ba115b592961290c8c49760b97247676
+   Decimals: 9
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-14 22:51:55.694 +0530]: Starting initChainRemoteConfig command
+    command: "burnmint-token-pool.init-chain-remote-config"
+    programId: "41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
+    mint: "6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz"
+    authority: "GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN"
+    remoteChainSelector: "16015286601757825753"
+    poolAddresses: "[]"
+    tokenAddress: "0xc06d7a73ba115b592961290c8c49760b97247676"
+    decimals: "9"
+    globalOptions: {
+      "environment": "devnet",
+      "execute": true,
+      "resolvedRpcUrl": "https://api.devnet.solana.com",
+      "keypair": "/Users/syed-cll/.config/solana/id.json",
+      "_signerKeypair": {
+        "_keypair": {
+          "publicKey": {
+            "0": 230,
+            "1": 211,
+            "2": 30,
+            ...
+            "29": 179,
+            "30": 114,
+            "31": 73
+          },
+          "secretKey": {
+            "0": 191,
+            "1": 198,
+            "2": 244,
+            ...
+            "61": 179,
+            "62": 114,
+            "63": 73
+          }
+        }
+      }
+    }
+INFO [2026-06-14 22:51:56.369 +0530]: Transaction built successfully
+    instructionName: "initChainRemoteConfig"
+    transactionSize: "293 bytes"
+    base58Length: "399 characters"
+    hexLength: "586 characters"
+    accountCount: 4
+    signerCount: 1
+    computeUnits: 23902
+INFO [2026-06-14 22:51:56.369 +0530]: Completed buildTransaction (initChainRemoteConfig)
+    durationMs: 671
+INFO [2026-06-14 22:51:56.551 +0530]:
+INFO [2026-06-14 22:51:56.551 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-14 22:51:56.551 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-14 22:51:56.551 +0530]:    Instruction: initChainRemoteConfig
+INFO [2026-06-14 22:51:56.551 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-14 22:51:56.551 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-14 22:51:57.322 +0530]: Transaction confirmed successfully
+    signature: "4pjmpEiS5s2NUTcaE1w4XeajiD2xN4o1keinVpWNdHMUs7wgYsqs3MGMn9ZA1Ze18RxmdyqQNidS2T91MXDLFA75"
+    attempt: 1
+INFO [2026-06-14 22:51:57.322 +0530]:
+INFO [2026-06-14 22:51:57.322 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-14 22:51:57.322 +0530]:
+INFO [2026-06-14 22:51:57.322 +0530]: 📋 Execution Details:
+INFO [2026-06-14 22:51:57.322 +0530]:    Instruction: initChainRemoteConfig
+INFO [2026-06-14 22:51:57.322 +0530]:    Signature:   4pjmpEiS5s2NUTcaE1w4XeajiD2xN4o1keinVpWNdHMUs7wgYsqs3MGMn9ZA1Ze18RxmdyqQNidS2T91MXDLFA75
+INFO [2026-06-14 22:51:57.322 +0530]:    Explorer:    https://explorer.solana.com/tx/4pjmpEiS5s2NUTcaE1w4XeajiD2xN4o1keinVpWNdHMUs7wgYsqs3MGMn9ZA1Ze18RxmdyqQNidS2T91MXDLFA75?cluster=devnet
+INFO [2026-06-14 22:51:57.322 +0530]:
+INFO [2026-06-14 22:51:57.322 +0530]: initChainRemoteConfig command completed successfully
+    command: "burnmint-token-pool.init-chain-remote-config"
+    transactionSize: "293 bytes"
+    computeUnits: 23902
 ```
 
 </Fragment>
@@ -1051,11 +1229,13 @@ In this step, you will use update the previously created chain configuration wit
 
 ```bash
 # Add Ethereum pool address to configuration
-yarn svm:pool:edit-chain-remote-config \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM \
-  --remote-chain ethereum-sepolia \
-  --pool-addresses $ETH_POOL_ADDRESS \
+pnpm bs58 --env devnet --execute burnmint-token-pool \
+  --instruction edit-chain-remote-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_WALLET_ADDRESS \
+  --remote-chain-selector $ETH_SEPOLIA_CHAIN_SELECTOR \
+  --pool-addresses "[\"$ETH_POOL_ADDRESS\"]" \
   --token-address $ETH_TOKEN_ADDRESS \
   --decimals 9
 ```
@@ -1065,49 +1245,87 @@ yarn svm:pool:edit-chain-remote-config \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-21T14:27:43.965Z] 🔗 CCIP Chain Remote Configuration Editor
-[2025-08-21T14:27:43.966Z] ==========================================
-[2025-08-21T14:27:43.994Z] Network: solana-devnet
-[2025-08-21T14:27:43.995Z] Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-21T14:27:43.995Z]
-[2025-08-21T14:27:43.995Z] 💰 WALLET BALANCE
-[2025-08-21T14:27:43.995Z] ==========================================
-[2025-08-21T14:27:44.403Z] SOL Balance: 65674241912 lamports (65.674241912 SOL)
-[2025-08-21T14:27:44.404Z]
-[2025-08-21T14:27:44.404Z] 📋 EDIT CONFIGURATION
-[2025-08-21T14:27:44.404Z] ==========================================
-[2025-08-21T14:27:44.405Z] Token Mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:27:44.405Z] Burn-Mint Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-21T14:27:44.405Z] Remote Chain: ethereum-sepolia
-[2025-08-21T14:27:44.405Z] Remote Chain Selector: 16015286601757825753
-[2025-08-21T14:27:44.405Z] Pool Addresses: 0x817FdAa9e7cd30C4838a82eEA7f09217C6d8c885
-[2025-08-21T14:27:44.405Z] Token Address: 0x5D74645E854922009723a817fe4e417A80E7c709
-[2025-08-21T14:27:44.405Z] Decimals: 9
-[2025-08-21T14:27:44.407Z]
-[2025-08-21T14:27:44.407Z] 🔧 EDITING CHAIN REMOTE CONFIG
-[2025-08-21T14:27:44.407Z] ==========================================
-[2025-08-21T14:27:44.407Z] Updating chain remote configuration...
-[2025-08-21T14:27:44.407Z] Editing chain remote config for chain 16015286601757825753 on mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:27:44.410Z] 📍 Pool Config PDA: 7Ln8Y43dSdbNgC9bx5UgigaDRrwVi3WYnhRWoNKCcjV1
-[2025-08-21T14:27:44.510Z] 📍 Chain Config PDA: 5W7ZYFtZ9bGgJTqVVYTQU35eK3MVjC2PePkwqWxweaGg
-[2025-08-21T14:27:58.252Z] Chain remote config edited: yQoTdkPTMr8gyBSpf5yatYouC86C99yesmcMqYaDMJkPxKvEuZ5NbuYHCYq3YCdeoa9ADXWhC8TgSAiFA482Y9j
-[2025-08-21T14:27:59.004Z]
-[2025-08-21T14:27:59.005Z] ✅ CHAIN CONFIG EDITED SUCCESSFULLY
-[2025-08-21T14:27:59.005Z] ==========================================
-[2025-08-21T14:27:59.005Z] Transaction Signature: yQoTdkPTMr8gyBSpf5yatYouC86C99yesmcMqYaDMJkPxKvEuZ5NbuYHCYq3YCdeoa9ADXWhC8TgSAiFA482Y9j
-[2025-08-21T14:27:59.005Z]
-[2025-08-21T14:27:59.005Z] 🔍 EXPLORER URLS
-[2025-08-21T14:27:59.005Z] ==========================================
-[2025-08-21T14:27:59.005Z] Transaction: https://explorer.solana.com/tx/yQoTdkPTMr8gyBSpf5yatYouC86C99yesmcMqYaDMJkPxKvEuZ5NbuYHCYq3YCdeoa9ADXWhC8TgSAiFA482Y9j?cluster=devnet
-[2025-08-21T14:27:59.005Z]
-[2025-08-21T14:27:59.005Z] 📋 NEXT STEPS
-[2025-08-21T14:27:59.005Z] ==========================================
-[2025-08-21T14:27:59.005Z] View updated configuration:
-[2025-08-21T14:27:59.005Z]   yarn svm:pool:get-info --token-mint GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A --burn-mint-pool-program 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-21T14:27:59.005Z]
-[2025-08-21T14:27:59.005Z] 🎉 Chain Configuration Update Complete!
-[2025-08-21T14:27:59.005Z] ✅ Remote chain ethereum-sepolia configuration updated
-[2025-08-21T14:27:59.005Z] ✅ Pool addresses: 1 configured
+🔄 Generating editChainRemoteConfig transaction...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
+   Mint: 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
+   Authority: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+   Remote Chain Selector: 16015286601757825753
+   Pool Addresses: 1 addresses
+   Token Address: c06d7a73ba115b592961290c8c49760b97247676
+   Decimals: 9
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-14 22:54:12.969 +0530]: Starting editChainRemoteConfig command
+    command: "burnmint-token-pool.edit-chain-remote-config"
+    programId: "41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
+    mint: "6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz"
+    authority: "GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN"
+    remoteChainSelector: "16015286601757825753"
+    poolAddresses: "[\"0x835f9b923858aa5aca7ac1c7389361482fc32c45\"]"
+    tokenAddress: "0xc06d7a73ba115b592961290c8c49760b97247676"
+    decimals: "9"
+    globalOptions: {
+      "environment": "devnet",
+      "execute": true,
+      "resolvedRpcUrl": "https://api.devnet.solana.com",
+      "keypair": "/Users/syed-cll/.config/solana/id.json",
+      "_signerKeypair": {
+        "_keypair": {
+          "publicKey": {
+            "0": 230,
+            "1": 211,
+            "2": 30,
+            ...
+            "29": 179,
+            "30": 114,
+            "31": 73
+          },
+          "secretKey": {
+            "0": 191,
+            "1": 198,
+            "2": 244,
+            ...
+            "61": 179,
+            "62": 114,
+            "63": 73
+          }
+        }
+      }
+    }
+INFO [2026-06-14 22:54:13.370 +0530]: Transaction built successfully
+    instructionName: "editChainRemoteConfig"
+    transactionSize: "317 bytes"
+    base58Length: "432 characters"
+    hexLength: "634 characters"
+    accountCount: 4
+    signerCount: 1
+    computeUnits: 25033
+INFO [2026-06-14 22:54:13.370 +0530]: Completed buildTransaction (editChainRemoteConfig)
+    durationMs: 397
+INFO [2026-06-14 22:54:13.550 +0530]:
+INFO [2026-06-14 22:54:13.550 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-14 22:54:13.550 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-14 22:54:13.550 +0530]:    Instruction: editChainRemoteConfig
+INFO [2026-06-14 22:54:13.550 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-14 22:54:13.550 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-14 22:54:14.264 +0530]: Transaction confirmed successfully
+    signature: "5qRYvTuqd5yZxTw71eMABcYZbmB6HcKndsoRZyof5FHzdB815FNmEsr3TjnC1sW6SrrAsQRckEvc3WeixpT2uWUZ"
+    attempt: 1
+INFO [2026-06-14 22:54:14.264 +0530]:
+INFO [2026-06-14 22:54:14.264 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-14 22:54:14.264 +0530]:
+INFO [2026-06-14 22:54:14.264 +0530]: 📋 Execution Details:
+INFO [2026-06-14 22:54:14.264 +0530]:    Instruction: editChainRemoteConfig
+INFO [2026-06-14 22:54:14.264 +0530]:    Signature:   5qRYvTuqd5yZxTw71eMABcYZbmB6HcKndsoRZyof5FHzdB815FNmEsr3TjnC1sW6SrrAsQRckEvc3WeixpT2uWUZ
+INFO [2026-06-14 22:54:14.264 +0530]:    Explorer:    https://explorer.solana.com/tx/5qRYvTuqd5yZxTw71eMABcYZbmB6HcKndsoRZyof5FHzdB815FNmEsr3TjnC1sW6SrrAsQRckEvc3WeixpT2uWUZ?cluster=devnet
+INFO [2026-06-14 22:54:14.264 +0530]:
+INFO [2026-06-14 22:54:14.265 +0530]: editChainRemoteConfig command completed successfully
+    command: "burnmint-token-pool.edit-chain-remote-config"
+    transactionSize: "317 bytes"
+    computeUnits: 25033
 ```
 
 </Fragment>
@@ -1142,7 +1360,7 @@ echo "✅ ETH Token: $ETH_TOKEN_ADDRESS"
 echo "✅ ETH Pool: $ETH_POOL_ADDRESS"
 echo "✅ SOL Token: $SOL_TOKEN_MINT"
 echo "✅ SOL Pool Config PDA: $SOL_POOL_CONFIG_PDA"
-echo "✅ Pool Program: $CCIP_POOL_PROGRAM"
+echo "✅ Pool Program: $SOL_CCIP_POOL_PROGRAM"
 ```
 
 </Fragment>
@@ -1150,10 +1368,10 @@ echo "✅ Pool Program: $CCIP_POOL_PROGRAM"
 <Fragment slot="panel.2">
 
 ```bash
-✅ ETH Token: 0x5D74645E854922009723a817fe4e417A80E7c709
-✅ ETH Pool: 0x817FdAa9e7cd30C4838a82eEA7f09217C6d8c885
-✅ SOL Token: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-✅ SOL Pool Config PDA: 7Ln8Y43dSdbNgC9bx5UgigaDRrwVi3WYnhRWoNKCcjV1
+✅ ETH Token: 0xc06d7a73ba115b592961290c8c49760b97247676
+✅ ETH Pool: 0x835f9b923858aa5aca7ac1c7389361482fc32c45
+✅ SOL Token: 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
+✅ SOL Pool Config PDA: HLRSx9TYk6Gaz9ZuWR9usmih5MyTpnKLjZg7aDCEk6nJ
 ✅ Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
 ```
 
@@ -1176,33 +1394,30 @@ npx hardhat applyChainUpdates \
   --remotechain solanaDevnet \
   --remotepooladdresses $SOL_POOL_CONFIG_PDA \
   --remotetokenaddress $SOL_TOKEN_MINT \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 </Fragment>
 
 <Fragment slot="panel.2">
 ```bash
-2025-08-21T14:36:07.013Z info: === Starting Chain Update Configuration ===
-2025-08-21T14:36:07.013Z info: 🔹 Local network: sepolia
-2025-08-21T14:36:07.014Z info: 🔹 Pool address: 0x817FdAa9e7cd30C4838a82eEA7f09217C6d8c885
-2025-08-21T14:36:07.014Z info: 🔹 Remote chain: solanaDevnet
-2025-08-21T14:36:07.014Z info: 🔹 Remote chain type detected: svm
-2025-08-21T14:36:07.014Z info: 🔹 Remote chain selector: 16423721717087811551
-2025-08-21T14:36:07.014Z info: 🔹 Parsed 1 remote pool addresses
-2025-08-21T14:36:07.031Z info: ✅ All addresses validated successfully
-2025-08-21T14:36:07.268Z info: 🔹 Using signer: 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-21T14:36:07.542Z info: ✅ Connected to pool contract
-2025-08-21T14:36:07.542Z info: 🔹 Remote pool address 1: 7Ln8Y43dSdbNgC9bx5UgigaDRrwVi3WYnhRWoNKCcjV1 → 0x5e372f7c8e240db45559d05c08dc863f0fbbdb8b3e653e326a3b285a9177c1e8
-2025-08-21T14:36:07.542Z info: 🔹 Remote token address: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A → 0xebc7f214ab28a28bfb39e13e984a9d9956bebfe57bbf6a43aafc379adf322b31
-2025-08-21T14:36:07.542Z info: === Rate Limiter Configuration ===
-2025-08-21T14:36:07.543Z info: 🔹 Outbound enabled: false
-2025-08-21T14:36:07.543Z info: 🔹 Inbound enabled: false
-2025-08-21T14:36:07.543Z info: === Executing Transaction ===
-2025-08-21T14:36:07.543Z info: 🔹 Sending applyChainUpdates transaction...
-2025-08-21T14:36:08.321Z info: 🔹 Transaction sent: 0x89be0fd4e38354f9f02805e71125683b6db9b575eb9bead9c96da0a52b6d8742
-2025-08-21T14:36:08.321Z info: 🔹 Waiting for 3 confirmations...
-2025-08-21T14:36:36.790Z info: ✅ Chain update applied successfully!
+2026-06-14T17:28:07.355Z info: === Starting Chain Update Configuration ===
+2026-06-14T17:28:07.356Z info: 🔹 Local network: ethereumSepolia
+2026-06-14T17:28:07.356Z info: 🔹 Pool address: 0x835f9b923858aa5aca7ac1c7389361482fc32c45
+2026-06-14T17:28:07.356Z info: 🔹 Remote chain: solanaDevnet
+2026-06-14T17:28:07.356Z info: 🔹 Remote chain family: svm
+2026-06-14T17:28:07.356Z info: 🔹 Remote chain selector: 16423721717087811551
+2026-06-14T17:28:12.784Z info: ✅ All addresses validated successfully
+2026-06-14T17:28:14.507Z info: ✅ Using signer: 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-14T17:28:16.087Z info: ✅ Connected to TokenPool contract
+2026-06-14T17:28:16.088Z info:   Remote pool 1: HLRSx9TYk6Gaz9ZuWR9usmih5MyTpnKLjZg7aDCEk6nJ → 0xf2b4ab42d25a7af94c26d6ae45f85feea735c4cbfe7ced81902f3c86e4b7c9df
+2026-06-14T17:28:16.089Z info: === Rate Limiter Configuration ===
+2026-06-14T17:28:16.089Z info: Outbound enabled: false
+2026-06-14T17:28:16.089Z info: Inbound enabled: false
+2026-06-14T17:28:16.089Z info: === Executing applyChainUpdates() ===
+2026-06-14T17:28:21.876Z info: 📤 TX sent: 0x99768c704d50e5d7fe12ae477da400d1e5c63b3b2226f7f05af51e69a447a36a
+2026-06-14T17:28:21.876Z info: Waiting for 3 confirmations...
+2026-06-14T17:28:53.826Z info: ✅ Chain update applied successfully on ethereumSepolia (3 confirmations)!
 ```
 
 </Fragment>
@@ -1235,7 +1450,7 @@ Register the BurnMint token pool with your token in the TokenAdminRegistry:
 npx hardhat setPool \
   --tokenaddress $ETH_TOKEN_ADDRESS \
   --pooladdress $ETH_POOL_ADDRESS \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 </Fragment>
@@ -1243,8 +1458,15 @@ npx hardhat setPool \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-21T14:37:37.713Z info: Setting pool for token 0x5D74645E854922009723a817fe4e417A80E7c709 to 0x817FdAa9e7cd30C4838a82eEA7f09217C6d8c885 by 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-21T14:38:14.160Z info: Pool set for token 0x5D74645E854922009723a817fe4e417A80E7c709 to 0x817FdAa9e7cd30C4838a82eEA7f09217C6d8c885
+2026-06-14T17:29:49.025Z info: 🔗 Setting pool for token 0xc06d7a73ba115b592961290c8c49760b97247676 on ethereumSepolia...
+2026-06-14T17:29:59.657Z info: 🔹 Using signer: 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-14T17:29:59.659Z info: Using TokenAdminRegistry: 0x95F29FEE11c5C55d26cCcf1DB6772DE953B37B82
+2026-06-14T17:30:00.786Z info: Checking token configuration for 0xc06d7a73ba115b592961290c8c49760b97247676...
+2026-06-14T17:30:01.692Z info: Token 0xc06d7a73ba115b592961290c8c49760b97247676 current admin: 0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA
+2026-06-14T17:30:01.693Z info: ✅ Current wallet 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca is the token administrator
+2026-06-14T17:30:01.693Z info: Setting pool 0x835f9b923858aa5aca7ac1c7389361482fc32c45 for token 0xc06d7a73ba115b592961290c8c49760b97247676...
+2026-06-14T17:30:08.372Z info: 📤 TX sent: 0x344f2a6eafe2ba24ebe7d07384a5f638a62acf95b48ecb0b62a686b294cdd838. Waiting for 3 confirmations...
+2026-06-14T17:30:40.392Z info: ✅ Pool successfully set for token 0xc06d7a73ba115b592961290c8c49760b97247676 → 0x835f9b923858aa5aca7ac1c7389361482fc32c45 on ethereumSepolia (3 confirmations)
 ```
 
 </Fragment>
@@ -1264,16 +1486,23 @@ Only the token administrator can perform this action.
 
 ### Step 2: Register Solana Pool
 
-**Switch to Terminal 1 (Solana Starter Kit)**
+**Switch to Terminal 1** (CCIP Solana BS58 Generator)
 
 ```bash
 pwd
-# Should show ../solana-starter-kit
+# Should show: .../ccip-solana-bs58-generator
+```
+
+Load variables from previous phases:
+
+```bash
+source ~/.phase1_vars
+source ~/.phase2_vars
 ```
 
 #### Create Address Lookup Table
 
-Address Lookup Tables (ALT) optimize Solana transactions by compressing addresses.
+Address Lookup Tables (ALT) optimize Solana transactions by compressing addresses. With EOA execution, create and populate the ALT in one step:
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Create ALT</Fragment>
@@ -1283,70 +1512,60 @@ Address Lookup Tables (ALT) optimize Solana transactions by compressing addresse
 <Fragment slot="panel.1">
 
 ```bash
-# Create ALT for your token configuration
-yarn svm:admin:create-alt \
-  --token-mint $SOL_TOKEN_MINT \
-  --pool-program $CCIP_POOL_PROGRAM
+# Create and populate ALT for your token configuration
+pnpm bs58 --env devnet --execute router \
+  --instruction create-lookup-table \
+  --program-id $SOL_CCIP_ROUTER \
+  --fee-quoter-program-id $SOL_CCIP_FEE_QUOTER_PROGRAM \
+  --pool-program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_WALLET_ADDRESS
 ```
+
+<Aside type="note" title="EOA ALT Creation">
+
+Because your wallet signs immediately with `--execute`, the one-step `create-lookup-table` command avoids the blockhash expiration constraint that applies to multisig workflows. For Squads-based deployments, use the two-step `pnpm create-alt` + `append-to-lookup-table` workflow instead.
+
+</Aside>
 
 </Fragment>
 
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-21T14:40:05.693Z] CCIP Token Pool Address Lookup Table Creation
-[2025-08-21T14:40:05.695Z] ===================================================
-[2025-08-21T14:40:05.722Z] Network: solana-devnet
-[2025-08-21T14:40:05.723Z] Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-21T14:40:05.723Z]
-[2025-08-21T14:40:05.723Z] 💰 WALLET BALANCE
-[2025-08-21T14:40:05.723Z] ===================================================
-[2025-08-21T14:40:06.121Z] SOL Balance: 65674069872 lamports (65.674069872 SOL)
-[2025-08-21T14:40:06.121Z]
-[2025-08-21T14:40:06.121Z] ⚙️  ALT CONFIGURATION
-[2025-08-21T14:40:06.121Z] ===================================================
-[2025-08-21T14:40:06.122Z] Token Mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:40:06.122Z] Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-21T14:40:06.122Z] Fee Quoter Program: FeeQPGkKDeRV1MgoYfMH6L8o3KeuYjwUZrgn4LRKfjHi
-[2025-08-21T14:40:06.122Z] Router Program: Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
-[2025-08-21T14:40:06.122Z] Token Program: Auto-detected from on-chain mint data
-[2025-08-21T14:40:06.122Z]
-[2025-08-21T14:40:06.122Z] 🏗️  CREATING ADDRESS LOOKUP TABLE
-[2025-08-21T14:40:06.122Z] ===================================================
-[2025-08-21T14:40:06.123Z] Creating token pool lookup table for mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:40:06.123Z] Getting mint account info for GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A to determine token program ID...
-[2025-08-21T14:40:06.219Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-21T14:40:20.085Z] Token pool lookup table created successfully. ALT address: 4kmUYW9Da5WwmhWS1ttREDdJCPF82fsSdLtbeso6xiKc
-[2025-08-21T14:40:20.090Z] Transaction signature: 4k6DACEo4PunpwEZWxEUyMq5QAPE1EhHPYQ69VbumWY9KeYgiKitu5GJhBvkdKC3Pamo5zqUoqpGEkX3LRjptxxt
-[2025-08-21T14:40:20.090Z]
-[2025-08-21T14:40:20.090Z] ✅ ALT CREATED SUCCESSFULLY
-[2025-08-21T14:40:20.090Z] ===================================================
-[2025-08-21T14:40:20.090Z] ALT Address: 4kmUYW9Da5WwmhWS1ttREDdJCPF82fsSdLtbeso6xiKc
-[2025-08-21T14:40:20.090Z] Transaction Signature: 4k6DACEo4PunpwEZWxEUyMq5QAPE1EhHPYQ69VbumWY9KeYgiKitu5GJhBvkdKC3Pamo5zqUoqpGEkX3LRjptxxt
-[2025-08-21T14:40:20.090Z] Total Addresses Count: 10
-[2025-08-21T14:40:20.090Z]
-[2025-08-21T14:40:20.090Z] 📋 ALT CONTENTS
-[2025-08-21T14:40:20.090Z] ===================================================
-[2025-08-21T14:40:20.091Z] [0]: 4kmUYW9Da5WwmhWS1ttREDdJCPF82fsSdLtbeso6xiKc (Lookup table itself)
-[2025-08-21T14:40:20.091Z] [1]: BfcUM2WKNpuqz5C3SZbZeCPHUd41eyZjMkgtNoo8MQA1 (Token admin registry)
-[2025-08-21T14:40:20.091Z] [2]: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB (Pool program)
-[2025-08-21T14:40:20.091Z] [3]: 7Ln8Y43dSdbNgC9bx5UgigaDRrwVi3WYnhRWoNKCcjV1 (Pool configuration)
-[2025-08-21T14:40:20.091Z] [4]: EjTvTxhQ14sQAY9FXazrvV7rMH4cX7XGRgTAMK7G4dnF (Pool token account)
-[2025-08-21T14:40:20.091Z] [5]: BwzTc3R77vf1dS4kj3JX8YGpCvjsg91vBDgyKJfeBkue (Pool signer)
-[2025-08-21T14:40:20.091Z] [6]: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA (Token program)
-[2025-08-21T14:40:20.091Z] [7]: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A (Token mint)
-[2025-08-21T14:40:20.091Z] [8]: EsEUgwB9Rks9ioiGNzgki1An8UqT7pJzLWioSoqPVMab (Fee token config)
-[2025-08-21T14:40:20.091Z] [9]: H6ZviaabTYZqUPgiSoMDbeVthcNW9ULcAuUu3zRLFqDR (CCIP router pool signer)
-[2025-08-21T14:40:20.091Z]
-[2025-08-21T14:40:20.091Z] 🔍 EXPLORER URLS
-[2025-08-21T14:40:20.092Z] ===================================================
-[2025-08-21T14:40:20.092Z] Transaction: https://explorer.solana.com/tx/4k6DACEo4PunpwEZWxEUyMq5QAPE1EhHPYQ69VbumWY9KeYgiKitu5GJhBvkdKC3Pamo5zqUoqpGEkX3LRjptxxt?cluster=devnet
-[2025-08-21T14:40:20.092Z]
-[2025-08-21T14:40:20.092Z] 🎉 ALT Creation Complete!
-[2025-08-21T14:40:20.092Z] ✅ Address Lookup Table: 4kmUYW9Da5WwmhWS1ttREDdJCPF82fsSdLtbeso6xiKc
-[2025-08-21T14:40:20.092Z] ✅ Contains 10 base CCIP addresses
-[2025-08-21T14:40:20.092Z] ✅ Total addresses: 10
-[2025-08-21T14:40:20.092Z] ✅ Ready to be registered with setPool
+🔄 Generating create_lookup_table transaction...
+INFO [2026-06-14 23:01:49.942 +0530]: Detected SPL Token v1
+    mint: "6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+🔄 Building and simulating transaction...
+INFO [2026-06-14 23:01:50.235 +0530]: Transaction built successfully
+    instructionName: "router.create_lookup_table"
+    transactionSize: "525 bytes"
+    base58Length: "716 characters"
+    hexLength: "1050 characters"
+    accountCount: 4
+    signerCount: 2
+    computeUnits: 19227
+INFO [2026-06-14 23:01:50.235 +0530]: Completed buildTransaction (router.create_lookup_table)
+    durationMs: 196
+INFO [2026-06-14 23:01:50.429 +0530]:
+INFO [2026-06-14 23:01:50.429 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-14 23:01:50.429 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-14 23:01:50.429 +0530]:    Instruction: router.create_lookup_table
+INFO [2026-06-14 23:01:50.429 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-14 23:01:50.429 +0530]:
+📮 Derived Lookup Table Address: FpXnqRcBEFtZsRVud8R5pKuSmnGjLvRDdtSHvLx8wSSQ
+INFO [2026-06-14 23:01:51.331 +0530]: Transaction confirmed successfully
+    signature: "5WS2n7FUyevWgCGNxUmfJhUu9F4qRBWA6rM74PMeguuM1gdDbs1fxZqV8pP7EdXSKzU8rkpgAckkerQZjv1N2tKB"
+    attempt: 1
+INFO [2026-06-14 23:01:51.331 +0530]:
+INFO [2026-06-14 23:01:51.331 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-14 23:01:51.331 +0530]:
+INFO [2026-06-14 23:01:51.331 +0530]: 📋 Execution Details:
+INFO [2026-06-14 23:01:51.331 +0530]:    Instruction: router.create_lookup_table
+INFO [2026-06-14 23:01:51.331 +0530]:    Signature:   5WS2n7FUyevWgCGNxUmfJhUu9F4qRBWA6rM74PMeguuM1gdDbs1fxZqV8pP7EdXSKzU8rkpgAckkerQZjv1N2tKB
+INFO [2026-06-14 23:01:51.331 +0530]:    Explorer:    https://explorer.solana.com/tx/5WS2n7FUyevWgCGNxUmfJhUu9F4qRBWA6rM74PMeguuM1gdDbs1fxZqV8pP7EdXSKzU8rkpgAckkerQZjv1N2tKB?cluster=devnet
+INFO [2026-06-14 23:01:51.331 +0530]:
 ```
 
 </Fragment>
@@ -1389,7 +1608,7 @@ echo "ALT Address: $SOL_ALT_ADDRESS"
 <Fragment slot="panel.2">
 
 ```bash
-ALT Address: 4kmUYW9Da5WwmhWS1ttREDdJCPF82fsSdLtbeso6xiKc
+ALT Address: FpXnqRcBEFtZsRVud8R5pKuSmnGjLvRDdtSHvLx8wSSQ
 ```
 
 </Fragment>
@@ -1407,10 +1626,13 @@ In this step, you will register the token pool with Solana's Router TokenAdminRe
 
 ```bash
 # Register pool with token admin registry
-yarn svm:admin:set-pool \
-  --token-mint $SOL_TOKEN_MINT \
-  --lookup-table $SOL_ALT_ADDRESS \
-  --writable-indices 3,4,7
+pnpm bs58 --env devnet --execute router \
+  --instruction set-pool \
+  --program-id $SOL_CCIP_ROUTER \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_WALLET_ADDRESS \
+  --pool-lookup-table $SOL_ALT_ADDRESS \
+  --writable-indexes "[3,4,7]"
 ```
 
 </Fragment>
@@ -1418,60 +1640,36 @@ yarn svm:admin:set-pool \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-21T14:47:28.423Z] CCIP Token Admin Registry Set Pool
-[2025-08-21T14:47:28.426Z] =============================================
-[2025-08-21T14:47:28.453Z] Network: solana-devnet
-[2025-08-21T14:47:28.453Z] Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-21T14:47:28.453Z]
-[2025-08-21T14:47:28.453Z] 💰 WALLET BALANCE
-[2025-08-21T14:47:28.453Z] =============================================
-[2025-08-21T14:47:28.837Z] SOL Balance: 65670557032 lamports (65.670557032 SOL)
-[2025-08-21T14:47:28.838Z]
-[2025-08-21T14:47:28.838Z] ⚙️  POOL CONFIGURATION
-[2025-08-21T14:47:28.838Z] =============================================
-[2025-08-21T14:47:28.839Z] Token Mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:47:28.839Z] Lookup Table: 4kmUYW9Da5WwmhWS1ttREDdJCPF82fsSdLtbeso6xiKc
-[2025-08-21T14:47:28.839Z] Writable Indices: [3, 4, 7]
-[2025-08-21T14:47:28.840Z]
-[2025-08-21T14:47:28.840Z] 🔍 REGISTRY VERIFICATION
-[2025-08-21T14:47:28.840Z] =============================================
-[2025-08-21T14:47:28.840Z] Checking current token admin registry...
-[2025-08-21T14:47:28.841Z] Fetching token admin registry for mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:47:31.826Z] Current administrator: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-21T14:47:31.827Z] Current pending administrator: 11111111111111111111111111111111
-[2025-08-21T14:47:31.827Z] Current lookup table: 11111111111111111111111111111111
-[2025-08-21T14:47:31.827Z]
-[2025-08-21T14:47:31.828Z] 🔍 LOOKUP TABLE VERIFICATION
-[2025-08-21T14:47:31.828Z] =============================================
-[2025-08-21T14:47:31.828Z] Verifying lookup table exists...
-[2025-08-21T14:47:32.073Z] Lookup table verified with 10 addresses
-[2025-08-21T14:47:32.073Z]
-[2025-08-21T14:47:32.073Z] 🏊 SETTING POOL
-[2025-08-21T14:47:32.073Z] =============================================
-[2025-08-21T14:47:32.073Z] Setting pool (registering ALT with token)...
-[2025-08-21T14:47:32.074Z] Setting pool for token GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A with lookup table 4kmUYW9Da5WwmhWS1ttREDdJCPF82fsSdLtbeso6xiKc
-[2025-08-21T14:47:45.897Z] Pool set successfully. Tx signature: 27YNFtLVwZoz7QxvxJ4pc6f7ce8WbyBogqjXvPJDquMBRS516CE1Jx8SNQ7i14JoVsehES6FKrJ3DWjtnUY6XvNs
-[2025-08-21T14:47:45.897Z]
-[2025-08-21T14:47:45.897Z] ✅ POOL SET SUCCESSFULLY
-[2025-08-21T14:47:45.897Z] =============================================
-[2025-08-21T14:47:45.897Z] Transaction Signature: 27YNFtLVwZoz7QxvxJ4pc6f7ce8WbyBogqjXvPJDquMBRS516CE1Jx8SNQ7i14JoVsehES6FKrJ3DWjtnUY6XvNs
-[2025-08-21T14:47:45.897Z]
-[2025-08-21T14:47:45.897Z] 🔍 EXPLORER URLS
-[2025-08-21T14:47:45.898Z] =============================================
-[2025-08-21T14:47:45.898Z] Transaction: https://explorer.solana.com/tx/27YNFtLVwZoz7QxvxJ4pc6f7ce8WbyBogqjXvPJDquMBRS516CE1Jx8SNQ7i14JoVsehES6FKrJ3DWjtnUY6XvNs?cluster=devnet
-[2025-08-21T14:47:45.898Z]
-[2025-08-21T14:47:45.898Z] 🔍 FINAL VERIFICATION
-[2025-08-21T14:47:45.898Z] =============================================
-[2025-08-21T14:47:45.898Z] Verifying pool registration...
-[2025-08-21T14:47:45.898Z] Fetching token admin registry for mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:47:45.997Z] ✅ Pool registration verified successfully!
-[2025-08-21T14:47:45.997Z] Registered lookup table: 4kmUYW9Da5WwmhWS1ttREDdJCPF82fsSdLtbeso6xiKc
-[2025-08-21T14:47:45.997Z] Writable indices: [3, 4, 7]
-[2025-08-21T14:47:45.997Z]
-[2025-08-21T14:47:45.997Z] 🎉 Pool Registration Complete!
-[2025-08-21T14:47:45.997Z] ✅ Token: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:47:45.998Z] ✅ ALT: 4kmUYW9Da5WwmhWS1ttREDdJCPF82fsSdLtbeso6xiKc
-[2025-08-21T14:47:45.998Z] ✅ Ready for CCIP cross-chain operations
+🔄 Generating set_pool transaction...
+🔄 Building and simulating transaction...
+INFO [2026-06-14 23:04:26.916 +0530]: Transaction built successfully
+    instructionName: "router.set_pool"
+    transactionSize: "252 bytes"
+    base58Length: "343 characters"
+    hexLength: "504 characters"
+    accountCount: 5
+    signerCount: 1
+    computeUnits: 32867
+INFO [2026-06-14 23:04:26.916 +0530]: Completed buildTransaction (router.set_pool)
+    durationMs: 375
+INFO [2026-06-14 23:04:27.080 +0530]:
+INFO [2026-06-14 23:04:27.080 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-14 23:04:27.080 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-14 23:04:27.080 +0530]:    Instruction: router.set_pool
+INFO [2026-06-14 23:04:27.080 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-14 23:04:27.080 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-14 23:04:27.967 +0530]: Transaction confirmed successfully
+    signature: "5jZ5RP2U6Q3f2QBNwFLjxL5ecXPDRUpp4CQheuqHRaM97Bg5pjMSuUuWERFd9JVAzFxGbYK8t1Cnwi3AEc1aX4f8"
+    attempt: 1
+INFO [2026-06-14 23:04:27.967 +0530]:
+INFO [2026-06-14 23:04:27.967 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-14 23:04:27.967 +0530]:
+INFO [2026-06-14 23:04:27.967 +0530]: 📋 Execution Details:
+INFO [2026-06-14 23:04:27.967 +0530]:    Instruction: router.set_pool
+INFO [2026-06-14 23:04:27.967 +0530]:    Signature:   5jZ5RP2U6Q3f2QBNwFLjxL5ecXPDRUpp4CQheuqHRaM97Bg5pjMSuUuWERFd9JVAzFxGbYK8t1Cnwi3AEc1aX4f8
+INFO [2026-06-14 23:04:27.967 +0530]:    Explorer:    https://explorer.solana.com/tx/5jZ5RP2U6Q3f2QBNwFLjxL5ecXPDRUpp4CQheuqHRaM97Bg5pjMSuUuWERFd9JVAzFxGbYK8t1Cnwi3AEc1aX4f8?cluster=devnet
+INFO [2026-06-14 23:04:27.967 +0530]:
 ```
 
 </Fragment>
@@ -1498,9 +1696,13 @@ export ETH_POOL_ADDRESS="$ETH_POOL_ADDRESS"
 export SOL_TOKEN_MINT="$SOL_TOKEN_MINT"
 export SOL_POOL_SIGNER_PDA="$SOL_POOL_SIGNER_PDA"
 export SOL_POOL_CONFIG_PDA="$SOL_POOL_CONFIG_PDA"
-export CCIP_POOL_PROGRAM="$CCIP_POOL_PROGRAM"
+export SOL_CCIP_POOL_PROGRAM="$SOL_CCIP_POOL_PROGRAM"
+export SOL_CCIP_ROUTER="$SOL_CCIP_ROUTER"
+export SOL_CCIP_FEE_QUOTER_PROGRAM="$SOL_CCIP_FEE_QUOTER_PROGRAM"
+export ETH_SEPOLIA_CHAIN_SELECTOR="$ETH_SEPOLIA_CHAIN_SELECTOR"
+export SOL_WALLET_ADDRESS="$SOL_WALLET_ADDRESS"
 
-# Phase 5 - ALT
+# Phase 4 - ALT
 export SOL_ALT_ADDRESS="$SOL_ALT_ADDRESS"
 EOF
 
@@ -1524,23 +1726,24 @@ echo "✅ Ready for cross-chain testing"
 
 ## Phase 5: Pre-Transfer Setup
 
-Before testing transfers, complete final setup steps.
+Before validating your configuration, complete final setup steps.
 
-### Step 1: Get Pool Signer PDA
+### Step 1: Verify Pool Signer PDA
 
-Extract the Pool Signer PDA for reference:
+Confirm the Pool Signer PDA matches your saved configuration:
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Get PDA</Fragment>
+<Fragment slot="tab.1">Verify PDA</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Get the Pool Signer PDA
-yarn svm:pool:get-pool-signer \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM
+# Optional: read onchain pool state to verify addresses
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-state \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT
 ```
 
 </Fragment>
@@ -1548,40 +1751,104 @@ yarn svm:pool:get-pool-signer \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-21T14:48:46.353Z] 🔍 CCIP Token Pool Signer PDA Reader (Read-Only)
-[2025-08-21T14:48:46.355Z] ==========================================
-[2025-08-21T14:48:46.355Z] Token Mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:48:46.355Z] Burn-Mint Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-21T14:48:46.355Z]
-[2025-08-21T14:48:46.355Z] 🔧 DERIVING POOL SIGNER PDA
-[2025-08-21T14:48:46.355Z] ==========================================
-[2025-08-21T14:48:46.355Z] Deriving Pool Signer PDA...
-[2025-08-21T14:48:46.356Z]
-[2025-08-21T14:48:46.357Z] 📋 POOL SIGNER PDA DETAILS
-[2025-08-21T14:48:46.357Z] ==========================================
-[2025-08-21T14:48:46.357Z] Address: BwzTc3R77vf1dS4kj3JX8YGpCvjsg91vBDgyKJfeBkue
-[2025-08-21T14:48:46.357Z] Bump Seed: 255
-[2025-08-21T14:48:46.357Z]
-[2025-08-21T14:48:46.357Z] 🔧 PDA DERIVATION
-[2025-08-21T14:48:46.357Z] ------------------------------------------
-[2025-08-21T14:48:46.357Z] Seeds: ["ccip_tokenpool_signer", "GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A"]
-[2025-08-21T14:48:46.357Z] Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-21T14:48:46.357Z]
+🔍 Reading token pool state...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
+   Mint: 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
+   State PDA: HLRSx9TYk6Gaz9ZuWR9usmih5MyTpnKLjZg7aDCEk6nJ
+✅ State account found
+
+📊 Token Pool State Account
+
+Program Information:
+  Program Type:         Burnmint Token Pool
+  Program ID:           41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
+  State Account:        HLRSx9TYk6Gaz9ZuWR9usmih5MyTpnKLjZg7aDCEk6nJ
+  Version:              1
+
+Token Configuration:
+  Mint:                 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
+  Decimals:             9
+  Token Program:        TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+
+Pool Accounts:
+  Pool Signer:          F8QX4ZZqjV1gMwaC3erYjVXrcm9QBsSDLNiPLbFEVwH1
+  Pool Token Account:   EP2Yhkc3yvRrxBK5dTNrcWivowYvaxGcrwi3dE1aPaYy
+
+Governance:
+  Owner:                GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+  Proposed Owner:       None
+  Rate Limit Admin:     GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+
+Configuration:
+  Router:               Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
+  Router Onramp Auth:   H6ZviaabTYZqUPgiSoMDbeVthcNW9ULcAuUu3zRLFqDR
+  RMN Remote:           RmnXLft1mSEwDgMKu2okYuHkiazxntFFcZFrrcXxYg7
+
+Access Control:
+  Allow List Enabled:   false
+  Allow List Size:      0 address(es)
+  Allow List:           Empty
+
+INFO [2026-06-14 23:08:57.352 +0530]: getState command completed successfully
+    command: "burnmint-token-pool.get-state"
 ```
 
 </Fragment>
 </Tabs>
 
-Confirm this matches your previously saved PDA:
+Compare the onchain **Pool Signer** with your saved variable:
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Verify Saved PDA</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
 
 ```bash
 echo "Saved Pool Signer PDA: $SOL_POOL_SIGNER_PDA"
-echo "Current Pool Signer PDA: BwzTc3R77vf1dS4kj3JX8YGpCvjsg91vBDgyKJfeBkue"
 ```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+Saved Pool Signer PDA: F8QX4ZZqjV1gMwaC3erYjVXrcm9QBsSDLNiPLbFEVwH1
+```
+
+</Fragment>
+</Tabs>
 
 ### Step 2: Delegate Token Authority
 
-In this step, you will delegate token approval to the fee-billing signer PDA, which is what enables CCIP to transfer tokens on your behalf when sending cross-chain messages.
+In this step, you will delegate token approval to the CCIP fee-billing signer PDA, which enables CCIP to transfer tokens on your behalf when sending cross-chain messages.
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Derive Fee-Billing Signer</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+# Derive the CCIP fee-billing signer PDA
+export SOL_CCIP_FEE_BILLING_SIGNER=$(solana find-program-derived-address $SOL_CCIP_ROUTER string:fee_billing_signer | head -1)
+
+echo "SOL_CCIP_FEE_BILLING_SIGNER=$SOL_CCIP_FEE_BILLING_SIGNER"
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+SOL_CCIP_FEE_BILLING_SIGNER=2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
+```
+
+</Fragment>
+</Tabs>
+
+Approve the fee-billing signer to transfer tokens from your ATA:
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Delegate Authority</Fragment>
@@ -1590,9 +1857,13 @@ In this step, you will delegate token approval to the fee-billing signer PDA, wh
 <Fragment slot="panel.1">
 
 ```bash
-# Delegate burn authority to Pool Signer PDA
-yarn svm:token:delegate \
-  --token-mint $SOL_TOKEN_MINT
+# --amount is u64 max (2^64 - 1): max delegation for CCIP fee billing
+pnpm bs58 --env devnet --execute spl-token \
+  --instruction approve \
+  --authority $SOL_WALLET_ADDRESS \
+  --mint $SOL_TOKEN_MINT \
+  --delegate $SOL_CCIP_FEE_BILLING_SIGNER \
+  --amount 18446744073709551615
 ```
 
 </Fragment>
@@ -1600,46 +1871,109 @@ yarn svm:token:delegate \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-21T14:53:04.921Z] 🔐 PROCESSING TOKEN DELEGATIONS
-[2025-08-21T14:53:04.921Z] =============================================
-[2025-08-21T14:53:04.921Z] Custom token mints provided: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:53:04.921Z] Using 'fee-billing' delegation type for ccip_send compatibility
-[2025-08-21T14:53:04.921Z] Added custom token delegation for: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:53:04.921Z]
-[1/1] Processing delegation for mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:53:04.922Z] Getting mint account info for GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A to determine token program ID...
-[2025-08-21T14:53:20.019Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-21T14:53:20.021Z] Token Program ID: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-21T14:53:20.021Z] Delegation Type: fee-billing
-[2025-08-21T14:53:20.022Z] Delegate Address: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
-[2025-08-21T14:53:20.022Z] Amount to delegate: 18446744073709551615
-[2025-08-21T14:53:20.024Z] User Token Account: Cg9BDeWtC938iPfboCost6Fr9g5VnZcDdKsst94JtFV9
-[2025-08-21T14:53:33.230Z] Token account Cg9BDeWtC938iPfboCost6Fr9g5VnZcDdKsst94JtFV9 exists.
-[2025-08-21T14:53:33.333Z] Sending transaction to delegate token authority...
-[2025-08-21T14:53:34.560Z] ✅ Token delegation successful!
-[2025-08-21T14:53:34.560Z] Transaction signature: Kvs6uvKsr8db6JwNS8qXoo7aSZrVMr2dLn5JSnsg6MRFVzDZafASCGP1C1vKUsjooE3f19KsAboaQMJQwSkTTEM
-[2025-08-21T14:53:34.560Z] Explorer URL: https://explorer.solana.com/tx/Kvs6uvKsr8db6JwNS8qXoo7aSZrVMr2dLn5JSnsg6MRFVzDZafASCGP1C1vKUsjooE3f19KsAboaQMJQwSkTTEM?cluster=devnet
-[2025-08-21T14:53:34.560Z]
-[2025-08-21T14:53:34.560Z] ✅ All delegations processed successfully
+INFO [2026-06-14 23:19:12.715 +0530]: Starting approve command
+    command: "spl-token.approve"
+    mint: "6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz"
+    delegate: "2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG"
+    authority: "GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN"
+    amount: "18446744073709551615"
+    globalOptions: {
+      "environment": "devnet",
+      "execute": true,
+      "resolvedRpcUrl": "https://api.devnet.solana.com",
+      "keypair": "/Users/syed-cll/.config/solana/id.json",
+      "_signerKeypair": {
+        "_keypair": {
+          "publicKey": {
+            "0": 230,
+            "1": 211,
+            "2": 30,
+            ...
+            "29": 179,
+            "30": 114,
+            "31": 73
+          },
+          "secretKey": {
+            "0": 191,
+            "1": 198,
+            "2": 244,
+            ...
+            "61": 179,
+            "62": 114,
+            "63": 73
+          }
+        }
+      }
+    }
+   ✅ Detected token program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+🔍 Auto-deriving Associated Token Account...
+   ✅ Derived ATA: 4PiwHZh1ZCcBCt6y1cDa7hvRWKmvzki4q9kQKYSvgHxK
+🔄 Generating approve transaction...
+   RPC URL: https://api.devnet.solana.com
+   Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+   Mint: 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
+   Token Account: 4PiwHZh1ZCcBCt6y1cDa7hvRWKmvzki4q9kQKYSvgHxK
+   Delegate: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
+   Authority (Token Account Owner): GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+   Amount: 18446744073709551615
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-14 23:19:13.071 +0530]: Detected SPL Token v1
+    mint: "6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+INFO [2026-06-14 23:19:13.230 +0530]: Transaction built successfully
+    instructionName: "approve"
+    transactionSize: "180 bytes"
+    base58Length: "245 characters"
+    hexLength: "360 characters"
+    accountCount: 3
+    signerCount: 1
+    computeUnits: 123
+INFO [2026-06-14 23:19:13.230 +0530]: Completed buildTransaction (approve)
+    durationMs: 158
+INFO [2026-06-14 23:19:13.388 +0530]:
+INFO [2026-06-14 23:19:13.388 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-14 23:19:13.388 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-14 23:19:13.388 +0530]:    Instruction: approve
+INFO [2026-06-14 23:19:13.388 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-14 23:19:13.389 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-14 23:19:14.083 +0530]: Transaction confirmed successfully
+    signature: "2VY1ELQgnfPd2PRcKgYe8Yd3HGJLLubU9F8mhd7Qv6TmWcTztFaA2Y1cyW1k75cmU9ypW7JWdjujssatb3wehe5X"
+    attempt: 1
+INFO [2026-06-14 23:19:14.083 +0530]:
+INFO [2026-06-14 23:19:14.083 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-14 23:19:14.083 +0530]:
+INFO [2026-06-14 23:19:14.083 +0530]: 📋 Execution Details:
+INFO [2026-06-14 23:19:14.083 +0530]:    Instruction: approve
+INFO [2026-06-14 23:19:14.083 +0530]:    Signature:   2VY1ELQgnfPd2PRcKgYe8Yd3HGJLLubU9F8mhd7Qv6TmWcTztFaA2Y1cyW1k75cmU9ypW7JWdjujssatb3wehe5X
+INFO [2026-06-14 23:19:14.083 +0530]:    Explorer:    https://explorer.solana.com/tx/2VY1ELQgnfPd2PRcKgYe8Yd3HGJLLubU9F8mhd7Qv6TmWcTztFaA2Y1cyW1k75cmU9ypW7JWdjujssatb3wehe5X?cluster=devnet
+INFO [2026-06-14 23:19:14.083 +0530]:
+INFO [2026-06-14 23:19:14.083 +0530]: approve command completed successfully
+    command: "spl-token.approve"
+    transactionSize: "180 bytes"
+    computeUnits: 123
 ```
 
 </Fragment>
 </Tabs>
 
-### Step 3: Verify Delegate
+### Step 3: Verify Delegation
 
-Check the previous step to verify the token is delegated to the Pool Signer PDA:
+Check that your token account is delegated to the fee-billing signer:
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Check Tokens</Fragment>
+<Fragment slot="tab.1">Find Token Account</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Verify token balance and authorities
-yarn svm:token:check \
-  --token-mint $SOL_TOKEN_MINT
+# Find your Associated Token Account (ATA) address
+export SOL_TOKEN_ACCOUNT=$(spl-token accounts $SOL_TOKEN_MINT --owner $SOL_WALLET_ADDRESS --addresses-only)
+
+echo "SOL_TOKEN_ACCOUNT=$SOL_TOKEN_ACCOUNT"
 ```
 
 </Fragment>
@@ -1647,60 +1981,64 @@ yarn svm:token:check \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-21T14:54:06.334Z] CCIP Token Approval Checker
-[2025-08-21T14:54:06.336Z] =========================================
-[2025-08-21T14:54:06.364Z] Network: solana-devnet
-[2025-08-21T14:54:06.364Z] Router Program: Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
-[2025-08-21T14:54:06.364Z] Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-21T14:54:06.364Z]
-[2025-08-21T14:54:06.364Z] 💰 WALLET BALANCE
-[2025-08-21T14:54:06.364Z] =========================================
-[2025-08-21T14:54:07.015Z] SOL Balance: 65.670547032 SOL (65670547032 lamports)
-[2025-08-21T14:54:07.015Z]
-[2025-08-21T14:54:07.015Z] 🔍 PROCESSING TOKEN APPROVALS
-[2025-08-21T14:54:07.015Z] =========================================
-[2025-08-21T14:54:07.015Z] Custom token mints provided: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:54:07.015Z] Using 'fee-billing' delegation type for ccip_send compatibility
-[2025-08-21T14:54:07.015Z] Added custom token check for: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:54:07.015Z]
-[1/1] Processing token: Custom Token (GsPeEMYi...)
-[2025-08-21T14:54:07.015Z] Mint: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-[2025-08-21T14:54:07.016Z] Getting mint account info for GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A to determine token program ID...
-[2025-08-21T14:54:07.116Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-21T14:54:07.116Z] Token Program ID: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-21T14:54:07.118Z] Token Account: Cg9BDeWtC938iPfboCost6Fr9g5VnZcDdKsst94JtFV9
-[2025-08-21T14:54:07.118Z] Expected Delegate (fee-billing): 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
-[2025-08-21T14:54:07.216Z] Balance: 1000000000000
-[2025-08-21T14:54:07.217Z] Actual Delegate: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
-[2025-08-21T14:54:07.217Z] Delegated Amount: 18446744073709551615
-[2025-08-21T14:54:07.217Z] Matches Expected Delegate: ✓ Yes
-[2025-08-21T14:54:07.217Z]
-[2025-08-21T14:54:07.217Z] 📋 TOKEN APPROVAL SUMMARY
-[2025-08-21T14:54:07.217Z] =========================================
-[2025-08-21T14:54:07.217Z] Token | Description | Balance | Delegate | Delegated Amount | Status
-[2025-08-21T14:54:07.217Z] ------|-------------|---------|----------|-----------------|-------
-[2025-08-21T14:54:07.217Z] GsPeEMYi... | Custom Token (GsPeEMYi...) | 1000000000000 | 2AjuzTy6... | 18446744073709551615 | ✓ Correct
-[2025-08-21T14:54:07.217Z]
-[2025-08-21T14:54:07.217Z] ✅ Token approval check completed successfully
+SOL_TOKEN_ACCOUNT=4PiwHZh1ZCcBCt6y1cDa7hvRWKmvzki4q9kQKYSvgHxK
 ```
 
 </Fragment>
 </Tabs>
 
-## Phase 6: Testing Cross-Chain Transfers
+Display token account and delegation status:
 
-In this step, you will test bidirectional token transfers to verify your setup.
+<Tabs client:visible>
+<Fragment slot="tab.1">Check Delegation</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+spl-token display $SOL_TOKEN_ACCOUNT
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+SPL Token Account
+  Address: 4PiwHZh1ZCcBCt6y1cDa7hvRWKmvzki4q9kQKYSvgHxK
+  Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+  Balance: 1000
+  Decimals: 9
+  Mint: 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
+  Owner: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+  State: Initialized
+  Delegation:
+    Delegate: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
+    Allowance: 18446744073.709551615
+  Close authority: (not set)
+```
+
+</Fragment>
+</Tabs>
+
+## Phase 6: Test Cross-Chain Transfers
+
+Validate your configuration, then execute bidirectional token transfers using the CCIP CLI.
+
+<Aside type="note" title="Cross-Chain Transfers with CCIP CLI">
+
+Use [`@chainlink/ccip-cli`](https://github.com/smartcontractkit/ccip-tools-ts) for bidirectional token transfers. Run Solana → EVM sends from Terminal 1 and EVM → Solana sends from Terminal 2. See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for full options.
+
+</Aside>
 
 Confirm you are in the correct directory (Terminal 1):
 
 ```bash
 pwd
-# Should output: ../solana-starter-kit
+# Should show: .../ccip-solana-bs58-generator
 ```
 
 ### Step 1: Load Complete Configuration
-
-Before testing, ensure all variables are available in your current terminal:
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Load All Variables</Fragment>
@@ -1711,13 +2049,16 @@ Before testing, ensure all variables are available in your current terminal:
 ```bash
 # Load complete configuration
 source ~/.ccip_complete_vars
+source ~/.phase2_vars
 
-# Verify all variables for testing
-echo "=== Testing Environment Ready ==="
+# Verify all variables
+echo "=== Configuration Validation ==="
 echo "✅ ETH Token: $ETH_TOKEN_ADDRESS"
+echo "✅ ETH Pool: $ETH_POOL_ADDRESS"
 echo "✅ SOL Token: $SOL_TOKEN_MINT"
+echo "✅ Pool Signer PDA: $SOL_POOL_SIGNER_PDA"
 echo "✅ ALT Address: $SOL_ALT_ADDRESS"
-echo "✅ Ready for cross-chain transfers"
+echo "✅ Wallet: $SOL_WALLET_ADDRESS"
 ```
 
 </Fragment>
@@ -1725,182 +2066,388 @@ echo "✅ Ready for cross-chain transfers"
 <Fragment slot="panel.2">
 
 ```bash
-=== Testing Environment Ready ===
-✅ ETH Token: 0x5D74645E854922009723a817fe4e417A80E7c709
-✅ SOL Token: GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A
-✅ ALT Address: 4kmUYW9Da5WwmhWS1ttREDdJCPF82fsSdLtbeso6xiKc
-✅ Ready for cross-chain transfers
+=== Configuration Validation ===
+✅ ETH Token: 0xc06d7a73ba115b592961290c8c49760b97247676
+✅ ETH Pool: 0x835f9b923858aa5aca7ac1c7389361482fc32c45
+✅ SOL Token: 6bqTkW43Xchd638N4EKymyVecSLVmVhwULHFw5R4hkz
+✅ Pool Signer PDA: F8QX4ZZqjV1gMwaC3erYjVXrcm9QBsSDLNiPLbFEVwH1
+✅ ALT Address: FpXnqRcBEFtZsRVud8R5pKuSmnGjLvRDdtSHvLx8wSSQ
+✅ Wallet: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
 ```
 
 </Fragment>
 </Tabs>
 
-### Step 2: Transfer Solana → Ethereum
-
-**In Terminal 1 (Solana Starter Kit)**
+### Step 2: Verify Solana Pool and Chain Config
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Transfer Command</Fragment>
-<Fragment slot="tab.2">Expected Output</Fragment>
-<Fragment slot="tab.3">Monitor Transfer</Fragment>
+<Fragment slot="tab.1">Verification Commands</Fragment>
+<Fragment slot="tab.2">What to Confirm</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Transfer 1 token from Solana to Ethereum
-yarn svm:token-transfer \
-  --token-mint $SOL_TOKEN_MINT \
-  --token-amount 1000000 \
-  --receiver <YOUR_ETHEREUM_ADDRESS>
+# Verify pool state
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-state \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT
+
+# Verify Ethereum Sepolia remote chain config
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-chain-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --remote-chain-selector $ETH_SEPOLIA_CHAIN_SELECTOR
+
+# Verify token balance and delegation
+spl-token balance $SOL_TOKEN_MINT
 ```
 
-Replace `<YOUR_ETHEREUM_ADDRESS>` with your Ethereum wallet address.
+</Fragment>
+
+<Fragment slot="panel.2">
+
+Confirm the following:
+
+- Pool owner matches `$SOL_WALLET_ADDRESS`
+- Mint authority is the Pool Signer PDA (`$SOL_POOL_SIGNER_PDA`)
+- Remote chain config includes your `$ETH_POOL_ADDRESS` and `$ETH_TOKEN_ADDRESS`
+- Token delegation is set to the fee-billing signer
+- Your wallet holds tokens for transfer testing
+
+</Fragment>
+</Tabs>
+
+### Step 3: Verify Ethereum Pool (Terminal 2)
+
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
+
+```bash
+npx hardhat getPoolConfig \
+  --pooladdress $ETH_POOL_ADDRESS \
+  --network ethereumSepolia
+```
+
+Confirm the Ethereum pool recognizes Solana Devnet with your `$SOL_POOL_CONFIG_PDA` and `$SOL_TOKEN_MINT`.
+
+### Configure CCIP CLI
+
+Export these RPC URLs once before your first transfer:
+
+```bash
+export SOLANA_DEVNET_RPC="https://api.devnet.solana.com"
+export ETHEREUM_SEPOLIA_RPC_URL="<YOUR_ETHEREUM_SEPOLIA_RPC_URL>"
+
+export ETH_CCIP_ROUTER="0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59"
+```
+
+Use the same `ETHEREUM_SEPOLIA_RPC_URL` from your env-enc setup in Terminal 2 (`npx env-enc view`). On `ccip-cli send`, the source chain RPC quotes fees and submits the transaction; for token-only transfers in this tutorial, that is the only RPC strictly required to send. Pass both RPCs on cross-chain commands anyway: the destination RPC is required for `ccip-cli show --wait` and for optional send features such as `--estimate-gas-limit` or `send --wait`.
+
+<Aside type="note" title="RPC and wallet configuration">
+  Repeat `--rpc` for multiple networks, or use `--rpcs` with comma-separated URLs. Alternatively, set `RPC_*` environment variables or a `.env` file — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration). Solana sends use `--wallet ~/.config/solana/id.json`. EVM sends: prefer `--wallet hardhat:<name>` from the Hardhat project directory ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)); alternatively export `PRIVATE_KEY` manually after `npx env-enc view` (Hardhat tasks load env-enc automatically, but `ccip-cli` does not). See [CCIP CLI wallet configuration](https://docs.chain.link/ccip/tools/cli/configuration#wallet-configuration).
+</Aside>
+
+### Transfer Solana → Ethereum
+
+**Terminal 1** (CCIP Solana BS58 Generator):
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Send Command</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+source ~/.ccip_complete_vars
+
+export ETH_RECEIVER_ADDRESS="<YOUR_ETHEREUM_RECEIVER_ADDRESS>"
+
+
+ccip-cli send \
+  -s solana-devnet \
+  -r $SOL_CCIP_ROUTER \
+  -d ethereum-testnet-sepolia \
+  --to $ETH_RECEIVER_ADDRESS \
+  -t $SOL_TOKEN_MINT=0.001 \
+  --wallet ~/.config/solana/id.json \
+  --rpc $SOLANA_DEVNET_RPC \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL
+```
 
 </Fragment>
 
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-21T14:58:03.313Z] 🔄 SENDING TOKEN TRANSFER
-[2025-08-21T14:58:03.313Z] =======================================
-[2025-08-21T14:58:03.313Z] Preparing CCIP message...
-[2025-08-21T14:58:03.314Z] Sending CCIP message to destination chain 16015286601757825753
-[2025-08-21T14:58:03.314Z] Building accounts for CCIP send to chain 16015286601757825753
-[2025-08-21T14:58:03.322Z] Getting mint account info for GsPeEMYi2D28ATyt5mWN3a8gxqoQGaxEyrqVJtjS4M9A to determine token program ID...
-[2025-08-21T14:58:03.417Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-21T14:58:17.154Z] CCIP message sent successfully: 3kzdDLfwBPm9KW9LjYBpNS9wbQY3phGK5b3oAic3So828VBp22qGM5UXqk3DKQ1UnNvRABr9v8dKt5mvSG6K8fvF
-[2025-08-21T14:58:17.156Z] Parsing CCIP message sent event for transaction: 3kzdDLfwBPm9KW9LjYBpNS9wbQY3phGK5b3oAic3So828VBp22qGM5UXqk3DKQ1UnNvRABr9v8dKt5mvSG6K8fvF
-[2025-08-21T14:58:17.759Z] Successfully extracted messageId: 0xccd4bf82b83aa2c868bd07995a833a211081f51859d6ae6200c7856590c8efcb
-[2025-08-21T14:58:17.760Z]
-[2025-08-21T14:58:17.760Z] ✅ TOKEN TRANSFER SENT SUCCESSFULLY
-[2025-08-21T14:58:17.760Z] =======================================
-[2025-08-21T14:58:17.760Z] Transaction Signature: 3kzdDLfwBPm9KW9LjYBpNS9wbQY3phGK5b3oAic3So828VBp22qGM5UXqk3DKQ1UnNvRABr9v8dKt5mvSG6K8fvF
-[2025-08-21T14:58:17.760Z] CCIP Message ID: 0xccd4bf82b83aa2c868bd07995a833a211081f51859d6ae6200c7856590c8efcb
-[2025-08-21T14:58:17.760Z]
-[2025-08-21T14:58:17.760Z] 🔍 EXPLORER URLS
-[2025-08-21T14:58:17.760Z] =======================================
-[2025-08-21T14:58:17.760Z] Solana Transaction: https://explorer.solana.com/tx/3kzdDLfwBPm9KW9LjYBpNS9wbQY3phGK5b3oAic3So828VBp22qGM5UXqk3DKQ1UnNvRABr9v8dKt5mvSG6K8fvF?cluster=devnet
-[2025-08-21T14:58:17.760Z] CCIP Explorer: https://ccip.chain.link/msg/0xccd4bf82b83aa2c868bd07995a833a211081f51859d6ae6200c7856590c8efcb
-[2025-08-21T14:58:17.760Z]
-[2025-08-21T14:58:17.761Z] 🎉 Transfer Complete!
-[2025-08-21T14:58:17.761Z] ✅ Sent 1000000 tokens to 0x9d087fC03ae39b088326b67fA3C788236645b717
-[2025-08-21T14:58:17.761Z] ✅ Message ID: 0xccd4bf82b83aa2c868bd07995a833a211081f51859d6ae6200c7856590c8efcb
-[2025-08-21T14:58:17.761Z] ✅ Monitor progress on CCIP Explorer: https://ccip.chain.link/msg/0xccd4bf82b83aa2c868bd07995a833a211081f51859d6ae6200c7856590c8efcb
-✨  Done in 18.52s.
+Using rate-limited fetch for public solana nodes, commands may be slow
+Fee: 17613485n = 0.017613485 SOL
+🚀 Sending message to 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca @ ethereum-testnet-sepolia , tx => WK3Fc9WeNEss7MnuS1XLib3vxyL4gijFA5Ph6PqrPhEGn4CXBBrstuLFirmyiQpYp2WsnFEzncFtXThn7DqNtcZ , messageId => 0xd613aacc883f19ca115d1441861b564daf7d959c6053a29d80017960d6cb1282
+Using rate-limited fetch for public solana nodes, commands may be slow
+Lane:
+┌────────────────┬────────────────────────────────────────────────┬────────────────────────────┐
+│ (index)        │ source                                         │ dest                       │
+├────────────────┼────────────────────────────────────────────────┼────────────────────────────┤
+│ name           │ 'solana-devnet'                                │ 'ethereum-testnet-sepolia' │
+│ chainId        │ 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' │ 11155111                   │
+│ chainSelector  │ 16423721717087811551n                          │ 16015286601757825753n      │
+│ onRamp/version │ 'Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C' │ '1.6.0'                    │
+└────────────────┴────────────────────────────────────────────────┴────────────────────────────┘
+Request (source):
+┌──────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)                  │ Values                                                                                    │
+├──────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
+│ messageId                │ '0xd613aacc883f19ca115d1441861b564daf7d959c6053a29d80017960d6cb1282'                      │
+│ origin                   │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                            │
+│ sender                   │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                            │
+│ receiver                 │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                              │
+│ sequenceNumber           │ 3075                                                                                      │
+│ nonce                    │ '0 => allow out-of-order exec'                                                            │
+│ gasLimit                 │ 0n                                                                                        │
+│ transactionHash          │ 'WK3Fc9WeNEss7MnuS1XLib3vxyL4gijFA5Ph6PqrPhEGn4CXBBrstuLFirmyiQpYp2WsnFEzncFtXThn7DqNtcZ' │
+│ logIndex                 │ 34                                                                                        │
+│ blockNumber              │ 469435194                                                                                 │
+│ timestamp                │ '2026-06-14 18:38:59 (1s ago)'                                                            │
+│ finalized                │ '12s left'                                                                                │
+│ fee                      │ '0.017613485 SOL'                                                                         │
+│ tokens                   │ '0.001 CCIP-AEM'                                                                          │
+│ data                     │ '0x'                                                                                      │
+│ feeValueJuels            │ 151641396000000000n                                                                       │
+│ allowOutOfOrderExecution │ true                                                                                      │
+└──────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────┘
+CCIP Explorer: https://ccip.chain.link/msg/0xd613aacc883f19ca115d1441861b564daf7d959c6053a29d80017960d6cb1282
 ```
-
-</Fragment>
-
-<Fragment slot="panel.3">
-
-Monitor your transfer:
-
-1. Check [CCIP Explorer](https://ccip.chain.link) with the message ID
-1. Verify token arrival in your Ethereum wallet
-1. Check balance on Etherscan
-
-Transfers typically complete within 5 minutes.
 
 </Fragment>
 </Tabs>
 
-### Step 3: Transfer Ethereum → Solana
+The `-t` flag uses human-readable amounts (0.001 tokens with 9 decimals = 1,000,000 smallest units).
 
-<Aside type="note" title="EVM Credentials Required">
-  For this direction, ensure your `.env` file in Terminal 1 contains your EVM credentials as set up in the
-  prerequisites.
+<Tabs client:visible>
+<Fragment slot="tab.1">Monitor Transfer</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+# Replace with the transaction hash or message ID from the send output
+ccip-cli show <TX_HASH_OR_MESSAGE_ID> --wait \
+  --rpc $SOLANA_DEVNET_RPC \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+Using rate-limited fetch for public solana nodes, commands may be slow
+Lane:
+┌────────────────┬────────────────────────────────────────────────┬────────────────────────────┐
+│ (index)        │ source                                         │ dest                       │
+├────────────────┼────────────────────────────────────────────────┼────────────────────────────┤
+│ name           │ 'solana-devnet'                                │ 'ethereum-testnet-sepolia' │
+│ chainId        │ 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' │ 11155111                   │
+│ chainSelector  │ 16423721717087811551n                          │ 16015286601757825753n      │
+│ onRamp/version │ 'Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C' │ '1.6.2'                    │
+└────────────────┴────────────────────────────────────────────────┴────────────────────────────┘
+Request (source):
+┌────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)                            │ Values                                                                                    │
+├────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┤
+│ messageId                          │ '0xd613aacc883f19ca115d1441861b564daf7d959c6053a29d80017960d6cb1282'                      │
+│ origin                             │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                            │
+│ sender                             │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                            │
+│ receiver                           │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                              │
+│ sequenceNumber                     │ 3075                                                                                      │
+│ nonce                              │ '0 => allow out-of-order exec'                                                            │
+│ gasLimit                           │ 0n                                                                                        │
+│ transactionHash                    │ 'WK3Fc9WeNEss7MnuS1XLib3vxyL4gijFA5Ph6PqrPhEGn4CXBBrstuLFirmyiQpYp2WsnFEzncFtXThn7DqNtcZ' │
+│ logIndex                           │ 1                                                                                         │
+│ blockNumber                        │ 469435194                                                                                 │
+│ timestamp                          │ '2026-06-14 18:38:59 (9m28s ago)'                                                         │
+│ finalized                          │ true                                                                                      │
+│ fee                                │ '0.017613485 SOL'                                                                         │
+│ tokens                             │ '0.001 CCIP-AEM'                                                                          │
+│ fees.fixedFeesDetails.tokenAddress │ 'So11111111111111111111111111111111111111112'                                             │
+│ fees.fixedFeesDetails.totalAmount  │ 17613485n                                                                                 │
+│ finality                           │ 0n                                                                                        │
+│ finalityType                       │ 'FINALIZED'                                                                               │
+│ routerAddress                      │ 'Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C'                                            │
+│ allowOutOfOrderExecution           │ true                                                                                      │
+│ status                             │ 'SUCCESS'                                                                                 │
+│ readyForManualExecution            │ false                                                                                     │
+│ receiptTransactionHash             │ '0x99c3eb95cf8f75279b606fce616cccb3a748e191730afa477f87a9a09bfdbbdd'                      │
+│ receiptTimestamp                   │ '2026-06-14 18:40:48'                                                                     │
+│ deliveryTime                       │ 109000n                                                                                   │
+│ offRamp                            │ '0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0'                                              │
+└────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────┘
+CCIP Explorer: https://ccip.chain.link/msg/0xd613aacc883f19ca115d1441861b564daf7d959c6053a29d80017960d6cb1282
+[SENT] Waiting for source chain finalization...
+[SOURCE_FINALIZED] Source chain finalized
+[SOURCE_FINALIZED] Waiting for commit on destination chain...
+[SUCCESS] Message executed on destination chain
+┌─────────────────┬──────────────────────────────────────────────────────────────────────┐
+│ (index)         │ Values                                                               │
+├─────────────────┼──────────────────────────────────────────────────────────────────────┤
+│ state           │ '✅ success'                                                         │
+│ gasUsed         │ 81076                                                                │
+│ origin          │ '0xC9b457C56Cd21ec88929C49BF052b856744fAE5f'                         │
+│ contract        │ '0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0'                         │
+│ transactionHash │ '0x99c3eb95cf8f75279b606fce616cccb3a748e191730afa477f87a9a09bfdbbdd' │
+│ logIndex        │ 178                                                                  │
+│ blockNumber     │ 11060184                                                             │
+│ timestamp       │ '2026-06-14 18:40:48 (1m49s after request)'                          │
+└─────────────────┴──────────────────────────────────────────────────────────────────────┘
+```
+
+</Fragment>
+</Tabs>
+
+### Transfer Ethereum → Solana
+
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
+
+`ccip-cli` does not load Hardhat env-enc automatically. Run these commands from the Hardhat project directory. Prefer [Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore) over exporting a private key in plain text.
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Hardhat keystore (Recommended)</Fragment>
+<Fragment slot="tab.2">PRIVATE_KEY (Alternative)</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+source ~/.ccip_complete_vars
+
+ccip-cli send \
+  -s ethereum-testnet-sepolia \
+  -r $ETH_CCIP_ROUTER \
+  -d solana-devnet \
+  --to $SOL_WALLET_ADDRESS \
+  -t $ETH_TOKEN_ADDRESS=1.0 \
+  --wallet hardhat:<YOUR_KEYSTORE_ACCOUNT_NAME> \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
+```
+
+Use the keystore account name from your Hardhat project (see [Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)). This keeps the signing key encrypted instead of in shell history.
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+source ~/.ccip_complete_vars
+
+# ccip-cli does not read env-enc — view and export the same key used in Phase 1
+npx env-enc view
+export PRIVATE_KEY="<YOUR_PRIVATE_KEY_FROM_ENV_ENC>"
+
+ccip-cli send \
+  -s ethereum-testnet-sepolia \
+  -r $ETH_CCIP_ROUTER \
+  -d solana-devnet \
+  --to $SOL_WALLET_ADDRESS \
+  -t $ETH_TOKEN_ADDRESS=1.0 \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
+```
+
+Do not commit or share the exported key. Prefer the Hardhat keystore tab for production-like workflows.
+
+</Fragment>
+</Tabs>
+
+For token-only transfers to Solana, `--to` is the destination wallet that receives minted tokens. CCIP fees are paid in native Sepolia ETH by default — ensure your wallet has sufficient ETH for gas and fees.
+
+<Aside type="note" title="Pay fees in LINK (optional)">
+  Add `--fee-token LINK` to pay CCIP fees in LINK instead of ETH (Sepolia LINK:
+  `0x779877A7B0D9E8603169DdbD7836e478b4624789`).
 </Aside>
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Transfer Command</Fragment>
+<Fragment slot="tab.1">Monitor Transfer</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
-<Fragment slot="tab.3">Monitor Transfer</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Transfer 1 token from Ethereum to Solana
-yarn evm:transfer \
-  --token $ETH_TOKEN_ADDRESS \
-  --amount 1000000000000000000 \
-  --token-receiver <YOUR_SOLANA_ADDRESS>
+ccip-cli show <TX_HASH_OR_MESSAGE_ID> --wait \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
 ```
-
-Replace `<YOUR_SOLANA_ADDRESS>` with your Solana wallet address.
 
 </Fragment>
 
 <Fragment slot="panel.2">
 
 ```bash
-📋 Transfer Summary
-[token-transfer] [INFO] =========================================
-[token-transfer] [INFO]
-==== Transfer Summary ====
-[token-transfer] [INFO] Source Chain: Ethereum Sepolia
-[token-transfer] [INFO] Destination Chain: Solana Devnet (16423721717087811551)
-[token-transfer] [INFO] Sender: 0x9d087fC03ae39b088326b67fA3C788236645b717
-[token-transfer] [INFO] Receiver: 11111111111111111111111111111111
-[token-transfer] [INFO] Token Receiver: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[token-transfer] [INFO] Fee Token: 0x779877A7B0D9E8603169DdbD7836e478b4624789
-[token-transfer] [INFO]
-Token Transfers:
-[token-transfer] [INFO]   1. 1000000000000000000 raw units (0x5D74645E854922009723a817fe4e417A80E7c709)
-[token-transfer] [INFO]
-Extra Args: Solana-specific, 228 bytes
-[token-transfer] [INFO]
-🚀 Executing Token Transfer
-[token-transfer] [INFO] =========================================
-[token-transfer] [INFO] Sending CCIP message...
-[ccip-messenger] [INFO] Estimated fee: 12401361273331257
-[ccip-messenger] [INFO] LINK already has sufficient allowance: 0.015695887955679318 (needed: 0.014881633527997508, surplus: 0.00081425442768181)
-[ccip-messenger] [INFO] Using existing allowance for fee token
-[ccip-messenger] [INFO] Approving 1.0 BnMCC for CCIP Router
-[ccip-messenger] [INFO] Approving 1.0 tokens for 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59
-[ccip-messenger] [INFO] BnMCC approved for CCIP Router
-[ccip-messenger] [INFO] ✅ Verified on-chain allowance for BnMCC: 1.0 (required: 1.0)
-[ccip-messenger] [INFO] Sending CCIP message...
-[ccip-messenger] [INFO] Sending CCIP message...
-[ccip-messenger] [INFO] Transaction sent: 0x867e54f6118e3d98e19bab192b73de58e3461be6683f3a693389d3cd466486c7
-[ccip-messenger] [INFO] Transaction sent: 0x867e54f6118e3d98e19bab192b73de58e3461be6683f3a693389d3cd466486c7
-[ccip-messenger] [INFO] Message ID: 0xeb9674db48c8b329955e097be481afb14f7ee0c08de359bdffe3ab71d5ab51e0
-[token-transfer] [INFO]
-🎉 Transfer Results
-[token-transfer] [INFO] =========================================
-[token-transfer] [INFO]
-==== Transfer Results ====
-[token-transfer] [INFO] Transaction Hash: 0x867e54f6118e3d98e19bab192b73de58e3461be6683f3a693389d3cd466486c7
-[token-transfer] [INFO] Transaction URL: https://sepolia.etherscan.io/tx/0x867e54f6118e3d98e19bab192b73de58e3461be6683f3a693389d3cd466486c7
-[token-transfer] [INFO] Message ID: 0xeb9674db48c8b329955e097be481afb14f7ee0c08de359bdffe3ab71d5ab51e0
-[token-transfer] [INFO] 👉 CCIP Explorer: https://ccip.chain.link/msg/0xeb9674db48c8b329955e097be481afb14f7ee0c08de359bdffe3ab71d5ab51e0
-[token-transfer] [INFO] Destination Chain Selector: 16423721717087811551
-[token-transfer] [INFO] Sequence Number: 740
-[token-transfer] [INFO]
-Message tracking for Solana destinations:
-[token-transfer] [INFO] Please check the CCIP Explorer link to monitor your message status.
-[token-transfer] [INFO]
-✅ Transaction completed on the source chain
-[token-transfer] [INFO]
-✅ Token Transfer Complete!
-[token-transfer] [INFO] 🔗 Your tokens are being bridged to Solana
-✨  Done in 74.30s.
+Lane:
+┌────────────────┬──────────────────────────────────────────────┬────────────────────────────────────────────────┐
+│ (index)        │ source                                       │ dest                                           │
+├────────────────┼──────────────────────────────────────────────┼────────────────────────────────────────────────┤
+│ name           │ 'ethereum-testnet-sepolia'                   │ 'solana-devnet'                                │
+│ chainId        │ 11155111                                     │ 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' │
+│ chainSelector  │ 16015286601757825753n                        │ 16423721717087811551n                          │
+│ onRamp/version │ '0x23a5084Fa78104F3DF11C63Ae59fcac4f6AD9DeE' │ '1.6.0'                                        │
+└────────────────┴──────────────────────────────────────────────┴────────────────────────────────────────────────┘
+Request (source):
+┌────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)                            │ Values                                                                                     │
+├────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ messageId                          │ '0x057a43d38b53bb700ffee472eec7a1c07ce7c9b7e61b8715401093f148e8084f'                       │
+│ origin                             │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ sender                             │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ receiver                           │ '11111111111111111111111111111111'                                                         │
+│ sequenceNumber                     │ 10198                                                                                      │
+│ nonce                              │ '0 => allow out-of-order exec'                                                             │
+│ computeUnits                       │ 0n                                                                                         │
+│ transactionHash                    │ '0x3857e86ca668dd5b73ee24792cf4197a485fe7b48fa82b7d0b77a7a43be6fc95'                       │
+│ logIndex                           │ 222                                                                                        │
+│ blockNumber                        │ 11061690                                                                                   │
+│ timestamp                          │ '2026-06-14 23:42:24 (16m12s ago)'                                                         │
+│ finalized                          │ true                                                                                       │
+│ fee                                │ '0.000348842365648143 WETH'                                                                │
+│ tokens                             │ '1.0 BnMAEM'                                                                               │
+│ accounts                           │ undefined                                                                                  │
+│ fees.fixedFeesDetails.tokenAddress │ '0x097D90c9d3E0B50Ca60e1ae45F6A81010f9FB534'                                               │
+│ fees.fixedFeesDetails.totalAmount  │ 348842365648143n                                                                           │
+│ finality                           │ 0n                                                                                         │
+│ finalityType                       │ 'FINALIZED'                                                                                │
+│ routerAddress                      │ '0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59'                                               │
+│ accountIsWritableBitmap            │ 0n                                                                                         │
+│ allowOutOfOrderExecution           │ true                                                                                       │
+│ tokenReceiver                      │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ status                             │ 'SUCCESS'                                                                                  │
+│ readyForManualExecution            │ false                                                                                      │
+│ receiptTransactionHash             │ '2jH2XxNGYCJj3K9iUu9yErPxUEGJmgSFsLDy5NbQcXjDvmWZTbw2ivQagxnQvY3wnz4YyRMWVYoEeJHTZ5CAAFUM' │
+│ receiptTimestamp                   │ '2026-06-14 23:56:22'                                                                      │
+│ deliveryTime                       │ 838000n                                                                                    │
+│ offRamp                            │ 'offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm'                                              │
+└────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
+CCIP Explorer: https://ccip.chain.link/msg/0x057a43d38b53bb700ffee472eec7a1c07ce7c9b7e61b8715401093f148e8084f
+[SENT] Waiting for source chain finalization...
+Using rate-limited fetch for public solana nodes, commands may be slow
+[SOURCE_FINALIZED] Source chain finalized
+[SOURCE_FINALIZED] Waiting for commit on destination chain...
+[SUCCESS] Message executed on destination chain
+┌─────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)         │ Values                                                                                     │
+├─────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ state           │ '✅ success'                                                                               │
+│ origin          │ 'Ha3SzUZBDhrxJBz7BmDAiKfhSAkpSSAnJ9bYH3vib6Bs'                                             │
+│ contract        │ 'offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm'                                              │
+│ transactionHash │ '2jH2XxNGYCJj3K9iUu9yErPxUEGJmgSFsLDy5NbQcXjDvmWZTbw2ivQagxnQvY3wnz4YyRMWVYoEeJHTZ5CAAFUM' │
+│ logIndex        │ 23                                                                                         │
+│ blockNumber     │ 469485513                                                                                  │
+│ timestamp       │ '2026-06-14 23:56:22 (14m after request)'                                                  │
+└─────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 </Fragment>
-
-<Fragment slot="panel.3">
-
-Monitor your transfer:
-
-1. Check [CCIP Explorer](https://ccip.chain.link) with the message ID
-1. Verify token arrival in your Ethereum wallet
-1. Check balance on Etherscan
-
-Transfers typically complete within 20 minutes.
-
-</Fragment>
-
 </Tabs>
+
+**Congratulations!** Your cross-chain token infrastructure is fully configured on both chains.
 
 ## Reference: Verification Commands
 
@@ -1908,13 +2455,14 @@ Use these commands to verify your setup at any point during the tutorial. Each s
 
 ### Solana Pool Verification
 
-**Terminal 1 (Solana Starter Kit)**
+**Terminal 1** (CCIP Solana BS58 Generator)
 
 ```bash
 # Verify pool configuration and status
-yarn svm:pool:get-info \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-state \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT
 ```
 
 **What this shows:**
@@ -1926,14 +2474,15 @@ yarn svm:pool:get-info \
 
 ### Solana Chain Configuration
 
-**Terminal 1 (Solana Starter Kit)**
+**Terminal 1** (CCIP Solana BS58 Generator)
 
 ```bash
-# Verify cross-chain configuration with Ethereum
-yarn svm:pool:get-chain-config \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM \
-  --remote-chain ethereum-sepolia
+# Verify cross-chain configuration with Ethereum Sepolia
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-chain-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --remote-chain-selector $ETH_SEPOLIA_CHAIN_SELECTOR
 ```
 
 **What this shows:**
@@ -1945,7 +2494,7 @@ yarn svm:pool:get-chain-config \
 
 ### Solana Token Balance
 
-**Terminal 1 (Solana Starter Kit)**
+**Terminal 1** (CCIP Solana BS58 Generator)
 
 ```bash
 # Check your token balance
@@ -1966,7 +2515,7 @@ spl-token balance $SOL_TOKEN_MINT
 # Verify Ethereum pool configuration
 npx hardhat getPoolConfig \
   --pooladdress $ETH_POOL_ADDRESS \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 **What this shows:**

--- a/src/content/ccip/tutorials/svm/cross-chain-tokens/index.mdx
+++ b/src/content/ccip/tutorials/svm/cross-chain-tokens/index.mdx
@@ -7,7 +7,7 @@ metadata:
   description: "Master cross-chain SPL token, Token-2022 development on Solana with Chainlink CCIP. Step-by-step tutorials from basic setup to production-ready multisig governance."
   excerpt: "CCT, Solana, SVM, cross-chain tokens, CCIP, SPL Token Program, Token-2022, tutorials, cross-chain interoperability, blockchain development"
   datePublished: "2025-08-13T00:53:46Z"
-  lastModified: "2025-08-13T00:53:46Z"
+  lastModified: "2026-06-15T00:53:46Z"
   estimatedTime: "10 minutes"
   difficulty: "advanced"
 ---

--- a/src/content/ccip/tutorials/svm/cross-chain-tokens/lock-release-multisig.mdx
+++ b/src/content/ccip/tutorials/svm/cross-chain-tokens/lock-release-multisig.mdx
@@ -7,7 +7,7 @@ metadata:
   description: "Build enterprise-grade cross-chain SPL, Token-2022 tokens with production governance. Lock and Mint mechanism with LockRelease pool on Solana and BurnMint pool on Ethereum."
   excerpt: "ccip cross-chain token tutorial solana ethereum lockrelease burnmint pools lock mint mechanism production governance spl token token-2022 architecture mainnet-ready enterprise security operational autonomy pool owner rebalancer liquidity management base58 transactions production deployment svm evm"
   datePublished: "2025-09-17T00:53:46Z"
-  lastModified: "2025-09-17T00:53:46Z"
+  lastModified: "2026-06-15T00:53:46Z"
   estimatedTime: "60 minutes"
   difficulty: "advanced"
 ---
@@ -105,10 +105,10 @@ npx env-enc view
 ```bash
 # Expected verification output
 $ npx env-enc view
-The following variables are encrypted and stored in /../smart-contract-examples/ccip/cct/hardhat/.env.enc
-PRIVATE_KEY = c8376...
-ETHEREUM_SEPOLIA_RPC_URL = https://sepolia.gateway.tenderly.co/...
-ETHERSCAN_API_KEY = 9AVYS...
+The following variables are encrypted and stored in .../smart-contract-examples/ccip/cct/hardhat/.env.enc
+PRIVATE_KEY = <redacted>
+ETHEREUM_SEPOLIA_RPC_URL = <your-rpc-url>
+ETHERSCAN_API_KEY = <your-api-key>
 ```
 
 </Fragment>
@@ -130,8 +130,8 @@ npx hardhat deployToken \
   --name "AEM Token" \
   --symbol "BnmAEM" \
   --decimals 18 \
-  --verifycontract true \
-  --network sepolia
+  --verifycontract \
+  --network ethereumSepolia
 
 # Copy the token address from the output above
 ```
@@ -141,21 +141,22 @@ npx hardhat deployToken \
 <Fragment slot="panel.2">
 
 ```bash
-$ npx hardhat deployToken \
-  --name "AEM Token" \
-  --symbol "BnmAEM" \
-  --decimals 18 \
-  --verifycontract true \
-  --network sepolia
-2025-09-17T13:25:08.998Z info: Deploying BurnMintERC20 contract to sepolia
-2025-09-17T13:25:08.999Z info: Waiting 3 blocks for transaction 0x85efdf28278a70fa8b826018093ee6936bcbb7d6008dfb0fa46be71aef45e750 to be confirmed...
-2025-09-17T13:26:25.774Z info: Token deployed to: 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715
-2025-09-17T13:26:25.829Z info: Granting mint and burn roles to 0x9d087fC03ae39b088326b67fA3C788236645b717
-k2025-09-17T13:32:13.527Z info: Verifying contract...
-The contract 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715 has already been verified on the block explorer. If you're trying to verify a partially verified contract, please use the --force flag.
-https://sepolia.etherscan.io/address/0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715#code
+2026-06-15T05:10:23.341Z info: 🚀 Deploying BurnMintERC20 to ethereumSepolia...
+2026-06-15T05:10:23.342Z info:    name: AEM Token, symbol: BnmAEM
+2026-06-15T05:10:26.391Z info: ⏳ Deployment tx: 0x9b0e71b2b5e483df17324fdfe4f8f89038f905d4c8197cdbbadb47f84410884a
+2026-06-15T05:10:26.391Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T05:11:00.669Z info: ✅ Token deployed at: 0x44490fee906a4cfd5e71a46c3ca2147287b018e7
+2026-06-15T05:11:01.125Z info: Granting mint and burn roles to 0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA...
+2026-06-15T05:11:02.224Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T05:11:37.028Z info: ✅ Mint/Burn roles granted.
+2026-06-15T05:11:37.028Z info: Verifying contract...
 
-2025-09-17T13:32:14.290Z info: Token contract deployed and verified
+The contract at 0x44490fee906a4cfd5e71a46c3ca2147287b018e7 has already been verified on Etherscan.
+
+If you need to verify a partially verified contract, please use the --force flag.
+
+Explorer: https://sepolia.etherscan.io/address/0x44490fee906a4cfd5e71a46c3ca2147287b018e7#code
+2026-06-15T05:11:39.874Z info: ✅ Token contract verified successfully
 ```
 
 </Fragment>
@@ -177,7 +178,6 @@ Verify the address is set correctly:
 
 ```bash
 echo "✅ Ethereum Token Address: $ETH_TOKEN_ADDRESS"
-
 ```
 
 </Fragment>
@@ -187,8 +187,7 @@ echo "✅ Ethereum Token Address: $ETH_TOKEN_ADDRESS"
 ```bash
 $ echo "✅ Ethereum Token Address: $ETH_TOKEN_ADDRESS"
 
-✅ Ethereum Token Address: 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715
-
+✅ Ethereum Token Address: 0x44490fee906a4cfd5e71a46c3ca2147287b018e7
 ```
 
 </Fragment>
@@ -210,8 +209,8 @@ npx hardhat deployTokenPool \
   --tokenaddress $ETH_TOKEN_ADDRESS \
   --localtokendecimals 18 \
   --pooltype burnMint \
-  --verifycontract true \
-  --network sepolia
+  --verifycontract \
+  --network ethereumSepolia
 ```
 
 </Fragment>
@@ -219,14 +218,24 @@ npx hardhat deployTokenPool \
 <Fragment slot="panel.2">
 
 ```bash
-2025-09-17T13:38:16.268Z info: Waiting 3 blocks for transaction 0xc709adc26e77d99aad479f0ba7c9613b37f661d30573996f32f06bf569fb3371 to be confirmed...
-2025-09-17T13:39:00.746Z info: Token pool deployed to: 0x4678b403781467761Df2f9364FeC48ae3f4F3857
-2025-09-17T13:39:00.748Z info: Granting mint and burn roles to 0x4678b403781467761Df2f9364FeC48ae3f4F3857 on token 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715
-2025-09-17T13:39:36.858Z info: Verifying contract...
-The contract 0x4678b403781467761Df2f9364FeC48ae3f4F3857 has already been verified on the block explorer. If you're trying to verify a partially verified contract, please use the --force flag.
-https://sepolia.etherscan.io/address/0x4678b403781467761Df2f9364FeC48ae3f4F3857#code
+2026-06-15T05:13:32.519Z info: 🚀 Deploying burnMint pool on ethereumSepolia
+2026-06-15T05:13:32.520Z info:    Token: 0x44490fee906a4cfd5e71a46c3ca2147287b018e7
+2026-06-15T05:13:32.520Z info:    Decimals: 18
+2026-06-15T05:13:32.520Z info:    Allowlist: None
+2026-06-15T05:13:35.589Z info: ⏳ Deployment tx: 0xe3f4ca157e146fd67fbb0f34475d51fba4f85f8b62ae9ed006cb0f5198cfcdd4
+2026-06-15T05:13:35.589Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T05:14:14.096Z info: ✅ Token pool deployed at: 0x80cd26e9325342b9be1cc7cab3e785afb44ebee4
+2026-06-15T05:14:14.096Z info: Granting mint and burn roles to 0x80cd26e9325342b9be1cc7cab3e785afb44ebee4 on token 0x44490fee906a4cfd5e71a46c3ca2147287b018e7
+2026-06-15T05:14:15.413Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T05:14:49.692Z info: ✅ Mint/Burn roles granted
+2026-06-15T05:14:49.692Z info: Verifying contract...
 
-2025-09-17T13:39:37.360Z info: Token pool contract deployed and verified
+The contract at 0x80cd26e9325342b9be1cc7cab3e785afb44ebee4 has already been verified on Etherscan.
+
+If you need to verify a partially verified contract, please use the --force flag.
+
+Explorer: https://sepolia.etherscan.io/address/0x80cd26e9325342b9be1cc7cab3e785afb44ebee4#code
+2026-06-15T05:14:52.869Z info: ✅ Token pool contract verified successfully
 ```
 
 </Fragment>
@@ -257,7 +266,7 @@ echo "✅ Ethereum Pool Address: $ETH_POOL_ADDRESS"
 
 ```bash
 $ echo "✅ Ethereum Pool Address: $ETH_POOL_ADDRESS"
-✅ Ethereum Pool Address: 0x4678b403781467761Df2f9364FeC48ae3f4F3857
+✅ Ethereum Pool Address: 0x80cd26e9325342b9be1cc7cab3e785afb44ebee4
 ```
 
 </Fragment>
@@ -278,12 +287,11 @@ Mint tokens for testing:
 npx hardhat mintTokens \
   --tokenaddress $ETH_TOKEN_ADDRESS \
   --amount 1000000000000000000000 \
-  --network sepolia
+  --network ethereumSepolia
 
 # Note: Balance can be checked in your wallet or through block explorer
 
 echo "✅ Tokens minted successfully"
-
 ```
 
 </Fragment>
@@ -291,9 +299,11 @@ echo "✅ Tokens minted successfully"
 <Fragment slot="panel.2">
 
 ```bash
-2025-09-17T13:45:36.112Z info: Minting 1000000000000000000000 of BnmAEM tokens to 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-09-17T13:46:01.229Z info: Minted 1000000000000000000000 of BnmAEM tokens to 0x9d087fC03ae39b088326b67fA3C788236645b717 - transaction hash: 0x2c7d65f00d976c5c11b8e89bda5c5cf717f332da56dc4e3bee3ce75b0b7bc881
-2025-09-17T13:46:01.330Z info: Current balance of 0x9d087fC03ae39b088326b67fA3C788236645b717 is 1000000000000000000000 BnmAEM
+2026-06-15T05:17:15.582Z info: 🪙 Minting 1000000000000000000000 BnmAEM to 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca...
+2026-06-15T05:17:17.106Z info: ⏳ Mint tx: 0x625f70d73ffac46fae50893c31598992de59dcbc18b1e7a0993532e4e0277a9a
+2026-06-15T05:17:17.106Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T05:17:51.825Z info: ✅ Minted 1000000000000000000000 BnmAEM to 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-15T05:17:51.826Z info:    Current balance of 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca: 1000000000000000000000 BnmAEM
 ✅ Tokens minted successfully
 ```
 
@@ -314,7 +324,7 @@ In this step, you will use the `claimAdmin` task to register your EOA as the adm
 # Claim admin role for CCIP token registry
 npx hardhat claimAdmin \
   --tokenaddress $ETH_TOKEN_ADDRESS \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 </Fragment>
@@ -322,10 +332,10 @@ npx hardhat claimAdmin \
 <Fragment slot="panel.2">
 
 ```bash
-2025-09-17T13:47:16.141Z info: 🎯 Attempting to claim admin for token 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715 using getCCIPAdmin mode
-2025-09-17T13:47:16.857Z info: Current token CCIP admin: 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-09-17T13:47:16.857Z info: Claiming admin of 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715 via getCCIPAdmin() for CCIP admin 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-09-17T13:49:01.204Z info: ✅ Successfully claimed admin of 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715 using getCCIPAdmin mode. Transaction: 0x0dd6907e9b95ebd308053f7bbf2d12cb971e1690752745f0abbceb4015011e2b
+2026-06-15T05:18:32.042Z info: 🎯 Claiming admin for 0x44490fee906a4cfd5e71a46c3ca2147287b018e7 using getCCIPAdmin mode
+2026-06-15T05:18:35.031Z info: ✅ Current wallet 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca is CCIP admin
+2026-06-15T05:18:36.836Z info: 📤 TX sent: 0x8fdf329f410457e19cb8b20d9f99c2e6a3c177a49cc6599a0ccd369bd6bcb2ff. Waiting for 3 confirmations...
+2026-06-15T05:19:15.606Z info: ✅ Admin claimed for 0x44490fee906a4cfd5e71a46c3ca2147287b018e7 on ethereumSepolia (3 confirmations)
 ```
 
 </Fragment>
@@ -345,7 +355,7 @@ In this step, you will use the `acceptAdminRole` task to accept the admin role f
 # Accept admin role to complete CCIP registration
 npx hardhat acceptAdminRole \
 --tokenaddress $ETH_TOKEN_ADDRESS \
---network sepolia
+--network ethereumSepolia
 ```
 
 </Fragment>
@@ -353,7 +363,12 @@ npx hardhat acceptAdminRole \
 <Fragment slot="panel.2">
 
 ```bash
-2025-09-17T13:50:02.036Z info: Accepted admin role for token 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715 tx: 0xfcbdba4d263418a24a353b2b2c622c563c499f0863eedcac935a19f32007eda0
+2026-06-15T05:19:37.981Z info: 🔄 Accepting admin role for 0x44490fee906a4cfd5e71a46c3ca2147287b018e7 on ethereumSepolia...
+2026-06-15T05:19:40.309Z info: Checking pending admin for 0x44490fee906a4cfd5e71a46c3ca2147287b018e7...
+2026-06-15T05:19:40.542Z info: ✅ Current wallet 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca is the pending admin
+2026-06-15T05:19:40.542Z info: Accepting admin role...
+2026-06-15T05:19:42.157Z info: 📤 TX sent: 0xf318cc095d005a98a54eaacd3a5a43f71a27473f965ebf1f24002b42066e11c4. Waiting for 3 confirmations...
+2026-06-15T05:20:12.418Z info: ✅ Admin role accepted for 0x44490fee906a4cfd5e71a46c3ca2147287b018e7 on ethereumSepolia (3 confirmations)
 ```
 
 </Fragment>
@@ -374,7 +389,7 @@ In this step, you will use the `setPool` task to register the BurnMint token poo
 npx hardhat setPool \
 --tokenaddress $ETH_TOKEN_ADDRESS \
 --pooladdress $ETH_POOL_ADDRESS \
---network sepolia
+--network ethereumSepolia
 ```
 
 </Fragment>
@@ -382,8 +397,15 @@ npx hardhat setPool \
 <Fragment slot="panel.2">
 
 ```bash
-2025-09-17T13:50:55.049Z info: Setting pool for token 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715 to 0x4678b403781467761Df2f9364FeC48ae3f4F3857 by 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-09-17T13:51:37.215Z info: Pool set for token 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715 to 0x4678b403781467761Df2f9364FeC48ae3f4F3857
+2026-06-15T05:20:35.410Z info: 🔗 Setting pool for token 0x44490fee906a4cfd5e71a46c3ca2147287b018e7 on ethereumSepolia...
+2026-06-15T05:20:37.795Z info: 🔹 Using signer: 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-15T05:20:37.796Z info: Using TokenAdminRegistry: 0x95F29FEE11c5C55d26cCcf1DB6772DE953B37B82
+2026-06-15T05:20:38.050Z info: Checking token configuration for 0x44490fee906a4cfd5e71a46c3ca2147287b018e7...
+2026-06-15T05:20:38.290Z info: Token 0x44490fee906a4cfd5e71a46c3ca2147287b018e7 current admin: 0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA
+2026-06-15T05:20:38.290Z info: ✅ Current wallet 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca is the token administrator
+2026-06-15T05:20:38.290Z info: Setting pool 0x80cd26e9325342b9be1cc7cab3e785afb44ebee4 for token 0x44490fee906a4cfd5e71a46c3ca2147287b018e7...
+2026-06-15T05:20:39.977Z info: 📤 TX sent: 0x30365ade48016fda44fd894454e5f4d1a9e3270420930074e392c1b85051d45c. Waiting for 3 confirmations...
+2026-06-15T05:21:14.426Z info: ✅ Pool successfully set for token 0x44490fee906a4cfd5e71a46c3ca2147287b018e7 → 0x80cd26e9325342b9be1cc7cab3e785afb44ebee4 on ethereumSepolia (3 confirmations)
 ```
 
 </Fragment>
@@ -414,8 +436,8 @@ echo "✅ ETH Pool: $ETH_POOL_ADDRESS"
 
 ```bash
 === Phase 1 Complete - EVM Setup ===
-✅ ETH Token: 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715
-✅ ETH Pool: 0x4678b403781467761Df2f9364FeC48ae3f4F3857
+✅ ETH Token: 0x44490fee906a4cfd5e71a46c3ca2147287b018e7
+✅ ETH Pool: 0x80cd26e9325342b9be1cc7cab3e785afb44ebee4
 ```
 
 </Fragment>
@@ -423,12 +445,12 @@ echo "✅ ETH Pool: $ETH_POOL_ADDRESS"
 
 <Aside type="note" title="Phase 1 Complete">
   **EVM Setup Complete**: You have successfully deployed and configured the EVM side. Next, you'll implement the
-  production-grade Solana side with dual-layer multisig governance.
+  production-grade Solana LockRelease setup with Squads governance.
 </Aside>
 
-## Phase 2: Solana Setup with Production Dual Multisig Governance
+## Phase 2: Solana LockRelease Setup with Squads Governance
 
-In this phase, you will implement the **production-grade multisig governance** architecture on Solana Devnet.
+In this phase, you will implement the **production-grade LockRelease pool** with Squads multisig governance on Solana Devnet.
 
 <Aside type="note" title="Terminal Context Check">
   **Current Focus: Terminal 1 (base58 Generator)** Switch to the base58 generator repository for transaction generation.
@@ -438,8 +460,8 @@ In this phase, you will implement the **production-grade multisig governance** a
 ### Step 1: Prepare base58 Environment
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Terminal Setup</Fragment>
-<Fragment slot="tab.2">Verification</Fragment>
+<Fragment slot="tab.1">Verify Location</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
@@ -449,7 +471,24 @@ In this phase, you will implement the **production-grade multisig governance** a
 pwd
 ```
 
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+/.../ccip-solana-bs58-generator
+```
+
+</Fragment>
+</Tabs>
+
 Set up CCIP constants on Solana Devnet (DO NOT CHANGE THESE)
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Setup Command</Fragment>
+<Fragment slot="tab.2">Verification</Fragment>
+
+<Fragment slot="panel.1">
 
 <Aside type="note" title="CCIP LockRelease Pool Program">
   The CCIP LockRelease pool program is a self-service pool program that allows you to initialize a pool for your token.
@@ -461,9 +500,9 @@ Set up CCIP constants on Solana Devnet (DO NOT CHANGE THESE)
 </Aside>
 
 ```bash
-export CCIP_POOL_PROGRAM="8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC"
-export CCIP_ROUTER_PROGRAM="Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C"
-export CCIP_FEE_QUOTER_PROGRAM="FeeQPGkKDeRV1MgoYfMH6L8o3KeuYjwUZrgn4LRKfjHi"
+export SOL_CCIP_POOL_PROGRAM="8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC"
+export SOL_CCIP_ROUTER="Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C"
+export SOL_CCIP_FEE_QUOTER_PROGRAM="FeeQPGkKDeRV1MgoYfMH6L8o3KeuYjwUZrgn4LRKfjHi"
 ```
 
 **Note**: You can find the Router, Fee Quoter, and self-serve pool programs addresses in the [CCIP Directory](/ccip/directory/testnet/chain/solana-devnet).
@@ -477,8 +516,8 @@ export SOL_WALLET_ADDRESS=$(solana address)
 Verify all required variables are set:
 
 ```bash
-echo "✅ Pool Program: $CCIP_POOL_PROGRAM"
-echo "✅ Router Program: $CCIP_ROUTER_PROGRAM"
+echo "✅ Pool Program: $SOL_CCIP_POOL_PROGRAM"
+echo "✅ Router Program: $SOL_CCIP_ROUTER"
 echo "✅ Squad Vault (from Prerequisites): $SOL_SQUAD_VAULT_MULTISIG"
 echo "✅ Recipient Wallet: $SOL_WALLET_ADDRESS"
 ```
@@ -490,14 +529,14 @@ echo "✅ Recipient Wallet: $SOL_WALLET_ADDRESS"
 ```bash
 ✅ Pool Program: 8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC
 ✅ Router Program: Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
-✅ Squad Vault (from Prerequisites): 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY
-✅ Recipient Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
+✅ Squad Vault (from Prerequisites): AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+✅ Recipient Wallet: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
 ```
 
 </Fragment>
 </Tabs>
 
-### Step 2: Create SPL Token (Layer 2 Foundation)
+### Step 2: Create SPL Token
 
 This command generates a transaction that creates a new SPL token mint with the following features:
 
@@ -547,60 +586,77 @@ pnpm bs58 spl-token \
 <Fragment slot="panel.2">
 
 ```bash
-INFO [2025-09-17 16:06:38.343 +0200]: 🔍 Validating create mint parameters...
-INFO [2025-09-17 16:06:38.343 +0200]: 📋 Token Program: spl-token (TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA)
-INFO [2025-09-17 16:06:38.344 +0200]: 📋 Decimals: 9
-INFO [2025-09-17 16:06:38.344 +0200]: 📋 Metaplex metadata enabled
-INFO [2025-09-17 16:06:38.344 +0200]:    Name: "AEM"
-INFO [2025-09-17 16:06:38.344 +0200]:    Symbol: "CCIP-AEM"
-INFO [2025-09-17 16:06:38.344 +0200]:    URI: https://cyan-pleasant-anteater-613.mypinata.cloud/ipfs/bafkreieirlwjqbtzniqsgcjebzexlcspcmvd4woh3ajvf2p4fuivkenw6i
-INFO [2025-09-17 16:06:38.344 +0200]: 📋 Initial supply: 5000000000000 smallest units
-INFO [2025-09-17 16:06:38.344 +0200]: 📋 Recipient: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-INFO [2025-09-17 16:06:38.344 +0200]: ✅ Parameter validation completed
-INFO [2025-09-17 16:06:38.344 +0200]: 🎨 Creating mint with Metaplex metadata...
-INFO [2025-09-17 16:06:38.352 +0200]: 📋 Generated mint address: FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1
-INFO [2025-09-17 16:06:38.352 +0200]: 📋 Mint seed: mint_1758117998344_621v0l
-INFO [2025-09-17 16:06:38.352 +0200]: 📋 Using token program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-INFO [2025-09-17 16:06:39.107 +0200]: 📋 Generated 3 instructions for mint + metadata creation
-INFO [2025-09-17 16:06:39.107 +0200]: 💰 Adding initial supply mint instructions...
-INFO [2025-09-17 16:06:39.107 +0200]: 📋 Creating ATA for recipient: 5dQxPofcZCuWASgwdCgR7MKzGGx9d596nsbMUcbuBrDZ
-INFO [2025-09-17 16:06:39.107 +0200]: 📋 Will mint 5000000000000 smallest units to 5dQxPofcZCuWASgwdCgR7MKzGGx9d596nsbMUcbuBrDZ
-INFO [2025-09-17 16:06:39.107 +0200]: 🔄 Building and simulating transaction...
+INFO [2026-06-15 10:55:29.488 +0530]: 🔍 Validating create mint parameters...
+INFO [2026-06-15 10:55:29.488 +0530]: 📋 Token Program: spl-token (TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA)
+INFO [2026-06-15 10:55:29.488 +0530]: 📋 Decimals: 9
+INFO [2026-06-15 10:55:29.488 +0530]: 📋 Metaplex metadata enabled
+INFO [2026-06-15 10:55:29.488 +0530]:    Name: "AEM"
+INFO [2026-06-15 10:55:29.488 +0530]:    Symbol: "CCIP-AEM"
+INFO [2026-06-15 10:55:29.488 +0530]:    URI: https://cyan-pleasant-anteater-613.mypinata.cloud/ipfs/bafkreieirlwjqbtzniqsgcjebzexlcspcmvd4woh3ajvf2p4fuivkenw6i
+INFO [2026-06-15 10:55:29.488 +0530]: 📋 Initial supply: 5000000000000 smallest units
+INFO [2026-06-15 10:55:29.488 +0530]: 📋 Recipient: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 10:55:29.489 +0530]: ✅ Parameter validation completed
+INFO [2026-06-15 10:55:29.489 +0530]: 🎨 Creating mint with Metaplex metadata...
+INFO [2026-06-15 10:55:29.491 +0530]: 📋 Generated mint address: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
+INFO [2026-06-15 10:55:29.491 +0530]: 📋 Mint seed: mint_1781501129489_6ou77e
+INFO [2026-06-15 10:55:29.491 +0530]: 📋 Using token program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+INFO [2026-06-15 10:55:29.921 +0530]: 📋 Generated 3 instructions for mint + metadata creation
+INFO [2026-06-15 10:55:29.921 +0530]: 💰 Adding initial supply mint instructions...
+INFO [2026-06-15 10:55:29.922 +0530]: 📋 Creating ATA for recipient: EgRUZ866e59bu2chrPDvz8Gq4Z6CPJkS2t6jDcqp9S9m
+INFO [2026-06-15 10:55:29.922 +0530]: 📋 Will mint 5000000000000 smallest units to EgRUZ866e59bu2chrPDvz8Gq4Z6CPJkS2t6jDcqp9S9m
+INFO [2026-06-15 10:55:29.923 +0530]: 🔄 Building and simulating transaction...
+INFO [2026-06-15 10:55:29.923 +0530]: 📋 Metadata PDA: HabbTjEoCjauLbYG4haXRkFNpnABsihrumBsYKZSS8AG
 🎯 COPY TRANSACTION DATA BELOW:
 
-Ued1nAAbK74eW6wNw6sSEWG7KgZbhDN8SiitDSsbj4nsgqMCq74iWHAyE8Rn9wbcBPMyPv9dckYig2MbPG3RMrRB372vVNmZenVm6mofpq6j4TY27H4VFKta2oBGABUuetC95JQFuNj77cRdhS2hmbyS1X9mkpioWQoDUT6B5ocX6MKGbfAMpZispy7yGqgVwgG3dUHGMMAZzzvxWkuxjdaEzLL5chrd1eNzGFRNwWJvZFQWQsn27LypwDVpmz4zDd1hDjK7sDtbGBRf6V11s5RajstjLc7tn4LGzxojiAMC3xcnLi4FkmfqN9JVt9ZQMx7Trxszqam32xDwkSvUJpThxLB2ETkFaLsUECD1Vt4jrUNET9TM1Q4pW6dojoNqt3BWSUJKgug3u4mXZnHcb3Y2a8xUzVBTrsX6N2rUA7mR4jbQniPnsKpMqLmSypRn8Z6r6vsCkCg5h8W2jHFmjg223GHGt3hFsRN87Gk13nTp3oonrdJWFXfhMp6cj6sf2cdMqrqe334eTjXijy6BjxSXhBJ3xGW95ip6VcLoi7a8JqkefxYsg8FVfFhe8nHsMjbFMQzwd1C5crfZVj4rQuR6fjHeCtdmTnzjBaeB78L3Jr6PVpJRA1xc5ZCFchxBgVxpz1zDHhmsExXYEv1xXbnpWwDJ2V59c1zQv9wZx4gEhFxNroVh24WctAzj5HXksuNPWaxEeDbtnx7AiTBG2Xfi5dcs6LcU24LwdTdZVQTdynppFCNmoKZnJqy2ZWcxuDnwmyekMq5jSphwt86wzzp5pJQvjHNywc7Y11nZeZWPp6UxxAG6nNqhyCN6Krrk86wdEAPjuEAh3ueCjTeV1ngrV5VYZMPXxwtTso97rU9bdnBujKQZAsKvj1TGXBYxXnd9riFo5fdHgzWSGKhG3fchPyxHGHcVcsTwuJovSKhSCCNs2k5qFzNNo92uRYT8XtEsA4aTJFHF6nAERVp4jccNLcAMhECfEmC2b5kkW45CrrGUt5mdRwQ2pNpDGiwXo4ieKKm5mdgeoW8pkPs7tYJTPNfWFHHK12XhjFt9SNDLEuoMTjqiRoByW2bwntCoJzsWhQBhLBsCdwcXy
+Ued1t9JWnpB6ojDXJk4iKCycwPLpRz88njSywTd6n3QcSYuN8oiYE615LFJJJo78VKQCPEqLm9XjafPMpZDCVLmTFnqqGniLihocYucEWmXKXqCqJnZ91f8CSteNfcwZMeh2AMYFcHhhPCn5qgu2zQZEqTcAsMuPYw9MZyiuDgR2AFPvXkpcw7vVe8g6XiquucULScAfdG7SxSjStZXXYPbfEV4KSs7BDhSpVEDCDL9qoJm2b43t7xK1ndVj4anspgGEhDVaLtDUS7x95m3Ym4gyWt9nFHzoasYPoBTpAR9bQMmTzYNsjtcYrd6mLcBQkQ2Y1YKFbkHWP72gZfswRhZrc2ZTdsV9KjdJzko4s2UHiyR7rX5nuDE8xWH9dCvxsNwNbMbQjM8ckr2JcfradLVzVEJyAnjKJeYAKnMrQEGchSzsG2rVi6tNAr1FU9noSNrTasrK7MPTjiDGGjsDL62tLb4wcRQVBg8WJQNjddUwmK7bSy37oyPso3Zv8c8S3BaFtRN6Nm351HWM963s4ScQEwjP8YnBLnT3t7RBDgvkhk6xh1GqC6ACMUoECc5usCMk1Cka7mnt6THddQCCun3MCdnsNtyv27FXwBB8AHygAqZrNXhhUAri9LtsfJhymrAFGM22T6j1yNSnu6UjrK1NnSGnanW4ftrZbU4rDvkC6wwsKNqGSt661ZU8EsoyxZn3guh5qwPE5g7KmzD2F3A6deqNYUJUqcXmUaDKyvLTWGhFfUP5tuBQPNaB1LWXZo2P5bTHg38ps2VprN9rY5AuNGo6dPSo3ciSMyDE6RfiKe6UQnkWjz4bEYsTcxaBQdSApYJYSpr3Waskce3iUm4Y4saUfZnUmjRU2pHGQarpUJGYYNpM2aBHboBqTTRCiYc2wDkj3AKysMM9xLZ8MsaRoP7muoFJaSur8HVidguerKmt2EbMSTee4mK5iE7qHP4cZEdu8HGaohaXmETKDF61fBF2PP6Sr9VgTEMTTzB7Nhp85gEWTzdf95y7f3h5cHs5NNp7uuGueSpV7Wjnx3X1LUJCxMCYVmTCpqiCQBicx1mCFGx3w4DrHXe4yMFzGKnyxonMzVK61Kes9
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-17 16:06:39.629 +0200]: Transaction built successfully
+INFO [2026-06-15 10:55:30.090 +0530]: Transaction built successfully
     instructionName: "spl-token.create_mint_with_metaplex"
     transactionSize: "810 bytes"
     base58Length: "1105 characters"
     hexLength: "1620 characters"
     accountCount: 2
     signerCount: 1
-    computeUnits: 78132
-INFO [2025-09-17 16:06:39.629 +0200]: Completed buildTransaction (spl-token.create_mint_with_metaplex)
-    durationMs: 522
-INFO [2025-09-17 16:06:39.629 +0200]: ✅ Transaction simulation completed
-INFO [2025-09-17 16:06:39.629 +0200]: 📋 Metadata PDA: FMg4GTceuuaKXez3aGX8Bq9etMVekPv3jzSCxYhdKY3V
-INFO [2025-09-17 16:06:39.629 +0200]:
-INFO [2025-09-17 16:06:39.629 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-17 16:06:39.629 +0200]:
-INFO [2025-09-17 16:06:39.629 +0200]: 📋 Transaction Details:
-INFO [2025-09-17 16:06:39.629 +0200]:    Instruction: spl-token.create_mint_with_metaplex
-INFO [2025-09-17 16:06:39.629 +0200]:    Size: 810 bytes
-INFO [2025-09-17 16:06:39.629 +0200]:    Base58 length: 1105 characters
-INFO [2025-09-17 16:06:39.665 +0200]:    Compute units: 78 132
-INFO [2025-09-17 16:06:39.665 +0200]:    Generated: 2025-09-17T14:06:39.629Z
-INFO [2025-09-17 16:06:39.665 +0200]:
-INFO [2025-09-17 16:06:39.665 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-17 16:06:39.665 +0200]:
-INFO [2025-09-17 16:06:39.665 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-17 16:06:39.665 +0200]:
-INFO [2025-09-17 16:06:39.665 +0200]: 📊 Account Information:
-INFO [2025-09-17 16:06:39.665 +0200]:    Total accounts: 2
-INFO [2025-09-17 16:06:39.665 +0200]:     1. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-09-17 16:06:39.665 +0200]:     2. FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1 (writable)
+    computeUnits: 63650
+INFO [2026-06-15 10:55:30.090 +0530]: Completed buildTransaction (spl-token.create_mint_with_metaplex)
+    durationMs: 167
+INFO [2026-06-15 10:55:30.090 +0530]:
+INFO [2026-06-15 10:55:30.090 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 10:55:30.090 +0530]:
+INFO [2026-06-15 10:55:30.090 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 10:55:30.090 +0530]:    Instruction: spl-token.create_mint_with_metaplex
+INFO [2026-06-15 10:55:30.090 +0530]:    Size: 810 bytes
+INFO [2026-06-15 10:55:30.090 +0530]:    Base58 length: 1105 characters
+INFO [2026-06-15 10:55:30.102 +0530]:    Compute units: 63,650
+INFO [2026-06-15 10:55:30.102 +0530]:    Generated: 2026-06-15T05:25:30.090Z
+INFO [2026-06-15 10:55:30.102 +0530]:
+INFO [2026-06-15 10:55:30.102 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 10:55:30.102 +0530]:
+INFO [2026-06-15 10:55:30.102 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 10:55:30.102 +0530]:
+INFO [2026-06-15 10:55:30.102 +0530]: 📊 Account Information:
+INFO [2026-06-15 10:55:30.102 +0530]:    Total accounts: 2
+INFO [2026-06-15 10:55:30.102 +0530]:     1. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 10:55:30.102 +0530]:     2. 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li (writable)
+INFO [2026-06-15 10:55:30.102 +0530]:
+INFO [2026-06-15 10:55:30.102 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 10:55:30.102 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 10:55:30.102 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 10:55:30.102 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 10:55:30.102 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 10:55:30.102 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 10:55:30.102 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 10:55:30.102 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 10:55:30.102 +0530]:
+INFO [2026-06-15 10:55:30.102 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 10:55:30.102 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 10:55:30.102 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 10:55:30.102 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 10:55:30.102 +0530]:    • Estimated compute units: 63,650
+INFO [2026-06-15 10:55:30.102 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 10:55:30.102 +0530]:
+INFO [2026-06-15 10:55:30.102 +0530]: ✅ Transaction simulation completed
 ```
 
 </Fragment>
@@ -610,8 +666,7 @@ INFO [2025-09-17 16:06:39.665 +0200]:     2. FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXT
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add
-  instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
 - **Review**: Verify transaction details, check authority and mint
 - **Simulate**: Simulate the transaction to ensure it will succeed
@@ -644,9 +699,7 @@ echo "✅ Token Mint: $SOL_TOKEN_MINT"
 <Fragment slot="panel.2">
 
 ```bash
-export SOL_TOKEN_MINT="FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1"
-
-✅ Token Mint: FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1
+✅ Token Mint: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
 ```
 
 </Fragment>
@@ -654,8 +707,8 @@ export SOL_TOKEN_MINT="FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1"
 
 ### Step 3: Initialize LockRelease Token Pool
 
-<Aside type="caution" title="Why Initialize Pool Before Mint Authority Transfer">
-  Since your Squad multisig currently holds the mint authority, you can initialize the pool without Chainlink Labs intervention.
+<Aside type="note" title="Self-Service Pool Initialization">
+  Since your Squad vault currently holds the mint authority, you can initialize the LockRelease pool without Chainlink Labs intervention.
 
 If you have an existing token where the mint authority is held by a wallet or another multisig under your control, you can transfer the mint authority to your Squad vault first to follow the self-service path. Otherwise, if you cannot control the mint authority, you can submit a [registration request](https://chain.link/ccip-contact?v=Tokens:%20Token%20admin%20registration) to have Chainlink Labs initialize the pool for you.
 
@@ -686,7 +739,7 @@ Generate the pool initialization transaction:
 # Generate pool initialization transaction
 pnpm bs58 lockrelease-token-pool --env devnet \
   --instruction initialize-pool \
-  --program-id $CCIP_POOL_PROGRAM \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG
 ```
@@ -696,45 +749,64 @@ pnpm bs58 lockrelease-token-pool --env devnet \
 <Fragment slot="panel.2">
 
 ```bash
-   ✅ Transaction simulation completed
+🔄 Generating initialize (pool) transaction...
+🔄 Building and simulating transaction...
 🎯 COPY TRANSACTION DATA BELOW:
 
-FBAuxuhVLrvnXFVrZZ818eWSCdJFif8x7mkKK5X6RBW7AUvzwxqqwRmJ2JvkPrG2RaHuujUWKY6h5ZyxGAn2iLqr7GybXbSYEDkLeUG67FZfY9uXeXNGARCPKrcFDBEnei6U2STumzYXeMTd8FM4H29q5ayCwpWc2wJz15xaeHRUXCA6fqH4YdKgE8Ryjvy5CDACRMF3jihw8MNfn4jrmEGqJZujB4J73eVstBkbVGQFmVDAYsTkSzSDLxy4UHbA6JMSre3XUfZM5u9f9pXAKANtRRpf6VgUTCJnnneBXhyTH5Mmm2LY8cZzQCfy5YfLs2xqBZw4nTAuLg3pR7yxWoraREJrWgVh72VLmLtpHcP8Rfk7wjjpEY2nNWDi
+FBAv1ygQ7d4A9pXavcpnpX3bSYzxYrqx2KhfKhBPUzFJr5rqwp3FQRZ3NWtLw9qLtN8z6jkkSLDn3wzNNMqFjmYGoQcGgVX5jfo7i3PDNr8B49pc5NHchLRQQDuP32gPtVQJ9xaXjN6tMqtY9f5unh77NbG3CTyN147B3hX6JetgSGToX48rwfjX6nJ13z7opbJN9VrXTf5DWy4q42bvTiBpCNUpj3T6rp3242GaAcWgmqGfNzLj9VFEp6MW3psuMQcp3bXAn2CFxnG4TaL7wdKmiYCqBdh6rK6T2kXfsvvq8wCwgbSz2edpZBiUhQme3DPSDtdDR8BrVNdLU5EcSa3Ddhvy8pmsyb9abrNsdfbnfxgmhdjxJGidhkeY
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-17 16:28:14.514 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 11:00:56.698 +0530]: Transaction built successfully
     instructionName: "lockrelease-token-pool.initialize"
     transactionSize: "279 bytes"
     base58Length: "380 characters"
     hexLength: "558 characters"
     accountCount: 7
     signerCount: 1
-    computeUnits: 25842
-INFO [2025-09-17 16:28:14.514 +0200]: Completed buildTransaction (lockrelease-token-pool.initialize)
-    durationMs: 436
-INFO [2025-09-17 16:28:14.515 +0200]:
-INFO [2025-09-17 16:28:14.515 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-17 16:28:14.515 +0200]:
-INFO [2025-09-17 16:28:14.515 +0200]: 📋 Transaction Details:
-INFO [2025-09-17 16:28:14.515 +0200]:    Instruction: lockrelease-token-pool.initialize
-INFO [2025-09-17 16:28:14.515 +0200]:    Size: 279 bytes
-INFO [2025-09-17 16:28:14.515 +0200]:    Base58 length: 380 characters
-INFO [2025-09-17 16:28:14.537 +0200]:    Compute units: 25 842
-INFO [2025-09-17 16:28:14.537 +0200]:    Generated: 2025-09-17T14:28:14.511Z
-INFO [2025-09-17 16:28:14.537 +0200]:
-INFO [2025-09-17 16:28:14.537 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-17 16:28:14.537 +0200]:
-INFO [2025-09-17 16:28:14.537 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-17 16:28:14.537 +0200]:
-INFO [2025-09-17 16:28:14.537 +0200]: 📊 Account Information:
-INFO [2025-09-17 16:28:14.537 +0200]:    Total accounts: 7
-INFO [2025-09-17 16:28:14.537 +0200]:     1. 9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1 (writable)
-INFO [2025-09-17 16:28:14.537 +0200]:     2. FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1 (read-only)
-INFO [2025-09-17 16:28:14.537 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-09-17 16:28:14.537 +0200]:     4. 11111111111111111111111111111111 (read-only)
-INFO [2025-09-17 16:28:14.537 +0200]:     5. 8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC (read-only)
-INFO [2025-09-17 16:28:14.537 +0200]:     6. AeMEQshfd7w72oGt5cMn8196zod6gQPWskbf5BY83W1B (read-only)
-INFO [2025-09-17 16:28:14.537 +0200]:     7. 6Nh9CWRGW69VJ7mnD9ELjm6BMkbvoGvVse2HuNuaHPqm (read-only)
+    computeUnits: 25788
+INFO [2026-06-15 11:00:56.698 +0530]: Completed buildTransaction (lockrelease-token-pool.initialize)
+    durationMs: 365
+INFO [2026-06-15 11:00:56.698 +0530]:
+INFO [2026-06-15 11:00:56.698 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 11:00:56.698 +0530]:
+INFO [2026-06-15 11:00:56.698 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 11:00:56.698 +0530]:    Instruction: lockrelease-token-pool.initialize
+INFO [2026-06-15 11:00:56.698 +0530]:    Size: 279 bytes
+INFO [2026-06-15 11:00:56.698 +0530]:    Base58 length: 380 characters
+INFO [2026-06-15 11:00:56.709 +0530]:    Compute units: 25,788
+INFO [2026-06-15 11:00:56.709 +0530]:    Generated: 2026-06-15T05:30:56.697Z
+INFO [2026-06-15 11:00:56.709 +0530]:
+INFO [2026-06-15 11:00:56.709 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 11:00:56.709 +0530]:
+INFO [2026-06-15 11:00:56.709 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 11:00:56.709 +0530]:
+INFO [2026-06-15 11:00:56.709 +0530]: 📊 Account Information:
+INFO [2026-06-15 11:00:56.709 +0530]:    Total accounts: 7
+INFO [2026-06-15 11:00:56.709 +0530]:     1. 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R (writable)
+INFO [2026-06-15 11:00:56.709 +0530]:     2. 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li (read-only)
+INFO [2026-06-15 11:00:56.709 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 11:00:56.709 +0530]:     4. 11111111111111111111111111111111 (read-only)
+INFO [2026-06-15 11:00:56.709 +0530]:     5. 8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC (read-only)
+INFO [2026-06-15 11:00:56.709 +0530]:     6. AeMEQshfd7w72oGt5cMn8196zod6gQPWskbf5BY83W1B (read-only)
+INFO [2026-06-15 11:00:56.709 +0530]:     7. 6Nh9CWRGW69VJ7mnD9ELjm6BMkbvoGvVse2HuNuaHPqm (read-only)
+INFO [2026-06-15 11:00:56.709 +0530]:
+INFO [2026-06-15 11:00:56.709 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 11:00:56.709 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 11:00:56.709 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 11:00:56.709 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 11:00:56.709 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 11:00:56.709 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 11:00:56.709 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 11:00:56.709 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 11:00:56.709 +0530]:
+INFO [2026-06-15 11:00:56.709 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 11:00:56.710 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 11:00:56.710 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 11:00:56.710 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 11:00:56.710 +0530]:    • Estimated compute units: 25,788
+INFO [2026-06-15 11:00:56.710 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 11:00:56.710 +0530]:
 ```
 
 </Fragment>
@@ -744,9 +816,9 @@ INFO [2025-09-17 16:28:14.537 +0200]:     7. 6Nh9CWRGW69VJ7mnD9ELjm6BMkbvoGvVse2
 
 | Account | Address                                        | Purpose                                                     |
 | ------- | ---------------------------------------------- | ----------------------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool State PDA** - Your main pool configuration           |
-| **#2**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | Token Mint (your token)                                     |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | Authority (your Squad vault)                                |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool State PDA** - Your main pool configuration           |
+| **#2**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | Token Mint (your token)                                     |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | Authority (your Squad vault)                                |
 | **#4**  | `11111111111111111111111111111111`             | System Program                                              |
 | **#5**  | `8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC` | CCIP Pool Program                                           |
 | **#6**  | `AeMEQshfd7w72oGt5cMn8196zod6gQPWskbf5BY83W1B` | Program Data PDA                                            |
@@ -761,8 +833,7 @@ INFO [2025-09-17 16:28:14.537 +0200]:     7. 6Nh9CWRGW69VJ7mnD9ELjm6BMkbvoGvVse2
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add
-  instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
 - **Review**: Verify pool initialization parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
@@ -773,10 +844,33 @@ INFO [2025-09-17 16:28:14.537 +0200]:     7. 6Nh9CWRGW69VJ7mnD9ELjm6BMkbvoGvVse2
 
 After execution, set the pool state address from the transaction:
 
+<Tabs client:visible>
+<Fragment slot="tab.1">Set Variable</Fragment>
+<Fragment slot="tab.2">Verification</Fragment>
+
+<Fragment slot="panel.1">
+
 ```bash
 # Set the pool state address from Account #1 in the transaction above
-export SOL_POOL_ADDRESS="9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1"
+export SOL_POOL_ADDRESS="<YOUR_ACTUAL_POOL_STATE_ADDRESS>"
 ```
+
+Verify the pool address:
+
+```bash
+echo "✅ Pool Address: $SOL_POOL_ADDRESS"
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+✅ Pool Address: 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R
+```
+
+</Fragment>
+</Tabs>
 
 ### Step 4: Derive Pool Signer PDA
 
@@ -794,7 +888,7 @@ pnpm bs58 utils \
   --env devnet \
   --instruction derive-accounts \
   --program-type lockrelease-token-pool \
-  --program-id "$CCIP_POOL_PROGRAM" \
+  --program-id "$SOL_CCIP_POOL_PROGRAM" \
   --mint "$SOL_TOKEN_MINT"
 ```
 
@@ -803,18 +897,29 @@ pnpm bs58 utils \
 <Fragment slot="panel.2">
 
 ```bash
+🔍 Deriving lockrelease-token-pool accounts...
+INFO [2026-06-15 11:05:01.719 +0530]: Starting deriveAccounts command
+    command: "derive-accounts"
+    programType: "lockrelease-token-pool"
+    programId: "8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC"
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
+
 📊 Derived Accounts:
 
 1. Pool State PDA
-   Address: 9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1
+   Address: 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R
    Seeds: ["ccip_tokenpool_config", mint]
-   Bump: 254
+   Bump: 252
    Description: Main pool configuration account (created by initialize-pool)
 
 2. Pool Signer PDA
-   Address: E8odUv4V4DXy3RWvkNYF7H33X9J56RtsFp4ExVXB86UA
+   Address: 5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk
    Seeds: ["ccip_tokenpool_signer", mint]
-   Bump: 253
+   Bump: 255
    Description: 🎯 CRITICAL: Autonomous liquidity authority for cross-chain operations
 
 3. Global Config PDA
@@ -824,18 +929,18 @@ pnpm bs58 utils \
    Description: Program-wide configuration settings
 
 4. Pool Token ATA
-   Address: A57bH91QkGuARh37JTN41fd3Vwcmf2bLzVHAVPB8Gaeg
+   Address: GQ4md7wUKmU35m4munp8giYg9osXCTaGVCPvNYzz8Wnu
    Seeds: [mint, pool_signer_pda, token_program]
    Description: Pool's token account (holds liquidity, owned by Pool Signer PDA)
 
 🎯 CRITICAL ADDRESS FOR CROSS-CHAIN OPERATIONS:
-   Pool Signer PDA: E8odUv4V4DXy3RWvkNYF7H33X9J56RtsFp4ExVXB86UA
+   Pool Signer PDA: 5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk
    ↳ This address signs token transfers for lock/release operations autonomously
 
-INFO [2025-09-17 16:40:21.923 +0200]: Detected SPL Token v1
-    mint: "FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1"
+INFO [2026-06-15 11:05:01.974 +0530]: Detected SPL Token v1
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
     programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-INFO [2025-09-17 16:40:21.927 +0200]: ✅ Account derivation completed successfully
+INFO [2026-06-15 11:05:01.975 +0530]: ✅ Account derivation completed successfully
     command: "derive-accounts"
 ```
 
@@ -867,8 +972,8 @@ echo "Pool Signer PDA: $SOL_POOL_SIGNER_PDA"
 <Fragment slot="panel.2">
 
 ```bash
-Pool Address: 9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1
-Pool Signer PDA: E8odUv4V4DXy3RWvkNYF7H33X9J56RtsFp4ExVXB86UA
+Pool Address: 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R
+Pool Signer PDA: 5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk
 ```
 
 </Fragment>
@@ -893,7 +998,7 @@ The [owner_propose_administrator](/ccip/concepts/cross-chain-token/svm/registrat
 ```bash
 # Generate administrator registration transaction
 pnpm bs58 router --env devnet --instruction owner-propose-administrator \
-  --program-id $CCIP_ROUTER_PROGRAM \
+  --program-id $SOL_CCIP_ROUTER \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --token-admin-registry-admin $SOL_SQUAD_VAULT_MULTISIG
@@ -904,44 +1009,62 @@ pnpm bs58 router --env devnet --instruction owner-propose-administrator \
 <Fragment slot="panel.2">
 
 ```bash
-  ✅ Transaction simulation completed
+🔄 Generating owner_propose_administrator transaction...
+🔄 Building and simulating transaction...
 🎯 COPY TRANSACTION DATA BELOW:
 
-jCi2q3RM6PzJZRhgUPyQh5bBo2juVuAMP2tXHnkmWowRbPHPuj17pStYamZxaECph64DmPGfSgiRQMDmgfUVazKHuFU5h9nh2oCuNfKXLLLdibzfMsX9sbNNCn61mus8Kdsq3xEjUsRbyHdPXLtQx7RCawpziJjXXgEB33xeFAbgzckm2fNaPE3ZkZpAF4XqT8jbHC3fr3Lq8QNfJMjStHEtRqMXhPG8VombmBZpRuSj4ynXNg3V85xF1ti6Epfbk2QHDwD6NogzBhnoReLbmDQDVZyayNsreKQUTSDWawPuUVvBfR9hab3f58d5gKA1kvmoJ8Avik2svbALGvV595PujEyuqsxSGYuoJcGSwmzXfbqofxN2hJihz
+jCi2zBJS8zFbgd7FMisv8MxZKac472KQX9mA3dgncufisCZ1WnkPpR9ACfrdsjsipfVyWKdLD7UUpytH5k6W8FRxAivmpD1eZdVNgf9qPa4VBvqvcx1jZrhknVLb4PTHEv8viQfRCxVswJ1Rr7jJkjzHR5iidyhrvKPVFKCx5rjwDCkW6n1nrXdmPZfwRB6hddyvJN9GsKsaKfhijsjp8jymujoLbfFh3FJ4MMH65EgQq8EzFvd7pt9JAcg61AY9LnchMcwEn9KhpQ1Pcx57nQ6tqm5QrCa4UZFvkZNhP62Xd71QgH5EuWHnygXwyN18ZujtTXgDTXUeMjcu7pP99tzLHSSk2cuBQC1qcqWbN2BE6ubCwkn7JZgv7
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-17 16:42:02.556 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 11:07:11.775 +0530]: Transaction built successfully
     instructionName: "router.owner_propose_administrator"
     transactionSize: "277 bytes"
     base58Length: "377 characters"
     hexLength: "554 characters"
     accountCount: 5
     signerCount: 1
-    computeUnits: 19785
-INFO [2025-09-17 16:42:02.556 +0200]: Completed buildTransaction (router.owner_propose_administrator)
-    durationMs: 428
-INFO [2025-09-17 16:42:02.556 +0200]:
-INFO [2025-09-17 16:42:02.556 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-17 16:42:02.556 +0200]:
-INFO [2025-09-17 16:42:02.556 +0200]: 📋 Transaction Details:
-INFO [2025-09-17 16:42:02.556 +0200]:    Instruction: router.owner_propose_administrator
-INFO [2025-09-17 16:42:02.556 +0200]:    Size: 277 bytes
-INFO [2025-09-17 16:42:02.556 +0200]:    Base58 length: 377 characters
-INFO [2025-09-17 16:42:02.578 +0200]:    Compute units: 19 785
-INFO [2025-09-17 16:42:02.578 +0200]:    Generated: 2025-09-17T14:42:02.552Z
-INFO [2025-09-17 16:42:02.578 +0200]:
-INFO [2025-09-17 16:42:02.578 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-17 16:42:02.578 +0200]:
-INFO [2025-09-17 16:42:02.579 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-17 16:42:02.579 +0200]:
-INFO [2025-09-17 16:42:02.579 +0200]: 📊 Account Information:
-INFO [2025-09-17 16:42:02.579 +0200]:    Total accounts: 5
-INFO [2025-09-17 16:42:02.579 +0200]:     1. 3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3 (read-only)
-INFO [2025-09-17 16:42:02.579 +0200]:     2. 89Jy2ZEz6LcvBPVQgR2YxPYVoF1sLugNRs3havQP8SvF (writable)
-INFO [2025-09-17 16:42:02.579 +0200]:     3. FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1 (read-only)
-INFO [2025-09-17 16:42:02.579 +0200]:     4. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-09-17 16:42:02.579 +0200]:     5. 11111111111111111111111111111111 (read-only)
-INFO [2025-09-17 16:42:02.579 +0200]:
+    computeUnits: 21231
+INFO [2026-06-15 11:07:11.775 +0530]: Completed buildTransaction (router.owner_propose_administrator)
+    durationMs: 413
+INFO [2026-06-15 11:07:11.775 +0530]:
+INFO [2026-06-15 11:07:11.775 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 11:07:11.775 +0530]:
+INFO [2026-06-15 11:07:11.776 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 11:07:11.776 +0530]:    Instruction: router.owner_propose_administrator
+INFO [2026-06-15 11:07:11.776 +0530]:    Size: 277 bytes
+INFO [2026-06-15 11:07:11.776 +0530]:    Base58 length: 377 characters
+INFO [2026-06-15 11:07:11.787 +0530]:    Compute units: 21,231
+INFO [2026-06-15 11:07:11.787 +0530]:    Generated: 2026-06-15T05:37:11.774Z
+INFO [2026-06-15 11:07:11.787 +0530]:
+INFO [2026-06-15 11:07:11.787 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 11:07:11.787 +0530]:
+INFO [2026-06-15 11:07:11.787 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 11:07:11.787 +0530]:
+INFO [2026-06-15 11:07:11.787 +0530]: 📊 Account Information:
+INFO [2026-06-15 11:07:11.787 +0530]:    Total accounts: 5
+INFO [2026-06-15 11:07:11.788 +0530]:     1. 3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3 (read-only)
+INFO [2026-06-15 11:07:11.788 +0530]:     2. 6gmKNyGtrSgB4gAH9yQyzXSPnDw1P5We9abZLEcuqdLY (writable)
+INFO [2026-06-15 11:07:11.788 +0530]:     3. 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li (read-only)
+INFO [2026-06-15 11:07:11.788 +0530]:     4. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 11:07:11.788 +0530]:     5. 11111111111111111111111111111111 (read-only)
+INFO [2026-06-15 11:07:11.788 +0530]:
+INFO [2026-06-15 11:07:11.788 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 11:07:11.788 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 11:07:11.788 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 11:07:11.788 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 11:07:11.788 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 11:07:11.788 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 11:07:11.788 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 11:07:11.788 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 11:07:11.788 +0530]:
+INFO [2026-06-15 11:07:11.788 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 11:07:11.788 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 11:07:11.788 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 11:07:11.788 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 11:07:11.788 +0530]:    • Estimated compute units: 21,231
+INFO [2026-06-15 11:07:11.788 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 11:07:11.788 +0530]:
 ```
 
 </Fragment>
@@ -952,9 +1075,9 @@ INFO [2025-09-17 16:42:02.579 +0200]:
 | Account | Address                                        | Description                                                           |
 | ------- | ---------------------------------------------- | --------------------------------------------------------------------- |
 | **#1**  | `3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3` | Router Config PDA (read-only)                                         |
-| **#2**  | `89Jy2ZEz6LcvBPVQgR2YxPYVoF1sLugNRs3havQP8SvF` | **🎯 Token Admin Registry PDA** - Gets created/updated for your token |
-| **#3**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | Token Mint (your token)                                               |
-| **#4**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | Authority/Payer (your Squad vault)                                    |
+| **#2**  | `6gmKNyGtrSgB4gAH9yQyzXSPnDw1P5We9abZLEcuqdLY` | **🎯 Token Admin Registry PDA** - Gets created/updated for your token |
+| **#3**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | Token Mint (your token)                                               |
+| **#4**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | Authority/Payer (your Squad vault)                                    |
 | **#5**  | `11111111111111111111111111111111`             | System Program                                                        |
 
 **What This Transaction Does:**
@@ -964,8 +1087,7 @@ This transaction proposes your Squad vault as the administrator for your token i
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add
-  instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
@@ -987,7 +1109,7 @@ The [accept_admin_role](/ccip/concepts/cross-chain-token/svm/registration-admini
 ```bash
 # Generate administrator role acceptance transaction
 pnpm bs58 router --env devnet --instruction accept-admin-role \
-  --program-id $CCIP_ROUTER_PROGRAM \
+  --program-id $SOL_CCIP_ROUTER \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG
 ```
@@ -997,43 +1119,61 @@ pnpm bs58 router --env devnet --instruction accept-admin-role \
 <Fragment slot="panel.2">
 
 ```bash
-   ✅ Transaction simulation completed
+🔄 Generating accept_admin_role_token_admin_registry transaction...
+🔄 Building and simulating transaction...
 🎯 COPY TRANSACTION DATA BELOW:
 
-2sM9hLJFuca8kadhK5vj9XrhMwgVdMHbbADrgprG7i6MGad9gW77P1GykbXWFHZMgLuXRqHZNCFumDUkDTGwiDdwSZkPyLa44mxqbg2PtBMzs7E8qm1JuieV5mZ8myN3ZC7ASf4wgXs1moDw622fbkM2YZzdEemu8Mkqym1jFzZBirSrFW69JHNcoPp6B2AaCVva59QCZqZWHE89MUn6Xz3C7y9bABQ4SWLsccNa96vdz97adb7TRGPxymekVMZwUq3FwifWoaUBbiKFXRxNwMXsUSZ7kiUbX
+2sM9hjkg4Y6d1pD6Zqca74vGeRSLBrpBnGsxsjPpmpcutTVk3mPUo5a2rkHQ1Tczom98LHWkwGVawktU7joRQPsQKBVmuwM9sdTHVQgotqnqdFrpS3eSmkWmynoD64ZpLAEsnHL4Zfi45sZBejE3hndCxJhxHQW8S2PFvp2Sqx1UecmdCDezA9FAbqtr4jHvLb5iFVyBBiuMLJ35BZHVDtumB4iPQmUrMRV5maj9VL6isz7AfoYk1URg6fu2WueF51cSQzUYg2VWBUyS1hHECxDpqC6Xq2Pvu
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-17 16:43:58.884 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 11:10:48.094 +0530]: Transaction built successfully
     instructionName: "router.accept_admin_role_token_admin_registry"
     transactionSize: "212 bytes"
     base58Length: "289 characters"
     hexLength: "424 characters"
     accountCount: 4
     signerCount: 1
-    computeUnits: 15454
-INFO [2025-09-17 16:43:58.884 +0200]: Completed buildTransaction (router.accept_admin_role_token_admin_registry)
-    durationMs: 420
-INFO [2025-09-17 16:43:58.884 +0200]:
-INFO [2025-09-17 16:43:58.884 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-17 16:43:58.884 +0200]:
-INFO [2025-09-17 16:43:58.884 +0200]: 📋 Transaction Details:
-INFO [2025-09-17 16:43:58.884 +0200]:    Instruction: router.accept_admin_role_token_admin_registry
-INFO [2025-09-17 16:43:58.884 +0200]:    Size: 212 bytes
-INFO [2025-09-17 16:43:58.884 +0200]:    Base58 length: 289 characters
-INFO [2025-09-17 16:43:58.896 +0200]:    Compute units: 15 454
-INFO [2025-09-17 16:43:58.896 +0200]:    Generated: 2025-09-17T14:43:58.883Z
-INFO [2025-09-17 16:43:58.896 +0200]:
-INFO [2025-09-17 16:43:58.896 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-17 16:43:58.896 +0200]:
-INFO [2025-09-17 16:43:58.897 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-17 16:43:58.897 +0200]:
-INFO [2025-09-17 16:43:58.897 +0200]: 📊 Account Information:
-INFO [2025-09-17 16:43:58.897 +0200]:    Total accounts: 4
-INFO [2025-09-17 16:43:58.897 +0200]:     1. 3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3 (read-only)
-INFO [2025-09-17 16:43:58.897 +0200]:     2. 89Jy2ZEz6LcvBPVQgR2YxPYVoF1sLugNRs3havQP8SvF (writable)
-INFO [2025-09-17 16:43:58.897 +0200]:     3. FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1 (read-only)
-INFO [2025-09-17 16:43:58.897 +0200]:     4. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-09-17 16:43:58.897 +0200]:
+    computeUnits: 16954
+INFO [2026-06-15 11:10:48.094 +0530]: Completed buildTransaction (router.accept_admin_role_token_admin_registry)
+    durationMs: 345
+INFO [2026-06-15 11:10:48.094 +0530]:
+INFO [2026-06-15 11:10:48.094 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 11:10:48.094 +0530]:
+INFO [2026-06-15 11:10:48.094 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 11:10:48.094 +0530]:    Instruction: router.accept_admin_role_token_admin_registry
+INFO [2026-06-15 11:10:48.094 +0530]:    Size: 212 bytes
+INFO [2026-06-15 11:10:48.094 +0530]:    Base58 length: 289 characters
+INFO [2026-06-15 11:10:48.103 +0530]:    Compute units: 16,954
+INFO [2026-06-15 11:10:48.103 +0530]:    Generated: 2026-06-15T05:40:48.094Z
+INFO [2026-06-15 11:10:48.103 +0530]:
+INFO [2026-06-15 11:10:48.103 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 11:10:48.103 +0530]:
+INFO [2026-06-15 11:10:48.103 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 11:10:48.103 +0530]:
+INFO [2026-06-15 11:10:48.103 +0530]: 📊 Account Information:
+INFO [2026-06-15 11:10:48.103 +0530]:    Total accounts: 4
+INFO [2026-06-15 11:10:48.103 +0530]:     1. 3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3 (read-only)
+INFO [2026-06-15 11:10:48.103 +0530]:     2. 6gmKNyGtrSgB4gAH9yQyzXSPnDw1P5We9abZLEcuqdLY (writable)
+INFO [2026-06-15 11:10:48.103 +0530]:     3. 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li (read-only)
+INFO [2026-06-15 11:10:48.103 +0530]:     4. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 11:10:48.103 +0530]:
+INFO [2026-06-15 11:10:48.103 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 11:10:48.103 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 11:10:48.103 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 11:10:48.103 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 11:10:48.103 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 11:10:48.103 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 11:10:48.103 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 11:10:48.103 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 11:10:48.103 +0530]:
+INFO [2026-06-15 11:10:48.103 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 11:10:48.103 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 11:10:48.103 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 11:10:48.103 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 11:10:48.103 +0530]:    • Estimated compute units: 16,954
+INFO [2026-06-15 11:10:48.103 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 11:10:48.103 +0530]:
 ```
 
 </Fragment>
@@ -1044,9 +1184,9 @@ INFO [2025-09-17 16:43:58.897 +0200]:
 | Account | Address                                        | Description                                                  |
 | ------- | ---------------------------------------------- | ------------------------------------------------------------ |
 | **#1**  | `3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3` | Router Config PDA (read-only)                                |
-| **#2**  | `89Jy2ZEz6LcvBPVQgR2YxPYVoF1sLugNRs3havQP8SvF` | **🎯 Token Admin Registry PDA** - Updates status to "active" |
-| **#3**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | Token Mint (your token)                                      |
-| **#4**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | Authority (your Squad vault - must be pending admin)         |
+| **#2**  | `6gmKNyGtrSgB4gAH9yQyzXSPnDw1P5We9abZLEcuqdLY` | **🎯 Token Admin Registry PDA** - Updates status to "active" |
+| **#3**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | Token Mint (your token)                                      |
+| **#4**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | Authority (your Squad vault - must be pending admin)         |
 
 **What This Transaction Does:**
 This is the **acceptance step** of the two-phase administrator registration. It updates the Token Admin Registry PDA (Account #2) from "pending administrator" to "active administrator" status. Your Squad vault explicitly accepts the administrator role, completing the secure registration process.
@@ -1057,8 +1197,7 @@ This is the **acceptance step** of the two-phase administrator registration. It 
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add
-  instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
@@ -1093,9 +1232,9 @@ spl-token create-account $SOL_TOKEN_MINT \
 <Fragment slot="panel.2">
 
 ```bash
-Creating account G7yVJJKDRBQDdbFttmA3G3oytFKBcsZH8VMdJWBXJKJB
+Creating account ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV
 
-Signature: 5pdDVU5gM9jmHy39HZjus4gGwZdRszmRYCuArikNok65dFcapEXgYJHexgvDKQkFgV4NzKXmQ2Fmgk2NASNgPGdB
+Signature: 5xxjavr2f6D9ptHUjJZYFzF91srb5yTSJWKcBh98h5vkMa6TmBf6KBzPKaKsztHjAfcvERPqbKKGhfHDrEGnampT
 ```
 
 </Fragment>
@@ -1103,7 +1242,7 @@ Signature: 5pdDVU5gM9jmHy39HZjus4gGwZdRszmRYCuArikNok65dFcapEXgYJHexgvDKQkFgV4Nz
 
 **Transaction Details:**
 
-- **Squad Vault ATA**: `G7yVJJKDRBQDdbFttmA3G3oytFKBcsZH8VMdJWBXJKJB` (example)
+- **Squad Vault ATA**: `ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV` (example)
 - **Owner**: Squad vault PDA
 
 ### Step 7: Mint Tokens for Pool Liquidity
@@ -1137,46 +1276,62 @@ pnpm bs58 spl-token --env devnet --instruction mint \
 <Fragment slot="panel.2">
 
 ```bash
-INFO [2025-09-18 09:33:52.996 +0200]: Detected SPL Token v1
-    mint: "FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1"
+INFO [2026-06-15 11:21:30.200 +0530]: Detected SPL Token v1
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
     programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-INFO [2025-09-18 09:33:53.356 +0200]: 🔄 Building and simulating transaction...
+INFO [2026-06-15 11:21:30.290 +0530]: 🔄 Building and simulating transaction...
 🎯 COPY TRANSACTION DATA BELOW:
 
-7HigstJQ54Hujv6W7j2KzbrADP2y2tsFY4tKdu4ZtzFMND8JksgYRQbY364Zcqwxn2FyCEZ4AsL9AoT25MBtMJnufiVRcsXY9KAm1qGXWXGZnAdPwANmRmiV4zXRxzdDSjfZhFDHU1Vze2m8YBZnuwGcJ8uV8quBVZB3CnWMDXAfioQNuAx8rFTHRhRbqUUgCStZUuGQHZ2xFMumiz2rynKSgSLAtvKmDSVALDb4zo34ej6CgAupK
+7HiguFFy8Up6ikfD5XFMWRS8tAY37NMhxqxLDSoy9TXw5QYqts51axhou7aS1omxCiYzP3nxYwhBhdKUNupFWzx6Lu8eszawPLG2CVJX9fuAaXpZPd4jPsBTGNHpg2WvZ6MjZ29g7fnWWBnjpyMD3QjB4yFkFRh1LjYYAjbkq2pdgHdZgMpX6FKrmsFYPenpn1XbGV6YXLRFefN5XFj5SBuf478hDcjcjEY8CPK9mkrgNHnjP3HRZ
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-18 09:33:53.856 +0200]: Transaction built successfully
+INFO [2026-06-15 11:21:30.464 +0530]: Transaction built successfully
     instructionName: "spl.mint"
     transactionSize: "180 bytes"
     base58Length: "245 characters"
     hexLength: "360 characters"
     accountCount: 3
     signerCount: 1
-    computeUnits: 4537
-INFO [2025-09-18 09:33:53.856 +0200]: Completed buildTransaction (spl.mint)
-    durationMs: 500
-INFO [2025-09-18 09:33:53.856 +0200]: ✅ Transaction simulation completed
-INFO [2025-09-18 09:33:53.856 +0200]:
-INFO [2025-09-18 09:33:53.856 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-18 09:33:53.856 +0200]:
-INFO [2025-09-18 09:33:53.856 +0200]: 📋 Transaction Details:
-INFO [2025-09-18 09:33:53.856 +0200]:    Instruction: spl.mint
-INFO [2025-09-18 09:33:53.856 +0200]:    Size: 180 bytes
-INFO [2025-09-18 09:33:53.856 +0200]:    Base58 length: 245 characters
-INFO [2025-09-18 09:33:53.878 +0200]:    Compute units: 4 537
-INFO [2025-09-18 09:33:53.878 +0200]:    Generated: 2025-09-18T07:33:53.855Z
-INFO [2025-09-18 09:33:53.878 +0200]:
-INFO [2025-09-18 09:33:53.878 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-18 09:33:53.878 +0200]:
-INFO [2025-09-18 09:33:53.878 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-18 09:33:53.878 +0200]:
-INFO [2025-09-18 09:33:53.878 +0200]: 📊 Account Information:
-INFO [2025-09-18 09:33:53.878 +0200]:    Total accounts: 3
-INFO [2025-09-18 09:33:53.878 +0200]:     1. FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1 (writable)
-INFO [2025-09-18 09:33:53.878 +0200]:     2. G7yVJJKDRBQDdbFttmA3G3oytFKBcsZH8VMdJWBXJKJB (writable)
-INFO [2025-09-18 09:33:53.878 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer)
-INFO [2025-09-18 09:33:53.878 +0200]:
+    computeUnits: 120
+INFO [2026-06-15 11:21:30.464 +0530]: Completed buildTransaction (spl.mint)
+    durationMs: 175
+INFO [2026-06-15 11:21:30.464 +0530]:
+INFO [2026-06-15 11:21:30.464 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 11:21:30.464 +0530]:
+INFO [2026-06-15 11:21:30.464 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 11:21:30.464 +0530]:    Instruction: spl.mint
+INFO [2026-06-15 11:21:30.465 +0530]:    Size: 180 bytes
+INFO [2026-06-15 11:21:30.465 +0530]:    Base58 length: 245 characters
+INFO [2026-06-15 11:21:30.473 +0530]:    Compute units: 120
+INFO [2026-06-15 11:21:30.473 +0530]:    Generated: 2026-06-15T05:51:30.464Z
+INFO [2026-06-15 11:21:30.473 +0530]:
+INFO [2026-06-15 11:21:30.473 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 11:21:30.473 +0530]:
+INFO [2026-06-15 11:21:30.473 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 11:21:30.473 +0530]:
+INFO [2026-06-15 11:21:30.473 +0530]: 📊 Account Information:
+INFO [2026-06-15 11:21:30.473 +0530]:    Total accounts: 3
+INFO [2026-06-15 11:21:30.473 +0530]:     1. 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li (writable)
+INFO [2026-06-15 11:21:30.473 +0530]:     2. ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV (writable)
+INFO [2026-06-15 11:21:30.473 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer)
+INFO [2026-06-15 11:21:30.473 +0530]:
+INFO [2026-06-15 11:21:30.473 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 11:21:30.473 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 11:21:30.473 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 11:21:30.473 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 11:21:30.473 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 11:21:30.473 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 11:21:30.473 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 11:21:30.473 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 11:21:30.473 +0530]:
+INFO [2026-06-15 11:21:30.473 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 11:21:30.473 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 11:21:30.473 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 11:21:30.473 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 11:21:30.473 +0530]:    • Estimated compute units: 120
+INFO [2026-06-15 11:21:30.473 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 11:21:30.473 +0530]:
+INFO [2026-06-15 11:21:30.473 +0530]: ✅ Transaction simulation completed
 ```
 
 </Fragment>
@@ -1186,9 +1341,9 @@ INFO [2025-09-18 09:33:53.878 +0200]:
 
 | Account | Address                                        | Description                                        |
 | ------- | ---------------------------------------------- | -------------------------------------------------- |
-| **#1**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | **Token Mint** (writable - supply updated)         |
-| **#2**  | `G7yVJJKDRBQDdbFttmA3G3oytFKBcsZH8VMdJWBXJKJB` | **Squad vault's ATA** (writable - receives tokens) |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer)                           |
+| **#1**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | **Token Mint** (writable - supply updated)         |
+| **#2**  | `ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV` | **Squad vault's ATA** (writable - receives tokens) |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer)                           |
 
 **What This Transaction Does:**
 This is a standard SPL token mint operation that mints tokens for the Squad vault to use as liquidity for the LockRelease pool. Since the Squad vault retains mint authority, it can directly mint tokens without requiring multisig operations.
@@ -1211,7 +1366,7 @@ This is a standard SPL token mint operation that mints tokens for the Squad vaul
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -1240,7 +1395,7 @@ Configure the Squad vault as the rebalancer for the LockRelease pool. The rebala
 pnpm bs58 lockrelease-token-pool \
   --env devnet \
   --instruction set-rebalancer \
-  --program-id $CCIP_POOL_PROGRAM \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --rebalancer $SOL_SQUAD_VAULT_MULTISIG
@@ -1251,41 +1406,81 @@ pnpm bs58 lockrelease-token-pool \
 <Fragment slot="panel.2">
 
 ```bash
+🔄 Generating setRebalancer transaction...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC
+   Mint: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
+   Authority (Pool Owner): AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+   New Rebalancer: AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-15 11:24:22.268 +0530]: Starting setRebalancer command
+    command: "lockrelease.set-rebalancer"
+    programId: "8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC"
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
+    authority: "AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB"
+    rebalancer: "AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
 🎯 COPY TRANSACTION DATA BELOW:
 
-RYjPmsuLnHHYWtrvFZ6PMPQQmTA7RBMDoijaBaAdrADSaYTbJZot5TX7vFMp74a8iV3yxPJnpJQhbzDGGceVTEQs91WY9fquwqobjPEu6GZmxkxpr1VpYx1c3NScVNSE3Qr6cw2RTka2hdsFrBQAFrSHzcTCprL8UovLCd82dNcRvJapo7Us2FgwGAJ97JyKYCWqPSRBJbjbq5ZnNDAPi9nDzGopuV9UFZb9rC5q1xmhnF2Gn3nTwAPGh4GJF6JgFZJ23Ct2A2yz3LP31S6QD8uDrYszq1n
+RYjPsC84gHPwuTMJAxAgTyHuRTaFgvyy764CBhKPpvJ7X7fup3iMbf8i31ytbws4P3KC9rNJB4cqCCbXxfeRuKRp7aG8DVSFP1JJY2B3mzARKtvBgkkYMc3hg9iYLdMW2q7V2MBBu7XG7BRiVRDL7PTnzKeq9cvrxPJMvGVikTfjPvgeCAmHcZGXqRAsTbDNspQHxzmo1k7o8qMdEp7tY9G9r9FM1PrwAzVHvSuygz3NZibc2X7vyKws2HxzaiU6Q6R8aXs9MCoJtaXbqZm9ZTMT7TApHKR
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-18 09:04:43.213 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 11:24:22.691 +0530]: Transaction built successfully
     instructionName: "setRebalancer"
     transactionSize: "211 bytes"
     base58Length: "287 characters"
     hexLength: "422 characters"
     accountCount: 3
     signerCount: 1
-    computeUnits: 8420
-INFO [2025-09-18 09:04:43.213 +0200]: Completed buildTransaction (setRebalancer)
-    durationMs: 1026
-INFO [2025-09-18 09:04:43.214 +0200]:
-INFO [2025-09-18 09:04:43.214 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-18 09:04:43.214 +0200]:
-INFO [2025-09-18 09:04:43.214 +0200]: 📋 Transaction Details:
-INFO [2025-09-18 09:04:43.214 +0200]:    Instruction: setRebalancer
-INFO [2025-09-18 09:04:43.214 +0200]:    Size: 211 bytes
-INFO [2025-09-18 09:04:43.214 +0200]:    Base58 length: 287 characters
-INFO [2025-09-18 09:04:43.231 +0200]:    Compute units: 8 420
-INFO [2025-09-18 09:04:43.231 +0200]:    Generated: 2025-09-18T07:04:43.213Z
-INFO [2025-09-18 09:04:43.231 +0200]:
-INFO [2025-09-18 09:04:43.231 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-18 09:04:43.231 +0200]:
-INFO [2025-09-18 09:04:43.231 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-18 09:04:43.231 +0200]:
-INFO [2025-09-18 09:04:43.231 +0200]: 📊 Account Information:
-INFO [2025-09-18 09:04:43.231 +0200]:    Total accounts: 3
-INFO [2025-09-18 09:04:43.231 +0200]:     1. 9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1 (writable)
-INFO [2025-09-18 09:04:43.231 +0200]:     2. FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1 (read-only)
-INFO [2025-09-18 09:04:43.231 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer)
-INFO [2025-09-18 09:04:43.231 +0200]:
+    computeUnits: 11419
+INFO [2026-06-15 11:24:22.691 +0530]: Completed buildTransaction (setRebalancer)
+    durationMs: 420
+INFO [2026-06-15 11:24:22.691 +0530]:
+INFO [2026-06-15 11:24:22.691 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 11:24:22.691 +0530]:
+INFO [2026-06-15 11:24:22.691 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 11:24:22.691 +0530]:    Instruction: setRebalancer
+INFO [2026-06-15 11:24:22.691 +0530]:    Size: 211 bytes
+INFO [2026-06-15 11:24:22.692 +0530]:    Base58 length: 287 characters
+INFO [2026-06-15 11:24:22.702 +0530]:    Compute units: 11,419
+INFO [2026-06-15 11:24:22.702 +0530]:    Generated: 2026-06-15T05:54:22.691Z
+INFO [2026-06-15 11:24:22.702 +0530]:
+INFO [2026-06-15 11:24:22.702 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 11:24:22.702 +0530]:
+INFO [2026-06-15 11:24:22.702 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 11:24:22.702 +0530]:
+INFO [2026-06-15 11:24:22.702 +0530]: 📊 Account Information:
+INFO [2026-06-15 11:24:22.702 +0530]:    Total accounts: 3
+INFO [2026-06-15 11:24:22.703 +0530]:     1. 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R (writable)
+INFO [2026-06-15 11:24:22.703 +0530]:     2. 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li (read-only)
+INFO [2026-06-15 11:24:22.703 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer)
+INFO [2026-06-15 11:24:22.703 +0530]:
+INFO [2026-06-15 11:24:22.703 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 11:24:22.703 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 11:24:22.703 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 11:24:22.703 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 11:24:22.703 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 11:24:22.703 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 11:24:22.703 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 11:24:22.703 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 11:24:22.703 +0530]:
+INFO [2026-06-15 11:24:22.703 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 11:24:22.703 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 11:24:22.703 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 11:24:22.703 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 11:24:22.703 +0530]:    • Estimated compute units: 11,419
+INFO [2026-06-15 11:24:22.703 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 11:24:22.703 +0530]:
+INFO [2026-06-15 11:24:22.703 +0530]: setRebalancer command completed successfully
+    command: "lockrelease.set-rebalancer"
+    transactionSize: "211 bytes"
+    computeUnits: 11419
 ```
 
 </Fragment>
@@ -1295,15 +1490,15 @@ INFO [2025-09-18 09:04:43.231 +0200]:
 
 | Account | Address                                        | Description                                  |
 | ------- | ---------------------------------------------- | -------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool state PDA** (writable)                |
-| **#2**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | **Token Mint** (read-only - your token mint) |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer)                     |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool state PDA** (writable)                |
+| **#2**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | **Token Mint** (read-only - your token mint) |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer)                     |
 
 <Aside type="note" title="Squads Execution Required">
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify rebalancer address matches your Squad vault
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -1335,9 +1530,9 @@ spl-token create-account $SOL_TOKEN_MINT \
 <Fragment slot="panel.2">
 
 ```bash
-Creating account A57bH91QkGuARh37JTN41fd3Vwcmf2bLzVHAVPB8Gaeg
+Creating account GQ4md7wUKmU35m4munp8giYg9osXCTaGVCPvNYzz8Wnu
 
-Signature: aXkYhnwBDk8wm2Ymc2SAmCbfVkC8beCfJZBfbJyhj3V4cTsYdU8V2fN3Cj35oBcEVn8BKwTJDyaE9QG93x3EEEt
+Signature: Civkv2vpxvNytAyPWkWjELa2FAqTH2zVTXgP6uvkPeKQ3B9K33tL83uzRxRFSbGgtJhwrc359wczaAdUGa2q4Af
 ```
 
 </Fragment>
@@ -1345,7 +1540,7 @@ Signature: aXkYhnwBDk8wm2Ymc2SAmCbfVkC8beCfJZBfbJyhj3V4cTsYdU8V2fN3Cj35oBcEVn8BK
 
 **Transaction Details:**
 
-- **Pool ATA**: `A57bH91QkGuARh37JTN41fd3Vwcmf2bLzVHAVPB8Gaeg` (example)
+- **Pool ATA**: `GQ4md7wUKmU35m4munp8giYg9osXCTaGVCPvNYzz8Wnu` (example)
 - **Owner**: Pool Signer PDA
 
 ### Step 10: Set Can Accept Liquidity
@@ -1369,7 +1564,7 @@ Configure the LockRelease pool to accept liquidity from the rebalancer. This set
 pnpm bs58 lockrelease-token-pool \
   --env devnet \
   --instruction set-can-accept-liquidity \
-  --program-id $CCIP_POOL_PROGRAM \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --allow true
@@ -1383,48 +1578,78 @@ pnpm bs58 lockrelease-token-pool \
 🔄 Generating setCanAcceptLiquidity transaction...
    RPC URL: https://api.devnet.solana.com
    Program ID: 8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC
-   Mint: FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1
-   Authority (Pool Owner): 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY
+   Mint: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
+   Authority (Pool Owner): AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
    Allow Liquidity: true
 ⚙️  Building transaction instruction...
    ✅ Instruction built successfully
 🔄 Building and simulating transaction...
-   ✅ Transaction simulation completed
+INFO [2026-06-15 11:28:18.773 +0530]: Starting setCanAcceptLiquidity command
+    command: "lockrelease.set-can-accept-liquidity"
+    programId: "8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC"
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
+    authority: "AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB"
+    allow: "true"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
 🎯 COPY TRANSACTION DATA BELOW:
 
-7Hj1bhWRhKR5W7YP8TbaTcGKiNTisZtdxfinXNypECf1twL34v3Ai2YdJkEqCF2rSZWAFgagJ2pVQMz67hypz75R1VhwPdj2jVhCiXByBWXA4Sn1YvPVBtr2gAc3anvu4joRrSzYQQwxPYrT48Ji5rkf728vwz7smZG36qyeHQ3R5L2XfA6FGHXuznpLZKf3yGQtm6sUxy6b6iK7xqhALjYDmBmVMtTy33uKmuZAuwxPorrMEwHUc
+7Hj1d4TzkjwGUx766FpbyRrJP9xnx3P6PSno6vjDUfwbc8kaNqeBU6Vn4q4233gyV9qdtsCPEUxQpy2vSrHKJhtqvKLWXUVLWLun2QGv7KsQPZthEW4WLXrmeWSfMZLT6HrtxcQ36NUwHhkcBEhT995qkch2ygYq2FFhZMhmDp17PnMQNgN7wSSkaQrAak4mLSYbkQPTuiVdQTU7j4ECo5HTLutcx1qbx6FGPzVvRCHQ1DfBzSv6t
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-18 09:43:34.382 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 11:28:19.113 +0530]: Transaction built successfully
     instructionName: "setCanAcceptLiquidity"
     transactionSize: "180 bytes"
     base58Length: "245 characters"
     hexLength: "360 characters"
     accountCount: 3
     signerCount: 1
-    computeUnits: 8382
-INFO [2025-09-18 09:43:34.382 +0200]: Completed buildTransaction (setCanAcceptLiquidity)
-    durationMs: 1156
-INFO [2025-09-18 09:43:34.382 +0200]:
-INFO [2025-09-18 09:43:34.382 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-18 09:43:34.382 +0200]:
-INFO [2025-09-18 09:43:34.382 +0200]: 📋 Transaction Details:
-INFO [2025-09-18 09:43:34.382 +0200]:    Instruction: setCanAcceptLiquidity
-INFO [2025-09-18 09:43:34.382 +0200]:    Size: 180 bytes
-INFO [2025-09-18 09:43:34.382 +0200]:    Base58 length: 245 characters
-INFO [2025-09-18 09:43:34.395 +0200]:    Compute units: 8 382
-INFO [2025-09-18 09:43:34.395 +0200]:    Generated: 2025-09-18T07:43:34.381Z
-INFO [2025-09-18 09:43:34.395 +0200]:
-INFO [2025-09-18 09:43:34.395 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-18 09:43:34.395 +0200]:
-INFO [2025-09-18 09:43:34.395 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-18 09:43:34.395 +0200]:
-INFO [2025-09-18 09:43:34.395 +0200]: 📊 Account Information:
-INFO [2025-09-18 09:43:34.395 +0200]:    Total accounts: 3
-INFO [2025-09-18 09:43:34.395 +0200]:     1. 9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1 (writable)
-INFO [2025-09-18 09:43:34.395 +0200]:     2. FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1 (read-only)
-INFO [2025-09-18 09:43:34.395 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer)
-INFO [2025-09-18 09:43:34.395 +0200]:
+    computeUnits: 11382
+INFO [2026-06-15 11:28:19.113 +0530]: Completed buildTransaction (setCanAcceptLiquidity)
+    durationMs: 336
+INFO [2026-06-15 11:28:19.113 +0530]:
+INFO [2026-06-15 11:28:19.113 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 11:28:19.113 +0530]:
+INFO [2026-06-15 11:28:19.113 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 11:28:19.113 +0530]:    Instruction: setCanAcceptLiquidity
+INFO [2026-06-15 11:28:19.113 +0530]:    Size: 180 bytes
+INFO [2026-06-15 11:28:19.113 +0530]:    Base58 length: 245 characters
+INFO [2026-06-15 11:28:19.123 +0530]:    Compute units: 11,382
+INFO [2026-06-15 11:28:19.123 +0530]:    Generated: 2026-06-15T05:58:19.112Z
+INFO [2026-06-15 11:28:19.123 +0530]:
+INFO [2026-06-15 11:28:19.123 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 11:28:19.123 +0530]:
+INFO [2026-06-15 11:28:19.124 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 11:28:19.124 +0530]:
+INFO [2026-06-15 11:28:19.124 +0530]: 📊 Account Information:
+INFO [2026-06-15 11:28:19.124 +0530]:    Total accounts: 3
+INFO [2026-06-15 11:28:19.124 +0530]:     1. 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R (writable)
+INFO [2026-06-15 11:28:19.124 +0530]:     2. 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li (read-only)
+INFO [2026-06-15 11:28:19.124 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer)
+INFO [2026-06-15 11:28:19.124 +0530]:
+INFO [2026-06-15 11:28:19.124 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 11:28:19.124 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 11:28:19.124 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 11:28:19.124 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 11:28:19.124 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 11:28:19.124 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 11:28:19.124 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 11:28:19.124 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 11:28:19.124 +0530]:
+INFO [2026-06-15 11:28:19.124 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 11:28:19.124 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 11:28:19.124 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 11:28:19.124 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 11:28:19.124 +0530]:    • Estimated compute units: 11,382
+INFO [2026-06-15 11:28:19.124 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 11:28:19.124 +0530]:
+INFO [2026-06-15 11:28:19.124 +0530]: setCanAcceptLiquidity command completed successfully
+    command: "lockrelease.set-can-accept-liquidity"
+    transactionSize: "180 bytes"
+    computeUnits: 11382
 ```
 
 </Fragment>
@@ -1434,9 +1659,9 @@ INFO [2025-09-18 09:43:34.395 +0200]:
 
 | Account | Address                                        | Description                                           |
 | ------- | ---------------------------------------------- | ----------------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool State PDA** (writable - configuration updated) |
-| **#2**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | **Token Mint** (read-only)                            |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer - pool owner authority)       |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool State PDA** (writable - configuration updated) |
+| **#2**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | **Token Mint** (read-only)                            |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer - pool owner authority)       |
 
 **Transaction Flow:**
 
@@ -1448,7 +1673,7 @@ INFO [2025-09-18 09:43:34.395 +0200]:
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify the liquidity acceptance setting is enabled
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -1488,51 +1713,90 @@ pnpm bs58 spl-token \
 <Fragment slot="panel.2">
 
 ```bash
-🔗 Validating RPC connectivity...
-INFO [2025-09-18 10:31:23.250 +0200]: Starting approve command
-    command: "spl-token.approve"
-    mint: "FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1"
-    delegate: "E8odUv4V4DXy3RWvkNYF7H33X9J56RtsFp4ExVXB86UA"
-    authority: "59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY"
-    amount: "50000000000"
-   ✅ RPC connection verified
 🔍 Detecting token program...
+INFO [2026-06-15 11:31:07.585 +0530]: Starting approve command
+    command: "spl-token.approve"
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
+    delegate: "5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk"
+    authority: "AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB"
+    amount: "50000000000"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
    ✅ Detected token program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
 🔍 Auto-deriving Associated Token Account...
-   ✅ Derived ATA: G7yVJJKDRBQDdbFttmA3G3oytFKBcsZH8VMdJWBXJKJB
+   ✅ Derived ATA: ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV
 🔄 Generating approve transaction...
-   ✅ Transaction simulation completed
+   RPC URL: https://api.devnet.solana.com
+   Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+   Mint: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
+   Token Account: ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV
+   Delegate: 5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk
+   Authority (Token Account Owner): AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+   Amount: 50000000000
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-15 11:31:08.052 +0530]: Detected SPL Token v1
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
 🎯 COPY TRANSACTION DATA BELOW:
 
-7Hj1bhWRhKR5W7YP8TbaTcGKiNTisZtdxfinXNypECf1twL3AQR2en5q8KUf724VbhaHMbSoTXeSe48z4V13fJ6A8JSSdihBt7KZ5UebTx44jyQwdjSXAkFSyJAE8cbC1SxaZdav5G836vhVzmP8ZPG8BcNofTzRBkEw6YdhSvZHXveZhC6fwJFmUFNacJ8z1VJdNGLPNhQwVTNV1Cd1ApdNKSxEhbKyiN6EQxhaJP6CnKFCusR1q
+7Hj1d4TzkjwGUx766FpbyRrJP9xnx3P6PSno6vjDUfwbc8kaPi2QHGGm9V1gfhFbzuhJi3tcjBEQJ5ryCG8vF4cQVmja4Mvj2veFeCcXjzPXw6WHtmdRiQKJHkCTpT1PHLDTeHKki1BeYKENWyjNuQC17P5EPNsPzjyzXjNgGooYN59knGd9tfyS2CNTQWP9jGGry4c6rEcYTPTcM9Ji8xkEC4dqhV216xxPtZLQ5ad3QsycLUFpT
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-18 10:31:25.343 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 11:31:08.211 +0530]: Transaction built successfully
     instructionName: "approve"
     transactionSize: "180 bytes"
     base58Length: "245 characters"
     hexLength: "360 characters"
     accountCount: 3
     signerCount: 1
-    computeUnits: 2903
-INFO [2025-09-18 10:31:25.343 +0200]: Completed buildTransaction (approve)
-    durationMs: 510
-INFO [2025-09-18 10:31:25.343 +0200]: ✅ Transaction simulation completed
-INFO [2025-09-18 10:31:25.343 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-18 10:31:25.343 +0200]: 📋 Transaction Details:
-INFO [2025-09-18 10:31:25.343 +0200]:    Instruction: approve
-INFO [2025-09-18 10:31:25.343 +0200]:    Size: 180 bytes
-INFO [2025-09-18 10:31:25.343 +0200]:    Base58 length: 245 characters
-INFO [2025-09-18 10:31:25.364 +0200]:    Compute units: 2 903
-INFO [2025-09-18 10:31:25.364 +0200]:    Generated: 2025-09-18T08:31:25.341Z
-INFO [2025-09-18 10:31:25.364 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-18 10:31:25.364 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-18 10:31:25.364 +0200]: 📊 Account Information:
-INFO [2025-09-18 10:31:25.364 +0200]:    Total accounts: 3
-INFO [2025-09-18 10:31:25.364 +0200]:     1. G7yVJJKDRBQDdbFttmA3G3oytFKBcsZH8VMdJWBXJKJB (writable)
-INFO [2025-09-18 10:31:25.364 +0200]:     2. E8odUv4V4DXy3RWvkNYF7H33X9J56RtsFp4ExVXB86UA (read-only)
-INFO [2025-09-18 10:31:25.364 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer)
-INFO [2025-09-18 10:31:25.364 +0200]:
+    computeUnits: 123
+INFO [2026-06-15 11:31:08.211 +0530]: Completed buildTransaction (approve)
+    durationMs: 154
+INFO [2026-06-15 11:31:08.211 +0530]:
+INFO [2026-06-15 11:31:08.211 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 11:31:08.211 +0530]:
+INFO [2026-06-15 11:31:08.211 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 11:31:08.211 +0530]:    Instruction: approve
+INFO [2026-06-15 11:31:08.211 +0530]:    Size: 180 bytes
+INFO [2026-06-15 11:31:08.211 +0530]:    Base58 length: 245 characters
+INFO [2026-06-15 11:31:08.222 +0530]:    Compute units: 123
+INFO [2026-06-15 11:31:08.222 +0530]:    Generated: 2026-06-15T06:01:08.211Z
+INFO [2026-06-15 11:31:08.222 +0530]:
+INFO [2026-06-15 11:31:08.222 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 11:31:08.222 +0530]:
+INFO [2026-06-15 11:31:08.222 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 11:31:08.222 +0530]:
+INFO [2026-06-15 11:31:08.222 +0530]: 📊 Account Information:
+INFO [2026-06-15 11:31:08.222 +0530]:    Total accounts: 3
+INFO [2026-06-15 11:31:08.222 +0530]:     1. ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV (writable)
+INFO [2026-06-15 11:31:08.222 +0530]:     2. 5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk (read-only)
+INFO [2026-06-15 11:31:08.222 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer)
+INFO [2026-06-15 11:31:08.222 +0530]:
+INFO [2026-06-15 11:31:08.222 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 11:31:08.222 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 11:31:08.222 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 11:31:08.222 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 11:31:08.222 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 11:31:08.222 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 11:31:08.222 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 11:31:08.222 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 11:31:08.222 +0530]:
+INFO [2026-06-15 11:31:08.222 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 11:31:08.222 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 11:31:08.222 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 11:31:08.222 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 11:31:08.222 +0530]:    • Estimated compute units: 123
+INFO [2026-06-15 11:31:08.222 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 11:31:08.222 +0530]:
+INFO [2026-06-15 11:31:08.222 +0530]: approve command completed successfully
+    command: "spl-token.approve"
+    transactionSize: "180 bytes"
+    computeUnits: 123
 ```
 
 </Fragment>
@@ -1542,9 +1806,9 @@ INFO [2025-09-18 10:31:25.364 +0200]:
 
 | Account | Address                                        | Description                                         |
 | ------- | ---------------------------------------------- | --------------------------------------------------- |
-| **#1**  | `G7yVJJKDRBQDdbFttmA3G3oytFKBcsZH8VMdJWBXJKJB` | **Squad Vault ATA** (writable - delegation updated) |
-| **#2**  | `E8odUv4V4DXy3RWvkNYF7H33X9J56RtsFp4ExVXB86UA` | **Pool Signer PDA** (read-only - delegate)          |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer - token account owner)      |
+| **#1**  | `ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV` | **Squad Vault ATA** (writable - delegation updated) |
+| **#2**  | `5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk` | **Pool Signer PDA** (read-only - delegate)          |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer - token account owner)      |
 
 **Transaction Flow:**
 
@@ -1555,7 +1819,7 @@ INFO [2025-09-18 10:31:25.364 +0200]:
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify delegate address is the Pool Signer PDA
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -1584,7 +1848,7 @@ Provide initial liquidity to the LockRelease pool using the tokens minted in Ste
 pnpm bs58 lockrelease-token-pool \
   --env devnet \
   --instruction provide-liquidity \
-  --program-id $CCIP_POOL_PROGRAM \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --amount "50000000000"
@@ -1597,50 +1861,94 @@ pnpm bs58 lockrelease-token-pool \
 <Fragment slot="panel.2">
 
 ```bash
+🔍 Detecting token program...
+INFO [2026-06-15 11:33:25.105 +0530]: Starting provideLiquidity command
+    command: "lockrelease.provide-liquidity"
+    programId: "8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC"
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
+    authority: "AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB"
+    amount: "50000000000"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
+   ✅ Detected token program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+🔍 Deriving rebalancer Associated Token Account...
+   ✅ Rebalancer ATA: ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV
+🔄 Generating provideLiquidity transaction...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC
+   Mint: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
+   Authority (Rebalancer): AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+   Amount: 50000000000
+   Rebalancer Token Account (ATA): ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV
+   Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
 🔄 Building and simulating transaction...
-   ✅ Transaction simulation completed
+INFO [2026-06-15 11:33:25.420 +0530]: Detected SPL Token v1
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
 🎯 COPY TRANSACTION DATA BELOW:
 
-47JrPNc32mdHLoAoD37ENgdggVTuZK2U9Qs59FsdJYsvq1KrMWU1APVBZqH6Yk4y1neaRRUBPyRCzTrz5PNZo8PwDvfUVuRswVYyaZD1ATYpiVirhgXDz86RHbUo3avZt89KErmWvr8NcjuvgZEfeH6QjfnTqBYxUiAYd7cbJh7LohKRZc9KHjkWRUrjPf9ogjkzieUQ5EkXVX3S4uUDca4hwckqCuCnSh8edkNwXdMdbPNjPdomiuiJnWMCmeJo7KkoZrq1tBVqftzdfJtNGrJHGVYjVGYPZq333edoiXzP16GGR2QCT218e6qm4phhdamqKNTeHuWynpDnC4nzZdBNXevZqqYihBPhk2tNEP1YSh1QAZyM1gtah5ZajCDRBZoEXVXnsDr7aVRWegPEeVTEbZkkqJMuHCyxKvQAMYRMm9kjE55
+47JrQ3dxQ6SaBEZBLV4t6LmoNxoehZXtMQ4xXyWA6recZ7EGPJofoGwaESmS9P2s7TZGB1wBK3bERoXAWQtHdE334scxZB6EgRLaX12zASA8WYTSRVjhzgkXuUnSHX7auxYsi9sHD8awaAGbe8jNkWpojJTHpVieXuPENbsjyT1DbMDLDgJfym9BAUhcdRthei4fczxKHWL3YByeTpucircat5pTx7Yvj25dog6g5YxZC7VDV9CBnqS7EgYBfTzPruBiLqGGEBVUR8mZ8fxbjeEBUaPqNcqq7Pzn8PrURG8zapeoxpMpL2SdvjmUrL2jyKzBLrNzRvv72Zjjmz56CgDZaVUoJVNiQvhXsN684A8mHpQkviieFRJv6jdJyoR6cWTMZiQ5j4w1iXEhVzWt2Sq2vRANhecVi2UkzpHCHMrHuicL7BV
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-18 10:37:14.484 +0200]: Detected SPL Token v1
-    mint: "FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1"
-    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-INFO [2025-09-18 10:37:15.022 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 11:33:25.621 +0530]: Transaction built successfully
     instructionName: "provideLiquidity"
     transactionSize: "319 bytes"
     base58Length: "435 characters"
     hexLength: "638 characters"
     accountCount: 7
     signerCount: 1
-    computeUnits: 28900
-INFO [2025-09-18 10:37:15.022 +0200]: Completed buildTransaction (provideLiquidity)
-    durationMs: 527
-INFO [2025-09-18 10:37:15.022 +0200]:
-INFO [2025-09-18 10:37:15.022 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-18 10:37:15.022 +0200]:
-INFO [2025-09-18 10:37:15.022 +0200]: 📋 Transaction Details:
-INFO [2025-09-18 10:37:15.022 +0200]:    Instruction: provideLiquidity
-INFO [2025-09-18 10:37:15.022 +0200]:    Size: 319 bytes
-INFO [2025-09-18 10:37:15.022 +0200]:    Base58 length: 435 characters
-INFO [2025-09-18 10:37:15.059 +0200]:    Compute units: 28 900
-INFO [2025-09-18 10:37:15.059 +0200]:    Generated: 2025-09-18T08:37:15.021Z
-INFO [2025-09-18 10:37:15.059 +0200]:
-INFO [2025-09-18 10:37:15.059 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-18 10:37:15.059 +0200]:
-INFO [2025-09-18 10:37:15.059 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-18 10:37:15.059 +0200]:
-INFO [2025-09-18 10:37:15.059 +0200]: 📊 Account Information:
-INFO [2025-09-18 10:37:15.059 +0200]:    Total accounts: 7
-INFO [2025-09-18 10:37:15.060 +0200]:     1. 9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1 (read-only)
-INFO [2025-09-18 10:37:15.060 +0200]:     2. TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA (read-only)
-INFO [2025-09-18 10:37:15.060 +0200]:     3. FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1 (writable)
-INFO [2025-09-18 10:37:15.060 +0200]:     4. E8odUv4V4DXy3RWvkNYF7H33X9J56RtsFp4ExVXB86UA (read-only)
-INFO [2025-09-18 10:37:15.060 +0200]:     5. A57bH91QkGuARh37JTN41fd3Vwcmf2bLzVHAVPB8Gaeg (writable)
-INFO [2025-09-18 10:37:15.060 +0200]:     6. G7yVJJKDRBQDdbFttmA3G3oytFKBcsZH8VMdJWBXJKJB (writable)
-INFO [2025-09-18 10:37:15.060 +0200]:     7. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer)
-INFO [2025-09-18 10:37:15.060 +0200]:
+    computeUnits: 22691
+INFO [2026-06-15 11:33:25.621 +0530]: Completed buildTransaction (provideLiquidity)
+    durationMs: 193
+INFO [2026-06-15 11:33:25.621 +0530]:
+INFO [2026-06-15 11:33:25.621 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 11:33:25.621 +0530]:
+INFO [2026-06-15 11:33:25.621 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 11:33:25.621 +0530]:    Instruction: provideLiquidity
+INFO [2026-06-15 11:33:25.622 +0530]:    Size: 319 bytes
+INFO [2026-06-15 11:33:25.622 +0530]:    Base58 length: 435 characters
+INFO [2026-06-15 11:33:25.637 +0530]:    Compute units: 22,691
+INFO [2026-06-15 11:33:25.637 +0530]:    Generated: 2026-06-15T06:03:25.621Z
+INFO [2026-06-15 11:33:25.637 +0530]:
+INFO [2026-06-15 11:33:25.637 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 11:33:25.637 +0530]:
+INFO [2026-06-15 11:33:25.637 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 11:33:25.637 +0530]:
+INFO [2026-06-15 11:33:25.637 +0530]: 📊 Account Information:
+INFO [2026-06-15 11:33:25.637 +0530]:    Total accounts: 7
+INFO [2026-06-15 11:33:25.637 +0530]:     1. 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R (read-only)
+INFO [2026-06-15 11:33:25.637 +0530]:     2. TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA (read-only)
+INFO [2026-06-15 11:33:25.637 +0530]:     3. 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li (writable)
+INFO [2026-06-15 11:33:25.637 +0530]:     4. 5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk (read-only)
+INFO [2026-06-15 11:33:25.637 +0530]:     5. GQ4md7wUKmU35m4munp8giYg9osXCTaGVCPvNYzz8Wnu (writable)
+INFO [2026-06-15 11:33:25.637 +0530]:     6. ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV (writable)
+INFO [2026-06-15 11:33:25.637 +0530]:     7. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer)
+INFO [2026-06-15 11:33:25.637 +0530]:
+INFO [2026-06-15 11:33:25.637 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 11:33:25.637 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 11:33:25.637 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 11:33:25.637 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 11:33:25.637 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 11:33:25.637 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 11:33:25.637 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 11:33:25.637 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 11:33:25.637 +0530]:
+INFO [2026-06-15 11:33:25.637 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 11:33:25.637 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 11:33:25.637 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 11:33:25.637 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 11:33:25.637 +0530]:    • Estimated compute units: 22,691
+INFO [2026-06-15 11:33:25.637 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 11:33:25.637 +0530]:
+INFO [2026-06-15 11:33:25.638 +0530]: provideLiquidity command completed successfully
+    command: "lockrelease.provide-liquidity"
+    transactionSize: "319 bytes"
+    computeUnits: 22691
 ```
 
 </Fragment>
@@ -1650,13 +1958,13 @@ INFO [2025-09-18 10:37:15.060 +0200]:
 
 | Account | Address                                        | Description                                         |
 | ------- | ---------------------------------------------- | --------------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool State PDA** (read-only)                      |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool State PDA** (read-only)                      |
 | **#2**  | `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`  | **Token Program** (read-only)                       |
-| **#3**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | **Token Mint** (writable)                           |
-| **#4**  | `E8odUv4V4DXy3RWvkNYF7H33X9J56RtsFp4ExVXB86UA` | **Pool Signer PDA** (read-only)                     |
-| **#5**  | `A57bH91QkGuARh37JTN41fd3Vwcmf2bLzVHAVPB8Gaeg` | **Pool Token ATA** (writable - receives liquidity)  |
-| **#6**  | `G7yVJJKDRBQDdbFttmA3G3oytFKBcsZH8VMdJWBXJKJB` | **Squad Vault ATA** (writable - provides liquidity) |
-| **#7**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer - rebalancer authority)     |
+| **#3**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | **Token Mint** (writable)                           |
+| **#4**  | `5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk` | **Pool Signer PDA** (read-only)                     |
+| **#5**  | `GQ4md7wUKmU35m4munp8giYg9osXCTaGVCPvNYzz8Wnu` | **Pool Token ATA** (writable - receives liquidity)  |
+| **#6**  | `ApwnQFrEvC2Zo9PD6YigMNDzQQPQvFm4bNE1EUtFZzMV` | **Squad Vault ATA** (writable - provides liquidity) |
+| **#7**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer - rebalancer authority)     |
 
 **Transaction Flow:**
 
@@ -1669,7 +1977,7 @@ INFO [2025-09-18 10:37:15.060 +0200]:
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify liquidity amount and token addresses
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -1688,9 +1996,9 @@ INFO [2025-09-18 10:37:15.060 +0200]:
 ```bash
 # Save all Solana variables
 cat > ~/.phase2_vars << EOF
-export CCIP_POOL_PROGRAM="$CCIP_POOL_PROGRAM"
-export CCIP_ROUTER_PROGRAM="$CCIP_ROUTER_PROGRAM"
-export CCIP_FEE_QUOTER_PROGRAM="$CCIP_FEE_QUOTER_PROGRAM"
+export SOL_CCIP_POOL_PROGRAM="$SOL_CCIP_POOL_PROGRAM"
+export SOL_CCIP_ROUTER="$SOL_CCIP_ROUTER"
+export SOL_CCIP_FEE_QUOTER_PROGRAM="$SOL_CCIP_FEE_QUOTER_PROGRAM"
 export SOL_SQUAD_VAULT_MULTISIG="$SOL_SQUAD_VAULT_MULTISIG"
 export SOL_TOKEN_MINT="$SOL_TOKEN_MINT"
 export SOL_POOL_ADDRESS="$SOL_POOL_ADDRESS"
@@ -1698,7 +2006,7 @@ export SOL_POOL_SIGNER_PDA="$SOL_POOL_SIGNER_PDA"
 export SOL_WALLET_ADDRESS="$SOL_WALLET_ADDRESS"
 EOF
 
-echo "=== Phase 2 Complete - Dual Multisig Setup ==="
+echo "=== Phase 2 Complete - LockRelease Setup ==="
 echo "✅ Token Mint: $SOL_TOKEN_MINT"
 echo "✅ Pool Address: $SOL_POOL_ADDRESS"
 echo "✅ Pool Signer PDA: $SOL_POOL_SIGNER_PDA"
@@ -1711,12 +2019,12 @@ echo "✅ Wallet Address: $SOL_WALLET_ADDRESS"
 <Fragment slot="panel.2">
 
 ```bash
-=== Phase 2 Complete - Dual Multisig Setup ===
-✅ Token Mint: FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1
-✅ Pool Address: 9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1
-✅ Pool Signer PDA: E8odUv4V4DXy3RWvkNYF7H33X9J56RtsFp4ExVXB86UA
-✅ Squads Multisig: 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY
-✅ Wallet Address: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
+=== Phase 2 Complete - LockRelease Setup ===
+✅ Token Mint: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
+✅ Pool Address: 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R
+✅ Pool Signer PDA: 5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk
+✅ Squads Multisig: AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+✅ Wallet Address: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
 ```
 
 </Fragment>
@@ -1755,9 +2063,7 @@ pwd
 # Load Phase 1 EVM variables
 
 source ~/.phase1_vars
-```
 
-```bash
 # Set chain selector for Ethereum Sepolia
 
 export ETHEREUM_SEPOLIA_CHAIN_SELECTOR="16015286601757825753"
@@ -1782,10 +2088,10 @@ $ source ~/.phase1_vars
 $ export ETHEREUM_SEPOLIA_CHAIN_SELECTOR="16015286601757825753"
 
 $ echo "✅ ETH Token: $ETH_TOKEN_ADDRESS"
-✅ ETH Token: 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715
+✅ ETH Token: 0x44490fee906a4cfd5e71a46c3ca2147287b018e7
 
 $ echo "✅ ETH Pool: $ETH_POOL_ADDRESS"
-✅ ETH Pool: 0x4678b403781467761Df2f9364FeC48ae3f4F3857
+✅ ETH Pool: 0x80cd26e9325342b9be1cc7cab3e785afb44ebee4
 
 $ echo "✅ Chain Selector: $ETHEREUM_SEPOLIA_CHAIN_SELECTOR"
 ✅ Chain Selector: 16015286601757825753
@@ -1798,8 +2104,8 @@ $ echo "✅ Chain Selector: $ETHEREUM_SEPOLIA_CHAIN_SELECTOR"
 
 Configure your token pool for cross-chain transfers to Ethereum Sepolia. This process involves two sequential operations:
 
-1. **Initialize Chain Remote Config**: Create the basic cross-chain configuration using [init_chain_remote_config](/ccip/api-reference/svm/v1.6.0/burn-mint-token-pool#init_chain_remote_config)
-1. **Edit Chain Remote Config**: Add the remote pool address using [edit_chain_remote_config](/ccip/api-reference/svm/v1.6.0/burn-mint-token-pool#edit_chain_remote_config)
+1. **Initialize Chain Remote Config**: Create the basic cross-chain configuration using [init_chain_remote_config](/ccip/api-reference/svm/v1.6.0/lock-release-token-pool#init_chain_remote_config)
+1. **Edit Chain Remote Config**: Add the remote pool address using [edit_chain_remote_config](/ccip/api-reference/svm/v1.6.0/lock-release-token-pool#edit_chain_remote_config)
 
 #### Step 2A: Initialize Chain Remote Config
 
@@ -1814,7 +2120,7 @@ Initialize the basic remote chain configuration for Ethereum Sepolia. Pool addre
 ```bash
 # Initialize basic cross-chain configuration (no rate limits, no pool addresses)
 pnpm bs58 lockrelease-token-pool --env devnet --instruction init-chain-remote-config \
-  --program-id $CCIP_POOL_PROGRAM \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --remote-chain-selector $ETHEREUM_SEPOLIA_CHAIN_SELECTOR \
@@ -1827,42 +2133,88 @@ pnpm bs58 lockrelease-token-pool --env devnet --instruction init-chain-remote-co
 <Fragment slot="panel.2">
 
 ```bash
+🔄 Generating initChainRemoteConfig transaction...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC
+   Mint: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
+   Authority: AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+   Remote Chain Selector: 16015286601757825753
+   Pool Addresses: 0 addresses (must be empty at init)
+   Token Address: 44490fee906a4cfd5e71a46c3ca2147287b018e7
+   Decimals: 18
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-15 11:38:25.993 +0530]: Starting initChainRemoteConfig command
+    command: "lockrelease-token-pool.init-chain-remote-config"
+    programId: "8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC"
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
+    authority: "AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB"
+    remoteChainSelector: "16015286601757825753"
+    poolAddresses: "[]"
+    tokenAddress: "0x44490fee906a4cfd5e71a46c3ca2147287b018e7"
+    decimals: "18"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
 🎯 COPY TRANSACTION DATA BELOW:
 
-Q14fzko7Rj4xtdvdxXYm7mVfqp8TtR6cCGwrWbEbohtoj9wCcLTpph6k2ST8ZM1GkJRFo1y4ANBbu3LQHCrGwPmZLKSFbjZhpiTqkCyoYy54VVyMtFDpupzto4MiRgmGY9Gg559TEhU8Z14PDuBuKrsps2V2tvZA2KhCRCAivQZLBaVHjUf9HZ5zmecwoQAepwU7ECtnDMxCyLxA9QKzpuAXZQUqYr7yR21Ejz5oQthigzkhvt7WYAD9sphFr3x4SuzndiRFxGF4LE3RoNaKTT4EKQQsB7t3xT6dWXHWoNkZacc99YSLu1KiKqMTJYYZMssbqxnmnfmE69gpmuKFbT4fsYUWzYGec8TPJMXS3j2ojwF4AYNQNDyGDoEykqk4fWieTNh9exX5kNd
+Q14g5jbgtmANfZSMSbAWmxrcrdnGPxD1uBo8aVDcQnQx6TTzcNmmkDrAgq3fP24ZnKvgdLnZfi9wHa83pQQfyifLqR4LzDV44zhoccts2rQwsLpwJuPwUFfsfq4PeTjoC6cZ2qugPDqYVhktzxbJVK4vD5PiVtwMLxf8znYMLoDwQMrmpd9HRTrAB7uhLPxTcDkLdRZWirgWc5mpgRiCfToa53mFiHJ5HSn58bjv2JgA1dWFSMkDdL1ph3Vd8c25isTcj9GxMgad8255vRV5mpavzqn5uRKyofDhtPTseFDSKGmrcfYqWuJztLwMJHBfpKF8H6JNo711o3EG1RPc5rHj7Dus68CZk43qe7w6AyjxZ8beQrW3ghp6A2CwjH3K4h8ji7j2ZD5jeA5
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-18 10:47:34.774 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 11:38:26.350 +0530]: Transaction built successfully
     instructionName: "initChainRemoteConfig"
     transactionSize: "293 bytes"
     base58Length: "399 characters"
     hexLength: "586 characters"
     accountCount: 4
     signerCount: 1
-    computeUnits: 14928
-INFO [2025-09-18 10:47:34.774 +0200]: Completed buildTransaction (initChainRemoteConfig)
-    durationMs: 1022
-INFO [2025-09-18 10:47:34.775 +0200]:
-INFO [2025-09-18 10:47:34.775 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-18 10:47:34.775 +0200]:
-INFO [2025-09-18 10:47:34.775 +0200]: 📋 Transaction Details:
-INFO [2025-09-18 10:47:34.775 +0200]:    Instruction: initChainRemoteConfig
-INFO [2025-09-18 10:47:34.775 +0200]:    Size: 293 bytes
-INFO [2025-09-18 10:47:34.775 +0200]:    Base58 length: 399 characters
-INFO [2025-09-18 10:47:34.811 +0200]:    Compute units: 14 928
-INFO [2025-09-18 10:47:34.811 +0200]:    Generated: 2025-09-18T08:47:34.773Z
-INFO [2025-09-18 10:47:34.811 +0200]:
-INFO [2025-09-18 10:47:34.812 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-18 10:47:34.812 +0200]:
-INFO [2025-09-18 10:47:34.812 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-18 10:47:34.812 +0200]:
-INFO [2025-09-18 10:47:34.812 +0200]: 📊 Account Information:
-INFO [2025-09-18 10:47:34.812 +0200]:    Total accounts: 4
-INFO [2025-09-18 10:47:34.812 +0200]:     1. 9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1 (read-only)
-INFO [2025-09-18 10:47:34.812 +0200]:     2. DzPjdCvEgJq6tyTvQtuh6i8WtPn6gWGmhaRM3DnCvwq9 (writable)
-INFO [2025-09-18 10:47:34.812 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-09-18 10:47:34.812 +0200]:     4. 11111111111111111111111111111111 (read-only)
-INFO [2025-09-18 10:47:34.812 +0200]:
+    computeUnits: 23895
+INFO [2026-06-15 11:38:26.350 +0530]: Completed buildTransaction (initChainRemoteConfig)
+    durationMs: 353
+INFO [2026-06-15 11:38:26.350 +0530]:
+INFO [2026-06-15 11:38:26.350 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 11:38:26.350 +0530]:
+INFO [2026-06-15 11:38:26.350 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 11:38:26.350 +0530]:    Instruction: initChainRemoteConfig
+INFO [2026-06-15 11:38:26.350 +0530]:    Size: 293 bytes
+INFO [2026-06-15 11:38:26.350 +0530]:    Base58 length: 399 characters
+INFO [2026-06-15 11:38:26.360 +0530]:    Compute units: 23,895
+INFO [2026-06-15 11:38:26.360 +0530]:    Generated: 2026-06-15T06:08:26.350Z
+INFO [2026-06-15 11:38:26.360 +0530]:
+INFO [2026-06-15 11:38:26.360 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 11:38:26.360 +0530]:
+INFO [2026-06-15 11:38:26.360 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 11:38:26.360 +0530]:
+INFO [2026-06-15 11:38:26.360 +0530]: 📊 Account Information:
+INFO [2026-06-15 11:38:26.360 +0530]:    Total accounts: 4
+INFO [2026-06-15 11:38:26.360 +0530]:     1. 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R (read-only)
+INFO [2026-06-15 11:38:26.360 +0530]:     2. 5ZctnHiRZyrtDirqfXxpo4aH6eNT7YTJZ3HZh5WJWMiX (writable)
+INFO [2026-06-15 11:38:26.360 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 11:38:26.360 +0530]:     4. 11111111111111111111111111111111 (read-only)
+INFO [2026-06-15 11:38:26.360 +0530]:
+INFO [2026-06-15 11:38:26.360 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 11:38:26.360 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 11:38:26.360 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 11:38:26.360 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 11:38:26.360 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 11:38:26.360 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 11:38:26.360 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 11:38:26.360 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 11:38:26.360 +0530]:
+INFO [2026-06-15 11:38:26.360 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 11:38:26.360 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 11:38:26.360 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 11:38:26.360 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 11:38:26.360 +0530]:    • Estimated compute units: 23,895
+INFO [2026-06-15 11:38:26.360 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 11:38:26.360 +0530]:
+INFO [2026-06-15 11:38:26.361 +0530]: initChainRemoteConfig command completed successfully
+    command: "lockrelease-token-pool.init-chain-remote-config"
+    transactionSize: "293 bytes"
+    computeUnits: 23895
 ```
 
 </Fragment>
@@ -1872,9 +2224,9 @@ INFO [2025-09-18 10:47:34.812 +0200]:
 
 | Account | Address                                        | Description                                         |
 | ------- | ---------------------------------------------- | --------------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool State PDA** (read-only - validation)         |
-| **#2**  | `DzPjdCvEgJq6tyTvQtuh6i8WtPn6gWGmhaRM3DnCvwq9` | **Chain Remote Config PDA** (writable - created)    |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer, writable - pool authority) |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool State PDA** (read-only - validation)         |
+| **#2**  | `5ZctnHiRZyrtDirqfXxpo4aH6eNT7YTJZ3HZh5WJWMiX` | **Chain Remote Config PDA** (writable - created)    |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer, writable - pool authority) |
 | **#4**  | `11111111111111111111111111111111`             | **System Program** (read-only - account creation)   |
 
 **What This Command Does:**
@@ -1883,7 +2235,7 @@ This initializes the **cross-chain configuration** for your Solana token to enab
 **Key Details:**
 
 - **Remote Chain**: Ethereum Sepolia (chain selector: `16015286601757825753`)
-- **Token Mapping**: Links to ERC20 token `0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715`
+- **Token Mapping**: Links to ERC20 token `0x44490fee906a4cfd5e71a46c3ca2147287b018e7`
 - **Decimal Precision**: 18 decimals (standard EVM token format)
 - **Basic Setup**: No rate limits or pool addresses configured at this stage
 - **Account Creation**: Creates a new Chain Remote Config PDA for this cross-chain relationship
@@ -1899,7 +2251,7 @@ This initializes the **cross-chain configuration** for your Solana token to enab
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -1909,7 +2261,7 @@ This initializes the **cross-chain configuration** for your Solana token to enab
 
 #### Step 2B: Edit Chain Remote Config (Add Remote Pool Address)
 
-After initializing the chain remote config, add the remote pool address to enable bidirectional cross-chain transfers. This uses [`edit_chain_remote_config`](/ccip/api-reference/svm/v1.6.0/burn-mint-token-pool#edit_chain_remote_config) to specify the Ethereum pool address.
+After initializing the chain remote config, add the remote pool address to enable bidirectional cross-chain transfers. This uses [`edit_chain_remote_config`](/ccip/api-reference/svm/v1.6.0/lock-release-token-pool#edit_chain_remote_config) to specify the Ethereum pool address.
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Command</Fragment>
@@ -1920,7 +2272,7 @@ After initializing the chain remote config, add the remote pool address to enabl
 ```bash
 # Configure chain connection and remote pool address
 pnpm bs58 lockrelease-token-pool --env devnet --instruction edit-chain-remote-config \
-  --program-id $CCIP_POOL_PROGRAM \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --remote-chain-selector $ETHEREUM_SEPOLIA_CHAIN_SELECTOR \
@@ -1934,41 +2286,88 @@ pnpm bs58 lockrelease-token-pool --env devnet --instruction edit-chain-remote-co
 <Fragment slot="panel.2">
 
 ```bash
+🔄 Generating editChainRemoteConfig transaction...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC
+   Mint: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
+   Authority: AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+   Remote Chain Selector: 16015286601757825753
+   Pool Addresses: 1 addresses
+   Token Address: 44490fee906a4cfd5e71a46c3ca2147287b018e7
+   Decimals: 18
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-15 11:42:12.719 +0530]: Starting editChainRemoteConfig command
+    command: "lockrelease-token-pool.edit-chain-remote-config"
+    programId: "8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC"
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
+    authority: "AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB"
+    remoteChainSelector: "16015286601757825753"
+    poolAddresses: "[\"0x80cd26e9325342b9be1cc7cab3e785afb44ebee4\"]"
+    tokenAddress: "0x44490fee906a4cfd5e71a46c3ca2147287b018e7"
+    decimals: "18"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
 🎯 COPY TRANSACTION DATA BELOW:
 
-AFoMMPcqYbM5kCTDs346jiU3HGiWW1moQm7vwGoWZ1eBtxTpuZLdtndY6k9ni2rBBeT4gS6G26tfJeaHnVzPaaK5Par896XgqZku6pU9kNJbTzbYVzekvTwnPftcvenPRHZvwXSJWVsWp1FzyNnHrVMQu8LUhMU6rFLBRDP1GK7BmPYrwuCnSoHcFDV2SPRFjJUAjJffbwmttYjztPXgeZfVYJv8JhNYYgKghtjZZaHEDG2vvLL1z6rkL2Way3WxDerELR9LsaTKMandU5m9CB5FLL4J4ps5H4J5D1Y7ePZ5RuUY3Th8cS35i23Nj9in6dZBk2HDxNznBCQ2cwvoXTwRvGV4dQi6LXTGAU45RTAJEyj6CYH8HdPFJVxGE8L6vGUDxakXYCvVzkXyZAjNQ9BZDkSAtPTvtydyMnrzHtVs7DA9
+AFoMPPpvGwnZ4Y3NzMYH5szHnSfKR5DVEBiNkyefN9eQdbhCmx3KPgdX552aWkmcnvJkJpN4oKriRxz999XD5rhhzf1m58Nmiq9K5XxeMX8fsgnagNDAPaKueaAoqZRe1efgbtEEB6HmLPk9LrU75dWDnqypo3D16uhwuzQ3EMcteib8kE2z2U7PwN8MH56y557v8XQtFGVzpSf4RFKBo96rDuJS2PiAjrMB1PXwub5XjKwFpGnaJhGo6NSFqmZ4JyY4jAG6sha2X6K6gCtNBurvmKwjnsU5F8tTmTygpqwX5xV1C8cHeGeGNwSJVxS13vZ2ALyYD6C3VXZkakocnjYutKCAhKy7ck5JsUHovjk4wQi4fL36UvUS6N5MCDhA1RVeSpnduu5pxQTvi4r4Bxce8RqVAA8KmgXVGuyjPhw8MEDw
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-18 10:49:45.470 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 11:42:13.127 +0530]: Transaction built successfully
     instructionName: "editChainRemoteConfig"
     transactionSize: "317 bytes"
     base58Length: "432 characters"
     hexLength: "634 characters"
     accountCount: 4
     signerCount: 1
-    computeUnits: 16058
-INFO [2025-09-18 10:49:45.470 +0200]: Completed buildTransaction (editChainRemoteConfig)
-    durationMs: 1055
-INFO [2025-09-18 10:49:45.470 +0200]:
-INFO [2025-09-18 10:49:45.470 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-18 10:49:45.470 +0200]:
-INFO [2025-09-18 10:49:45.470 +0200]: 📋 Transaction Details:
-INFO [2025-09-18 10:49:45.470 +0200]:    Instruction: editChainRemoteConfig
-INFO [2025-09-18 10:49:45.470 +0200]:    Size: 317 bytes
-INFO [2025-09-18 10:49:45.470 +0200]:    Base58 length: 432 characters
-INFO [2025-09-18 10:49:45.482 +0200]:    Compute units: 16 058
-INFO [2025-09-18 10:49:45.482 +0200]:    Generated: 2025-09-18T08:49:45.469Z
-INFO [2025-09-18 10:49:45.482 +0200]:
-INFO [2025-09-18 10:49:45.482 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-18 10:49:45.482 +0200]:
-INFO [2025-09-18 10:49:45.482 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-18 10:49:45.482 +0200]:
-INFO [2025-09-18 10:49:45.482 +0200]: 📊 Account Information:
-INFO [2025-09-18 10:49:45.482 +0200]:    Total accounts: 4
-INFO [2025-09-18 10:49:45.482 +0200]:     1. 9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1 (read-only)
-INFO [2025-09-18 10:49:45.482 +0200]:     2. DzPjdCvEgJq6tyTvQtuh6i8WtPn6gWGmhaRM3DnCvwq9 (writable)
-INFO [2025-09-18 10:49:45.482 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-09-18 10:49:45.482 +0200]:     4. 11111111111111111111111111111111 (read-only)
+    computeUnits: 25026
+INFO [2026-06-15 11:42:13.127 +0530]: Completed buildTransaction (editChainRemoteConfig)
+    durationMs: 404
+INFO [2026-06-15 11:42:13.127 +0530]:
+INFO [2026-06-15 11:42:13.127 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 11:42:13.127 +0530]:
+INFO [2026-06-15 11:42:13.127 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 11:42:13.127 +0530]:    Instruction: editChainRemoteConfig
+INFO [2026-06-15 11:42:13.127 +0530]:    Size: 317 bytes
+INFO [2026-06-15 11:42:13.127 +0530]:    Base58 length: 432 characters
+INFO [2026-06-15 11:42:13.139 +0530]:    Compute units: 25,026
+INFO [2026-06-15 11:42:13.139 +0530]:    Generated: 2026-06-15T06:12:13.127Z
+INFO [2026-06-15 11:42:13.139 +0530]:
+INFO [2026-06-15 11:42:13.139 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 11:42:13.139 +0530]:
+INFO [2026-06-15 11:42:13.139 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 11:42:13.139 +0530]:
+INFO [2026-06-15 11:42:13.139 +0530]: 📊 Account Information:
+INFO [2026-06-15 11:42:13.139 +0530]:    Total accounts: 4
+INFO [2026-06-15 11:42:13.139 +0530]:     1. 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R (read-only)
+INFO [2026-06-15 11:42:13.139 +0530]:     2. 5ZctnHiRZyrtDirqfXxpo4aH6eNT7YTJZ3HZh5WJWMiX (writable)
+INFO [2026-06-15 11:42:13.139 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 11:42:13.139 +0530]:     4. 11111111111111111111111111111111 (read-only)
+INFO [2026-06-15 11:42:13.139 +0530]:
+INFO [2026-06-15 11:42:13.139 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 11:42:13.139 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 11:42:13.139 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 11:42:13.139 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 11:42:13.139 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 11:42:13.139 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 11:42:13.139 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 11:42:13.139 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 11:42:13.139 +0530]:
+INFO [2026-06-15 11:42:13.139 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 11:42:13.139 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 11:42:13.139 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 11:42:13.139 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 11:42:13.139 +0530]:    • Estimated compute units: 25,026
+INFO [2026-06-15 11:42:13.139 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 11:42:13.139 +0530]:
+INFO [2026-06-15 11:42:13.139 +0530]: editChainRemoteConfig command completed successfully
+    command: "lockrelease-token-pool.edit-chain-remote-config"
+    transactionSize: "317 bytes"
+    computeUnits: 25026
 ```
 
 </Fragment>
@@ -1979,9 +2378,9 @@ INFO [2025-09-18 10:49:45.482 +0200]:     4. 11111111111111111111111111111111 (r
 
 | Account | Address                                        | Description                                                    |
 | ------- | ---------------------------------------------- | -------------------------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool State PDA** (read-only - authority validation)          |
-| **#2**  | `DzPjdCvEgJq6tyTvQtuh6i8WtPn6gWGmhaRM3DnCvwq9` | **Chain Remote Config PDA** (writable - configuration updated) |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault Authority** (signer, writable - fee payer)       |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool State PDA** (read-only - authority validation)          |
+| **#2**  | `5ZctnHiRZyrtDirqfXxpo4aH6eNT7YTJZ3HZh5WJWMiX` | **Chain Remote Config PDA** (writable - configuration updated) |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault Authority** (signer, writable - fee payer)       |
 | **#4**  | `11111111111111111111111111111111`             | **System Program** (read-only - account operations)            |
 
 **Transaction Flow:**
@@ -1994,7 +2393,7 @@ INFO [2025-09-18 10:49:45.482 +0200]:     4. 11111111111111111111111111111111 (r
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -2038,7 +2437,7 @@ This command configures inbound and outbound rate limiting for token transfers b
 pnpm bs58 lockrelease-token-pool \
   --env devnet \
   --instruction set-chain-rate-limit \
-  --program-id $CCIP_POOL_PROGRAM \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --remote-chain-selector $ETHEREUM_SEPOLIA_CHAIN_SELECTOR \
@@ -2055,42 +2454,89 @@ pnpm bs58 lockrelease-token-pool \
 <Fragment slot="panel.2">
 
 ```bash
-   ✅ Transaction simulation completed
+🔄 Generating setChainRateLimit transaction...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC
+   Mint: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
+   Authority: AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+   Remote Chain Selector: 16015286601757825753
+   Inbound Rate Limit: enabled (capacity: 20000000000, rate: 100000000)
+   Outbound Rate Limit: enabled (capacity: 18000000000, rate: 100000000)
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-15 11:44:33.172 +0530]: Starting setChainRateLimit command
+    command: "lockrelease-token-pool.set-chain-rate-limit"
+    programId: "8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC"
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
+    authority: "AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB"
+    remoteChainSelector: "16015286601757825753"
+    inboundEnabled: "true"
+    inboundCapacity: "20000000000"
+    inboundRate: "100000000"
+    outboundEnabled: "true"
+    outboundCapacity: "18000000000"
+    outboundRate: "100000000"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
 🎯 COPY TRANSACTION DATA BELOW:
 
-2osuKVgAa7jk8Ahvr7KPjeNDY7RAx29vFbgbkrKwtnGKbSjECQcQjPMm6h9QVSo2jAk3ouZqHMvedvxpspQThPe4mh73jvUCdhEnxkRqb3Qr3f6wNtgW2bYRRBupfZia75n5Twp1M9sjqfphZWx54gWa9MuMRR29BP4LxU3gHQuFMbuR6pfrEbZg73THtLiq3DFnAxVS7ns2FcukKbET62p4GCJdgWUm4g3XntsrfCXCYrZjXkZa2TveQBy4oZuWhR92R4kdPMLAUaLZSHNLKYFugXxWMAv9Zbh48gWRNC4Tm6PToMokBoSpMJ3Kr9kg1pYH22WKRQro5jSFh4wPCRmRq
+2osuKtP31rW7xJebzwQn4Xqs8QpiBRYpQVTWtwq69tqevXsBzfPT8j3W6gfqhHwFymNeA2C4qDgPjH32ZNUvEoXE8NSgz7zgi4ZzY28pvLb5McqJRUtkcyVjpaP6T9MRd1U1z6dqjv9B2oZ1sbuinSU1VhxnLvPawfgqpdzqpJFn8gTsbGc1snz8nyEmtY4D3fFBjVnDt2NhnXSUcA5pgh9zTa99czaL43kZRCEioRV1siLmmq1PCpTGEbbbnDHfYq4SwEk75wU95br27AYJDBmSat9chFCEG7BFDrVZQtf8JAsmoRxqLPybD46nUy5F1iLRDQ3MdYJJVc5yPo1rmFfqy
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-18 10:59:45.133 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 11:44:33.518 +0530]: Transaction built successfully
     instructionName: "setChainRateLimit"
     transactionSize: "253 bytes"
     base58Length: "345 characters"
     hexLength: "506 characters"
     accountCount: 3
     signerCount: 1
-    computeUnits: 12586
-INFO [2025-09-18 10:59:45.133 +0200]: Completed buildTransaction (setChainRateLimit)
-    durationMs: 1018
-INFO [2025-09-18 10:59:45.133 +0200]:
-INFO [2025-09-18 10:59:45.133 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-18 10:59:45.133 +0200]:
-INFO [2025-09-18 10:59:45.133 +0200]: 📋 Transaction Details:
-INFO [2025-09-18 10:59:45.133 +0200]:    Instruction: setChainRateLimit
-INFO [2025-09-18 10:59:45.133 +0200]:    Size: 253 bytes
-INFO [2025-09-18 10:59:45.133 +0200]:    Base58 length: 345 characters
-INFO [2025-09-18 10:59:45.155 +0200]:    Compute units: 12 586
-INFO [2025-09-18 10:59:45.155 +0200]:    Generated: 2025-09-18T08:59:45.132Z
-INFO [2025-09-18 10:59:45.155 +0200]:
-INFO [2025-09-18 10:59:45.155 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-18 10:59:45.155 +0200]:
-INFO [2025-09-18 10:59:45.155 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-18 10:59:45.155 +0200]:
-INFO [2025-09-18 10:59:45.155 +0200]: 📊 Account Information:
-INFO [2025-09-18 10:59:45.155 +0200]:    Total accounts: 3
-INFO [2025-09-18 10:59:45.155 +0200]:     1. 9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1 (read-only)
-INFO [2025-09-18 10:59:45.155 +0200]:     2. DzPjdCvEgJq6tyTvQtuh6i8WtPn6gWGmhaRM3DnCvwq9 (writable)
-INFO [2025-09-18 10:59:45.155 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-09-18 10:59:45.155 +0200]:
+    computeUnits: 21591
+INFO [2026-06-15 11:44:33.518 +0530]: Completed buildTransaction (setChainRateLimit)
+    durationMs: 341
+INFO [2026-06-15 11:44:33.518 +0530]:
+INFO [2026-06-15 11:44:33.518 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 11:44:33.518 +0530]:
+INFO [2026-06-15 11:44:33.518 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 11:44:33.518 +0530]:    Instruction: setChainRateLimit
+INFO [2026-06-15 11:44:33.518 +0530]:    Size: 253 bytes
+INFO [2026-06-15 11:44:33.518 +0530]:    Base58 length: 345 characters
+INFO [2026-06-15 11:44:33.529 +0530]:    Compute units: 21,591
+INFO [2026-06-15 11:44:33.529 +0530]:    Generated: 2026-06-15T06:14:33.518Z
+INFO [2026-06-15 11:44:33.529 +0530]:
+INFO [2026-06-15 11:44:33.529 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 11:44:33.529 +0530]:
+INFO [2026-06-15 11:44:33.529 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 11:44:33.529 +0530]:
+INFO [2026-06-15 11:44:33.529 +0530]: 📊 Account Information:
+INFO [2026-06-15 11:44:33.529 +0530]:    Total accounts: 3
+INFO [2026-06-15 11:44:33.529 +0530]:     1. 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R (read-only)
+INFO [2026-06-15 11:44:33.530 +0530]:     2. 5ZctnHiRZyrtDirqfXxpo4aH6eNT7YTJZ3HZh5WJWMiX (writable)
+INFO [2026-06-15 11:44:33.530 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 11:44:33.530 +0530]:
+INFO [2026-06-15 11:44:33.530 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 11:44:33.530 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 11:44:33.530 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 11:44:33.530 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 11:44:33.530 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 11:44:33.530 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 11:44:33.530 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 11:44:33.530 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 11:44:33.530 +0530]:
+INFO [2026-06-15 11:44:33.530 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 11:44:33.530 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 11:44:33.530 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 11:44:33.530 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 11:44:33.530 +0530]:    • Estimated compute units: 21,591
+INFO [2026-06-15 11:44:33.530 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 11:44:33.530 +0530]:
+INFO [2026-06-15 11:44:33.530 +0530]: setChainRateLimit command completed successfully
+    command: "lockrelease-token-pool.set-chain-rate-limit"
+    transactionSize: "253 bytes"
+    computeUnits: 21591
 ```
 
 </Fragment>
@@ -2100,15 +2546,15 @@ INFO [2025-09-18 10:59:45.155 +0200]:
 
 | Account | Address                                        | Type                 | Purpose                                                           |
 | ------- | ---------------------------------------------- | -------------------- | ----------------------------------------------------------------- |
-| **#1**  | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Read-only**        | **Pool State PDA** - Main pool configuration account              |
-| **#2**  | `DzPjdCvEgJq6tyTvQtuh6i8WtPn6gWGmhaRM3DnCvwq9` | **Writable**         | **Chain Config PDA** - Chain-specific config (stores rate limits) |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Signer, Writable** | **Authority** - Your Squad vault that can modify rate limits      |
+| **#1**  | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Read-only**        | **Pool State PDA** - Main pool configuration account              |
+| **#2**  | `5ZctnHiRZyrtDirqfXxpo4aH6eNT7YTJZ3HZh5WJWMiX` | **Writable**         | **Chain Config PDA** - Chain-specific config (stores rate limits) |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Signer, Writable** | **Authority** - Your Squad vault that can modify rate limits      |
 
 <Aside type="note" title="Squads Execution Required">
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -2133,9 +2579,9 @@ This command creates an **Address Lookup Table (ALT)** that stores frequently us
 ```bash
 # Generate address lookup table creation transaction
 pnpm bs58 router --env devnet --instruction create-lookup-table \
-  --program-id $CCIP_ROUTER_PROGRAM \
-  --fee-quoter-program-id $CCIP_FEE_QUOTER_PROGRAM \
-  --pool-program-id $CCIP_POOL_PROGRAM \
+  --program-id $SOL_CCIP_ROUTER \
+  --fee-quoter-program-id $SOL_CCIP_FEE_QUOTER_PROGRAM \
+  --pool-program-id $SOL_CCIP_POOL_PROGRAM \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG
 ```
@@ -2145,44 +2591,78 @@ pnpm bs58 router --env devnet --instruction create-lookup-table \
 <Fragment slot="panel.2">
 
 ```bash
-📮 Derived Lookup Table Address: C3a5U5C4Sn8fywXmV4ZX6JAfYoQrEhAqF5daL39ScKSy
-   ✅ Transaction simulation completed
+🔄 Generating create_lookup_table transaction...
+🔄 Building and simulating transaction...
+INFO [2026-06-15 11:46:46.017 +0530]: Detected SPL Token v1
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
 🎯 COPY TRANSACTION DATA BELOW:
 
-CfLxxNdmxNBMcAM3gnQ1YoKRx7fTChKjPVewQBLAXx8tWyp6Cxc5GTzM3QCCQDosAG1h6uVRNy3yHz8GPthfefdKJkz1eeFPV1AugM1gnfKRWvgzLNzfCK9mtrHgzJQnc2t6xVzsziGmUbyBktdCcWLqcG484hcxMgwzTwPoU1M7E5eTx2Up1JMdBMups2KPCE99cqV9t7KpghhB8A2KhFjKLjJNp3YN4Kz3vht3QXK13Qo6TcUn5DmE3eGY7p8LtFiGzEWD1tkvkAGjnHB5mZnFZvghnLruSRr73Cfr4LTEBntfR7zVDRx4idNCPRGH6jy5LMEMCMUpu6GoZ4SbvtmwYmN4ZRqKqehB71MNoj2hkU5QdqxctMFJ61NDNUL7Zhdh9SdZxJRoa7GnMaHVyzErPhFSdoM2obiJjwTFGCDKiwyxpZZyvJjV7srJeaFTKrdi5crnf54riAmGjRYzxPngpchTjQwq8Ezxp8uaiWNxYnzEBCdLnjp1mUAA9WgfDEEtbJRMxP7A4uf8rFhrekrdLTvD9pVspcLzVY8T3Dp2bbVHE6x5YtN8JnXJQM7CGaTuy54b8zwS6Q5sswgJ3Y6HWXK5y2tKEwMcShGcszuNPw1uiJQJMQJwinCGTKodtjXw1DYcVA7ujVT7vDxWjhrvmwBqUgKqNMfMfGwHtbJTcAp46knwvkfcoAizMWCSsrUMcDZsFxEe
+CfLxzu487s26azqHSEwgDpDHVCircfZKPKbwGKjMxfPai6EjeRRsXCJGi6mYpxAaxP4AVoV56Gb47KiVsG8KJ3BdUnuni1a3eobn3sxqvogdY3BVSKu7ai8L9UrLNnyzF6CsUSGKBxrx95EbGP2TViZVik5vsTuvHZCgzufvxPpP6h66BhcCDULJFbE2S1UrjLwJvcyfG3uusyrw4Cz3injMUKzz1qFqaHxUpJGJGAaAFgPvsrr8dBsz244MXDZRrqUt13XZjLAiwHg3n7u6ifWDk4zot3sCjQZCFaLzYQwk5VCLRE7cRU2ZjAUrKK95H8WbwL5vGxG5z9LN9Y9LcqzWbh3Rq3iGL1s3fVr2791fw6ExMM3wYtZ5Zmew4aHyP7M76QswqwmSTAdY9GqYFcU6oQmcjYcc6DZuX8NVAS9Zok7dUVMZM1NSJW46XrGUdJGq6TeBP1V5E7LY4hM2hwonCDM1QiJKnXR6JvFRiAgYo8QYCmeVe5Rmqwnw2VJMnFVMc9PhaZxpwX3GJCbWggNT3ZYivHrdMGJ3fpD8JfahKEhsVLTFin8pGabrYPgHWsR3guxDnWKt9vcyoPXqhbbXMocTiPeaKneRPXR8LXqCCgWmvdy4So1Fa85MPLjAKDu4m1mGuDVGcRkXAW7HHaBL1d4W1ybd2xETuVwPxLbaRJyLWgTTvWi9BgM8B5bsGnU4eUWUs6mQ
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-18 11:00:56.836 +0200]: Transaction built successfully
+📮 Derived Lookup Table Address: 2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK
+   ✅ Transaction simulation completed
+
+⚠️  ALT CREATION TIMING CONSTRAINT
+   This transaction must be imported AND executed within 60-90 seconds
+   due to slot-dependent address derivation.
+
+💡 RECOMMENDED: Use the companion tool for immediate execution:
+   pnpm create-alt --keypair <EOA_KEYPAIR> --authority AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB \
+     --program-id Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C \
+     --fee-quoter-program-id FeeQPGkKDeRV1MgoYfMH6L8o3KeuYjwUZrgn4LRKfjHi \
+     --pool-program-id 8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC \
+     --mint 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li \
+     --env devnet
+
+INFO [2026-06-15 11:46:46.293 +0530]: Transaction built successfully
     instructionName: "router.create_lookup_table"
     transactionSize: "525 bytes"
     base58Length: "716 characters"
     hexLength: "1050 characters"
     accountCount: 4
     signerCount: 2
-    computeUnits: 19341
-INFO [2025-09-18 11:00:56.836 +0200]: Completed buildTransaction (router.create_lookup_table)
-    durationMs: 515
-INFO [2025-09-18 11:00:56.836 +0200]:
-INFO [2025-09-18 11:00:56.836 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-18 11:00:56.836 +0200]:
-INFO [2025-09-18 11:00:56.836 +0200]: 📋 Transaction Details:
-INFO [2025-09-18 11:00:56.836 +0200]:    Instruction: router.create_lookup_table
-INFO [2025-09-18 11:00:56.836 +0200]:    Size: 525 bytes
-INFO [2025-09-18 11:00:56.836 +0200]:    Base58 length: 716 characters
-INFO [2025-09-18 11:00:56.852 +0200]:    Compute units: 19 341
-INFO [2025-09-18 11:00:56.852 +0200]:    Generated: 2025-09-18T09:00:56.835Z
-INFO [2025-09-18 11:00:56.852 +0200]:
-INFO [2025-09-18 11:00:56.852 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-18 11:00:56.852 +0200]:
-INFO [2025-09-18 11:00:56.853 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-18 11:00:56.853 +0200]:
-INFO [2025-09-18 11:00:56.853 +0200]: 📊 Account Information:
-INFO [2025-09-18 11:00:56.853 +0200]:    Total accounts: 4
-INFO [2025-09-18 11:00:56.853 +0200]:     1. C3a5U5C4Sn8fywXmV4ZX6JAfYoQrEhAqF5daL39ScKSy (writable)
-INFO [2025-09-18 11:00:56.853 +0200]:     2. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer)
-INFO [2025-09-18 11:00:56.853 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-09-18 11:00:56.853 +0200]:     4. 11111111111111111111111111111111 (read-only)
-INFO [2025-09-18 11:00:56.853 +0200]:
+    computeUnits: 19227
+INFO [2026-06-15 11:46:46.293 +0530]: Completed buildTransaction (router.create_lookup_table)
+    durationMs: 182
+INFO [2026-06-15 11:46:46.293 +0530]:
+INFO [2026-06-15 11:46:46.293 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 11:46:46.293 +0530]:
+INFO [2026-06-15 11:46:46.293 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 11:46:46.293 +0530]:    Instruction: router.create_lookup_table
+INFO [2026-06-15 11:46:46.293 +0530]:    Size: 525 bytes
+INFO [2026-06-15 11:46:46.293 +0530]:    Base58 length: 716 characters
+INFO [2026-06-15 11:46:46.304 +0530]:    Compute units: 19,227
+INFO [2026-06-15 11:46:46.304 +0530]:    Generated: 2026-06-15T06:16:46.293Z
+INFO [2026-06-15 11:46:46.304 +0530]:
+INFO [2026-06-15 11:46:46.304 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 11:46:46.304 +0530]:
+INFO [2026-06-15 11:46:46.304 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 11:46:46.304 +0530]:
+INFO [2026-06-15 11:46:46.304 +0530]: 📊 Account Information:
+INFO [2026-06-15 11:46:46.304 +0530]:    Total accounts: 4
+INFO [2026-06-15 11:46:46.304 +0530]:     1. 2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK (writable)
+INFO [2026-06-15 11:46:46.304 +0530]:     2. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer)
+INFO [2026-06-15 11:46:46.304 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 11:46:46.304 +0530]:     4. 11111111111111111111111111111111 (read-only)
+INFO [2026-06-15 11:46:46.304 +0530]:
+INFO [2026-06-15 11:46:46.304 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 11:46:46.304 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 11:46:46.304 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 11:46:46.304 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 11:46:46.304 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 11:46:46.304 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 11:46:46.304 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 11:46:46.304 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 11:46:46.304 +0530]:
+INFO [2026-06-15 11:46:46.304 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 11:46:46.304 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 11:46:46.304 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 11:46:46.304 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 11:46:46.304 +0530]:    • Estimated compute units: 19,227
+INFO [2026-06-15 11:46:46.304 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 11:46:46.304 +0530]:
 ```
 
 </Fragment>
@@ -2192,9 +2672,9 @@ INFO [2025-09-18 11:00:56.853 +0200]:
 
 | Account | Address                                        | Description                                               |
 | ------- | ---------------------------------------------- | --------------------------------------------------------- |
-| **#1**  | `C3a5U5C4Sn8fywXmV4ZX6JAfYoQrEhAqF5daL39ScKSy` | **ALT Account** (writable - being created)                |
-| **#2**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **ALT Authority** (signer - will own the table)           |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Fee Payer** (signer, writable - pays creation costs)    |
+| **#1**  | `2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK` | **ALT Account** (writable - being created)                |
+| **#2**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **ALT Authority** (signer - will own the table)           |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Fee Payer** (signer, writable - pays creation costs)    |
 | **#4**  | `11111111111111111111111111111111`             | **System Program** (read-only - handles account creation) |
 
 **What This Command Does:**
@@ -2203,7 +2683,7 @@ This command creates the ALT infrastructure needed for efficient CCIP operations
 
 **Transaction Flow:**
 
-1. **ALT Creation**: Creates lookup table account `C3a5U...` with Squad Vault as authority
+1. **ALT Creation**: Creates lookup table account `2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK` with Squad Vault as authority
 1. **Core Address Addition**: Adds essential CCIP accounts (programs, PDAs) to the table
 1. **Index Assignment**: Each address gets a unique 1-byte index for future reference
 
@@ -2217,14 +2697,14 @@ The created lookup table will contain indices for these accounts in this exact o
 
 | Index | Account Address                                | Purpose                                    |
 | ----- | ---------------------------------------------- | ------------------------------------------ |
-| **0** | `C3a5U5C4Sn8fywXmV4ZX6JAfYoQrEhAqF5daL39ScKSy` | **ALT Address (Self-Reference)**           |
-| **1** | `89Jy2ZEz6LcvBPVQgR2YxPYVoF1sLugNRs3havQP8SvF` | **Token Admin Registry PDA**               |
+| **0** | `2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK` | **ALT Address (Self-Reference)**           |
+| **1** | `6gmKNyGtrSgB4gAH9yQyzXSPnDw1P5We9abZLEcuqdLY` | **Token Admin Registry PDA**               |
 | **2** | `8eqh8wppT9c5rw4ERqNCffvU6cNFJWff9WmkcYtmGiqC` | **Pool Program ID**                        |
-| **3** | `9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1` | **Pool State PDA**                         |
-| **4** | `A57bH91QkGuARh37JTN41fd3Vwcmf2bLzVHAVPB8Gaeg` | **Pool Signer's Associated Token Account** |
-| **5** | `E8odUv4V4DXy3RWvkNYF7H33X9J56RtsFp4ExVXB86UA` | **Pool Signer PDA**                        |
+| **3** | `9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R` | **Pool State PDA**                         |
+| **4** | `GQ4md7wUKmU35m4munp8giYg9osXCTaGVCPvNYzz8Wnu` | **Pool Signer's Associated Token Account** |
+| **5** | `5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk` | **Pool Signer PDA**                        |
 | **6** | `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`  | **Token Program ID (SPL Token v1)**        |
-| **7** | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | **Token Mint**                             |
+| **7** | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | **Token Mint**                             |
 | **8** | `84grjTssjNyuDsaxJGkpJB8t17Y9sQt1G81R5AQyZ1Rr` | **Fee Quoter Token Config PDA**            |
 | **9** | `DPyeT76APQQVQD7EJRVw8Y6gLYjGkC5CdbdHQTQkpoN2` | **Router External Token Pools Signer PDA** |
 
@@ -2238,7 +2718,7 @@ The created lookup table will contain indices for these accounts in this exact o
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -2271,7 +2751,7 @@ echo "✅ Address Lookup Table: $SOL_ADDRESS_LOOKUP_TABLE"
 <Fragment slot="panel.2">
 
 ```bash
-✅ Address Lookup Table: C3a5U5C4Sn8fywXmV4ZX6JAfYoQrEhAqF5daL39ScKSy
+✅ Address Lookup Table: 2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK
 ```
 
 </Fragment>
@@ -2296,7 +2776,7 @@ Register your token pool with the CCIP Router using [set_pool](/ccip/api-referen
 ```bash
 # Generate pool registration transaction
 pnpm bs58 router --env devnet --instruction set-pool \
-  --program-id $CCIP_ROUTER_PROGRAM \
+  --program-id $SOL_CCIP_ROUTER \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --pool-lookup-table $SOL_ADDRESS_LOOKUP_TABLE \
@@ -2308,44 +2788,62 @@ pnpm bs58 router --env devnet --instruction set-pool \
 <Fragment slot="panel.2">
 
 ```bash
-   ✅ Transaction simulation completed
+🔄 Generating set_pool transaction...
+🔄 Building and simulating transaction...
 🎯 COPY TRANSACTION DATA BELOW:
 
-QmCar77mNEqzAzGvMRsXQY9UpezF7qcPt7iURnmpvC88c6Kwr3gd6bJHPKGmwqcPxFQjtKgHxjCRqcutU6hnZAn1bTiz7K2M9c4VBqvUqtMMJRvBk7AcL2nohnjwrKEgatZwoxftC4f4MyvhTizzbBBgyzuFEnduq3oGKaPFXKDeWFpTmfZfmDWeqeYQMFYS5xxnGrxNJWpRXgStvfbEcKy3AnaJd2rDRHp8rXtissTD3x3rHsd6GkWTRh1ZtmdBCjkmTGoGFaVZPdELSdkmA9Aw7Dyo9qPUymsMQPWvHNXx7jjct4ovGBRcRC7WajLHJDPCcztCtPSKGuHfuRk9jmx
+QmCawFUFrWLVf4xbxo2fJyttTDxiAsdLTbZfn4tgZUjn1Tcfy6NYjTXp3aUxzwfZek1mAYXZci1DYhTzSj9eK7824BicLJVHt7EyJVs7sxwXE1TzRh4zfDijK1hnHFMZunQr9A61zxxQKyx357zsmKhuVFtXySUPgQKUZ1QzqvossZWqHHTgiMB8rDmgw4DPWt891CP3wwoD16Xo88aeSwxG1KFqYsXy1eCqii3nzZSyzZEfcxw6ybkGpwfEpCdPYrmZjk7JTuN7JSA3KFDVP11yrEpD87RjpSin69wMYwuDyEZeYiNRQjXPjRcc1qrTBF3gt9DcAJXGhdRQXQym2U6
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-09-18 11:10:00.055 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 11:54:50.199 +0530]: Transaction built successfully
     instructionName: "router.set_pool"
     transactionSize: "252 bytes"
     base58Length: "343 characters"
     hexLength: "504 characters"
     accountCount: 5
     signerCount: 1
-    computeUnits: 29867
-INFO [2025-09-18 11:10:00.056 +0200]: Completed buildTransaction (router.set_pool)
-    durationMs: 445
-INFO [2025-09-18 11:10:00.056 +0200]:
-INFO [2025-09-18 11:10:00.056 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-09-18 11:10:00.056 +0200]:
-INFO [2025-09-18 11:10:00.056 +0200]: 📋 Transaction Details:
-INFO [2025-09-18 11:10:00.056 +0200]:    Instruction: router.set_pool
-INFO [2025-09-18 11:10:00.056 +0200]:    Size: 252 bytes
-INFO [2025-09-18 11:10:00.056 +0200]:    Base58 length: 343 characters
-INFO [2025-09-18 11:10:00.093 +0200]:    Compute units: 29 867
-INFO [2025-09-18 11:10:00.093 +0200]:    Generated: 2025-09-18T09:10:00.051Z
-INFO [2025-09-18 11:10:00.093 +0200]:
-INFO [2025-09-18 11:10:00.093 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-09-18 11:10:00.093 +0200]:
-INFO [2025-09-18 11:10:00.093 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-09-18 11:10:00.093 +0200]:
-INFO [2025-09-18 11:10:00.093 +0200]: 📊 Account Information:
-INFO [2025-09-18 11:10:00.093 +0200]:    Total accounts: 5
-INFO [2025-09-18 11:10:00.093 +0200]:     1. 3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3 (read-only)
-INFO [2025-09-18 11:10:00.093 +0200]:     2. 89Jy2ZEz6LcvBPVQgR2YxPYVoF1sLugNRs3havQP8SvF (writable)
-INFO [2025-09-18 11:10:00.093 +0200]:     3. FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1 (read-only)
-INFO [2025-09-18 11:10:00.093 +0200]:     4. C3a5U5C4Sn8fywXmV4ZX6JAfYoQrEhAqF5daL39ScKSy (read-only)
-INFO [2025-09-18 11:10:00.093 +0200]:     5. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-09-18 11:10:00.093 +0200]:
+    computeUnits: 35867
+INFO [2026-06-15 11:54:50.199 +0530]: Completed buildTransaction (router.set_pool)
+    durationMs: 448
+INFO [2026-06-15 11:54:50.199 +0530]:
+INFO [2026-06-15 11:54:50.199 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 11:54:50.199 +0530]:
+INFO [2026-06-15 11:54:50.199 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 11:54:50.199 +0530]:    Instruction: router.set_pool
+INFO [2026-06-15 11:54:50.199 +0530]:    Size: 252 bytes
+INFO [2026-06-15 11:54:50.199 +0530]:    Base58 length: 343 characters
+INFO [2026-06-15 11:54:50.208 +0530]:    Compute units: 35,867
+INFO [2026-06-15 11:54:50.208 +0530]:    Generated: 2026-06-15T06:24:50.198Z
+INFO [2026-06-15 11:54:50.208 +0530]:
+INFO [2026-06-15 11:54:50.208 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 11:54:50.208 +0530]:
+INFO [2026-06-15 11:54:50.208 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 11:54:50.208 +0530]:
+INFO [2026-06-15 11:54:50.208 +0530]: 📊 Account Information:
+INFO [2026-06-15 11:54:50.208 +0530]:    Total accounts: 5
+INFO [2026-06-15 11:54:50.209 +0530]:     1. 3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3 (read-only)
+INFO [2026-06-15 11:54:50.209 +0530]:     2. 6gmKNyGtrSgB4gAH9yQyzXSPnDw1P5We9abZLEcuqdLY (writable)
+INFO [2026-06-15 11:54:50.209 +0530]:     3. 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li (read-only)
+INFO [2026-06-15 11:54:50.209 +0530]:     4. 2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK (read-only)
+INFO [2026-06-15 11:54:50.209 +0530]:     5. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 11:54:50.209 +0530]:
+INFO [2026-06-15 11:54:50.209 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 11:54:50.209 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 11:54:50.209 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 11:54:50.209 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 11:54:50.209 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 11:54:50.209 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 11:54:50.209 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 11:54:50.209 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 11:54:50.209 +0530]:
+INFO [2026-06-15 11:54:50.209 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 11:54:50.209 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 11:54:50.209 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 11:54:50.209 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 11:54:50.209 +0530]:    • Estimated compute units: 35,867
+INFO [2026-06-15 11:54:50.209 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 11:54:50.209 +0530]:
 ```
 
 </Fragment>
@@ -2356,10 +2854,10 @@ INFO [2025-09-18 11:10:00.093 +0200]:
 | Account | Address                                        | Description                                                 |
 | ------- | ---------------------------------------------- | ----------------------------------------------------------- |
 | **#1**  | `3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3` | **Router Config PDA** (read-only - configuration reference) |
-| **#2**  | `89Jy2ZEz6LcvBPVQgR2YxPYVoF1sLugNRs3havQP8SvF` | **Token Admin Registry PDA** (writable - pool registration) |
-| **#3**  | `FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1` | **Token Mint** (read-only - token identification)           |
-| **#4**  | `C3a5U5C4Sn8fywXmV4ZX6JAfYoQrEhAqF5daL39ScKSy` | **Address Lookup Table** (read-only - ALT registration)     |
-| **#5**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault Authority** (signer, writable - admin & fees) |
+| **#2**  | `6gmKNyGtrSgB4gAH9yQyzXSPnDw1P5We9abZLEcuqdLY` | **Token Admin Registry PDA** (writable - pool registration) |
+| **#3**  | `3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li` | **Token Mint** (read-only - token identification)           |
+| **#4**  | `2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK` | **Address Lookup Table** (read-only - ALT registration)     |
+| **#5**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault Authority** (signer, writable - admin & fees) |
 
 **What This Command Does:**
 
@@ -2391,7 +2889,7 @@ Based on the ALT order established earlier:
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -2416,14 +2914,13 @@ export ETH_POOL_ADDRESS="$ETH_POOL_ADDRESS"
 
 # Phase 2 - Solana
 
-export CCIP_POOL_PROGRAM="$CCIP_POOL_PROGRAM"
-export CCIP_ROUTER_PROGRAM="$CCIP_ROUTER_PROGRAM"
+export SOL_CCIP_POOL_PROGRAM="$SOL_CCIP_POOL_PROGRAM"
+export SOL_CCIP_ROUTER="$SOL_CCIP_ROUTER"
 export SOL_SQUAD_VAULT_MULTISIG="$SOL_SQUAD_VAULT_MULTISIG"
 export SOL_WALLET_ADDRESS="$SOL_WALLET_ADDRESS"
 export SOL_TOKEN_MINT="$SOL_TOKEN_MINT"
 export SOL_POOL_ADDRESS="$SOL_POOL_ADDRESS"
 export SOL_POOL_SIGNER_PDA="$SOL_POOL_SIGNER_PDA"
-export SOL_SPL_MULTISIG="$SOL_SPL_MULTISIG"
 export SOL_ADDRESS_LOOKUP_TABLE="$SOL_ADDRESS_LOOKUP_TABLE"
 
 # Chain Selectors
@@ -2443,7 +2940,7 @@ echo "✅ All variables saved to ~/.all_vars"
 
 ```bash
 === Phase 3 Complete - Cross-Chain Configuration ===
-✅ Address Lookup Table: C3a5U5C4Sn8fywXmV4ZX6JAfYoQrEhAqF5daL39ScKSy
+✅ Address Lookup Table: 2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK
 ✅ Cross-chain connection configured
 ✅ All variables saved to ~/.all_vars
 ```
@@ -2491,11 +2988,11 @@ echo "✅ SOL ALT: $SOL_ADDRESS_LOOKUP_TABLE"
 
 ```bash
 /.../smart-contract-examples/ccip/cct/hardhat
-✅ ETH Token: 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715
-✅ ETH Pool: 0x4678b403781467761Df2f9364FeC48ae3f4F3857
-✅ SOL Token: FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1
-✅ SOL Pool: 9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1
-✅ SOL ALT: C3a5U5C4Sn8fywXmV4ZX6JAfYoQrEhAqF5daL39ScKSy
+✅ ETH Token: 0x44490fee906a4cfd5e71a46c3ca2147287b018e7
+✅ ETH Pool: 0x80cd26e9325342b9be1cc7cab3e785afb44ebee4
+✅ SOL Token: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
+✅ SOL Pool: 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R
+✅ SOL ALT: 2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK
 ```
 
 </Fragment>
@@ -2543,7 +3040,7 @@ npx hardhat applyChainUpdates \
   --inboundratelimitenabled true \
   --inboundratelimitcapacity 20000000000000000000 \
   --inboundratelimitrate 100000000000000000 \
- --network sepolia
+ --network ethereumSepolia
 ```
 
 </Fragment>
@@ -2557,7 +3054,7 @@ npx hardhat applyChainUpdates \
   --remotechain solanaDevnet \
   --remotepooladdresses $SOL_POOL_ADDRESS \
   --remotetokenaddress $SOL_TOKEN_MINT \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 </Fragment>
@@ -2565,29 +3062,27 @@ npx hardhat applyChainUpdates \
 <Fragment slot="panel.3">
 
 ```bash
-2025-09-18T09:21:58.804Z info: === Starting Chain Update Configuration ===
-2025-09-18T09:21:58.805Z info: 🔹 Local network: sepolia
-2025-09-18T09:21:58.805Z info: 🔹 Pool address: 0x4678b403781467761Df2f9364FeC48ae3f4F3857
-2025-09-18T09:21:58.805Z info: 🔹 Remote chain: solanaDevnet
-2025-09-18T09:21:58.805Z info: 🔹 Remote chain type detected: svm
-2025-09-18T09:21:58.805Z info: 🔹 Remote chain selector: 16423721717087811551
-2025-09-18T09:21:58.805Z info: 🔹 Parsed 1 remote pool addresses
-2025-09-18T09:21:58.825Z info: ✅ All addresses validated successfully
-2025-09-18T09:21:59.376Z info: 🔹 Using signer: 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-09-18T09:21:59.716Z info: ✅ Connected to pool contract
-2025-09-18T09:21:59.716Z info: 🔹 Remote pool address 1: 9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1 → 0x7e3d0758b16a2af735e7079ea4490eae495f7e444028346384a3a95f593f5ce0
-2025-09-18T09:21:59.716Z info: 🔹 Remote token address: FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1 → 0xd743d465642ec7a0828aacbbada2acaa6884c4b92ae41638cf2325a7a70af840
-2025-09-18T09:21:59.716Z info: === Rate Limiter Configuration ===
-2025-09-18T09:21:59.716Z info: 🔹 Outbound enabled: true
-2025-09-18T09:21:59.716Z info: 🔹 Outbound capacity: 18000000000000000000
-2025-09-18T09:21:59.716Z info: 🔹 Outbound rate: 100000000000000000
-2025-09-18T09:21:59.716Z info: 🔹 Inbound enabled: true
-2025-09-18T09:21:59.716Z info: 🔹 Inbound capacity: 20000000000000000000
-2025-09-18T09:21:59.716Z info: 🔹 Inbound rate: 100000000000000000
-2025-09-18T09:21:59.716Z info: === Executing Transaction ===
-2025-09-18T09:21:59.716Z info: 🔹 Sending applyChainUpdates transaction...
-2025-09-18T09:22:00.455Z info: 🔹 Transaction sent: 0x2a0ea9c95b3ad9945b82a55a3871b9ba475e453daf2eaf4dcf266cdd0b46f088
-2025-09-18T09:22:00.455Z info: 🔹 Waiting for 3 confirmations...
+2026-06-15T06:28:49.745Z info: === Starting Chain Update Configuration ===
+2026-06-15T06:28:49.746Z info: 🔹 Local network: ethereumSepolia
+2026-06-15T06:28:49.746Z info: 🔹 Pool address: 0x80cd26e9325342b9be1cc7cab3e785afb44ebee4
+2026-06-15T06:28:49.746Z info: 🔹 Remote chain: solanaDevnet
+2026-06-15T06:28:49.746Z info: 🔹 Remote chain family: svm
+2026-06-15T06:28:49.746Z info: 🔹 Remote chain selector: 16423721717087811551
+2026-06-15T06:28:54.209Z info: ✅ All addresses validated successfully
+2026-06-15T06:28:55.539Z info: ✅ Using signer: 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-15T06:28:56.848Z info: ✅ Connected to TokenPool contract
+2026-06-15T06:28:56.849Z info:   Remote pool 1: 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R → 0x826e378d9d0841269f94a32bd978c6477f504af547e848849b52fe3c1ff63ba2
+2026-06-15T06:28:56.849Z info: === Rate Limiter Configuration ===
+2026-06-15T06:28:56.850Z info: Outbound enabled: true
+2026-06-15T06:28:56.850Z info:   capacity: 18000000000000000000
+2026-06-15T06:28:56.850Z info:   rate: 100000000000000000
+2026-06-15T06:28:56.850Z info: Inbound enabled: true
+2026-06-15T06:28:56.850Z info:   capacity: 20000000000000000000
+2026-06-15T06:28:56.850Z info:   rate: 100000000000000000
+2026-06-15T06:28:56.850Z info: === Executing applyChainUpdates() ===
+2026-06-15T06:29:00.954Z info: 📤 TX sent: 0x73a3398a4b2bb2924f6e1d716a75838b693e8893b4998034ce9477a032b4deba
+2026-06-15T06:29:00.954Z info: Waiting for 3 confirmations...
+2026-06-15T06:29:40.771Z info: ✅ Chain update applied successfully on ethereumSepolia (3 confirmations)!
 ```
 
 </Fragment>
@@ -2595,39 +3090,42 @@ npx hardhat applyChainUpdates \
 <Fragment slot="panel.4">
 
 ```bash
-2025-09-18T09:21:58.804Z info: === Starting Chain Update Configuration ===
-2025-09-18T09:21:58.805Z info: 🔹 Local network: sepolia
-2025-09-18T09:21:58.805Z info: 🔹 Pool address: 0x4678b403781467761Df2f9364FeC48ae3f4F3857
-2025-09-18T09:21:58.805Z info: 🔹 Remote chain: solanaDevnet
-2025-09-18T09:21:58.805Z info: 🔹 Remote chain type detected: svm
-2025-09-18T09:21:58.805Z info: 🔹 Remote chain selector: 16423721717087811551
-2025-09-18T09:21:58.805Z info: 🔹 Parsed 1 remote pool addresses
-2025-09-18T09:21:58.825Z info: ✅ All addresses validated successfully
-2025-09-18T09:21:59.376Z info: 🔹 Using signer: 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-09-18T09:21:59.716Z info: ✅ Connected to pool contract
-2025-09-18T09:21:59.716Z info: 🔹 Remote pool address 1: 9VnLxEtwJgnGALzhhXJTtRr4GF83z95aCypPiRFGi9d1 → 0x7e3d0758b16a2af735e7079ea4490eae495f7e444028346384a3a95f593f5ce0
-2025-09-18T09:21:59.716Z info: 🔹 Remote token address: FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1 → 0xd743d465642ec7a0828aacbbada2acaa6884c4b92ae41638cf2325a7a70af840
-2025-09-18T09:21:58.804Z  info: === Rate Limiter Configuration ===
-2025-09-18T09:21:58.804Z  info: 🔹 No rate limits configured (unlimited transfers)
-2025-09-18T09:21:58.804Z  info: === Executing Transaction ===
-2025-09-18T09:21:58.804Z  info: 🔹 Sending applyChainUpdates transaction...
-2025-09-18T09:21:58.804Z  info: 🔹 Transaction sent: 0x7f89ab2c3d4e5f6789abc123def4567890abcdef1234567890abcdef12345678
-2025-09-18T09:21:58.804Z  info: 🔹 Waiting for 3 confirmations...
-2025-09-18T09:21:58.804Z  info: ✅ Chain update applied successfully!
+2026-06-15T06:31:10.745Z info: === Starting Chain Update Configuration ===
+2026-06-15T06:31:10.746Z info: 🔹 Local network: ethereumSepolia
+2026-06-15T06:31:10.746Z info: 🔹 Pool address: 0x80cd26e9325342b9be1cc7cab3e785afb44ebee4
+2026-06-15T06:31:10.746Z info: 🔹 Remote chain: solanaDevnet
+2026-06-15T06:31:10.746Z info: 🔹 Remote chain family: svm
+2026-06-15T06:31:10.746Z info: 🔹 Remote chain selector: 16423721717087811551
+2026-06-15T06:31:12.209Z info: ✅ All addresses validated successfully
+2026-06-15T06:31:12.539Z info: ✅ Using signer: 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-15T06:31:12.848Z info: ✅ Connected to TokenPool contract
+2026-06-15T06:31:12.849Z info:   Remote pool 1: 9n9UgFppJCanCjy6cd3tEudEemUf4bQRR8PgiXN7Rp4R → 0x826e378d9d0841269f94a32bd978c6477f504af547e848849b52fe3c1ff63ba2
+2026-06-15T06:31:12.849Z info: === Rate Limiter Configuration ===
+2026-06-15T06:31:12.850Z info: Outbound enabled: false
+2026-06-15T06:31:12.850Z info: Inbound enabled: false
+2026-06-15T06:31:12.850Z info: === Executing applyChainUpdates() ===
+2026-06-15T06:31:14.954Z info: 📤 TX sent: 0xa8f3c2e91d4b6789f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6e5f4a3b2
+2026-06-15T06:31:14.954Z info: Waiting for 3 confirmations...
+2026-06-15T06:31:54.771Z info: ✅ Chain update applied successfully on ethereumSepolia (3 confirmations)!
 ```
 
 </Fragment>
 </Tabs>
 
-## Phase 5: Testing and Validation
+## Phase 5: Pre-Transfer Setup, Validation, and Testing
 
 <Aside type="note" title="Terminal Context Check">
-  **Current Focus: Terminal 3 (Solana Testing)** Switch to the Solana Starter Kit repository for comprehensive testing.
+  **Current Focus: Terminal 1 (CCIP Solana BS58 Generator)** Complete pre-transfer setup and validate your
+  configuration. Governance steps use Squads; delegation and verification use your local wallet with `--execute`.
 </Aside>
 
-### Step 1: Load Phase 4 Variables
+<Aside type="note" title="Cross-Chain Transfers with CCIP CLI">
 
-Before testing cross-chain transfers, ensure your terminal environment is properly configured:
+Use [`@chainlink/ccip-cli`](https://github.com/smartcontractkit/ccip-tools-ts) for bidirectional token transfers. Run Solana → EVM sends from Terminal 1 and EVM → Solana sends from Terminal 2. See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for full options.
+
+</Aside>
+
+### Step 1: Load Configuration
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Command</Fragment>
@@ -2636,29 +3134,18 @@ Before testing cross-chain transfers, ensure your terminal environment is proper
 <Fragment slot="panel.1">
 
 ```bash
-# Check current directory
-# This should be the solana-starter-kit directory (Terminal 3)
+# Check current directory (Terminal 1)
 pwd
-```
+# Should show: .../ccip-solana-bs58-generator
 
-Load all environment variables
-
-```bash
+# Load all environment variables
 source ~/.all_vars
-```
 
-Set Ethereum receiver for testing
-
-```bash
-export ETH_RECEIVER_ADDRESS="<YOUR_ETH_RECEIVER_ADDRESS>"
-```
-
-Verify critical variables for Solana Starter Kit
-
-```bash
+# Verify critical variables
 echo "SOL_TOKEN_MINT: $SOL_TOKEN_MINT"
 echo "ETH_TOKEN_ADDRESS: $ETH_TOKEN_ADDRESS"
-echo "ETH_RECEIVER_ADDRESS: $ETH_RECEIVER_ADDRESS"
+echo "SOL_POOL_SIGNER_PDA: $SOL_POOL_SIGNER_PDA"
+echo "SOL_ADDRESS_LOOKUP_TABLE: $SOL_ADDRESS_LOOKUP_TABLE"
 echo "SOL_WALLET_ADDRESS: $SOL_WALLET_ADDRESS"
 ```
 
@@ -2667,25 +3154,22 @@ echo "SOL_WALLET_ADDRESS: $SOL_WALLET_ADDRESS"
 <Fragment slot="panel.2">
 
 ```bash
-/.../solana-starter-kit
-SOL_TOKEN_MINT: FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1
-ETH_TOKEN_ADDRESS: 0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715
-ETH_RECEIVER_ADDRESS: 0x9d087fC03ae39b088326b67fA3C788236645b717
-SOL_WALLET_ADDRESS: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
+/.../ccip-solana-bs58-generator
+SOL_TOKEN_MINT: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
+ETH_TOKEN_ADDRESS: 0x44490fee906a4cfd5e71a46c3ca2147287b018e7
+SOL_POOL_SIGNER_PDA: 5FBAzopzmZ1oo2aadR1PKfTZqK7viBYipjvDVMyEQxzk
+SOL_ADDRESS_LOOKUP_TABLE: 2xNjGFuymdCu2KMqDtNTTVuhyFUYvXhbWz29Q1kAnPVK
+SOL_WALLET_ADDRESS: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
 ```
 
 </Fragment>
 </Tabs>
 
-### Transfer Direction 1: Solana → Ethereum
+### Step 2: Pre-Transfer Setup
 
-Test the production multisig setup with a cross-chain transfer from Solana Devnet to Ethereum Sepolia:
+Before cross-chain transfers (when available), complete token delegation so CCIP can move tokens from your wallet.
 
-#### Prepare for Testing
-
-Before testing cross-chain transfers, you need to create the pool's Associated Token Account (ATA) and prepare your tokens:
-
-##### Check Token Balance
+#### Check Token Balance
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Command</Fragment>
@@ -2694,20 +3178,23 @@ Before testing cross-chain transfers, you need to create the pool's Associated T
 <Fragment slot="panel.1">
 
 ```bash
-# Check your current token balance
 spl-token balance $SOL_TOKEN_MINT
 ```
 
 </Fragment>
 
 <Fragment slot="panel.2">
+
 ```bash
-5001
+5000
 ```
+
 </Fragment>
 </Tabs>
 
-##### Delegate Token Authority
+#### Create Pool Associated Token Account
+
+If not created during pool setup, create the pool's ATA:
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Command</Fragment>
@@ -2716,8 +3203,10 @@ spl-token balance $SOL_TOKEN_MINT
 <Fragment slot="panel.1">
 
 ```bash
-# Delegate tokens for CCIP transfers
-yarn svm:token:delegate --token-mint $SOL_TOKEN_MINT
+# Create ATA owned by the Pool Signer PDA
+spl-token create-account $SOL_TOKEN_MINT \
+  --owner $SOL_POOL_SIGNER_PDA \
+  --fee-payer $HOME/.config/solana/id.json
 ```
 
 </Fragment>
@@ -2725,53 +3214,27 @@ yarn svm:token:delegate --token-mint $SOL_TOKEN_MINT
 <Fragment slot="panel.2">
 
 ```bash
-[2025-09-18T09:27:29.767Z] CCIP Token Authority Delegator
-[2025-09-18T09:27:29.770Z] =============================================
-[2025-09-18T09:27:29.797Z] Network: solana-devnet
-[2025-09-18T09:27:29.797Z] Router Program: Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
-[2025-09-18T09:27:29.797Z] Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-09-18T09:27:29.798Z]
-[2025-09-18T09:27:29.798Z] 💰 WALLET BALANCE
-[2025-09-18T09:27:29.798Z] =============================================
-[2025-09-18T09:27:30.160Z] SOL Balance: 94.525081465 SOL (94525081465 lamports)
-[2025-09-18T09:27:30.161Z]
-[2025-09-18T09:27:30.161Z] 🔐 PROCESSING TOKEN DELEGATIONS
-[2025-09-18T09:27:30.161Z] =============================================
-[2025-09-18T09:27:30.161Z] Custom token mints provided: FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1
-[2025-09-18T09:27:30.161Z] Using 'fee-billing' delegation type for ccip_send compatibility
-[2025-09-18T09:27:30.161Z] Added custom token delegation for: FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1
-[2025-09-18T09:27:30.161Z]
-[1/1] Processing delegation for mint: FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1
-[2025-09-18T09:27:30.161Z] Getting mint account info for FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1 to determine token program ID...
-[2025-09-18T09:27:30.277Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-09-18T09:27:30.278Z] Token Program ID: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-09-18T09:27:30.278Z] Delegation Type: fee-billing
-[2025-09-18T09:27:30.279Z] Delegate Address: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
-[2025-09-18T09:27:30.279Z] Amount to delegate: 18446744073709551615
-[2025-09-18T09:27:30.280Z] User Token Account: 5dQxPofcZCuWASgwdCgR7MKzGGx9d596nsbMUcbuBrDZ
-[2025-09-18T09:27:30.385Z] Token account 5dQxPofcZCuWASgwdCgR7MKzGGx9d596nsbMUcbuBrDZ exists.
-[2025-09-18T09:27:30.490Z] Sending transaction to delegate token authority...
-[2025-09-18T09:27:31.259Z] ✅ Token delegation successful!
-[2025-09-18T09:27:31.259Z] Transaction signature: 58P1nNhRQz44HF1sPvXh6PkLf7MWCCBYeP5Jaq7xADjfxQHAJLoxroGjRoRTpwKDzgi5zan2Xom6JHztPkgdZYdk
-[2025-09-18T09:27:31.259Z] Explorer URL: https://explorer.solana.com/tx/58P1nNhRQz44HF1sPvXh6PkLf7MWCCBYeP5Jaq7xADjfxQHAJLoxroGjRoRTpwKDzgi5zan2Xom6JHztPkgdZYdk?cluster=devnet
-[2025-09-18T09:27:31.259Z]
-[2025-09-18T09:27:31.259Z] ✅ All delegations processed successfully
+Creating account GQ4md7wUKmU35m4munp8giYg9osXCTaGVCPvNYzz8Wnu
+
+Signature: Civkv2vpxvNytAyPWkWjELa2FAqTH2zVTXgP6uvkPeKQ3B9K33tL83uzRxRFSbGgtJhwrc359wczaAdUGa2q4Af
 ```
 
 </Fragment>
 </Tabs>
 
-#### Transfer tokens from Solana Devnet to Ethereum Sepolia
+#### Delegate Token Authority
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Transfer Command</Fragment>
+<Fragment slot="tab.1">Derive Fee-Billing Signer</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Execute cross-chain transfer from Solana to Ethereum
-yarn svm:token-transfer --token-mint $SOL_TOKEN_MINT --token-amount 1000000 --receiver $ETH_RECEIVER_ADDRESS
+# Derive the CCIP fee-billing signer PDA
+export SOL_CCIP_FEE_BILLING_SIGNER=$(solana find-program-derived-address $SOL_CCIP_ROUTER string:fee_billing_signer | head -1)
+
+echo "SOL_CCIP_FEE_BILLING_SIGNER=$SOL_CCIP_FEE_BILLING_SIGNER"
 ```
 
 </Fragment>
@@ -2779,109 +3242,281 @@ yarn svm:token-transfer --token-mint $SOL_TOKEN_MINT --token-amount 1000000 --re
 <Fragment slot="panel.2">
 
 ```bash
-[2025-09-18T09:28:17.635Z] 🚀 CCIP Token Transfer
-[2025-09-18T09:28:17.636Z] =======================================
-[2025-09-18T09:28:17.666Z] Network: devnet
-[2025-09-18T09:28:17.667Z] Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-09-18T09:28:17.667Z]
-[2025-09-18T09:28:17.667Z] 💰 WALLET BALANCE
-[2025-09-18T09:28:17.667Z] =======================================
-[2025-09-18T09:28:18.066Z] SOL Balance: 94525076465 lamports (94.525076465 SOL)
-[2025-09-18T09:28:18.067Z]
-[2025-09-18T09:28:18.067Z] 🌉 CCIP ROUTER INFORMATION
-[2025-09-18T09:28:18.067Z] =======================================
-[2025-09-18T09:28:18.067Z] CCIP Router Program ID: Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
-[2025-09-18T09:28:18.067Z] Fee Quoter Program ID: FeeQPGkKDeRV1MgoYfMH6L8o3KeuYjwUZrgn4LRKfjHi
-[2025-09-18T09:28:18.067Z] RMN Remote Program ID: RmnXLft1mSEwDgMKu2okYuHkiazxntFFcZFrrcXxYg7
-[2025-09-18T09:28:18.068Z] Using native SOL as fee token
-[2025-09-18T09:28:18.068Z]
-[2025-09-18T09:28:18.068Z] 📋 TOKEN TRANSFER PARAMETERS
-[2025-09-18T09:28:18.068Z] ===========================================
-[2025-09-18T09:28:18.068Z] Destination Chain: ethereum-sepolia
-[2025-09-18T09:28:18.068Z] Destination Chain Selector: 16015286601757825753
-[2025-09-18T09:28:18.068Z] EVM Receiver Address: 0x9d087fC03ae39b088326b67fA3C788236645b717
-[2025-09-18T09:28:18.068Z] Token Mint: FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1
-[2025-09-18T09:28:18.068Z] Token Amount: 1000000
-[2025-09-18T09:28:18.068Z] Fee Token: 11111111111111111111111111111111
-[2025-09-18T09:28:18.068Z] Gas Limit: 0
-[2025-09-18T09:28:18.068Z] Allow Out Of Order Execution: true
-[2025-09-18T09:28:18.069Z]
-[2025-09-18T09:28:18.069Z] 🔄 SENDING TOKEN TRANSFER
-[2025-09-18T09:28:18.069Z] =======================================
-[2025-09-18T09:28:18.069Z] Preparing CCIP message...
-[2025-09-18T09:28:18.072Z] Sending CCIP message to destination chain 16015286601757825753
-[2025-09-18T09:28:18.073Z] Building accounts for CCIP send to chain 16015286601757825753
-[2025-09-18T09:28:18.079Z] Getting mint account info for FVJeMAQSH9dJvVmhe8NHC2DHTEEqT5cgVXTL5CYYmKu1 to determine token program ID...
-[2025-09-18T09:28:18.194Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-09-18T09:28:31.439Z] CCIP message sent successfully: 4w81mpUozjJsEvHrkukCejbA9byMjkHacwtqM5cJD19XQu8MvXzoJ4YTqqkoEvBfP7HPvdivMA3Q1MePA16PdCXM
-[2025-09-18T09:28:31.441Z] Parsing CCIP message sent event for transaction: 4w81mpUozjJsEvHrkukCejbA9byMjkHacwtqM5cJD19XQu8MvXzoJ4YTqqkoEvBfP7HPvdivMA3Q1MePA16PdCXM
-[2025-09-18T09:28:31.564Z] Successfully extracted messageId: 0xd92433fea1fab2b9b2efa8d6091df0b5156bb159c883b94dada725539e5edace
-[2025-09-18T09:28:31.564Z]
-[2025-09-18T09:28:31.564Z] ✅ TOKEN TRANSFER SENT SUCCESSFULLY
-[2025-09-18T09:28:31.564Z] =======================================
-[2025-09-18T09:28:31.564Z] Transaction Signature: 4w81mpUozjJsEvHrkukCejbA9byMjkHacwtqM5cJD19XQu8MvXzoJ4YTqqkoEvBfP7HPvdivMA3Q1MePA16PdCXM
-[2025-09-18T09:28:31.564Z] CCIP Message ID: 0xd92433fea1fab2b9b2efa8d6091df0b5156bb159c883b94dada725539e5edace
-[2025-09-18T09:28:31.564Z]
-[2025-09-18T09:28:31.564Z] 🔍 EXPLORER URLS
-[2025-09-18T09:28:31.564Z] =======================================
-[2025-09-18T09:28:31.565Z] Solana Transaction: https://explorer.solana.com/tx/4w81mpUozjJsEvHrkukCejbA9byMjkHacwtqM5cJD19XQu8MvXzoJ4YTqqkoEvBfP7HPvdivMA3Q1MePA16PdCXM?cluster=devnet
-[2025-09-18T09:28:31.565Z] CCIP Explorer: https://ccip.chain.link/msg/0xd92433fea1fab2b9b2efa8d6091df0b5156bb159c883b94dada725539e5edace
-[2025-09-18T09:28:31.565Z]
-[2025-09-18T09:28:31.565Z] 🎉 Transfer Complete!
-[2025-09-18T09:28:31.565Z] ✅ Sent 1000000 tokens to 0x9d087fC03ae39b088326b67fA3C788236645b717
-[2025-09-18T09:28:31.565Z] ✅ Message ID: 0xd92433fea1fab2b9b2efa8d6091df0b5156bb159c883b94dada725539e5edace
-[2025-09-18T09:28:31.565Z] ✅ Monitor progress on CCIP Explorer: https://ccip.chain.link/msg/0xd92433fea1fab2b9b2efa8d6091df0b5156bb159c883b94dada725539e5edace
+SOL_CCIP_FEE_BILLING_SIGNER=2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
 ```
 
 </Fragment>
 </Tabs>
 
-#### Monitor and Verify Transaction
+Approve the fee-billing signer to transfer tokens from your ATA:
 
-Upon successful execution, the system generates critical tracking identifiers for transaction monitoring and verification.
+<Tabs client:visible>
+<Fragment slot="tab.1">Delegate Authority</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
 
-**Transaction Identifiers:**
+<Fragment slot="panel.1">
 
-- **Transaction Signature**: `4w81mpUozjJsEvHrkukCejbA9byMjkHacwtqM5cJD19XQu8MvXzoJ4YTqqkoEvBfP7HPvdivMA3Q1MePA16PdCXM`
-- **CCIP Message ID**: `0xd92433fea1fab2b9b2efa8d6091df0b5156bb159c883b94dada725539e5edace`
-
-**CCIP Explorer** (Primary monitoring interface):
-
-```
-https://ccip.chain.link/msg/0xd92433fea1fab2b9b2efa8d6091df0b5156bb159c883b94dada725539e5edace
-```
-
-The CCIP Explorer provides comprehensive transaction visibility:
-
-- Source chain (Solana) transaction confirmation
-- CCIP message processing and routing
-- Destination chain (Ethereum) message delivery
-- Token minting completion on Ethereum
-
-**Solana Explorer** (Source chain verification):
-
-```
-https://explorer.solana.com/tx/4w81mpUozjJsEvHrkukCejbA9byMjkHacwtqM5cJD19XQu8MvXzoJ4YTqqkoEvBfP7HPvdivMA3Q1MePA16PdCXM?cluster=devnet
+```bash
+# --amount is u64 max (2^64 - 1): max delegation for CCIP fee billing
+pnpm bs58 --env devnet --execute spl-token \
+  --instruction approve \
+  --authority $SOL_WALLET_ADDRESS \
+  --mint $SOL_TOKEN_MINT \
+  --delegate $SOL_CCIP_FEE_BILLING_SIGNER \
+  --amount 18446744073709551615
 ```
 
-### Transfer Direction 2: Ethereum → Solana
+</Fragment>
 
-<Aside type="note" title="Terminal Environment">
-  **Continue in Terminal 3** (Solana Starter Kit directory). No need to switch terminals - the Solana Starter Kit
-  handles Ethereum → Solana transfers as well.
+<Fragment slot="panel.2">
+
+```bash
+🔍 Detecting token program...
+INFO [2026-06-15 12:05:29.062 +0530]: Starting approve command
+    command: "spl-token.approve"
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
+    delegate: "2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG"
+    authority: "GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN"
+    amount: "18446744073709551615"
+    globalOptions: {
+      "environment": "devnet",
+      "execute": true,
+      "resolvedRpcUrl": "https://api.devnet.solana.com",
+      "keypair": "/Users/syed-cll/.config/solana/id.json",
+      "_signerKeypair": {
+        "_keypair": {
+          "publicKey": {
+            "0": 230,
+            "1": 211,
+            "2": 30,
+            ...
+            "29": 179,
+            "30": 114,
+            "31": 73
+          },
+          "secretKey": {
+            "0": 191,
+            "1": 198,
+            "2": 244,
+            ...
+            "61": 179,
+            "62": 114,
+            "63": 73
+          }
+        }
+      }
+    }
+   ✅ Detected token program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+🔍 Auto-deriving Associated Token Account...
+   ✅ Derived ATA: EgRUZ866e59bu2chrPDvz8Gq4Z6CPJkS2t6jDcqp9S9m
+🔄 Generating approve transaction...
+   RPC URL: https://api.devnet.solana.com
+   Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+   Mint: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
+   Token Account: EgRUZ866e59bu2chrPDvz8Gq4Z6CPJkS2t6jDcqp9S9m
+   Delegate: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
+   Authority (Token Account Owner): GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+   Amount: 18446744073709551615
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-15 12:05:29.376 +0530]: Detected SPL Token v1
+    mint: "3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+INFO [2026-06-15 12:05:29.572 +0530]: Transaction built successfully
+    instructionName: "approve"
+    transactionSize: "180 bytes"
+    base58Length: "245 characters"
+    hexLength: "360 characters"
+    accountCount: 3
+    signerCount: 1
+    computeUnits: 123
+INFO [2026-06-15 12:05:29.572 +0530]: Completed buildTransaction (approve)
+    durationMs: 192
+INFO [2026-06-15 12:05:29.761 +0530]:
+INFO [2026-06-15 12:05:29.761 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-15 12:05:29.761 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 12:05:29.761 +0530]:    Instruction: approve
+INFO [2026-06-15 12:05:29.761 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-15 12:05:29.761 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-15 12:05:30.685 +0530]: Transaction confirmed successfully
+    signature: "8ARFqsNXfc75kWaYekcCMmjp4XcosYAfNfFwt9ZvXPms5U9UdYGtANoMNcVWnngWMufH4hFGxvzm94UUTrYfVxT"
+    attempt: 1
+INFO [2026-06-15 12:05:30.685 +0530]:
+INFO [2026-06-15 12:05:30.685 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-15 12:05:30.685 +0530]:
+INFO [2026-06-15 12:05:30.685 +0530]: 📋 Execution Details:
+INFO [2026-06-15 12:05:30.685 +0530]:    Instruction: approve
+INFO [2026-06-15 12:05:30.685 +0530]:    Signature:   8ARFqsNXfc75kWaYekcCMmjp4XcosYAfNfFwt9ZvXPms5U9UdYGtANoMNcVWnngWMufH4hFGxvzm94UUTrYfVxT
+INFO [2026-06-15 12:05:30.685 +0530]:    Explorer:    https://explorer.solana.com/tx/8ARFqsNXfc75kWaYekcCMmjp4XcosYAfNfFwt9ZvXPms5U9UdYGtANoMNcVWnngWMufH4hFGxvzm94UUTrYfVxT?cluster=devnet
+INFO [2026-06-15 12:05:30.685 +0530]:
+INFO [2026-06-15 12:05:30.686 +0530]: approve command completed successfully
+    command: "spl-token.approve"
+    transactionSize: "180 bytes"
+    computeUnits: 123
+```
+
+</Fragment>
+</Tabs>
+
+#### Verify Delegation
+
+Check that your token account is delegated to the fee-billing signer:
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Find Token Account</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+# Find your Associated Token Account (ATA) address
+export SOL_TOKEN_ACCOUNT=$(spl-token accounts $SOL_TOKEN_MINT --owner $SOL_WALLET_ADDRESS --addresses-only)
+
+echo "SOL_TOKEN_ACCOUNT=$SOL_TOKEN_ACCOUNT"
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+SOL_TOKEN_ACCOUNT=EgRUZ866e59bu2chrPDvz8Gq4Z6CPJkS2t6jDcqp9S9m
+```
+
+</Fragment>
+</Tabs>
+
+Display token account and delegation status:
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Check Delegation</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+spl-token display $SOL_TOKEN_ACCOUNT
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+SPL Token Account
+  Address: EgRUZ866e59bu2chrPDvz8Gq4Z6CPJkS2t6jDcqp9S9m
+  Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+  Balance: 5000
+  Decimals: 9
+  Mint: 3nLW4zA3xdZmKY5SyhP2RRr7BDMKLuh4SQ9kFTDsx1Li
+  Owner: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+  State: Initialized
+  Delegation:
+    Delegate: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
+    Allowance: 18446744073.709551615
+  Close authority: (not set)
+```
+
+</Fragment>
+</Tabs>
+
+### Step 3: Verify Solana Pool and Chain Config
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Verification Commands</Fragment>
+<Fragment slot="tab.2">What to Confirm</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+# Verify pool state
+pnpm bs58 --env devnet lockrelease-token-pool \
+  --instruction get-state \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT
+
+# Verify Ethereum Sepolia remote chain config
+pnpm bs58 --env devnet lockrelease-token-pool \
+  --instruction get-chain-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --remote-chain-selector $ETHEREUM_SEPOLIA_CHAIN_SELECTOR
+
+# Verify token configuration
+spl-token display $SOL_TOKEN_MINT
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+Confirm the following:
+
+- Pool owner matches your Squads vault (`$SOL_SQUAD_VAULT_MULTISIG`)
+- Remote chain config includes `$ETH_POOL_ADDRESS` and `$ETH_TOKEN_ADDRESS`
+- Pool liquidity and rebalancer settings match your Phase 2 configuration
+- Rate limit settings match your Phase 3 configuration (if enabled)
+- Token delegation is set to the fee-billing signer
+
+</Fragment>
+</Tabs>
+
+### Step 4: Verify Ethereum Pool (Terminal 2)
+
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
+
+```bash
+npx hardhat getPoolConfig \
+  --pooladdress $ETH_POOL_ADDRESS \
+  --network ethereumSepolia
+```
+
+Confirm the Ethereum pool recognizes Solana Devnet with your `$SOL_POOL_ADDRESS` and `$SOL_TOKEN_MINT`.
+
+### Configure CCIP CLI
+
+Export these RPC URLs once before your first transfer:
+
+```bash
+export SOLANA_DEVNET_RPC="https://api.devnet.solana.com"
+export ETHEREUM_SEPOLIA_RPC_URL="<YOUR_ETHEREUM_SEPOLIA_RPC_URL>"
+
+export ETH_CCIP_ROUTER="0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59"
+```
+
+Use the same `ETHEREUM_SEPOLIA_RPC_URL` from your env-enc setup in Terminal 2 (`npx env-enc view`). On `ccip-cli send`, the source chain RPC quotes fees and submits the transaction; for token-only transfers in this tutorial, that is the only RPC strictly required to send. Pass both RPCs on cross-chain commands anyway: the destination RPC is required for `ccip-cli show --wait` and for optional send features such as `--estimate-gas-limit` or `send --wait`.
+
+<Aside type="note" title="RPC and wallet configuration">
+  Repeat `--rpc` for multiple networks, or use `--rpcs` with comma-separated URLs. Alternatively, set `RPC_*` environment variables or a `.env` file — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration). Solana sends use `--wallet ~/.config/solana/id.json`. EVM sends: prefer `--wallet hardhat:<name>` from the Hardhat project directory ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)); alternatively export `PRIVATE_KEY` manually after `npx env-enc view` (Hardhat tasks load env-enc automatically, but `ccip-cli` does not). See [CCIP CLI wallet configuration](https://docs.chain.link/ccip/tools/cli/configuration#wallet-configuration).
 </Aside>
 
-#### Transfer tokens from Ethereum Sepolia to Solana Devnet
+### Transfer Solana → Ethereum
+
+**Terminal 1** (CCIP Solana BS58 Generator):
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Transfer Command</Fragment>
+<Fragment slot="tab.1">Send Command</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Execute cross-chain transfer from Ethereum to Solana
-yarn evm:transfer --token $ETH_TOKEN_ADDRESS --amount 1000000000000000000 --token-receiver $SOL_WALLET_ADDRESS
+source ~/.all_vars
+
+export ETH_RECEIVER_ADDRESS="<YOUR_ETHEREUM_RECEIVER_ADDRESS>"
+
+
+ccip-cli send \
+  -s solana-devnet \
+  -r $SOL_CCIP_ROUTER \
+  -d ethereum-testnet-sepolia \
+  --to $ETH_RECEIVER_ADDRESS \
+  -t $SOL_TOKEN_MINT=0.001 \
+  --wallet ~/.config/solana/id.json \
+  --rpc $SOLANA_DEVNET_RPC \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL
 ```
 
 </Fragment>
@@ -2889,115 +3524,346 @@ yarn evm:transfer --token $ETH_TOKEN_ADDRESS --amount 1000000000000000000 --toke
 <Fragment slot="panel.2">
 
 ```bash
-[token-transfer] [INFO] 🚀 EVM to Solana CCIP Token Transfer
-[token-transfer] [INFO] =========================================
-chainId ethereum-sepolia
-[token-transfer] [INFO] Source Chain: ethereum-sepolia
-[token-transfer] [INFO] Fee Token: link
-[token-transfer] [INFO] Token Receiver: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[token-transfer] [INFO] Compute Units: 0
-[token-transfer] [INFO]
-==== Environment Information ====
-chainId ethereum-sepolia
-[token-transfer] [INFO] Router Address: 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59
-[ccip-messenger] [INFO] Creating client for chain: Ethereum Sepolia (ethereum-sepolia)
-[token-transfer] [INFO] Wallet Address: 0x9d087fC03ae39b088326b67fA3C788236645b717
-[token-transfer] [INFO] Native Balance: 572.729689746812179857 ETH
-[token-transfer] [INFO]
-🔍 Validating Token Transfer
-[token-transfer] [INFO] =========================================
-[token-transfer] [INFO] Token: BnmAEM (0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715)
-[token-transfer] [INFO] Token Balance: 1000.0 BnmAEM
-[token-transfer] [INFO] Token: BnmAEM (0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715)
-[token-transfer] [INFO] Token Balance: 1000.0 BnmAEM
-[token-transfer] [INFO] Transfer Amount: 1.0 BnmAEM
-[token-transfer] [INFO] ✅ Token validation successful
-[token-transfer] [INFO] Using fee token: 0x779877A7B0D9E8603169DdbD7836e478b4624789
-[token-transfer] [INFO] Creating CCIP message request
-[token-transfer] [INFO]
-📋 Transfer Summary
-[token-transfer] [INFO] =========================================
-[token-transfer] [INFO]
-==== Transfer Summary ====
-[token-transfer] [INFO] Source Chain: Ethereum Sepolia
-[token-transfer] [INFO] Destination Chain: Solana Devnet (16423721717087811551)
-[token-transfer] [INFO] Sender: 0x9d087fC03ae39b088326b67fA3C788236645b717
-[token-transfer] [INFO] Receiver: 11111111111111111111111111111111
-[token-transfer] [INFO] Token Receiver: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[token-transfer] [INFO] Fee Token: 0x779877A7B0D9E8603169DdbD7836e478b4624789
-[token-transfer] [INFO]
-Token Transfers:
-[token-transfer] [INFO]   1. 1000000000000000000 raw units (0x563eb47F0D8bE95CAF70ec2b7bB9Cdca6f045715)
-[token-transfer] [INFO]
-Extra Args: Solana-specific, 228 bytes
-[token-transfer] [INFO]
-🚀 Executing Token Transfer
-[token-transfer] [INFO] =========================================
-[token-transfer] [INFO] Sending CCIP message...
-[ccip-messenger] [INFO] Estimated fee: 13007637462782528
-[ccip-messenger] [INFO] Approving 0.015609164955339033 LINK for CCIP Router
-[ccip-messenger] [INFO] This token is being used as the fee token with a 20% buffer included
-[ccip-messenger] [INFO] Approving 0.015609164955339033 tokens for 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59
-[ccip-messenger] [INFO] LINK approved for CCIP Router
-[ccip-messenger] [INFO] ✅ Verified on-chain allowance for LINK: 0.015609164955339033 (required: 0.015609164955339033)
-[ccip-messenger] [INFO] Approving 1.0 BnmAEM for CCIP Router
-[ccip-messenger] [INFO] Approving 1.0 tokens for 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59
-[ccip-messenger] [INFO] BnmAEM approved for CCIP Router
-[ccip-messenger] [INFO] ✅ Verified on-chain allowance for BnmAEM: 1.0 (required: 1.0)
-[ccip-messenger] [INFO] Sending CCIP message...
-[ccip-messenger] [INFO] Sending CCIP message...
-[ccip-messenger] [INFO] Transaction sent: 0xcacca1de44800d4e88544597b1b9f8190db93ae2f2144bb3b92aafd73b626c3d
-[ccip-messenger] [INFO] Transaction sent: 0xcacca1de44800d4e88544597b1b9f8190db93ae2f2144bb3b92aafd73b626c3d
-[ccip-messenger] [INFO] Message ID: 0xb8327a54fcf042f6fa9ca236372ea68835204802ca13ebfc34c7f839631ee567
-[token-transfer] [INFO]
-🎉 Transfer Results
-[token-transfer] [INFO] =========================================
-[token-transfer] [INFO]
-==== Transfer Results ====
-[token-transfer] [INFO] Transaction Hash: 0xcacca1de44800d4e88544597b1b9f8190db93ae2f2144bb3b92aafd73b626c3d
-[token-transfer] [INFO] Transaction URL: https://sepolia.etherscan.io/tx/0xcacca1de44800d4e88544597b1b9f8190db93ae2f2144bb3b92aafd73b626c3d
-[token-transfer] [INFO] Message ID: 0xb8327a54fcf042f6fa9ca236372ea68835204802ca13ebfc34c7f839631ee567
-[token-transfer] [INFO] 👉 CCIP Explorer: https://ccip.chain.link/msg/0xb8327a54fcf042f6fa9ca236372ea68835204802ca13ebfc34c7f839631ee567
-[token-transfer] [INFO] Destination Chain Selector: 16423721717087811551
-[token-transfer] [INFO] Sequence Number: 1263
-[token-transfer] [INFO]
-Message tracking for Solana destinations:
-[token-transfer] [INFO] Please check the CCIP Explorer link to monitor your message status.
-[token-transfer] [INFO]
-✅ Transaction completed on the source chain
-[token-transfer] [INFO]
-✅ Token Transfer Complete!
-[token-transfer] [INFO] 🔗 Your tokens are being bridged to Solana
-✨  Done in 130.28s.
+Using rate-limited fetch for public solana nodes, commands may be slow
+Fee: 142389061n = 0.142389061 SOL
+🚀 Sending message to 0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA @ ethereum-testnet-sepolia , tx => 4FTNhm9uAJamxNpwWVPJHgeRbmD1brERaLK851DAaN2NVFX9xbCbVPvBuDPr7a1x2qTiwxfaVRtXe38KmQy4WL4q, messageId => 0x0a9df10ea209acd356112f15bcecca37188e9ce674f05fb8481bd83336e3582e
+Using rate-limited fetch for public solana nodes, commands may be slow
+Lane:
+┌────────────────┬────────────────────────────────────────────────┬────────────────────────────┐
+│ (index)        │ source                                         │ dest                       │
+├────────────────┼────────────────────────────────────────────────┼────────────────────────────┤
+│ name           │ 'solana-devnet'                                │ 'ethereum-testnet-sepolia' │
+│ chainId        │ 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' │ 11155111                   │
+│ chainSelector  │ 16423721717087811551n                          │ 16015286601757825753n      │
+│ onRamp/version │ 'Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C' │ '1.6.0'                    │
+└────────────────┴────────────────────────────────────────────────┴────────────────────────────┘
+Request (source):
+┌──────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)                  │ Values                                                                                     │
+├──────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ messageId                │ '0x0a9df10ea209acd356112f15bcecca37188e9ce674f05fb8481bd83336e3582e'                       │
+│ origin                   │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ sender                   │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ receiver                 │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ sequenceNumber           │ 3078                                                                                       │
+│ nonce                    │ '0 => allow out-of-order exec'                                                             │
+│ gasLimit                 │ 0n                                                                                         │
+│ transactionHash          │ '4FTNhm9uAJamxNpwWVPJHgeRbmD1brERaLK851DAaN2NVFX9xbCbVPvBuDPr7a1x2qTiwxfaVRtXe38KmQy4WL4q' │
+│ logIndex                 │ 32                                                                                         │
+│ blockNumber              │ 469549684                                                                                  │
+│ timestamp                │ '2026-06-15 06:41:03 (2s ago)'                                                             │
+│ finalized                │ '11s left'                                                                                 │
+│ fee                      │ '0.142389061 SOL'                                                                          │
+│ tokens                   │ '0.001 CCIP-AEM'                                                                           │
+│ data                     │ '0x'                                                                                       │
+│ feeValueJuels            │ 1234686353000000000n                                                                       │
+│ allowOutOfOrderExecution │ true                                                                                       │
+└──────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
+CCIP Explorer: https://ccip.chain.link/msg/0x0a9df10ea209acd356112f15bcecca37188e9ce674f05fb8481bd83336e3582e
 ```
 
 </Fragment>
 </Tabs>
 
-#### Monitor and Verify Transaction
+The `-t` flag uses human-readable amounts (0.001 tokens with 9 decimals = 1,000,000 smallest units).
 
-Upon successful execution, the system generates distinct tracking identifiers for comprehensive monitoring across both blockchain networks.
+<Tabs client:visible>
+<Fragment slot="tab.1">Monitor Transfer</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
 
-**Transaction Identifiers:**
+<Fragment slot="panel.1">
 
-- **Ethereum Transaction Hash**: `0xcacca1de44800d4e88544597b1b9f8190db93ae2f2144bb3b92aafd73b626c3d`
-- **CCIP Message ID**: `0xb8327a54fcf042f6fa9ca236372ea68835204802ca13ebfc34c7f839631ee567`
-
-**CCIP Explorer** (Primary monitoring interface):
-
+```bash
+# Replace with the transaction hash or message ID from the send output
+ccip-cli show <TX_HASH_OR_MESSAGE_ID> --wait \
+  --rpc $SOLANA_DEVNET_RPC \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL
 ```
-https://ccip.chain.link/msg/0xb8327a54fcf042f6fa9ca236372ea68835204802ca13ebfc34c7f839631ee567
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+Using rate-limited fetch for public solana nodes, commands may be slow
+Lane:
+┌────────────────┬────────────────────────────────────────────────┬────────────────────────────┐
+│ (index)        │ source                                         │ dest                       │
+├────────────────┼────────────────────────────────────────────────┼────────────────────────────┤
+│ name           │ 'solana-devnet'                                │ 'ethereum-testnet-sepolia' │
+│ chainId        │ 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' │ 11155111                   │
+│ chainSelector  │ 16423721717087811551n                          │ 16015286601757825753n      │
+│ onRamp/version │ 'Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C' │ '1.6.2'                    │
+└────────────────┴────────────────────────────────────────────────┴────────────────────────────┘
+Request (source):
+┌────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)                            │ Values                                                                                     │
+├────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ messageId                          │ '0x0a9df10ea209acd356112f15bcecca37188e9ce674f05fb8481bd83336e3582e'                       │
+│ origin                             │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ sender                             │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ receiver                           │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ sequenceNumber                     │ 3078                                                                                       │
+│ nonce                              │ '0 => allow out-of-order exec'                                                             │
+│ gasLimit                           │ 0n                                                                                         │
+│ transactionHash                    │ '4FTNhm9uAJamxNpwWVPJHgeRbmD1brERaLK851DAaN2NVFX9xbCbVPvBuDPr7a1x2qTiwxfaVRtXe38KmQy4WL4q' │
+│ logIndex                           │ 2                                                                                          │
+│ blockNumber                        │ 469549684                                                                                  │
+│ timestamp                          │ '2026-06-15 06:41:03 (2m7s ago)'                                                           │
+│ finalized                          │ true                                                                                       │
+│ fee                                │ '0.142389061 SOL'                                                                          │
+│ tokens                             │ '0.001 CCIP-AEM'                                                                           │
+│ fees.fixedFeesDetails.tokenAddress │ 'So11111111111111111111111111111111111111112'                                              │
+│ fees.fixedFeesDetails.totalAmount  │ 142389061n                                                                                 │
+│ finality                           │ 0n                                                                                         │
+│ finalityType                       │ 'FINALIZED'                                                                                │
+│ routerAddress                      │ 'Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C'                                             │
+│ allowOutOfOrderExecution           │ true                                                                                       │
+│ status                             │ 'SUCCESS'                                                                                  │
+│ readyForManualExecution            │ false                                                                                      │
+│ receiptTransactionHash             │ '0x7f77fbcf340c39bfe7a2188cf904bd0aff302b08bd3e9729c663b84d32135b5f'                       │
+│ receiptTimestamp                   │ '2026-06-15 06:42:36'                                                                      │
+│ deliveryTime                       │ 93000n                                                                                     │
+│ offRamp                            │ '0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0'                                               │
+└────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
+CCIP Explorer: https://ccip.chain.link/msg/0x0a9df10ea209acd356112f15bcecca37188e9ce674f05fb8481bd83336e3582e
+[SENT] Waiting for source chain finalization...
+[SOURCE_FINALIZED] Source chain finalized
+[SOURCE_FINALIZED] Waiting for commit on destination chain...
+[SUCCESS] Message executed on destination chain
+┌─────────────────┬──────────────────────────────────────────────────────────────────────┐
+│ (index)         │ Values                                                               │
+├─────────────────┼──────────────────────────────────────────────────────────────────────┤
+│ state           │ '✅ success'                                                         │
+│ gasUsed         │ 87342                                                                │
+│ origin          │ '0x450166B0bEFDf977B458f7131cE412808162151d'                         │
+│ contract        │ '0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0'                         │
+│ transactionHash │ '0x7f77fbcf340c39bfe7a2188cf904bd0aff302b08bd3e9729c663b84d32135b5f' │
+│ logIndex        │ 538                                                                  │
+│ blockNumber     │ 11063786                                                             │
+│ timestamp       │ '2026-06-15 06:42:36 (1m33s after request)'                          │
+└─────────────────┴──────────────────────────────────────────────────────────────────────┘
 ```
 
-The CCIP Explorer provides comprehensive transaction visibility:
+</Fragment>
+</Tabs>
 
-- Source chain (Ethereum) transaction confirmation
-- CCIP message processing and routing
-- Destination chain (Solana) message delivery
-- Token minting completion on Solana network
+### Transfer Ethereum → Solana
 
-**Ethereum Sepolia Explorer** (Source chain verification):
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
 
+`ccip-cli` does not load Hardhat env-enc automatically. Run these commands from the Hardhat project directory. Prefer [Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore) over exporting a private key in plain text.
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Hardhat keystore (Recommended)</Fragment>
+<Fragment slot="tab.2">PRIVATE_KEY (Alternative)</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+source ~/.all_vars
+
+ccip-cli send \
+  -s ethereum-testnet-sepolia \
+  -r $ETH_CCIP_ROUTER \
+  -d solana-devnet \
+  --to $SOL_WALLET_ADDRESS \
+  -t $ETH_TOKEN_ADDRESS=1.0 \
+  --wallet hardhat:<YOUR_KEYSTORE_ACCOUNT_NAME> \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
 ```
-https://sepolia.etherscan.io/tx/0xcacca1de44800d4e88544597b1b9f8190db93ae2f2144bb3b92aafd73b626c3d
+
+Use the keystore account name from your Hardhat project (see [Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)). This keeps the signing key encrypted instead of in shell history.
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+source ~/.all_vars
+
+# ccip-cli does not read env-enc — view and export the same key used in Phase 1
+npx env-enc view
+export PRIVATE_KEY="<YOUR_PRIVATE_KEY_FROM_ENV_ENC>"
+
+ccip-cli send \
+  -s ethereum-testnet-sepolia \
+  -r $ETH_CCIP_ROUTER \
+  -d solana-devnet \
+  --to $SOL_WALLET_ADDRESS \
+  -t $ETH_TOKEN_ADDRESS=1.0 \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
 ```
+
+Do not commit or share the exported key. Prefer the Hardhat keystore tab for production-like workflows.
+
+</Fragment>
+</Tabs>
+
+For token-only transfers to Solana, `--to` is the destination wallet that receives minted tokens. CCIP fees are paid in native Sepolia ETH by default — ensure your wallet has sufficient ETH for gas and fees.
+
+<Aside type="note" title="Pay fees in LINK (optional)">
+  Add `--fee-token LINK` to pay CCIP fees in LINK instead of ETH (Sepolia LINK:
+  `0x779877A7B0D9E8603169DdbD7836e478b4624789`).
+</Aside>
+
+<Aside type="note" title="Your transfer identifiers will differ">
+
+Use the Sepolia transaction hash from your `ccip-cli send` command with `ccip-cli show <TX_HASH> --wait`. Message IDs, timestamps, and Solana receipt signatures are unique per transfer. The example below shows the expected **completed** output shape once the message executes on Solana Devnet.
+
+</Aside>
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Monitor Transfer</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+ccip-cli show <TX_HASH_OR_MESSAGE_ID> --wait \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+Lane:
+┌────────────────┬──────────────────────────────────────────────┬────────────────────────────────────────────────┐
+│ (index)        │ source                                       │ dest                                           │
+├────────────────┼──────────────────────────────────────────────┼────────────────────────────────────────────────┤
+│ name           │ 'ethereum-testnet-sepolia'                   │ 'solana-devnet'                                │
+│ chainId        │ 11155111                                     │ 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' │
+│ chainSelector  │ 16015286601757825753n                        │ 16423721717087811551n                          │
+│ onRamp/version │ '0x23a5084Fa78104F3DF11C63Ae59fcac4f6AD9DeE' │ '1.6.0'                                        │
+└────────────────┴──────────────────────────────────────────────┴────────────────────────────────────────────────┘
+Request (source):
+┌────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)                            │ Values                                                                                     │
+├────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ messageId                          │ '0x6888c83aadeeacda5a1b1bf9ea3db55b31a86408a0d00a8c1e8f6e43f5ba24f0'                       │
+│ origin                             │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ sender                             │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ receiver                           │ '11111111111111111111111111111111'                                                         │
+│ sequenceNumber                     │ 10202                                                                                      │
+│ nonce                              │ '0 => allow out-of-order exec'                                                             │
+│ computeUnits                       │ 0n                                                                                         │
+│ transactionHash                    │ '0x332b661e35fa170fa82365fc52feb9845ba5f7d46b6e019eeed6ece2f7a76b57'                       │
+│ logIndex                           │ 595                                                                                        │
+│ blockNumber                        │ 11063788                                                                                   │
+│ timestamp                          │ '2026-06-15 06:43:00 (18m45s ago)'                                                         │
+│ finalized                          │ true                                                                                       │
+│ fee                                │ '0.000349783015387082 WETH'                                                                │
+│ tokens                             │ '1.0 BnmAEM'                                                                               │
+│ accounts                           │ undefined                                                                                  │
+│ fees.fixedFeesDetails.tokenAddress │ '0x097D90c9d3E0B50Ca60e1ae45F6A81010f9FB534'                                               │
+│ fees.fixedFeesDetails.totalAmount  │ 349783015387082n                                                                           │
+│ finality                           │ 0n                                                                                         │
+│ finalityType                       │ 'FINALIZED'                                                                                │
+│ routerAddress                      │ '0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59'                                               │
+│ accountIsWritableBitmap            │ 0n                                                                                         │
+│ allowOutOfOrderExecution           │ true                                                                                       │
+│ tokenReceiver                      │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ status                             │ 'SUCCESS'                                                                                  │
+│ readyForManualExecution            │ false                                                                                      │
+│ receiptTransactionHash             │ '2xM9H1tB2hiNAjzn2Sn7bCZUMWXQB43uAfPBwAgsC4RFsNmRZvzzDcxxgpmBPGMycyUgNBFzb5dE2gPtUMLr6MJi' │
+│ receiptTimestamp                   │ '2026-06-15 06:58:47'                                                                      │
+│ deliveryTime                       │ 947000n                                                                                    │
+│ offRamp                            │ 'offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm'                                              │
+└────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
+CCIP Explorer: https://ccip.chain.link/msg/0x6888c83aadeeacda5a1b1bf9ea3db55b31a86408a0d00a8c1e8f6e43f5ba24f0
+[SENT] Waiting for source chain finalization...
+Using rate-limited fetch for public solana nodes, commands may be slow
+[SOURCE_FINALIZED] Source chain finalized
+[SOURCE_FINALIZED] Waiting for commit on destination chain...
+[SUCCESS] Message executed on destination chain
+┌─────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)         │ Values                                                                                     │
+├─────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ state           │ '✅ success'                                                                               │
+│ origin          │ 'Ha3SzUZBDhrxJBz7BmDAiKfhSAkpSSAnJ9bYH3vib6Bs'                                             │
+│ contract        │ 'offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm'                                              │
+│ transactionHash │ '2xM9H1tB2hiNAjzn2Sn7bCZUMWXQB43uAfPBwAgsC4RFsNmRZvzzDcxxgpmBPGMycyUgNBFzb5dE2gPtUMLr6MJi' │
+│ logIndex        │ 24                                                                                         │
+│ blockNumber     │ 469552487                                                                                  │
+│ timestamp       │ '2026-06-15 06:58:47 (15m47s after request)'                                               │
+└─────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+</Fragment>
+</Tabs>
+
+### Optional: Test Rate Limit Enforcement
+
+If you configured rate limits in Phase 3, attempt a transfer that exceeds capacity (25 tokens vs 20-token limit):
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Solana → EVM (expect failure)</Fragment>
+<Fragment slot="tab.2">EVM → Solana (expect failure)</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+# Terminal 1
+
+ccip-cli send \
+  -s solana-devnet \
+  -r $SOL_CCIP_ROUTER \
+  -d ethereum-testnet-sepolia \
+  --to $ETH_RECEIVER_ADDRESS \
+  -t $SOL_TOKEN_MINT=25 \
+  --wallet ~/.config/solana/id.json \
+  --rpc $SOLANA_DEVNET_RPC \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL
+```
+
+Expect `RLMaxCapacityExceeded` (Error 6015) when limits are enabled.
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+# Terminal 2 — use the same wallet option as the E→S transfer above
+
+ccip-cli send \
+  -s ethereum-testnet-sepolia \
+  -r $ETH_CCIP_ROUTER \
+  -d solana-devnet \
+  --to $SOL_WALLET_ADDRESS \
+  -t $ETH_TOKEN_ADDRESS=25 \
+  --wallet hardhat:<YOUR_KEYSTORE_ACCOUNT_NAME> \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
+```
+
+Expect `TokenMaxCapacityExceeded` (selector `0x1a76572a`) when limits are enabled.
+
+</Fragment>
+</Tabs>
+
+### Optional: Verify Rate Limit Configuration
+
+If you configured rate limits in Phase 3, confirm they appear in your chain configuration:
+
+```bash
+# Terminal 1 — inspect Solana outbound/inbound rate limits
+pnpm bs58 --env devnet lockrelease-token-pool \
+  --instruction get-chain-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --remote-chain-selector $ETHEREUM_SEPOLIA_CHAIN_SELECTOR
+```
+
+```bash
+# Terminal 2 — inspect EVM rate limit settings
+npx hardhat getPoolConfig \
+  --pooladdress $ETH_POOL_ADDRESS \
+  --network ethereumSepolia
+```
+
+**Congratulations!** Your production Lock/Release cross-chain token infrastructure with Squads governance is fully configured on both chains.

--- a/src/content/ccip/tutorials/svm/cross-chain-tokens/production-multisig-tutorial.mdx
+++ b/src/content/ccip/tutorials/svm/cross-chain-tokens/production-multisig-tutorial.mdx
@@ -7,7 +7,7 @@ metadata:
   description: "Build enterprise-grade cross-chain SPL, Token-2022 tokens with dual-layer multisig governance. Production-ready Chainlink CCIP implementation using Squads + SPL multisig."
   excerpt: "ccip cross-chain token tutorial solana ethereum burnmint pools path-a multisig production squads governance spl token token-2022 multisig architecture mainnet-ready enterprise dual-layer security operational autonomy pool signer pda token admin registry governance multisig base58 transactions production deployment svm evm"
   datePublished: "2025-08-13T00:53:46Z"
-  lastModified: "2025-08-13T00:53:46Z"
+  lastModified: "2026-06-15T00:53:46Z"
   estimatedTime: "60 minutes"
   difficulty: "advanced"
 ---
@@ -106,10 +106,10 @@ npx env-enc view
 ```bash
 # Expected verification output
 $ npx env-enc view
-The following variables are encrypted and stored in /../smart-contract-examples/ccip/cct/hardhat/.env.enc
-PRIVATE_KEY = c8376...
-ETHEREUM_SEPOLIA_RPC_URL = https://sepolia.gateway.tenderly.co/...
-ETHERSCAN_API_KEY = 9AVYS...
+The following variables are encrypted and stored in .../smart-contract-examples/ccip/cct/hardhat/.env.enc
+PRIVATE_KEY = <redacted>
+ETHEREUM_SEPOLIA_RPC_URL = <your-rpc-url>
+ETHERSCAN_API_KEY = <your-api-key>
 ```
 
 </Fragment>
@@ -131,8 +131,8 @@ npx hardhat deployToken \
   --name "AEM Token" \
   --symbol "BnmAEM" \
   --decimals 18 \
-  --verifycontract true \
-  --network sepolia
+  --verifycontract \
+  --network ethereumSepolia
 
 # Copy the token address from the output above
 ```
@@ -142,15 +142,22 @@ npx hardhat deployToken \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-19T08:27:05.937Z info: Deploying BurnMintERC20 contract to sepolia
-2025-08-19T08:27:05.938Z info: Waiting 3 blocks for transaction 0xf12c79fde1e0a82fb9d1f543be270f0c114597f04a391144b82da90873f32dd9 to be confirmed...
-2025-08-19T08:27:36.850Z info: Token deployed to: 0x7c57A9d966c3E6e344621C512d510f76575640ED
-2025-08-19T08:27:36.931Z info: Granting mint and burn roles to 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-19T08:28:12.846Z info: Verifying contract...
-The contract 0x7c57A9d966c3E6e344621C512d510f76575640ED has already been verified on the block explorer. If you're trying to verify a partially verified contract, please use the --force flag.
-https://sepolia.etherscan.io/address/0x7c57A9d966c3E6e344621C512d510f76575640ED#code
+2026-06-15T02:13:08.069Z info: 🚀 Deploying BurnMintERC20 to ethereumSepolia...
+2026-06-15T02:13:08.070Z info:    name: AEM Token, symbol: BnmAEM
+2026-06-15T02:13:11.271Z info: ⏳ Deployment tx: 0x14b95ce298b558c75b32a725b6ade65081fb0cfcb3f6d8fe418ae269f7c4d55a
+2026-06-15T02:13:11.272Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T02:13:37.103Z info: ✅ Token deployed at: 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184
+2026-06-15T02:13:37.554Z info: Granting mint and burn roles to 0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA...
+2026-06-15T02:13:38.674Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T02:14:17.239Z info: ✅ Mint/Burn roles granted.
+2026-06-15T02:14:17.240Z info: Verifying contract...
 
-2025-08-19T08:28:13.485Z info: Token contract deployed and verified
+The contract at 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184 has already been verified on Etherscan.
+
+If you need to verify a partially verified contract, please use the --force flag.
+
+Explorer: https://sepolia.etherscan.io/address/0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184#code
+2026-06-15T02:14:20.167Z info: ✅ Token contract verified successfully
 ```
 
 </Fragment>
@@ -172,7 +179,6 @@ Verify the address is set correctly:
 
 ```bash
 echo "✅ Ethereum Token Address: $ETH_TOKEN_ADDRESS"
-
 ```
 
 </Fragment>
@@ -182,8 +188,7 @@ echo "✅ Ethereum Token Address: $ETH_TOKEN_ADDRESS"
 ```bash
 $ echo "✅ Ethereum Token Address: $ETH_TOKEN_ADDRESS"
 
-✅ Ethereum Token Address: 0x7c57A9d966c3E6e344621C512d510f76575640ED
-
+✅ Ethereum Token Address: 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184
 ```
 
 </Fragment>
@@ -205,8 +210,8 @@ npx hardhat deployTokenPool \
   --tokenaddress $ETH_TOKEN_ADDRESS \
   --localtokendecimals 18 \
   --pooltype burnMint \
-  --verifycontract true \
-  --network sepolia
+  --verifycontract \
+  --network ethereumSepolia
 ```
 
 </Fragment>
@@ -214,14 +219,24 @@ npx hardhat deployTokenPool \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-19T08:29:39.462Z info: Waiting 3 blocks for transaction 0xb0e4210ff5af4bbb095011ab6a514835f3954df286342e0ce3e197490d6618d0 to be confirmed...
-2025-08-19T08:30:13.223Z info: Token pool deployed to: 0x88965fF139bbA53D6e02a49a80c29d8c65645bA7
-2025-08-19T08:30:13.224Z info: Granting mint and burn roles to 0x88965fF139bbA53D6e02a49a80c29d8c65645bA7 on token 0x7c57A9d966c3E6e344621C512d510f76575640ED
-2025-08-19T08:30:48.914Z info: Verifying contract...
-The contract 0x88965fF139bbA53D6e02a49a80c29d8c65645bA7 has already been verified on the block explorer. If you're trying to verify a partially verified contract, please use the --force flag.
-https://sepolia.etherscan.io/address/0x88965fF139bbA53D6e02a49a80c29d8c65645bA7#code
+2026-06-15T02:15:20.985Z info: 🚀 Deploying burnMint pool on ethereumSepolia
+2026-06-15T02:15:20.986Z info:    Token: 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184
+2026-06-15T02:15:20.986Z info:    Decimals: 18
+2026-06-15T02:15:20.986Z info:    Allowlist: None
+2026-06-15T02:15:24.267Z info: ⏳ Deployment tx: 0xc9c69358b1bea84aa2e3a1272ddfaf4acc97984d3bc789f1767aa8ebe113b203
+2026-06-15T02:15:24.268Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T02:16:02.874Z info: ✅ Token pool deployed at: 0x7115d906b67f9bc1a70ab16a8e38c603d9669749
+2026-06-15T02:16:02.875Z info: Granting mint and burn roles to 0x7115d906b67f9bc1a70ab16a8e38c603d9669749 on token 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184
+2026-06-15T02:16:04.278Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T02:16:38.732Z info: ✅ Mint/Burn roles granted
+2026-06-15T02:16:38.733Z info: Verifying contract...
 
-2025-08-19T08:30:49.738Z info: Token pool contract deployed and verified
+The contract at 0x7115d906b67f9bc1a70ab16a8e38c603d9669749 has already been verified on Etherscan.
+
+If you need to verify a partially verified contract, please use the --force flag.
+
+Explorer: https://sepolia.etherscan.io/address/0x7115d906b67f9bc1a70ab16a8e38c603d9669749#code
+2026-06-15T02:16:41.809Z info: ✅ Token pool contract verified successfully
 ```
 
 </Fragment>
@@ -252,7 +267,7 @@ echo "✅ Ethereum Pool Address: $ETH_POOL_ADDRESS"
 
 ```bash
 $ echo "✅ Ethereum Pool Address: $ETH_POOL_ADDRESS"
-✅ Ethereum Pool Address: 0x88965fF139bbA53D6e02a49a80c29d8c65645bA7
+✅ Ethereum Pool Address: 0x7115d906b67f9bc1a70ab16a8e38c603d9669749
 ```
 
 </Fragment>
@@ -273,12 +288,11 @@ Mint tokens for testing:
 npx hardhat mintTokens \
   --tokenaddress $ETH_TOKEN_ADDRESS \
   --amount 1000000000000000000000 \
-  --network sepolia
+  --network ethereumSepolia
 
 # Note: Balance can be checked in your wallet or through block explorer
 
 echo "✅ Tokens minted successfully"
-
 ```
 
 </Fragment>
@@ -286,20 +300,11 @@ echo "✅ Tokens minted successfully"
 <Fragment slot="panel.2">
 
 ```bash
-$ # Mint 1000 tokens for testing
-npx hardhat mintTokens \
-  --tokenaddress $ETH_TOKEN_ADDRESS \
-  --amount 1000000000000000000000 \
-  --network sepolia
-
-# Note: Balance can be checked in your wallet or through block explorer
-
-echo "✅ Tokens minted successfully"
-
-
-2025-08-19T08:32:48.373Z info: Minting 1000000000000000000000 of BnmAEM tokens to 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-19T08:33:26.184Z info: Minted 1000000000000000000000 of BnmAEM tokens to 0x9d087fC03ae39b088326b67fA3C788236645b717 - transaction hash: 0x5705fa74b30e89edbee7e37ffd7ef07181efe1d6f47f46d6b1ab3ee32e13147f
-2025-08-19T08:33:26.309Z info: Current balance of 0x9d087fC03ae39b088326b67fA3C788236645b717 is 1000000000000000000000 BnmAEM
+2026-06-15T02:17:35.518Z info: 🪙 Minting 1000000000000000000000 BnmAEM to 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca...
+2026-06-15T02:17:37.201Z info: ⏳ Mint tx: 0x1cdc4a47c7480d1fe4b1faae8a551bc321e737f09a376630e4fa072cda608536
+2026-06-15T02:17:37.201Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T02:18:16.137Z info: ✅ Minted 1000000000000000000000 BnmAEM to 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-15T02:18:16.137Z info:    Current balance of 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca: 1000000000000000000000 BnmAEM
 ✅ Tokens minted successfully
 ```
 
@@ -320,7 +325,7 @@ In this step, you will use the `claimAdmin` task to register your EOA as the adm
 # Claim admin role for CCIP token registry
 npx hardhat claimAdmin \
   --tokenaddress $ETH_TOKEN_ADDRESS \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 </Fragment>
@@ -328,10 +333,10 @@ npx hardhat claimAdmin \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-19T08:33:54.466Z info: 🎯 Attempting to claim admin for token 0x7c57A9d966c3E6e344621C512d510f76575640ED using getCCIPAdmin mode
-2025-08-19T08:33:55.360Z info: Current token CCIP admin: 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-19T08:33:55.360Z info: Claiming admin of 0x7c57A9d966c3E6e344621C512d510f76575640ED via getCCIPAdmin() for CCIP admin 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-19T08:34:24.566Z info: ✅ Successfully claimed admin of 0x7c57A9d966c3E6e344621C512d510f76575640ED using getCCIPAdmin mode. Transaction: 0xa9559185000c9be2f5d23cca1a7ab5357935c7810dad7674a09193178c2551f6
+2026-06-15T02:19:38.212Z info: 🎯 Claiming admin for 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184 using getCCIPAdmin mode
+2026-06-15T02:19:41.279Z info: ✅ Current wallet 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca is CCIP admin
+2026-06-15T02:19:42.928Z info: 📤 TX sent: 0x755387fa8a9c5fde16421916cd51662aa2422851b8c424d1a005e0a2f3d67b61. Waiting for 3 confirmations...
+2026-06-15T02:20:13.013Z info: ✅ Admin claimed for 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184 on ethereumSepolia (3 confirmations)
 ```
 
 </Fragment>
@@ -351,7 +356,7 @@ In this step, you will use the `acceptAdminRole` task to accept the admin role f
 # Accept admin role to complete CCIP registration
 npx hardhat acceptAdminRole \
 --tokenaddress $ETH_TOKEN_ADDRESS \
---network sepolia
+--network ethereumSepolia
 ```
 
 </Fragment>
@@ -359,7 +364,12 @@ npx hardhat acceptAdminRole \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-19T08:35:25.061Z info: Accepted admin role for token 0x7c57A9d966c3E6e344621C512d510f76575640ED tx: 0x1fc8625eb46b32bce986a9b7a151c9d21a46b90a5480c043b09be5dc603eb428
+2026-06-15T02:20:44.300Z info: 🔄 Accepting admin role for 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184 on ethereumSepolia...
+2026-06-15T02:20:46.491Z info: Checking pending admin for 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184...
+2026-06-15T02:20:46.709Z info: ✅ Current wallet 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca is the pending admin
+2026-06-15T02:20:46.710Z info: Accepting admin role...
+2026-06-15T02:20:48.341Z info: 📤 TX sent: 0x3e5adbac941a1653bfd393127e7d37678453d0a4355009ae0dd7b42c53291a70. Waiting for 3 confirmations...
+2026-06-15T02:21:26.960Z info: ✅ Admin role accepted for 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184 on ethereumSepolia (3 confirmations)
 ```
 
 </Fragment>
@@ -380,7 +390,7 @@ In this step, you will use the `setPool` task to register the BurnMint token poo
 npx hardhat setPool \
 --tokenaddress $ETH_TOKEN_ADDRESS \
 --pooladdress $ETH_POOL_ADDRESS \
---network sepolia
+--network ethereumSepolia
 ```
 
 </Fragment>
@@ -388,8 +398,15 @@ npx hardhat setPool \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-19T08:35:53.810Z info: Setting pool for token 0x7c57A9d966c3E6e344621C512d510f76575640ED to 0x88965fF139bbA53D6e02a49a80c29d8c65645bA7 by 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-19T08:36:25.922Z info: Pool set for token 0x7c57A9d966c3E6e344621C512d510f76575640ED to 0x88965fF139bbA53D6e02a49a80c29d8c65645bA7
+2026-06-15T02:21:54.807Z info: 🔗 Setting pool for token 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184 on ethereumSepolia...
+2026-06-15T02:21:57.200Z info: 🔹 Using signer: 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-15T02:21:57.201Z info: Using TokenAdminRegistry: 0x95F29FEE11c5C55d26cCcf1DB6772DE953B37B82
+2026-06-15T02:21:57.436Z info: Checking token configuration for 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184...
+2026-06-15T02:21:57.686Z info: Token 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184 current admin: 0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA
+2026-06-15T02:21:57.687Z info: ✅ Current wallet 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca is the token administrator
+2026-06-15T02:21:57.687Z info: Setting pool 0x7115d906b67f9bc1a70ab16a8e38c603d9669749 for token 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184...
+2026-06-15T02:21:59.266Z info: 📤 TX sent: 0x3f8d7a1143cf1c90635a067fd93822e59881a1479536c0fe57877c145722bafd. Waiting for 3 confirmations...
+2026-06-15T02:22:29.413Z info: ✅ Pool successfully set for token 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184 → 0x7115d906b67f9bc1a70ab16a8e38c603d9669749 on ethereumSepolia (3 confirmations)
 ```
 
 </Fragment>
@@ -411,7 +428,6 @@ echo "export ETH_POOL_ADDRESS=\"$ETH_POOL_ADDRESS\"" >> ~/.phase1_vars
 echo "=== Phase 1 Complete - EVM Setup ==="
 echo "✅ ETH Token: $ETH_TOKEN_ADDRESS"
 echo "✅ ETH Pool: $ETH_POOL_ADDRESS"
-
 ```
 
 </Fragment>
@@ -419,18 +435,9 @@ echo "✅ ETH Pool: $ETH_POOL_ADDRESS"
 <Fragment slot="panel.2">
 
 ```bash
-$ # Save Phase 1 variables for later use
-echo "export ETH_TOKEN_ADDRESS=\"$ETH_TOKEN_ADDRESS\"" > ~/.phase1_vars
-echo "export ETH_POOL_ADDRESS=\"$ETH_POOL_ADDRESS\"" >> ~/.phase1_vars
-
-echo "=== Phase 1 Complete - EVM Setup ==="
-echo "✅ ETH Token: $ETH_TOKEN_ADDRESS"
-echo "✅ ETH Pool: $ETH_POOL_ADDRESS"
-
-
 === Phase 1 Complete - EVM Setup ===
-✅ ETH Token: 0x7c57A9d966c3E6e344621C512d510f76575640ED
-✅ ETH Pool: 0x88965fF139bbA53D6e02a49a80c29d8c65645bA7
+✅ ETH Token: 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184
+✅ ETH Pool: 0x7115d906b67f9bc1a70ab16a8e38c603d9669749
 ```
 
 </Fragment>
@@ -453,8 +460,8 @@ In this phase, you will implement the **production-grade dual-layer multisig gov
 ### Step 1: Prepare base58 Environment
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Terminal Setup</Fragment>
-<Fragment slot="tab.2">Verification</Fragment>
+<Fragment slot="tab.1">Verify Location</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
@@ -464,7 +471,24 @@ In this phase, you will implement the **production-grade dual-layer multisig gov
 pwd
 ```
 
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+/.../ccip-solana-bs58-generator
+```
+
+</Fragment>
+</Tabs>
+
 Set up CCIP constants on Solana Devnet (DO NOT CHANGE THESE)
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Setup Command</Fragment>
+<Fragment slot="tab.2">Verification</Fragment>
+
+<Fragment slot="panel.1">
 
 <Aside type="note" title="CCIP BurnMint Pool Program">
   The CCIP BurnMint pool program is a self-service pool program that allows you to create a pool for your token.
@@ -476,9 +500,9 @@ Set up CCIP constants on Solana Devnet (DO NOT CHANGE THESE)
 </Aside>
 
 ```bash
-export CCIP_POOL_PROGRAM="41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
-export CCIP_ROUTER_PROGRAM="Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C"
-export CCIP_FEE_QUOTER_PROGRAM="FeeQPGkKDeRV1MgoYfMH6L8o3KeuYjwUZrgn4LRKfjHi"
+export SOL_CCIP_POOL_PROGRAM="41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
+export SOL_CCIP_ROUTER="Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C"
+export SOL_CCIP_FEE_QUOTER_PROGRAM="FeeQPGkKDeRV1MgoYfMH6L8o3KeuYjwUZrgn4LRKfjHi"
 ```
 
 **Note**: You can find the Router, Fee Quoter, and self-serve pool programs addresses in the [CCIP Directory](/ccip/directory/testnet/chain/solana-devnet).
@@ -492,8 +516,8 @@ export SOL_WALLET_ADDRESS=$(solana address)
 Verify all required variables are set:
 
 ```bash
-echo "✅ Pool Program: $CCIP_POOL_PROGRAM"
-echo "✅ Router Program: $CCIP_ROUTER_PROGRAM"
+echo "✅ Pool Program: $SOL_CCIP_POOL_PROGRAM"
+echo "✅ Router Program: $SOL_CCIP_ROUTER"
 echo "✅ Squad Vault (from Prerequisites): $SOL_SQUAD_VAULT_MULTISIG"
 echo "✅ Recipient Wallet: $SOL_WALLET_ADDRESS"
 ```
@@ -503,27 +527,10 @@ echo "✅ Recipient Wallet: $SOL_WALLET_ADDRESS"
 <Fragment slot="panel.2">
 
 ```bash
-$ # Terminal 1: Verify location
-# Should output: ccip-solana-bs58-generator
-pwd
-
-/.../ccip-solana-bs58-generator
-
-$ export CCIP_POOL_PROGRAM="41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
-export CCIP_ROUTER_PROGRAM="Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C"
-export CCIP_FEE_QUOTER_PROGRAM="FeeQPGkKDeRV1MgoYfMH6L8o3KeuYjwUZrgn4LRKfjHi"
-
-$ export SOL_WALLET_ADDRESS=$(solana address)
-
-$ echo "✅ Pool Program: $CCIP_POOL_PROGRAM"
-echo "✅ Router Program: $CCIP_ROUTER_PROGRAM"
-echo "✅ Squad Vault (from Prerequisites): $SOL_SQUAD_VAULT_MULTISIG"
-echo "✅ Recipient Wallet: $SOL_WALLET_ADDRESS"
-
 ✅ Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
 ✅ Router Program: Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
-✅ Squad Vault (from Prerequisites): 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY
-✅ Recipient Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
+✅ Squad Vault (from Prerequisites): AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+✅ Recipient Wallet: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
 ```
 
 </Fragment>
@@ -579,52 +586,77 @@ pnpm bs58 spl-token \
 <Fragment slot="panel.2">
 
 ```bash
-INFO [2025-08-19 10:41:03.504 +0200]: 📋 Recipient: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-INFO [2025-08-19 10:41:03.504 +0200]: ✅ Parameter validation completed
-INFO [2025-08-19 10:41:03.504 +0200]: 🎨 Creating mint with Metaplex metadata...
-INFO [2025-08-19 10:41:03.509 +0200]: 📋 Generated mint address: 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci
-INFO [2025-08-19 10:41:03.509 +0200]: 📋 Mint seed: mint_1755592863504_4jeion
-INFO [2025-08-19 10:41:03.509 +0200]: 📋 Using token program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-INFO [2025-08-19 10:41:04.364 +0200]: 📋 Generated 3 instructions for mint + metadata creation
-INFO [2025-08-19 10:41:04.364 +0200]: 💰 Adding initial supply mint instructions...
-INFO [2025-08-19 10:41:04.364 +0200]: 📋 Creating ATA for recipient: 84FvKxAQpHtSaFLguFygoPPEaRorZpTjs8rmMCxuwqUF
-INFO [2025-08-19 10:41:04.364 +0200]: 📋 Will mint 5000000000000 smallest units to 84FvKxAQpHtSaFLguFygoPPEaRorZpTjs8rmMCxuwqUF
-INFO [2025-08-19 10:41:04.364 +0200]: 🔄 Building and simulating transaction...
+INFO [2026-06-15 08:03:01.523 +0530]: 🔍 Validating create mint parameters...
+INFO [2026-06-15 08:03:01.523 +0530]: 📋 Token Program: spl-token (TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA)
+INFO [2026-06-15 08:03:01.523 +0530]: 📋 Decimals: 9
+INFO [2026-06-15 08:03:01.523 +0530]: 📋 Metaplex metadata enabled
+INFO [2026-06-15 08:03:01.523 +0530]:    Name: "AEM"
+INFO [2026-06-15 08:03:01.523 +0530]:    Symbol: "CCIP-AEM"
+INFO [2026-06-15 08:03:01.523 +0530]:    URI: https://cyan-pleasant-anteater-613.mypinata.cloud/ipfs/bafkreieirlwjqbtzniqsgcjebzexlcspcmvd4woh3ajvf2p4fuivkenw6i
+INFO [2026-06-15 08:03:01.523 +0530]: 📋 Initial supply: 5000000000000 smallest units
+INFO [2026-06-15 08:03:01.523 +0530]: 📋 Recipient: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 08:03:01.524 +0530]: ✅ Parameter validation completed
+INFO [2026-06-15 08:03:01.524 +0530]: 🎨 Creating mint with Metaplex metadata...
+INFO [2026-06-15 08:03:01.526 +0530]: 📋 Generated mint address: hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub
+INFO [2026-06-15 08:03:01.526 +0530]: 📋 Mint seed: mint_1781490781524_o1hlbt
+INFO [2026-06-15 08:03:01.526 +0530]: 📋 Using token program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+INFO [2026-06-15 08:03:01.982 +0530]: 📋 Generated 3 instructions for mint + metadata creation
+INFO [2026-06-15 08:03:01.982 +0530]: 💰 Adding initial supply mint instructions...
+INFO [2026-06-15 08:03:01.982 +0530]: 📋 Creating ATA for recipient: gKhGBvVGw62EdjfdNQFvVvvbg8CqdepTrdmSdVsEDBS
+INFO [2026-06-15 08:03:01.983 +0530]: 📋 Will mint 5000000000000 smallest units to gKhGBvVGw62EdjfdNQFvVvvbg8CqdepTrdmSdVsEDBS
+INFO [2026-06-15 08:03:01.983 +0530]: 🔄 Building and simulating transaction...
+INFO [2026-06-15 08:03:01.983 +0530]: 📋 Metadata PDA: 7ndwZpSAP4BRYY42Aph3knmRfUxdJbKAAm7CnDcurGp5
 🎯 COPY TRANSACTION DATA BELOW:
 
-Ued1nAAbK74eW6wNw6sSEWG7KgZbhDN8SiitDSsbj4nsgqMC5EysX1bBSHm99DmH3ivSZi1kUUuM5CpsZut6Rxw7vvUrNFe7ENG3W6xwkc9Ua9GSbGUrq8YgFkkeYgAVmDgGoULFw3cSKsisNwKuaiLKAYrKkxEn6Mv7NXutQFgsec7GqTBQak4xd1VkmJL6PkYU2F8neRa3mRwSTRZCgfb97DBJk88bVoo7CmR1mnerVD9yxNbDWz9TvZzNXTDMxn6uSwjFbis38qBwpbf93P5AshL7ybhMQW9kvZUTYoWg7SAc25Vq9y5kvToyfk4f9KqyzvfgcbM4KyXSvzeEjHHjBM3t7ipacWgUmLr8HWE5QikmTf21PvaqG36nwZMxxJSD5wBHcrtBjNVJz7xEp3YLL5kHe7bJxwpCB8M3CAHko4o5oKMVdU6V1SLy3FTY27732jitvPL7ZmzprwdKTpmjsmr6p3hD1xwVTJsPzk9opKyntiso8pExxruwyrmJTZDwyc75jWwDCKYtPhrZyRicj9tdS4ZYw9NBBwXDtB7d8xQH1mcsSxdmHEV6kzG7u7Jed77jUUGaJRk2DdvPfKkY7rxYUgaH2vgrPN1JXz3mHrr6muEU4btVbtFtLTV1Re22zJjF3rU2SNTJ6ghk3rC1PerB4JCZn3cmqcxbht4JDhNcVNHx5NbGeGjPeACp2mBDqtVeVD7NGS1ryjahsiMKg34MntFhe9nUKnargM2v7tWRhDHxetzRrEo6Zrs4rzFBXGiDJVnMGbwqcRX6rLBXpmLDC524pDGkPyiJ5WtuL82SF3133XXrA71q2c1JM1qget53Jg4FUZYLnVLSSECZLeMd7k1HoHSyzAAjnR69JStsbhaAFusLUfqpNbCNEK2iCkVjWhhZxewYk7VwkenLZridbxzJy1S53mVnF23G4ZrzgpVofiy9fFWufWxLCZwdteWzqb5aXpQV7stKBhm8eHPyVsTVVKDhiZ9atrpdtRvX5MBU4Zow5vYXiHmZLmS7qdhPqRUgMzhxoBUb1HQ6EoaE69NjC8UZHHtVYBHM4f2BM2HKnogwts5ogBvDiNR7UteFoNqsiiTou
+Ued1t9JWnpB6ojDXJk4iKCycwPLpRz88njSywTd6n3QcSYuN1DwZAuQU48J9jxKvCKxJWgsHahfcjCggoVpRjp7n8YFAyWaeD78zNJHTWxXvmz8zYHDvKYpoFJ7boSxP6vBF9UDsX29rBQ4BNktjtdP8xR4pYKedrd9h6whuP2khWXno77JfRkd13Q21Ux3Wkq7qoXCoDfvZqgticxALcqfJQAjJNysMHh5qbpZzSvB62pXuGYT5bmyiX1tCDnCTAsCxE2YCAMnrPrJZWffDWxCUHarWuGNeWu9hsdgGbPe8vpeqQgmkJJcVygXD3BVwmqNroBKybitYX8ehVYc4pPpHFCFsRen99pb3PBAVwbrkqSmuCWhUmz5Wfwsi3oFc3kBRTtUfnMGNnKtaDUx6J92ztfoyLoAE3UTv6TbJDJZEQvJaUyfPNdXojYDM35c6Apbkiy5KtVv9VhoJzD3SuHZBKHy1onRw4JATTqCtGbnRi4L4ksjchPiUc9u7KvwVe8F9u3MVNNX2AeDoNUb4VU7g5prXnNbXN8AWxXdRsjV734NYroCELhVbgX5sDnMx3EZZEiutAvKDdxvLhfQ1swomFCm6YP9gbyQrPsbqKeovUzECj8Ka6AG1JCCXSQGF6KqwAJBQt2LbZdmzvbPBbbyRDSy8dbWEfyFrbhCwzNADs8A9HZdVcQpjgWXwj7DkXF5tnWTD5g1TZ1dhHdx5WcQtgT96kzed6zQo2BbW44VJWNHpPXaFHJsxEJEWRehkrAxsrGLSMYfn2jsiebewoduXFKHV9KeNe5haBYPji1VBNbkenZsGmbeXFbujKfXNZ5iLBR3PvSKo8hmTm8xhig2QjM6XyvYeZbQiygEYCicZFKbTNvfgCJaWJDdk7ePwtKkseajSuYeGGG8ATn1KkBX83caNPgbNejiA2J9sW18MphqnLu2ffymDJhH71R2eNgHfg6TH4K9BGytaNXCfHBRGqrubZEcABnLuUejMrUuKxPTwDXu4LTP8tveJFhQREn4RZUxkWRXXA89V2qE5Fm7MwmVNF5Df93s6gVw2f1CG61Gvk9uATKRxgRJWmNrW26pRgjNKUrtWKDB1y
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-08-19 10:41:04.919 +0200]: Transaction built successfully
+INFO [2026-06-15 08:03:02.145 +0530]: Transaction built successfully
     instructionName: "spl-token.create_mint_with_metaplex"
     transactionSize: "810 bytes"
     base58Length: "1105 characters"
     hexLength: "1620 characters"
     accountCount: 2
     signerCount: 1
-    computeUnits: 73632
-INFO [2025-08-19 10:41:04.919 +0200]: Completed buildTransaction (spl-token.create_mint_with_metaplex)
-    durationMs: 554
-INFO [2025-08-19 10:41:04.919 +0200]: ✅ Transaction simulation completed
-INFO [2025-08-19 10:41:04.919 +0200]: 📋 Metadata PDA: KTc5wu4SR6q3u2AMeWNSVVyYAPUp4WqFbcFqfFSXq8o
-INFO [2025-08-19 10:41:04.919 +0200]:
-INFO [2025-08-19 10:41:04.919 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-08-19 10:41:04.919 +0200]:
-INFO [2025-08-19 10:41:04.919 +0200]: 📋 Transaction Details:
-INFO [2025-08-19 10:41:04.919 +0200]:    Instruction: spl-token.create_mint_with_metaplex
-INFO [2025-08-19 10:41:04.919 +0200]:    Size: 810 bytes
-INFO [2025-08-19 10:41:04.919 +0200]:    Base58 length: 1105 characters
-INFO [2025-08-19 10:41:04.977 +0200]:    Compute units: 73 632
-INFO [2025-08-19 10:41:04.977 +0200]:    Generated: 2025-08-19T08:41:04.918Z
-INFO [2025-08-19 10:41:04.977 +0200]:
-INFO [2025-08-19 10:41:04.977 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-08-19 10:41:04.977 +0200]:
-INFO [2025-08-19 10:41:04.977 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-08-19 10:41:04.977 +0200]:
-INFO [2025-08-19 10:41:04.977 +0200]: 📊 Account Information:
-INFO [2025-08-19 10:41:04.977 +0200]:    Total accounts: 2
-INFO [2025-08-19 10:41:04.977 +0200]:     1. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-08-19 10:41:04.977 +0200]:     2. 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci (writable)
+    computeUnits: 59159
+INFO [2026-06-15 08:03:02.145 +0530]: Completed buildTransaction (spl-token.create_mint_with_metaplex)
+    durationMs: 162
+INFO [2026-06-15 08:03:02.145 +0530]:
+INFO [2026-06-15 08:03:02.145 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 08:03:02.145 +0530]:
+INFO [2026-06-15 08:03:02.145 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 08:03:02.145 +0530]:    Instruction: spl-token.create_mint_with_metaplex
+INFO [2026-06-15 08:03:02.145 +0530]:    Size: 810 bytes
+INFO [2026-06-15 08:03:02.145 +0530]:    Base58 length: 1105 characters
+INFO [2026-06-15 08:03:02.152 +0530]:    Compute units: 59,159
+INFO [2026-06-15 08:03:02.152 +0530]:    Generated: 2026-06-15T02:33:02.145Z
+INFO [2026-06-15 08:03:02.152 +0530]:
+INFO [2026-06-15 08:03:02.152 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 08:03:02.152 +0530]:
+INFO [2026-06-15 08:03:02.153 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 08:03:02.153 +0530]:
+INFO [2026-06-15 08:03:02.153 +0530]: 📊 Account Information:
+INFO [2026-06-15 08:03:02.153 +0530]:    Total accounts: 2
+INFO [2026-06-15 08:03:02.153 +0530]:     1. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 08:03:02.153 +0530]:     2. hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub (writable)
+INFO [2026-06-15 08:03:02.153 +0530]:
+INFO [2026-06-15 08:03:02.153 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 08:03:02.153 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 08:03:02.153 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 08:03:02.153 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 08:03:02.153 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 08:03:02.153 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 08:03:02.153 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 08:03:02.153 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 08:03:02.153 +0530]:
+INFO [2026-06-15 08:03:02.153 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 08:03:02.153 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 08:03:02.153 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 08:03:02.153 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 08:03:02.153 +0530]:    • Estimated compute units: 59,159
+INFO [2026-06-15 08:03:02.153 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 08:03:02.153 +0530]:
+INFO [2026-06-15 08:03:02.153 +0530]: ✅ Transaction simulation completed
 ```
 
 </Fragment>
@@ -634,8 +666,7 @@ INFO [2025-08-19 10:41:04.977 +0200]:     2. 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhK
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add
-  instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
 - **Review**: Verify transaction details, check authority and mint
 - **Simulate**: Simulate the transaction to ensure it will succeed
@@ -668,9 +699,7 @@ echo "✅ Token Mint: $SOL_TOKEN_MINT"
 <Fragment slot="panel.2">
 
 ```bash
-export SOL_TOKEN_MINT="3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci"
-
-✅ Token Mint: 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci
+✅ Token Mint: hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub
 ```
 
 </Fragment>
@@ -713,7 +742,7 @@ Generate the pool initialization transaction:
 ```bash
 # Generate pool initialization transaction
 pnpm bs58 burnmint-token-pool --env devnet --instruction initialize-pool \
-  --program-id $CCIP_POOL_PROGRAM \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG
 ```
@@ -723,46 +752,64 @@ pnpm bs58 burnmint-token-pool --env devnet --instruction initialize-pool \
 <Fragment slot="panel.2">
 
 ```bash
-   ✅ Transaction simulation completed
+🔄 Generating initialize (pool) transaction...
+🔄 Building and simulating transaction...
 🎯 COPY TRANSACTION DATA BELOW:
 
-FBAuxuhVLrvnXFVrZZ818eWSCdJFif8x7mkKK5X6RBW7AUvzjUyee1dLHdns8dzaxgXeKWbQxzJDaFVVNnrGRDkY1ikrnGtrryGaF7dSoNJy9hvLajf4CAw1arFj2EmDn3BQDZAdiMucRWY8vJu1PJpZpDkAqdGdd2mzEuQsC6v3Xrbnuxpim1JvTEEX6sLawAuuodvzK4MVYQpjACG7hzadt6dbNTd7HFugFRfNWzakVmgWiiwCM559wP4UZ9ic7TVtyJFuarDtWgsqqyT7Rk4GfiHbLmQhLWttYFng8TQbuw1zQFG98SHgzTfy9LzuFagqztGLREu2kSARUCaQ1TQda1SYiVmWcQFm6dvr8ZC6ZiaizDKqwRKhaQSY
+FBAv1ygQ7d4A9pXavcpnpX3bSYzxYrqx2KhfKhBPUzFJr5rqj2d7Uow4onYpUkEChmVKXh6MiCWJmnYhSUxYtz8sJPrgyYLpjECLeYahtHYo49SM8MvGfdzdaErj9PV2jCtasFegtw5NXCcYhdZzotFruk6apSpuDeaefpJQ69MsgEP2w4aYqQxbFY57FwYjhtVyBMBBALn2EkBqSPfJJG9fix3uTAL5Ho51TbGYCn8UHvDWZaqVbBzxRNxwbE5Kmdm3rPebhGSZB6TQ1Tgw67zocNPtPyryM8tLqog2jWD3UgTqxBEBx9EVB17xjXYKdXFDUteWyBRrvhRiX81hGq5FAZp5FUHYceZ5f2A56G7GKLjA8KvtPTMic9fi
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-08-19 10:45:58.745 +0200]: Transaction built successfully
-    instructionName: "burnmint.initialize"
+   ✅ Transaction simulation completed
+INFO [2026-06-15 08:17:08.736 +0530]: Transaction built successfully
+    instructionName: "burnmint-token-pool.initialize"
     transactionSize: "279 bytes"
     base58Length: "380 characters"
     hexLength: "558 characters"
     accountCount: 7
     signerCount: 1
-    computeUnits: 27373
-INFO [2025-08-19 10:45:58.745 +0200]: Completed buildTransaction (burnmint.initialize)
-    durationMs: 393
-INFO [2025-08-19 10:45:58.745 +0200]:
-INFO [2025-08-19 10:45:58.745 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-08-19 10:45:58.745 +0200]:
-INFO [2025-08-19 10:45:58.745 +0200]: 📋 Transaction Details:
-INFO [2025-08-19 10:45:58.745 +0200]:    Instruction: burnmint.initialize
-INFO [2025-08-19 10:45:58.745 +0200]:    Size: 279 bytes
-INFO [2025-08-19 10:45:58.745 +0200]:    Base58 length: 380 characters
-INFO [2025-08-19 10:45:58.757 +0200]:    Compute units: 27 373
-INFO [2025-08-19 10:45:58.757 +0200]:    Generated: 2025-08-19T08:45:58.744Z
-INFO [2025-08-19 10:45:58.757 +0200]:
-INFO [2025-08-19 10:45:58.757 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-08-19 10:45:58.757 +0200]:
-INFO [2025-08-19 10:45:58.758 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-08-19 10:45:58.758 +0200]:
-INFO [2025-08-19 10:45:58.758 +0200]: 📊 Account Information:
-INFO [2025-08-19 10:45:58.758 +0200]:    Total accounts: 7
-INFO [2025-08-19 10:45:58.758 +0200]:     1. 2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M (writable)
-INFO [2025-08-19 10:45:58.758 +0200]:     2. 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci (read-only)
-INFO [2025-08-19 10:45:58.758 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-08-19 10:45:58.758 +0200]:     4. 11111111111111111111111111111111 (read-only)
-INFO [2025-08-19 10:45:58.758 +0200]:     5. 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB (read-only)
-INFO [2025-08-19 10:45:58.758 +0200]:     6. 4sVSCJqG9ZKEvnpN38qTzb7Kc8QdHakBgB87HN3FYRaz (read-only)
-INFO [2025-08-19 10:45:58.758 +0200]:     7. E4Bsi43kX3iwXAFia2ebm1mS5Xkmmdv3minZDnfo7Zzf (read-only)
-INFO [2025-08-19 10:45:58.758 +0200]:
+    computeUnits: 31818
+INFO [2026-06-15 08:17:08.736 +0530]: Completed buildTransaction (burnmint-token-pool.initialize)
+    durationMs: 361
+INFO [2026-06-15 08:17:08.736 +0530]:
+INFO [2026-06-15 08:17:08.736 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 08:17:08.736 +0530]:
+INFO [2026-06-15 08:17:08.737 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 08:17:08.737 +0530]:    Instruction: burnmint-token-pool.initialize
+INFO [2026-06-15 08:17:08.737 +0530]:    Size: 279 bytes
+INFO [2026-06-15 08:17:08.737 +0530]:    Base58 length: 380 characters
+INFO [2026-06-15 08:17:08.748 +0530]:    Compute units: 31,818
+INFO [2026-06-15 08:17:08.748 +0530]:    Generated: 2026-06-15T02:47:08.735Z
+INFO [2026-06-15 08:17:08.748 +0530]:
+INFO [2026-06-15 08:17:08.748 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 08:17:08.748 +0530]:
+INFO [2026-06-15 08:17:08.748 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 08:17:08.748 +0530]:
+INFO [2026-06-15 08:17:08.748 +0530]: 📊 Account Information:
+INFO [2026-06-15 08:17:08.748 +0530]:    Total accounts: 7
+INFO [2026-06-15 08:17:08.748 +0530]:     1. 2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu (writable)
+INFO [2026-06-15 08:17:08.748 +0530]:     2. hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub (read-only)
+INFO [2026-06-15 08:17:08.748 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 08:17:08.748 +0530]:     4. 11111111111111111111111111111111 (read-only)
+INFO [2026-06-15 08:17:08.748 +0530]:     5. 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB (read-only)
+INFO [2026-06-15 08:17:08.748 +0530]:     6. 4sVSCJqG9ZKEvnpN38qTzb7Kc8QdHakBgB87HN3FYRaz (read-only)
+INFO [2026-06-15 08:17:08.748 +0530]:     7. E4Bsi43kX3iwXAFia2ebm1mS5Xkmmdv3minZDnfo7Zzf (read-only)
+INFO [2026-06-15 08:17:08.748 +0530]:
+INFO [2026-06-15 08:17:08.748 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 08:17:08.748 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 08:17:08.748 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 08:17:08.748 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 08:17:08.748 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 08:17:08.748 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 08:17:08.748 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 08:17:08.748 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 08:17:08.748 +0530]:
+INFO [2026-06-15 08:17:08.748 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 08:17:08.748 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 08:17:08.748 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 08:17:08.748 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 08:17:08.748 +0530]:    • Estimated compute units: 31,818
+INFO [2026-06-15 08:17:08.748 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 08:17:08.748 +0530]:
 ```
 
 </Fragment>
@@ -772,9 +819,9 @@ INFO [2025-08-19 10:45:58.758 +0200]:
 
 | Account | Address                                        | Purpose                                                     |
 | ------- | ---------------------------------------------- | ----------------------------------------------------------- |
-| **#1**  | `2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M` | **Pool State PDA** - Your main pool configuration           |
-| **#2**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | Token Mint (your token)                                     |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | Authority (your Squad vault)                                |
+| **#1**  | `2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu` | **Pool State PDA** - Your main pool configuration           |
+| **#2**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | Token Mint (your token)                                     |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | Authority (your Squad vault)                                |
 | **#4**  | `11111111111111111111111111111111`             | System Program                                              |
 | **#5**  | `41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB` | CCIP Pool Program                                           |
 | **#6**  | `4sVSCJqG9ZKEvnpN38qTzb7Kc8QdHakBgB87HN3FYRaz` | Program Data PDA                                            |
@@ -789,8 +836,7 @@ INFO [2025-08-19 10:45:58.758 +0200]:
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add
-  instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
 - **Review**: Verify pool initialization parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
@@ -801,10 +847,33 @@ INFO [2025-08-19 10:45:58.758 +0200]:
 
 After execution, set the pool state address from the transaction:
 
+<Tabs client:visible>
+<Fragment slot="tab.1">Set Variable</Fragment>
+<Fragment slot="tab.2">Verification</Fragment>
+
+<Fragment slot="panel.1">
+
 ```bash
 # Set the pool state address from Account #1 in the transaction above
-export SOL_POOL_ADDRESS="2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M"
+export SOL_POOL_ADDRESS="<YOUR_ACTUAL_POOL_STATE_ADDRESS>"
 ```
+
+Verify the pool address:
+
+```bash
+echo "✅ Pool Address: $SOL_POOL_ADDRESS"
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+✅ Pool Address: 2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu
+```
+
+</Fragment>
+</Tabs>
 
 ### Step 4: Derive Pool Signer PDA
 
@@ -822,7 +891,7 @@ pnpm bs58 utils \
   --env devnet \
   --instruction derive-accounts \
   --program-type burnmint-token-pool \
-  --program-id "$CCIP_POOL_PROGRAM" \
+  --program-id "$SOL_CCIP_POOL_PROGRAM" \
   --mint "$SOL_TOKEN_MINT"
 ```
 
@@ -831,18 +900,29 @@ pnpm bs58 utils \
 <Fragment slot="panel.2">
 
 ```bash
+🔍 Deriving burnmint-token-pool accounts...
+INFO [2026-06-15 08:22:10.837 +0530]: Starting deriveAccounts command
+    command: "derive-accounts"
+    programType: "burnmint-token-pool"
+    programId: "41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
+    mint: "hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
+
 📊 Derived Accounts:
 
 1. Pool State PDA
-   Address: 2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M
+   Address: 2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu
    Seeds: ["ccip_tokenpool_config", mint]
-   Bump: 253
+   Bump: 254
    Description: Main pool configuration account (created by initialize-pool)
 
 2. Pool Signer PDA
-   Address: 8NTqDH8dFj7aU5FBWeNMJwjsR1gZMR7criaEaDMEE24r
+   Address: 62So4PhmWWzMpVXKzsCXdNUfrrB4jGXTVda9BzS6HTeo
    Seeds: ["ccip_tokenpool_signer", mint]
-   Bump: 255
+   Bump: 253
    Description: 🎯 CRITICAL: Autonomous mint/burn authority for cross-chain operations
 
 3. Global Config PDA
@@ -852,18 +932,18 @@ pnpm bs58 utils \
    Description: Program-wide configuration settings
 
 4. Pool Token ATA
-   Address: BKkeydRQWKDc5dR7euwhYi47TDLV99o8pD83ncGA2LdZ
+   Address: 2Lzp4uRF6N2x65aMpKqFrajFukAbTCtQcG8thVgqcsEh
    Seeds: [mint, pool_signer_pda, token_program]
    Description: Pool's token account (owned by Pool Signer PDA)
 
 🎯 CRITICAL ADDRESS FOR CROSS-CHAIN OPERATIONS:
-   Pool Signer PDA: 8NTqDH8dFj7aU5FBWeNMJwjsR1gZMR7criaEaDMEE24r
+   Pool Signer PDA: 62So4PhmWWzMpVXKzsCXdNUfrrB4jGXTVda9BzS6HTeo
    ↳ This address signs all mint/burn transactions autonomously
 
-INFO [2025-08-19 10:49:35.438 +0200]: Detected SPL Token v1
-    mint: "3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci"
+INFO [2026-06-15 08:22:11.104 +0530]: Detected SPL Token v1
+    mint: "hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub"
     programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-INFO [2025-08-19 10:49:35.439 +0200]: ✅ Account derivation completed successfully
+INFO [2026-06-15 08:22:11.106 +0530]: ✅ Account derivation completed successfully
     command: "derive-accounts"
 ```
 
@@ -895,8 +975,8 @@ echo "Pool Signer PDA: $SOL_POOL_SIGNER_PDA"
 <Fragment slot="panel.2">
 
 ```bash
-Pool Address: 2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M
-Pool Signer PDA: 8NTqDH8dFj7aU5FBWeNMJwjsR1gZMR7criaEaDMEE24r
+Pool Address: 2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu
+Pool Signer PDA: 62So4PhmWWzMpVXKzsCXdNUfrrB4jGXTVda9BzS6HTeo
 ```
 
 </Fragment>
@@ -921,7 +1001,7 @@ The [owner_propose_administrator](/ccip/concepts/cross-chain-token/svm/registrat
 ```bash
 # Generate administrator registration transaction
 pnpm bs58 router --env devnet --instruction owner-propose-administrator \
-  --program-id $CCIP_ROUTER_PROGRAM \
+  --program-id $SOL_CCIP_ROUTER \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --token-admin-registry-admin $SOL_SQUAD_VAULT_MULTISIG
@@ -932,44 +1012,62 @@ pnpm bs58 router --env devnet --instruction owner-propose-administrator \
 <Fragment slot="panel.2">
 
 ```bash
-   ✅ Transaction simulation completed
+🔄 Generating owner_propose_administrator transaction...
+🔄 Building and simulating transaction...
 🎯 COPY TRANSACTION DATA BELOW:
 
-jCi2q3RM6PzJZRhgUPyQh5bBo2juVuAMP2tXHnkmWowRbPHPaxUKNzaBipQdvpWSJSWKcMF1WENep5oSQyXVgrRfymPuGdu3ZcGKKS1Pi6VzMhTJxd77XXWhwcm2E8992W2PyoqwWcL6HfqD4UdAehr3UboTVM8yBAZg55mGRpmy7gQrNnsTJYZRgtNB4FcA9dU7248M5HUadVTZNJsyXsq1jRnVhpFUp8uUDqiqE5enQFiVV9RVsHvNYzhNppXuQhgfcJqouVPKFK76EHH721Caa3mATF2m2BHmgUDLWTswoukxtypzB8arzeK6aa6d1EYqTkf648cT3Q96GKad7jKnseHubT6Nq8e8RNo3SVfZZYgLxbbCJExBW
+jCi2zBJS8zFbgd7FMisv8MxZKac472KQX9mA3dgncufisCZ1X415QuNpkCb25EkyBr2qj43VXPAZVZToFvsmDxdv3kUoVAXBVRAnVNtcWKWc2Y4qezTSjTD7xsLugoZ6mXe9PSegYhY9M8Wkk8Mag3DBUrkSzkha1NoWk26qBjNWYMmNvDoQSv3ev1W8rEK1cmK7aSEAYSgUy1LnB1f1YCUwEQ9A4SdJAvJoEHHugAcK2F8NKyYwe2TbPfLWbsdRJVeYNPJSEv24Ddm8DyFP2tU2hkXbqbUUVen5RFKHS8mghUWScAbfomYtVLqfm5tW3ytz43SA3vrd1CKfL1ad1NvjxY4wiQ81Jkc5chtb2jjBD5U6d9vL1ZgeP
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-08-19 10:51:42.775 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 08:32:10.160 +0530]: Transaction built successfully
     instructionName: "router.owner_propose_administrator"
     transactionSize: "277 bytes"
     base58Length: "377 characters"
     hexLength: "554 characters"
     accountCount: 5
     signerCount: 1
-    computeUnits: 25785
-INFO [2025-08-19 10:51:42.776 +0200]: Completed buildTransaction (router.owner_propose_administrator)
-    durationMs: 920
-INFO [2025-08-19 10:51:42.776 +0200]:
-INFO [2025-08-19 10:51:42.776 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-08-19 10:51:42.776 +0200]:
-INFO [2025-08-19 10:51:42.776 +0200]: 📋 Transaction Details:
-INFO [2025-08-19 10:51:42.776 +0200]:    Instruction: router.owner_propose_administrator
-INFO [2025-08-19 10:51:42.776 +0200]:    Size: 277 bytes
-INFO [2025-08-19 10:51:42.776 +0200]:    Base58 length: 377 characters
-INFO [2025-08-19 10:51:42.788 +0200]:    Compute units: 25 785
-INFO [2025-08-19 10:51:42.788 +0200]:    Generated: 2025-08-19T08:51:42.775Z
-INFO [2025-08-19 10:51:42.788 +0200]:
-INFO [2025-08-19 10:51:42.788 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-08-19 10:51:42.788 +0200]:
-INFO [2025-08-19 10:51:42.788 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-08-19 10:51:42.788 +0200]:
-INFO [2025-08-19 10:51:42.788 +0200]: 📊 Account Information:
-INFO [2025-08-19 10:51:42.788 +0200]:    Total accounts: 5
-INFO [2025-08-19 10:51:42.788 +0200]:     1. 3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3 (read-only)
-INFO [2025-08-19 10:51:42.789 +0200]:     2. 4maPuX2fcDmCkQv1Qa6RmQa2yGpeZLxiqKy9ybwazGft (writable)
-INFO [2025-08-19 10:51:42.789 +0200]:     3. 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci (read-only)
-INFO [2025-08-19 10:51:42.789 +0200]:     4. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-08-19 10:51:42.789 +0200]:     5. 11111111111111111111111111111111 (read-only)
-INFO [2025-08-19 10:51:42.789 +0200]:
+    computeUnits: 19731
+INFO [2026-06-15 08:32:10.160 +0530]: Completed buildTransaction (router.owner_propose_administrator)
+    durationMs: 400
+INFO [2026-06-15 08:32:10.160 +0530]:
+INFO [2026-06-15 08:32:10.160 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 08:32:10.160 +0530]:
+INFO [2026-06-15 08:32:10.160 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 08:32:10.160 +0530]:    Instruction: router.owner_propose_administrator
+INFO [2026-06-15 08:32:10.160 +0530]:    Size: 277 bytes
+INFO [2026-06-15 08:32:10.160 +0530]:    Base58 length: 377 characters
+INFO [2026-06-15 08:32:10.171 +0530]:    Compute units: 19,731
+INFO [2026-06-15 08:32:10.171 +0530]:    Generated: 2026-06-15T03:02:10.159Z
+INFO [2026-06-15 08:32:10.171 +0530]:
+INFO [2026-06-15 08:32:10.171 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 08:32:10.171 +0530]:
+INFO [2026-06-15 08:32:10.172 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 08:32:10.172 +0530]:
+INFO [2026-06-15 08:32:10.172 +0530]: 📊 Account Information:
+INFO [2026-06-15 08:32:10.172 +0530]:    Total accounts: 5
+INFO [2026-06-15 08:32:10.172 +0530]:     1. 3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3 (read-only)
+INFO [2026-06-15 08:32:10.172 +0530]:     2. 6jWPxptvZKTiLFNdLT39uG1HHa1DXnUqFpi6VttNGrH3 (writable)
+INFO [2026-06-15 08:32:10.172 +0530]:     3. hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub (read-only)
+INFO [2026-06-15 08:32:10.172 +0530]:     4. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 08:32:10.172 +0530]:     5. 11111111111111111111111111111111 (read-only)
+INFO [2026-06-15 08:32:10.172 +0530]:
+INFO [2026-06-15 08:32:10.172 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 08:32:10.172 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 08:32:10.172 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 08:32:10.172 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 08:32:10.172 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 08:32:10.172 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 08:32:10.172 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 08:32:10.172 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 08:32:10.172 +0530]:
+INFO [2026-06-15 08:32:10.172 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 08:32:10.172 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 08:32:10.172 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 08:32:10.172 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 08:32:10.172 +0530]:    • Estimated compute units: 19,731
+INFO [2026-06-15 08:32:10.172 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 08:32:10.172 +0530]:
 ```
 
 </Fragment>
@@ -980,9 +1078,9 @@ INFO [2025-08-19 10:51:42.789 +0200]:
 | Account | Address                                        | Description                                                           |
 | ------- | ---------------------------------------------- | --------------------------------------------------------------------- |
 | **#1**  | `3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3` | Router Config PDA (read-only)                                         |
-| **#2**  | `4maPuX2fcDmCkQv1Qa6RmQa2yGpeZLxiqKy9ybwazGft` | **🎯 Token Admin Registry PDA** - Gets created/updated for your token |
-| **#3**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | Token Mint (your token)                                               |
-| **#4**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | Authority/Payer (your Squad vault)                                    |
+| **#2**  | `6jWPxptvZKTiLFNdLT39uG1HHa1DXnUqFpi6VttNGrH3` | **🎯 Token Admin Registry PDA** - Gets created/updated for your token |
+| **#3**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | Token Mint (your token)                                               |
+| **#4**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | Authority/Payer (your Squad vault)                                    |
 | **#5**  | `11111111111111111111111111111111`             | System Program                                                        |
 
 **What This Transaction Does:**
@@ -992,8 +1090,7 @@ This transaction proposes your Squad vault as the administrator for your token i
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add
-  instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
@@ -1015,7 +1112,7 @@ The [accept_admin_role](/ccip/concepts/cross-chain-token/svm/registration-admini
 ```bash
 # Generate administrator role acceptance transaction
 pnpm bs58 router --env devnet --instruction accept-admin-role \
-  --program-id $CCIP_ROUTER_PROGRAM \
+  --program-id $SOL_CCIP_ROUTER \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG
 ```
@@ -1025,43 +1122,61 @@ pnpm bs58 router --env devnet --instruction accept-admin-role \
 <Fragment slot="panel.2">
 
 ```bash
-   ✅ Transaction simulation completed
+🔄 Generating accept_admin_role_token_admin_registry transaction...
+🔄 Building and simulating transaction...
 🎯 COPY TRANSACTION DATA BELOW:
 
-2sM9hLJFuca8kadhK5vj9XrhMwgVdMHbbADrgprG7i6MGad9ffvR3CzUGpR6kVfkb8S5xg29JHkdB838KZYEhH6r1uLVVEYyhpeoMZMkP4aT51PVc1MqqSWfU9TDRoy3oqBtEe5y1WefUEYCMknDR93F7qkYgWGHTyTeqVg7G5ADTcXV8563psXRdJ52ERNyU6gAxphpBpnetmDAsseMQRgojGL3U8e4ZbWYzA3jULcukB3yYJ2MFQQiAphZvv1utGifPzc8suH9WT7oFPGGXktpLu5tn6EHB
+2sM9hjkg4Y6d1pD6Zqca74vGeRSLBrpBnGsxsjPpmpcutTVk3n4e8Wd7S4qBEfzAkxoCdyNBbdMuatpJq4yTCQM3HfY7bz2oR4bc4KQHHS9AJo6Ct8A615FR1vZJS3WUvk6miYRUFDkEJQYybC8p9HpCMVejMyCaXaREaEujJCcoJbRhSEoS7TVsjetAoGiJxdNaDTZNsXD9scmf8n8jWSf7ixwCYRmg6d7PaFBTmBYuNMz73bc3RFjspc7eKAn5FCh8zktHuzKTznsETzdCsMjaS6HFwe7js
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-08-19 10:54:24.134 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 08:36:38.368 +0530]: Transaction built successfully
     instructionName: "router.accept_admin_role_token_admin_registry"
     transactionSize: "212 bytes"
     base58Length: "289 characters"
     hexLength: "424 characters"
     accountCount: 4
     signerCount: 1
-    computeUnits: 21454
-INFO [2025-08-19 10:54:24.134 +0200]: Completed buildTransaction (router.accept_admin_role_token_admin_registry)
-    durationMs: 423
-INFO [2025-08-19 10:54:24.135 +0200]:
-INFO [2025-08-19 10:54:24.135 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-08-19 10:54:24.135 +0200]:
-INFO [2025-08-19 10:54:24.135 +0200]: 📋 Transaction Details:
-INFO [2025-08-19 10:54:24.135 +0200]:    Instruction: router.accept_admin_role_token_admin_registry
-INFO [2025-08-19 10:54:24.135 +0200]:    Size: 212 bytes
-INFO [2025-08-19 10:54:24.135 +0200]:    Base58 length: 289 characters
-INFO [2025-08-19 10:54:24.155 +0200]:    Compute units: 21 454
-INFO [2025-08-19 10:54:24.155 +0200]:    Generated: 2025-08-19T08:54:24.133Z
-INFO [2025-08-19 10:54:24.155 +0200]:
-INFO [2025-08-19 10:54:24.155 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-08-19 10:54:24.155 +0200]:
-INFO [2025-08-19 10:54:24.155 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-08-19 10:54:24.155 +0200]:
-INFO [2025-08-19 10:54:24.155 +0200]: 📊 Account Information:
-INFO [2025-08-19 10:54:24.155 +0200]:    Total accounts: 4
-INFO [2025-08-19 10:54:24.155 +0200]:     1. 3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3 (read-only)
-INFO [2025-08-19 10:54:24.155 +0200]:     2. 4maPuX2fcDmCkQv1Qa6RmQa2yGpeZLxiqKy9ybwazGft (writable)
-INFO [2025-08-19 10:54:24.155 +0200]:     3. 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci (read-only)
-INFO [2025-08-19 10:54:24.155 +0200]:     4. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-08-19 10:54:24.155 +0200]:
+    computeUnits: 15454
+INFO [2026-06-15 08:36:38.368 +0530]: Completed buildTransaction (router.accept_admin_role_token_admin_registry)
+    durationMs: 455
+INFO [2026-06-15 08:36:38.368 +0530]:
+INFO [2026-06-15 08:36:38.368 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 08:36:38.368 +0530]:
+INFO [2026-06-15 08:36:38.368 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 08:36:38.368 +0530]:    Instruction: router.accept_admin_role_token_admin_registry
+INFO [2026-06-15 08:36:38.368 +0530]:    Size: 212 bytes
+INFO [2026-06-15 08:36:38.368 +0530]:    Base58 length: 289 characters
+INFO [2026-06-15 08:36:38.379 +0530]:    Compute units: 15,454
+INFO [2026-06-15 08:36:38.379 +0530]:    Generated: 2026-06-15T03:06:38.367Z
+INFO [2026-06-15 08:36:38.379 +0530]:
+INFO [2026-06-15 08:36:38.379 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 08:36:38.379 +0530]:
+INFO [2026-06-15 08:36:38.380 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 08:36:38.380 +0530]:
+INFO [2026-06-15 08:36:38.380 +0530]: 📊 Account Information:
+INFO [2026-06-15 08:36:38.380 +0530]:    Total accounts: 4
+INFO [2026-06-15 08:36:38.380 +0530]:     1. 3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3 (read-only)
+INFO [2026-06-15 08:36:38.380 +0530]:     2. 6jWPxptvZKTiLFNdLT39uG1HHa1DXnUqFpi6VttNGrH3 (writable)
+INFO [2026-06-15 08:36:38.380 +0530]:     3. hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub (read-only)
+INFO [2026-06-15 08:36:38.380 +0530]:     4. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 08:36:38.380 +0530]:
+INFO [2026-06-15 08:36:38.380 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 08:36:38.380 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 08:36:38.380 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 08:36:38.380 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 08:36:38.380 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 08:36:38.380 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 08:36:38.380 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 08:36:38.380 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 08:36:38.380 +0530]:
+INFO [2026-06-15 08:36:38.380 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 08:36:38.380 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 08:36:38.380 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 08:36:38.380 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 08:36:38.380 +0530]:    • Estimated compute units: 15,454
+INFO [2026-06-15 08:36:38.380 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 08:36:38.380 +0530]:
 ```
 
 </Fragment>
@@ -1072,9 +1187,9 @@ INFO [2025-08-19 10:54:24.155 +0200]:
 | Account | Address                                        | Description                                                  |
 | ------- | ---------------------------------------------- | ------------------------------------------------------------ |
 | **#1**  | `3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3` | Router Config PDA (read-only)                                |
-| **#2**  | `4maPuX2fcDmCkQv1Qa6RmQa2yGpeZLxiqKy9ybwazGft` | **🎯 Token Admin Registry PDA** - Updates status to "active" |
-| **#3**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | Token Mint (your token)                                      |
-| **#4**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | Authority (your Squad vault - must be pending admin)         |
+| **#2**  | `6jWPxptvZKTiLFNdLT39uG1HHa1DXnUqFpi6VttNGrH3` | **🎯 Token Admin Registry PDA** - Updates status to "active" |
+| **#3**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | Token Mint (your token)                                      |
+| **#4**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | Authority (your Squad vault - must be pending admin)         |
 
 **What This Transaction Does:**
 This is the **acceptance step** of the two-phase administrator registration. It updates the Token Admin Registry PDA (Account #2) from "pending administrator" to "active administrator" status. Your Squad vault explicitly accepts the administrator role, completing the secure registration process.
@@ -1085,8 +1200,7 @@ This is the **acceptance step** of the two-phase administrator registration. It 
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add
-  instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
@@ -1131,47 +1245,63 @@ pnpm bs58 spl-token --env devnet --instruction create-multisig \
 <Fragment slot="panel.2">
 
 ```bash
-INFO [2025-08-19 11:24:27.533 +0200]: Detected SPL Token v1
-    mint: "3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci"
-    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-INFO [2025-08-19 11:24:27.768 +0200]: 🔄 Building and simulating transaction...
-📮 Derived SPL Token Multisig Address: 6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK
+📮 Derived SPL Token Multisig Address: 3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX
 💡 Address derived from: authority + sha256("production-multisig" + mint).hex().slice(0,32) + tokenProgram
+INFO [2026-06-15 08:40:27.414 +0530]: Detected SPL Token v1
+    mint: "hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+INFO [2026-06-15 08:40:27.506 +0530]: 🔄 Building and simulating transaction...
 🎯 COPY TRANSACTION DATA BELOW:
 
-WCDiJTnTwq6VYymu17E2pTDSNLf6YU2MHxD4ADPmNY9wBbPPwZSUsvkwx9CXeWN7qwzDZBL7c6X6U4CuWmEu7RVajVku8nrVynK7xHKkZNgjfYvSgH7e5Uu4ucZ4W4Sgenosw3Sy6p14ZBoMXnkgqkpaeTmbxUgkDx9By5LMSgpAfmPSiDzMGNque5sv7m3V4V26Sdf4mCufEWjaX2sf49xwWxAGgjqU8yZ7evz4HkMBuKcmbxPRm2M1UCbefjXo2ZqTq873T69Mv72jYKDTWPnCfPaz7xgrpswCNcLEDsFaQRdmuw3uCe8PDdV3xnEM695PJtMrdbMUwpEoR7MmHywSssE6KAJZ4xMxWCaaNamyK2XaEFpVGQQGvU56NPPT3vfQkHLF2ipJ6whnzo1EDwJtxXu77MhTxYSCQeN7suq8Z1NjRbPsWk8bFPptfQFceiuicaUcJstW2p7zY7jxXhpPa2GpGduf5T41pSYrkt58BasrRVpU
+WCDiQnLJH3zA77eqJ2auuEMCa1NJz9woANE14hbg1zEC7jXMQoLn1QGwjeQtanXX6xBrdytPjFgErnhViNWSutu5iFuZw8qj26ep9KVcd2CwhcmPqNvFX4wHRZUNe1m3JWey2gRDmNDHY4DwPvHcHauXMoyNHipUPctH3X3yi9R4sdVuhAwUNaGUp41teGHUDSXY3DQGnMH7VsLDm5eeNXDHzP2N8Wg6ZhG7uPbCzmY5y3h6yw5PrLgBNNyr4jkLGQv1B4vQwBzfZp5v27DYtYKT1eD3zbFn3nNAD6FxAc3aLok1FhPNnjLWJLVS75JgwkSuiyGMUwnuBuyqvTrF7PTSUooF8PatnSP3YQwDxgiV89QCTpvcT29dqDVvjmw78vLz8YBWkg14JKKznLc6roDmSqq6yvYG192krqRNadFTfht43uP2fMSg56MEY1eHsfGUtKCRyHeknQxAGY63DjRoFdd3BvsX839Azrcu1PcPr5oWmh2x
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-08-19 11:24:28.324 +0200]: Transaction built successfully
+INFO [2026-06-15 08:40:27.693 +0530]: Transaction built successfully
     instructionName: "spl.create_multisig"
     transactionSize: "367 bytes"
     base58Length: "500 characters"
     hexLength: "734 characters"
     accountCount: 2
     signerCount: 1
-    computeUnits: 2931
-INFO [2025-08-19 11:24:28.324 +0200]: Completed buildTransaction (spl.create_multisig)
-    durationMs: 556
-INFO [2025-08-19 11:24:28.324 +0200]: ✅ Transaction simulation completed
-INFO [2025-08-19 11:24:28.325 +0200]:
-INFO [2025-08-19 11:24:28.325 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-08-19 11:24:28.325 +0200]:
-INFO [2025-08-19 11:24:28.325 +0200]: 📋 Transaction Details:
-INFO [2025-08-19 11:24:28.325 +0200]:    Instruction: spl.create_multisig
-INFO [2025-08-19 11:24:28.325 +0200]:    Size: 367 bytes
-INFO [2025-08-19 11:24:28.325 +0200]:    Base58 length: 500 characters
-INFO [2025-08-19 11:24:28.353 +0200]:    Compute units: 2 931
-INFO [2025-08-19 11:24:28.353 +0200]:    Generated: 2025-08-19T09:24:28.323Z
-INFO [2025-08-19 11:24:28.353 +0200]:
-INFO [2025-08-19 11:24:28.353 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-08-19 11:24:28.353 +0200]:
-INFO [2025-08-19 11:24:28.353 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-08-19 11:24:28.353 +0200]:
-INFO [2025-08-19 11:24:28.354 +0200]: 📊 Account Information:
-INFO [2025-08-19 11:24:28.354 +0200]:    Total accounts: 2
-INFO [2025-08-19 11:24:28.354 +0200]:     1. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-08-19 11:24:28.354 +0200]:     2. 6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK (writable)
-INFO [2025-08-19 11:24:28.354 +0200]:
+    computeUnits: 317
+INFO [2026-06-15 08:40:27.693 +0530]: Completed buildTransaction (spl.create_multisig)
+    durationMs: 186
+INFO [2026-06-15 08:40:27.693 +0530]:
+INFO [2026-06-15 08:40:27.693 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 08:40:27.693 +0530]:
+INFO [2026-06-15 08:40:27.693 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 08:40:27.693 +0530]:    Instruction: spl.create_multisig
+INFO [2026-06-15 08:40:27.693 +0530]:    Size: 367 bytes
+INFO [2026-06-15 08:40:27.693 +0530]:    Base58 length: 500 characters
+INFO [2026-06-15 08:40:27.706 +0530]:    Compute units: 317
+INFO [2026-06-15 08:40:27.706 +0530]:    Generated: 2026-06-15T03:10:27.693Z
+INFO [2026-06-15 08:40:27.706 +0530]:
+INFO [2026-06-15 08:40:27.706 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 08:40:27.706 +0530]:
+INFO [2026-06-15 08:40:27.706 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 08:40:27.706 +0530]:
+INFO [2026-06-15 08:40:27.706 +0530]: 📊 Account Information:
+INFO [2026-06-15 08:40:27.706 +0530]:    Total accounts: 2
+INFO [2026-06-15 08:40:27.706 +0530]:     1. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 08:40:27.706 +0530]:     2. 3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX (writable)
+INFO [2026-06-15 08:40:27.706 +0530]:
+INFO [2026-06-15 08:40:27.706 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 08:40:27.706 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 08:40:27.706 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 08:40:27.706 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 08:40:27.706 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 08:40:27.706 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 08:40:27.706 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 08:40:27.706 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 08:40:27.706 +0530]:
+INFO [2026-06-15 08:40:27.706 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 08:40:27.706 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 08:40:27.706 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 08:40:27.706 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 08:40:27.706 +0530]:    • Estimated compute units: 317
+INFO [2026-06-15 08:40:27.706 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 08:40:27.706 +0530]:
+INFO [2026-06-15 08:40:27.706 +0530]: ✅ Transaction simulation completed
 ```
 
 </Fragment>
@@ -1181,15 +1311,15 @@ INFO [2025-08-19 11:24:28.354 +0200]:
 
 | Account | Address                                        | Description                               |
 | ------- | ---------------------------------------------- | ----------------------------------------- |
-| **#1**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Payer/Authority** (your Squad vault)    |
-| **#2**  | `6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK` | **🎯 SPL Token Multisig** (newly created) |
+| **#1**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Payer/Authority** (your Squad vault)    |
+| **#2**  | `3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX` | **🎯 SPL Token Multisig** (newly created) |
 
 **What This Transaction Does:**
 This creates an **SPL Token Multisig** account that will control your token's mint authority. The CLI automatically detected SPL Token v1 and created the appropriate multisig type.
 
 **Key Details:**
 
-- **Generated Multisig Address**: `6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK`
+- **Generated Multisig Address**: `3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX`
 - **Multisig Signers**: Pool Signer PDA + Squad vault
 - **Threshold**: 1 (either signer can authorize mint operations)
 - **Hybrid Control**: Enables both automated CCIP operations and human governance
@@ -1198,7 +1328,7 @@ This creates an **SPL Token Multisig** account that will control your token's mi
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -1229,7 +1359,7 @@ echo "✅ SPL Multisig: $SOL_SPL_MULTISIG"
 <Fragment slot="panel.2">
 
 ```bash
-✅ SPL Multisig: 6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK
+✅ SPL Multisig: 3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX
 ```
 
 </Fragment>
@@ -1268,43 +1398,59 @@ pnpm bs58 spl-token --env devnet --instruction transfer-mint-authority \
 ```bash
 🎯 COPY TRANSACTION DATA BELOW:
 
-ebWdNECFDo2Uj45BAmovEt5J6YEvDjvLxqcRfWy6uDBmd3XUoviCTAsTXTkoqhQr8w1ZtYqqojwJHSK15QSZ4NrCBKSpb26R2xnC9FdjUpqz2i8VRhYekXjuEAkmDCDKgKnVxg9QhSHDhCofwrBKob8NJuq5eahgMHqPPziQEnz4AJNVkL1ZdG52HchNxvc9PeDVGyy7dwxvcGHiAAsApvq7Lxd31pVBU87kfwShT73
+ebWdWNFhuGinVAQnt9sMpWPabw6CwHKXVERVZQCg48S2yWseshdn366QFPpZvpg8pF9Bq91HzHbMoZgBV9kqJ6s6w6TCRAZxFmjnj4DQxAUomo3xs1ejMZ1AFHgXnBQi5srP9DWFXgbWoakvx4DRD19HJqjUG72TGQBxxnhz1JP45ksgcSrWYKm5GNAyHQomPX45JCopta3Bd3X8sGdFT9dYn6AFmeEkRCZ2yPdFphs
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-08-19 11:27:51.659 +0200]: Detected SPL Token v1
-    mint: "3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci"
+INFO [2026-06-15 08:46:23.823 +0530]: Detected SPL Token v1
+    mint: "hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub"
     programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-INFO [2025-08-19 11:27:51.660 +0200]: 🔄 Building and simulating transaction...
-INFO [2025-08-19 11:27:52.013 +0200]: Transaction built successfully
+INFO [2026-06-15 08:46:23.824 +0530]: 🔄 Building and simulating transaction...
+INFO [2026-06-15 08:46:23.980 +0530]: Transaction built successfully
     instructionName: "spl.transfer_mint_authority"
     transactionSize: "173 bytes"
     base58Length: "235 characters"
     hexLength: "346 characters"
     accountCount: 2
     signerCount: 1
-    computeUnits: 3006
-INFO [2025-08-19 11:27:52.013 +0200]: Completed buildTransaction (spl.transfer_mint_authority)
-    durationMs: 353
-INFO [2025-08-19 11:27:52.013 +0200]: ✅ Transaction simulation completed
-INFO [2025-08-19 11:27:52.014 +0200]:
-INFO [2025-08-19 11:27:52.014 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-08-19 11:27:52.014 +0200]:
-INFO [2025-08-19 11:27:52.014 +0200]: 📋 Transaction Details:
-INFO [2025-08-19 11:27:52.014 +0200]:    Instruction: spl.transfer_mint_authority
-INFO [2025-08-19 11:27:52.014 +0200]:    Size: 173 bytes
-INFO [2025-08-19 11:27:52.014 +0200]:    Base58 length: 235 characters
-INFO [2025-08-19 11:27:52.031 +0200]:    Compute units: 3 006
-INFO [2025-08-19 11:27:52.031 +0200]:    Generated: 2025-08-19T09:27:52.012Z
-INFO [2025-08-19 11:27:52.031 +0200]:
-INFO [2025-08-19 11:27:52.031 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-08-19 11:27:52.031 +0200]:
-INFO [2025-08-19 11:27:52.031 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-08-19 11:27:52.031 +0200]:
-INFO [2025-08-19 11:27:52.031 +0200]: 📊 Account Information:
-INFO [2025-08-19 11:27:52.031 +0200]:    Total accounts: 2
-INFO [2025-08-19 11:27:52.031 +0200]:     1. 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci (writable)
-INFO [2025-08-19 11:27:52.031 +0200]:     2. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer)
-INFO [2025-08-19 11:27:52.031 +0200]:
+    computeUnits: 125
+INFO [2026-06-15 08:46:23.980 +0530]: Completed buildTransaction (spl.transfer_mint_authority)
+    durationMs: 156
+INFO [2026-06-15 08:46:23.980 +0530]:
+INFO [2026-06-15 08:46:23.980 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 08:46:23.980 +0530]:
+INFO [2026-06-15 08:46:23.980 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 08:46:23.980 +0530]:    Instruction: spl.transfer_mint_authority
+INFO [2026-06-15 08:46:23.980 +0530]:    Size: 173 bytes
+INFO [2026-06-15 08:46:23.980 +0530]:    Base58 length: 235 characters
+INFO [2026-06-15 08:46:23.993 +0530]:    Compute units: 125
+INFO [2026-06-15 08:46:23.993 +0530]:    Generated: 2026-06-15T03:16:23.979Z
+INFO [2026-06-15 08:46:23.993 +0530]:
+INFO [2026-06-15 08:46:23.993 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 08:46:23.993 +0530]:
+INFO [2026-06-15 08:46:23.993 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 08:46:23.993 +0530]:
+INFO [2026-06-15 08:46:23.993 +0530]: 📊 Account Information:
+INFO [2026-06-15 08:46:23.993 +0530]:    Total accounts: 2
+INFO [2026-06-15 08:46:23.993 +0530]:     1. hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub (writable)
+INFO [2026-06-15 08:46:23.993 +0530]:     2. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer)
+INFO [2026-06-15 08:46:23.993 +0530]:
+INFO [2026-06-15 08:46:23.993 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 08:46:23.993 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 08:46:23.993 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 08:46:23.993 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 08:46:23.993 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 08:46:23.993 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 08:46:23.993 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 08:46:23.993 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 08:46:23.993 +0530]:
+INFO [2026-06-15 08:46:23.993 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 08:46:23.993 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 08:46:23.993 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 08:46:23.993 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 08:46:23.993 +0530]:    • Estimated compute units: 125
+INFO [2026-06-15 08:46:23.993 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 08:46:23.993 +0530]:
+INFO [2026-06-15 08:46:23.993 +0530]: ✅ Transaction simulation completed
 ```
 
 </Fragment>
@@ -1314,21 +1460,20 @@ INFO [2025-08-19 11:27:52.031 +0200]:
 
 | Account | Address                                        | Description                                   |
 | ------- | ---------------------------------------------- | --------------------------------------------- |
-| **#1**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | **Token Mint** (writable - authority updated) |
-| **#2**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Current Authority** (signer - Squad vault)  |
+| **#1**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | **Token Mint** (writable - authority updated) |
+| **#2**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Current Authority** (signer - Squad vault)  |
 
 **Key Details:**
 
-- **Current Authority**: `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` (Squad vault)
-- **New Authority**: `6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK` (SPL Token Multisig)
-- **Token Mint**: `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` (authority field updated)
+- **Current Authority**: `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` (Squad vault)
+- **New Authority**: `3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX` (SPL Token Multisig)
+- **Token Mint**: `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub` (authority field updated)
 
 <Aside type="note" title="Squads Execution Required">
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add
-  instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
@@ -1375,47 +1520,63 @@ pnpm bs58 spl-token --env devnet --instruction mint \
 <Fragment slot="panel.2">
 
 ```bash
-INFO [2025-08-19 11:31:39.221 +0200]: Detected SPL Token v1
-    mint: "3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci"
+INFO [2026-06-15 08:52:03.242 +0530]: Detected SPL Token v1
+    mint: "hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub"
     programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-INFO [2025-08-19 11:31:39.330 +0200]: 🔄 Building and simulating transaction...
+INFO [2026-06-15 08:52:03.319 +0530]: 🔄 Building and simulating transaction...
 🎯 COPY TRANSACTION DATA BELOW:
 
-9FDWqLKmG2btBeVbENTJckgTiiKUamXHwp2Dpy79xXu7jHWsVBPJWNMUseUfhgBtajbtJGGdTxvommWDSV6W55NcxkL8AYboXxZg5auKS5YiwmDMmZMCMHeQGzizsBhrzrM3TWrETt1jty34wt5DDGYAR2nCAoprQ94tw1ucLvxwf8JhBBN4PVspbiuR4z7Eb4NVJ3XbV2Q8jNJRS68ujcYZTm62iDQtdtN7Mrx7Xyukmvdtufgeqw2GDr5kBTUVtoe33S6PQ7YTicNJ47spFdDfcYRSALoVNF
+9FDWs7rMsQrSvtR1sVHAhsnEdSpxvFrJrsQR972U6ki1he4BAiYBEZLRct47owtf91sWBGUsNwqEGR6cfDgYAkUfx9MTAUffrLwcWPoNX9Emc63eFdjjaSxGhHjD1HJmeX2r55F4huroJhsYiYSC1xaQvkPRUaXwZUHQg2FL3RgqDWaVg9HBHKnhoDwmbMcp21a5zAEL3M9x1K6K6edUjE77katfvNPi5asX19Acd1SQoZrCmXWUrefYKdfyS6zsNR7dJNVp62wGrq218fsthrk24tYrZkQ38T
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-08-19 11:31:39.544 +0200]: Transaction built successfully
+INFO [2026-06-15 08:52:03.475 +0530]: Transaction built successfully
     instructionName: "spl.mint"
     transactionSize: "213 bytes"
     base58Length: "290 characters"
     hexLength: "426 characters"
     accountCount: 4
     signerCount: 1
-    computeUnits: 5365
-INFO [2025-08-19 11:31:39.544 +0200]: Completed buildTransaction (spl.mint)
-    durationMs: 214
-INFO [2025-08-19 11:31:39.544 +0200]: ✅ Transaction simulation completed
-INFO [2025-08-19 11:31:39.544 +0200]:
-INFO [2025-08-19 11:31:39.544 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-08-19 11:31:39.544 +0200]:
-INFO [2025-08-19 11:31:39.544 +0200]: 📋 Transaction Details:
-INFO [2025-08-19 11:31:39.544 +0200]:    Instruction: spl.mint
-INFO [2025-08-19 11:31:39.544 +0200]:    Size: 213 bytes
-INFO [2025-08-19 11:31:39.544 +0200]:    Base58 length: 290 characters
-INFO [2025-08-19 11:31:39.562 +0200]:    Compute units: 5 365
-INFO [2025-08-19 11:31:39.562 +0200]:    Generated: 2025-08-19T09:31:39.544Z
-INFO [2025-08-19 11:31:39.562 +0200]:
-INFO [2025-08-19 11:31:39.562 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-08-19 11:31:39.562 +0200]:
-INFO [2025-08-19 11:31:39.562 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-08-19 11:31:39.562 +0200]:
-INFO [2025-08-19 11:31:39.562 +0200]: 📊 Account Information:
-INFO [2025-08-19 11:31:39.562 +0200]:    Total accounts: 4
-INFO [2025-08-19 11:31:39.562 +0200]:     1. 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci (writable)
-INFO [2025-08-19 11:31:39.562 +0200]:     2. 84FvKxAQpHtSaFLguFygoPPEaRorZpTjs8rmMCxuwqUF (writable)
-INFO [2025-08-19 11:31:39.562 +0200]:     3. 6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK (read-only)
-INFO [2025-08-19 11:31:39.562 +0200]:     4. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer)
-INFO [2025-08-19 11:31:39.562 +0200]:
+    computeUnits: 252
+INFO [2026-06-15 08:52:03.475 +0530]: Completed buildTransaction (spl.mint)
+    durationMs: 156
+INFO [2026-06-15 08:52:03.475 +0530]:
+INFO [2026-06-15 08:52:03.475 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 08:52:03.475 +0530]:
+INFO [2026-06-15 08:52:03.475 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 08:52:03.475 +0530]:    Instruction: spl.mint
+INFO [2026-06-15 08:52:03.475 +0530]:    Size: 213 bytes
+INFO [2026-06-15 08:52:03.475 +0530]:    Base58 length: 290 characters
+INFO [2026-06-15 08:52:03.488 +0530]:    Compute units: 252
+INFO [2026-06-15 08:52:03.488 +0530]:    Generated: 2026-06-15T03:22:03.474Z
+INFO [2026-06-15 08:52:03.488 +0530]:
+INFO [2026-06-15 08:52:03.488 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 08:52:03.488 +0530]:
+INFO [2026-06-15 08:52:03.488 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 08:52:03.488 +0530]:
+INFO [2026-06-15 08:52:03.488 +0530]: 📊 Account Information:
+INFO [2026-06-15 08:52:03.488 +0530]:    Total accounts: 4
+INFO [2026-06-15 08:52:03.488 +0530]:     1. hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub (writable)
+INFO [2026-06-15 08:52:03.488 +0530]:     2. gKhGBvVGw62EdjfdNQFvVvvbg8CqdepTrdmSdVsEDBS (writable)
+INFO [2026-06-15 08:52:03.488 +0530]:     3. 3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX (read-only)
+INFO [2026-06-15 08:52:03.488 +0530]:     4. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer)
+INFO [2026-06-15 08:52:03.488 +0530]:
+INFO [2026-06-15 08:52:03.488 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 08:52:03.488 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 08:52:03.488 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 08:52:03.488 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 08:52:03.488 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 08:52:03.488 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 08:52:03.488 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 08:52:03.488 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 08:52:03.488 +0530]:
+INFO [2026-06-15 08:52:03.488 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 08:52:03.488 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 08:52:03.488 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 08:52:03.488 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 08:52:03.488 +0530]:    • Estimated compute units: 252
+INFO [2026-06-15 08:52:03.488 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 08:52:03.488 +0530]:
+INFO [2026-06-15 08:52:03.488 +0530]: ✅ Transaction simulation completed
 ```
 
 </Fragment>
@@ -1425,10 +1586,10 @@ INFO [2025-08-19 11:31:39.562 +0200]:
 
 | Account | Address                                        | Description                                         |
 | ------- | ---------------------------------------------- | --------------------------------------------------- |
-| **#1**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | **Token Mint** (writable - supply updated)          |
-| **#2**  | `84FvKxAQpHtSaFLguFygoPPEaRorZpTjs8rmMCxuwqUF` | **Recipient's ATA** (writable - receives tokens)    |
-| **#3**  | `6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK` | **SPL Token Multisig** (read-only - mint authority) |
-| **#4**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer - multisig member)          |
+| **#1**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | **Token Mint** (writable - supply updated)          |
+| **#2**  | `gKhGBvVGw62EdjfdNQFvVvvbg8CqdepTrdmSdVsEDBS`  | **Recipient's ATA** (writable - receives tokens)    |
+| **#3**  | `3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX` | **SPL Token Multisig** (read-only - mint authority) |
+| **#4**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer - multisig member)          |
 
 **What This Transaction Does:**
 This is an **SPL Token Multisig Mint** operation that proves your dual-layer governance is working correctly. The Squad vault acts as a signer for the SPL Token Multisig that now controls mint authority.
@@ -1436,9 +1597,9 @@ This is an **SPL Token Multisig Mint** operation that proves your dual-layer gov
 **Key Details:**
 
 - **Amount**: 1,000,000,000 smallest units = 1 token (with 9 decimals)
-- **Recipient**: Your wallet address (`EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB`)
-- **Mint Authority**: SPL Token Multisig (`6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK`)
-- **Multisig Signer**: Squad vault (`59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY`)
+- **Recipient**: Your wallet address (`GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN`)
+- **Mint Authority**: SPL Token Multisig (`3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX`)
+- **Multisig Signer**: Squad vault (`AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB`)
 - **Token Program**: SPL Token v1 (`TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`)
 
 **Transaction Flow:**
@@ -1452,7 +1613,7 @@ This is an **SPL Token Multisig Mint** operation that proves your dual-layer gov
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -1471,9 +1632,9 @@ This is an **SPL Token Multisig Mint** operation that proves your dual-layer gov
 ```bash
 # Save all Solana variables
 cat > ~/.phase2_vars << EOF
-export CCIP_POOL_PROGRAM="$CCIP_POOL_PROGRAM"
-export CCIP_ROUTER_PROGRAM="$CCIP_ROUTER_PROGRAM"
-export CCIP_FEE_QUOTER_PROGRAM="$CCIP_FEE_QUOTER_PROGRAM"
+export SOL_CCIP_POOL_PROGRAM="$SOL_CCIP_POOL_PROGRAM"
+export SOL_CCIP_ROUTER="$SOL_CCIP_ROUTER"
+export SOL_CCIP_FEE_QUOTER_PROGRAM="$SOL_CCIP_FEE_QUOTER_PROGRAM"
 export SOL_SQUAD_VAULT_MULTISIG="$SOL_SQUAD_VAULT_MULTISIG"
 export SOL_TOKEN_MINT="$SOL_TOKEN_MINT"
 export SOL_POOL_ADDRESS="$SOL_POOL_ADDRESS"
@@ -1489,7 +1650,6 @@ echo "✅ Pool Signer PDA: $SOL_POOL_SIGNER_PDA"
 echo "✅ Squads Multisig: $SOL_SQUAD_VAULT_MULTISIG"
 echo "✅ SPL Multisig: $SOL_SPL_MULTISIG"
 echo "✅ Wallet Address: $SOL_WALLET_ADDRESS"
-
 ```
 
 </Fragment>
@@ -1498,12 +1658,12 @@ echo "✅ Wallet Address: $SOL_WALLET_ADDRESS"
 
 ```bash
 === Phase 2 Complete - Dual Multisig Setup ===
-✅ Token Mint: 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci
-✅ Pool Address: 2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M
-✅ Pool Signer PDA: 8NTqDH8dFj7aU5FBWeNMJwjsR1gZMR7criaEaDMEE24r
-✅ Squads Multisig: 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY
-✅ SPL Multisig: 6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK
-✅ Wallet Address: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
+✅ Token Mint: hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub
+✅ Pool Address: 2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu
+✅ Pool Signer PDA: 62So4PhmWWzMpVXKzsCXdNUfrrB4jGXTVda9BzS6HTeo
+✅ Squads Multisig: AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+✅ SPL Multisig: 3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX
+✅ Wallet Address: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
 ```
 
 </Fragment>
@@ -1561,7 +1721,6 @@ export ETHEREUM_SEPOLIA_CHAIN_SELECTOR="16015286601757825753"
 echo "✅ ETH Token: $ETH_TOKEN_ADDRESS"
 echo "✅ ETH Pool: $ETH_POOL_ADDRESS"
 echo "✅ Chain Selector: $ETHEREUM_SEPOLIA_CHAIN_SELECTOR"
-
 ```
 
 </Fragment>
@@ -1577,10 +1736,10 @@ $ source ~/.phase1_vars
 $ export ETHEREUM_SEPOLIA_CHAIN_SELECTOR="16015286601757825753"
 
 $ echo "✅ ETH Token: $ETH_TOKEN_ADDRESS"
-✅ ETH Token: 0x7c57A9d966c3E6e344621C512d510f76575640ED
+✅ ETH Token: 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184
 
 $ echo "✅ ETH Pool: $ETH_POOL_ADDRESS"
-✅ ETH Pool: 0x88965fF139bbA53D6e02a49a80c29d8c65645bA7
+✅ ETH Pool: 0x7115d906b67f9bc1a70ab16a8e38c603d9669749
 
 $ echo "✅ Chain Selector: $ETHEREUM_SEPOLIA_CHAIN_SELECTOR"
 ✅ Chain Selector: 16015286601757825753
@@ -1609,7 +1768,7 @@ Initialize the basic remote chain configuration for Ethereum Sepolia. Pool addre
 ```bash
 # Initialize basic cross-chain configuration (no rate limits, no pool addresses)
 pnpm bs58 burnmint-token-pool --env devnet --instruction init-chain-remote-config \
-  --program-id $CCIP_POOL_PROGRAM \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --remote-chain-selector $ETHEREUM_SEPOLIA_CHAIN_SELECTOR \
@@ -1622,43 +1781,88 @@ pnpm bs58 burnmint-token-pool --env devnet --instruction init-chain-remote-confi
 <Fragment slot="panel.2">
 
 ```bash
-   ✅ Transaction simulation completed
+🔄 Generating initChainRemoteConfig transaction...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
+   Mint: hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub
+   Authority: AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+   Remote Chain Selector: 16015286601757825753
+   Pool Addresses: 0 addresses (must be empty at init)
+   Token Address: 8b7ce78b89f05eaec2e803e638ff5b0f6f009184
+   Decimals: 18
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-15 09:08:54.451 +0530]: Starting initChainRemoteConfig command
+    command: "burnmint-token-pool.init-chain-remote-config"
+    programId: "41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
+    mint: "hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub"
+    authority: "AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB"
+    remoteChainSelector: "16015286601757825753"
+    poolAddresses: "[]"
+    tokenAddress: "0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184"
+    decimals: "18"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
 🎯 COPY TRANSACTION DATA BELOW:
 
-Q14fzko7Rj4xtdvdxXYm7mVfqp8TtR6cCGwrWbEbohtoj9wCMCAi9QxmiC4AQ4K8sGMJi16oCcLDJcj4cv9iz7XjSeojPFBTWgBGwYyBNx4eyLv7k4MUuTkK9bjAd5QzRFDavgwwx2bed7LjkwZSnZdeiJaTBgbHxh8bEDmCpvPR8hhcKM7uAsniNFuhGqfSfmYduiHkxd8zUL29tC634x6W3tDmq7WXBawuoUUpwQxFevaWJcPUqui2QrDM2yXiBXRwGksTxSPn1tr2ZL97A4GZ6zTv9JWaDtkKci9MBNp5pWsRvr97TF79zpuprDRh4ZFSnutm9XV1zmSRXxL8rcYo3jR9hQgq4AfEknV7JmNsuHB3h7s4QzfwVY1oK8PC1wSL6a6MJ4EjFey
+Q14g5jbgtmANfZSMSbAWmxrcrdnGPxD1uBo8aVDcQnQx6TTzqxMFyh9TVRBWDHZUR4VfubX8rAFgCp7c8Eo3MwiZjeA4V1ouP7VwhRmmh8N16BVLWQiQx1sGgTK6LmjdUrNfoivsGxgY9LemmbW6HDH6abBM4efhBsfoGZvzFVQ5L3jjcvU1uzC93MwM3WQDtoDQGpkjYQkoEFon99L3KARFyCHhAVdFRdvDXrR9foWo8Rsod4Ap8vimqNWRCcPyQmh3mgeNPHUS1pqLunparTxbfpQqmhfgqd43J7wsbyCU7cDfg78pZZDRrDmwGkrUVfrKLYvBZCKdFrmWQnuKLJ1EHKqhgd4B7DcoErYvr2L5c1vBGL7SADdVrSqdwrQ9WDfTUuKP5TDt6Zf
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-08-19 11:37:00.167 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 09:08:54.905 +0530]: Transaction built successfully
     instructionName: "initChainRemoteConfig"
     transactionSize: "293 bytes"
     base58Length: "399 characters"
     hexLength: "586 characters"
     accountCount: 4
     signerCount: 1
-    computeUnits: 17935
-INFO [2025-08-19 11:37:00.167 +0200]: Completed buildTransaction (initChainRemoteConfig)
-    durationMs: 431
-INFO [2025-08-19 11:37:00.167 +0200]:
-INFO [2025-08-19 11:37:00.167 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-08-19 11:37:00.167 +0200]:
-INFO [2025-08-19 11:37:00.167 +0200]: 📋 Transaction Details:
-INFO [2025-08-19 11:37:00.167 +0200]:    Instruction: initChainRemoteConfig
-INFO [2025-08-19 11:37:00.167 +0200]:    Size: 293 bytes
-INFO [2025-08-19 11:37:00.167 +0200]:    Base58 length: 399 characters
-INFO [2025-08-19 11:37:00.185 +0200]:    Compute units: 17 935
-INFO [2025-08-19 11:37:00.185 +0200]:    Generated: 2025-08-19T09:37:00.166Z
-INFO [2025-08-19 11:37:00.185 +0200]:
-INFO [2025-08-19 11:37:00.185 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-08-19 11:37:00.185 +0200]:
-INFO [2025-08-19 11:37:00.185 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-08-19 11:37:00.185 +0200]:
-INFO [2025-08-19 11:37:00.185 +0200]: 📊 Account Information:
-INFO [2025-08-19 11:37:00.185 +0200]:    Total accounts: 4
-INFO [2025-08-19 11:37:00.186 +0200]:     1. 2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M (read-only)
-INFO [2025-08-19 11:37:00.186 +0200]:     2. 8zdWLvsAgLQkRmBDATR3j8xVQzcdwrRNZtPZH5kU37jg (writable)
-INFO [2025-08-19 11:37:00.186 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-08-19 11:37:00.186 +0200]:     4. 11111111111111111111111111111111 (read-only)
-INFO [2025-08-19 11:37:00.186 +0200]:
+    computeUnits: 19402
+INFO [2026-06-15 09:08:54.905 +0530]: Completed buildTransaction (initChainRemoteConfig)
+    durationMs: 450
+INFO [2026-06-15 09:08:54.906 +0530]:
+INFO [2026-06-15 09:08:54.906 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 09:08:54.906 +0530]:
+INFO [2026-06-15 09:08:54.906 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 09:08:54.906 +0530]:    Instruction: initChainRemoteConfig
+INFO [2026-06-15 09:08:54.906 +0530]:    Size: 293 bytes
+INFO [2026-06-15 09:08:54.906 +0530]:    Base58 length: 399 characters
+INFO [2026-06-15 09:08:54.916 +0530]:    Compute units: 19,402
+INFO [2026-06-15 09:08:54.916 +0530]:    Generated: 2026-06-15T03:38:54.905Z
+INFO [2026-06-15 09:08:54.916 +0530]:
+INFO [2026-06-15 09:08:54.917 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 09:08:54.917 +0530]:
+INFO [2026-06-15 09:08:54.917 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 09:08:54.917 +0530]:
+INFO [2026-06-15 09:08:54.917 +0530]: 📊 Account Information:
+INFO [2026-06-15 09:08:54.917 +0530]:    Total accounts: 4
+INFO [2026-06-15 09:08:54.917 +0530]:     1. 2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu (read-only)
+INFO [2026-06-15 09:08:54.917 +0530]:     2. A3TEVLHYCbBzncbmVtiZAsK9R281n9oe4DZwMZyKy5p2 (writable)
+INFO [2026-06-15 09:08:54.917 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 09:08:54.917 +0530]:     4. 11111111111111111111111111111111 (read-only)
+INFO [2026-06-15 09:08:54.917 +0530]:
+INFO [2026-06-15 09:08:54.917 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 09:08:54.917 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 09:08:54.917 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 09:08:54.917 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 09:08:54.917 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 09:08:54.917 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 09:08:54.917 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 09:08:54.917 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 09:08:54.917 +0530]:
+INFO [2026-06-15 09:08:54.917 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 09:08:54.917 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 09:08:54.917 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 09:08:54.917 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 09:08:54.917 +0530]:    • Estimated compute units: 19,402
+INFO [2026-06-15 09:08:54.917 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 09:08:54.917 +0530]:
+INFO [2026-06-15 09:08:54.917 +0530]: initChainRemoteConfig command completed successfully
+    command: "burnmint-token-pool.init-chain-remote-config"
+    transactionSize: "293 bytes"
+    computeUnits: 19402
 ```
 
 </Fragment>
@@ -1668,9 +1872,9 @@ INFO [2025-08-19 11:37:00.186 +0200]:
 
 | Account | Address                                        | Description                                         |
 | ------- | ---------------------------------------------- | --------------------------------------------------- |
-| **#1**  | `2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M` | **Pool State PDA** (read-only - validation)         |
-| **#2**  | `8zdWLvsAgLQkRmBDATR3j8xVQzcdwrRNZtPZH5kU37jg` | **Chain Remote Config PDA** (writable - created)    |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault** (signer, writable - pool authority) |
+| **#1**  | `2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu` | **Pool State PDA** (read-only - validation)         |
+| **#2**  | `A3TEVLHYCbBzncbmVtiZAsK9R281n9oe4DZwMZyKy5p2` | **Chain Remote Config PDA** (writable - created)    |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault** (signer, writable - pool authority) |
 | **#4**  | `11111111111111111111111111111111`             | **System Program** (read-only - account creation)   |
 
 **What This Command Does:**
@@ -1679,7 +1883,7 @@ This initializes the **cross-chain configuration** for your Solana token to enab
 **Key Details:**
 
 - **Remote Chain**: Ethereum Sepolia (chain selector: `16015286601757825753`)
-- **Token Mapping**: Links to ERC20 token `0x7c57A9d966c3E6e344621C512d510f76575640ED`
+- **Token Mapping**: Links to ERC20 token `0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184`
 - **Decimal Precision**: 18 decimals (standard EVM token format)
 - **Basic Setup**: No rate limits or pool addresses configured at this stage
 - **Account Creation**: Creates a new Chain Remote Config PDA for this cross-chain relationship
@@ -1695,7 +1899,7 @@ This initializes the **cross-chain configuration** for your Solana token to enab
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -1716,7 +1920,7 @@ After initializing the chain remote config, add the remote pool address to enabl
 ```bash
 # Configure chain connection and remote pool address
 pnpm bs58 burnmint-token-pool --env devnet --instruction edit-chain-remote-config \
-  --program-id $CCIP_POOL_PROGRAM \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --remote-chain-selector $ETHEREUM_SEPOLIA_CHAIN_SELECTOR \
@@ -1730,42 +1934,88 @@ pnpm bs58 burnmint-token-pool --env devnet --instruction edit-chain-remote-confi
 <Fragment slot="panel.2">
 
 ```bash
-   ✅ Transaction simulation completed
+🔄 Generating editChainRemoteConfig transaction...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
+   Mint: hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub
+   Authority: AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+   Remote Chain Selector: 16015286601757825753
+   Pool Addresses: 1 addresses
+   Token Address: 8b7ce78b89f05eaec2e803e638ff5b0f6f009184
+   Decimals: 18
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-15 09:13:31.147 +0530]: Starting editChainRemoteConfig command
+    command: "burnmint-token-pool.edit-chain-remote-config"
+    programId: "41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
+    mint: "hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub"
+    authority: "AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB"
+    remoteChainSelector: "16015286601757825753"
+    poolAddresses: "[\"0x7115d906b67f9bc1a70ab16a8e38c603d9669749\"]"
+    tokenAddress: "0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184"
+    decimals: "18"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
 🎯 COPY TRANSACTION DATA BELOW:
 
-AFoMMPcqYbM5kCTDs346jiU3HGiWW1moQm7vwGoWZ1eBtxTpoTvzsCFwMC3soXz1EoHHX6RqQL3WuZiMWxkpnS4ZquERERu4KFTvTtJiThcUDUUzaSWva652hWqxFnY3PoeUnJqQTaY9BQ2BhcLWW25XbKwUF5jYT7pfEjc4y22pestM3GCmuukaHyDUPr1xoJmEUqRtEFLRbYkG16fxUi8EzxS1iAqeziVEiF5M6fUeJTsmcdLM8hA7W3s5eHMfGTv6t3Phpds6BoUuzeFH5wu4U1dtcmDveMWS1uDkHvfxkYweXHgLXUVhudkquXgNBLr2CJ6Y6MtqoQokRUZaToBTCyDVGrZJYKPD8Saig2QSSQQ2qtLzEg9GywjzcaPcG9EuDshVsGP5KuqbCWVPEt4nwZe7FFbs1jvWRD1uBeaaA3o7
+AFoMPPpvGwnZ4Y3NzMYH5szHnSfKR5DVEBiNkyefN9eQdbhCsQwncNrBH6yt2ngwTxZtBUgeTaKSMEaevUjWZ6WqoajmGj5vFcgATkEo7saA5zdcjsjiqC79GUNCsYRYEmShb8cTUBgtGKE2N59vAREx1DHdnRkjvL1jwVHcV1JnBxTMnf1hFCxZXWxQpZmtxjR7F4imo1sFJhehPvXqfn9Vo4WrBf11xmm1VPQYEpQN2k484hfW361BJ6yPMnK5xbv7fkP9nfaTWUnCno6zaM632cqfua9BVDSbxxvKwNuTk4BYC2EUhWhu6WFddn2YgJvNoaZ3jFcmRF8kQb48Bvs4Z62NoMYn66JuPEMAdqTetg91gzTLpxS1QKEsXbbieTpGp5DVRxksv21sT1NAhYcGfRnTdjSaAbApHjQ2V6rxmNqF
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-08-19 11:38:44.662 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 09:13:31.628 +0530]: Transaction built successfully
     instructionName: "editChainRemoteConfig"
     transactionSize: "317 bytes"
     base58Length: "432 characters"
     hexLength: "634 characters"
     accountCount: 4
     signerCount: 1
-    computeUnits: 19063
-INFO [2025-08-19 11:38:44.662 +0200]: Completed buildTransaction (editChainRemoteConfig)
-    durationMs: 1056
-INFO [2025-08-19 11:38:44.662 +0200]:
-INFO [2025-08-19 11:38:44.662 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-08-19 11:38:44.662 +0200]:
-INFO [2025-08-19 11:38:44.662 +0200]: 📋 Transaction Details:
-INFO [2025-08-19 11:38:44.662 +0200]:    Instruction: editChainRemoteConfig
-INFO [2025-08-19 11:38:44.662 +0200]:    Size: 317 bytes
-INFO [2025-08-19 11:38:44.662 +0200]:    Base58 length: 432 characters
-INFO [2025-08-19 11:38:44.675 +0200]:    Compute units: 19 063
-INFO [2025-08-19 11:38:44.675 +0200]:    Generated: 2025-08-19T09:38:44.662Z
-INFO [2025-08-19 11:38:44.675 +0200]:
-INFO [2025-08-19 11:38:44.675 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-08-19 11:38:44.675 +0200]:
-INFO [2025-08-19 11:38:44.675 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-08-19 11:38:44.675 +0200]:
-INFO [2025-08-19 11:38:44.676 +0200]: 📊 Account Information:
-INFO [2025-08-19 11:38:44.676 +0200]:    Total accounts: 4
-INFO [2025-08-19 11:38:44.676 +0200]:     1. 2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M (read-only)
-INFO [2025-08-19 11:38:44.676 +0200]:     2. 8zdWLvsAgLQkRmBDATR3j8xVQzcdwrRNZtPZH5kU37jg (writable)
-INFO [2025-08-19 11:38:44.676 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-08-19 11:38:44.676 +0200]:     4. 11111111111111111111111111111111 (read-only)
+    computeUnits: 20533
+INFO [2026-06-15 09:13:31.628 +0530]: Completed buildTransaction (editChainRemoteConfig)
+    durationMs: 477
+INFO [2026-06-15 09:13:31.628 +0530]:
+INFO [2026-06-15 09:13:31.628 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 09:13:31.628 +0530]:
+INFO [2026-06-15 09:13:31.628 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 09:13:31.628 +0530]:    Instruction: editChainRemoteConfig
+INFO [2026-06-15 09:13:31.628 +0530]:    Size: 317 bytes
+INFO [2026-06-15 09:13:31.628 +0530]:    Base58 length: 432 characters
+INFO [2026-06-15 09:13:31.637 +0530]:    Compute units: 20,533
+INFO [2026-06-15 09:13:31.637 +0530]:    Generated: 2026-06-15T03:43:31.628Z
+INFO [2026-06-15 09:13:31.637 +0530]:
+INFO [2026-06-15 09:13:31.637 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 09:13:31.637 +0530]:
+INFO [2026-06-15 09:13:31.637 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 09:13:31.637 +0530]:
+INFO [2026-06-15 09:13:31.637 +0530]: 📊 Account Information:
+INFO [2026-06-15 09:13:31.637 +0530]:    Total accounts: 4
+INFO [2026-06-15 09:13:31.637 +0530]:     1. 2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu (read-only)
+INFO [2026-06-15 09:13:31.637 +0530]:     2. A3TEVLHYCbBzncbmVtiZAsK9R281n9oe4DZwMZyKy5p2 (writable)
+INFO [2026-06-15 09:13:31.637 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 09:13:31.637 +0530]:     4. 11111111111111111111111111111111 (read-only)
+INFO [2026-06-15 09:13:31.637 +0530]:
+INFO [2026-06-15 09:13:31.637 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 09:13:31.637 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 09:13:31.637 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 09:13:31.637 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 09:13:31.637 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 09:13:31.637 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 09:13:31.637 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 09:13:31.637 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 09:13:31.637 +0530]:
+INFO [2026-06-15 09:13:31.637 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 09:13:31.637 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 09:13:31.637 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 09:13:31.637 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 09:13:31.637 +0530]:    • Estimated compute units: 20,533
+INFO [2026-06-15 09:13:31.637 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 09:13:31.637 +0530]:
+INFO [2026-06-15 09:13:31.637 +0530]: editChainRemoteConfig command completed successfully
+    command: "burnmint-token-pool.edit-chain-remote-config"
+    transactionSize: "317 bytes"
+    computeUnits: 20533
 ```
 
 </Fragment>
@@ -1776,9 +2026,9 @@ INFO [2025-08-19 11:38:44.676 +0200]:     4. 11111111111111111111111111111111 (r
 
 | Account | Address                                        | Description                                                    |
 | ------- | ---------------------------------------------- | -------------------------------------------------------------- |
-| **#1**  | `2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M` | **Pool State PDA** (read-only - authority validation)          |
-| **#2**  | `8zdWLvsAgLQkRmBDATR3j8xVQzcdwrRNZtPZH5kU37jg` | **Chain Remote Config PDA** (writable - configuration updated) |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault Authority** (signer, writable - fee payer)       |
+| **#1**  | `2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu` | **Pool State PDA** (read-only - authority validation)          |
+| **#2**  | `A3TEVLHYCbBzncbmVtiZAsK9R281n9oe4DZwMZyKy5p2` | **Chain Remote Config PDA** (writable - configuration updated) |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault Authority** (signer, writable - fee payer)       |
 | **#4**  | `11111111111111111111111111111111`             | **System Program** (read-only - account operations)            |
 
 **Transaction Flow:**
@@ -1791,7 +2041,7 @@ INFO [2025-08-19 11:38:44.676 +0200]:     4. 11111111111111111111111111111111 (r
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -1835,7 +2085,7 @@ This command configures inbound and outbound rate limiting for token transfers b
 pnpm bs58 burnmint-token-pool \
   --env devnet \
   --instruction set-chain-rate-limit \
-  --program-id $CCIP_POOL_PROGRAM \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --remote-chain-selector $ETHEREUM_SEPOLIA_CHAIN_SELECTOR \
@@ -1852,42 +2102,89 @@ pnpm bs58 burnmint-token-pool \
 <Fragment slot="panel.2">
 
 ```bash
-   ✅ Transaction simulation completed
+🔄 Generating setChainRateLimit transaction...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
+   Mint: hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub
+   Authority: AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB
+   Remote Chain Selector: 16015286601757825753
+   Inbound Rate Limit: enabled (capacity: 20000000000, rate: 100000000)
+   Outbound Rate Limit: enabled (capacity: 18000000000, rate: 100000000)
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-15 09:17:10.371 +0530]: Starting setChainRateLimit command
+    command: "burnmint-token-pool.set-chain-rate-limit"
+    programId: "41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
+    mint: "hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub"
+    authority: "AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB"
+    remoteChainSelector: "16015286601757825753"
+    inboundEnabled: "true"
+    inboundCapacity: "20000000000"
+    inboundRate: "100000000"
+    outboundEnabled: "true"
+    outboundCapacity: "18000000000"
+    outboundRate: "100000000"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
 🎯 COPY TRANSACTION DATA BELOW:
 
-2osuKVgAa7jk8Ahvr7KPjeNDY7RAx29vFbgbkrKwtnGKbSjEBDZbyrk8Svt46YPLxMkn7AKWi4WYm6oTDYsffKExgZgJRjxvWLgjePpC8UdLhWJZaELXK6wtr3QDSXRgjn9fnW9LGBjSVyo7a7iZLeRQFgygicqXm9FegoDqP6EVHrweoFTcQRUZo4LgMMQnLps9K55APbvesDGXH9yPTUSFTnNrjFGSqqxsNZq8aptDiq4G3CMUBSX9vycyk34qNj9uvWoSmKGkHnypMd7M5Ao5Ws4WuZgCwFYMdfzqJSrRV49umK7FtC4zJ4653fHYMqkQGNh47Ld2qnjjtSgaaUFuR
+2osuKtP31rW7xJebzwQn4Xqs8QpiBRYpQVTWtwq69tqevXsC1jJcB5D93DuUYshzs2Z8jjRANiKBxmSGhBuqkYinKvCK29HDtd2Uyi47ncTMMnFUh8F5vs2QcZ9H8162JPkvEwHVLjXhuvF4e9e8VHRMGmEFk3W3uXwveVT3Q9UdaTx9qnVgUd2ynU6e2H159KdgZ2N1vKHEJNUuX4JEVgbo3ruvUjv7vFYiZ3pYaFStGgzRcdqqDJZigGYiv4oQ35AbTxfhDuJcUeL3nL9BRRAx2Kvu4E3wDKHDLTLk9ch9bQFKYvVc1SHuXWkNnHR3aEMwiLp88XJMvcfsCgEWw9hDh
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-08-19 11:40:52.986 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 09:17:10.712 +0530]: Transaction built successfully
     instructionName: "setChainRateLimit"
     transactionSize: "253 bytes"
     base58Length: "345 characters"
     hexLength: "506 characters"
     accountCount: 3
     signerCount: 1
-    computeUnits: 15592
-INFO [2025-08-19 11:40:52.986 +0200]: Completed buildTransaction (setChainRateLimit)
-    durationMs: 1272
-INFO [2025-08-19 11:40:52.987 +0200]:
-INFO [2025-08-19 11:40:52.987 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-08-19 11:40:52.987 +0200]:
-INFO [2025-08-19 11:40:52.987 +0200]: 📋 Transaction Details:
-INFO [2025-08-19 11:40:52.987 +0200]:    Instruction: setChainRateLimit
-INFO [2025-08-19 11:40:52.987 +0200]:    Size: 253 bytes
-INFO [2025-08-19 11:40:52.987 +0200]:    Base58 length: 345 characters
-INFO [2025-08-19 11:40:53.001 +0200]:    Compute units: 15 592
-INFO [2025-08-19 11:40:53.001 +0200]:    Generated: 2025-08-19T09:40:52.986Z
-INFO [2025-08-19 11:40:53.001 +0200]:
-INFO [2025-08-19 11:40:53.001 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-08-19 11:40:53.001 +0200]:
-INFO [2025-08-19 11:40:53.001 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-08-19 11:40:53.001 +0200]:
-INFO [2025-08-19 11:40:53.001 +0200]: 📊 Account Information:
-INFO [2025-08-19 11:40:53.001 +0200]:    Total accounts: 3
-INFO [2025-08-19 11:40:53.001 +0200]:     1. 2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M (read-only)
-INFO [2025-08-19 11:40:53.001 +0200]:     2. 8zdWLvsAgLQkRmBDATR3j8xVQzcdwrRNZtPZH5kU37jg (writable)
-INFO [2025-08-19 11:40:53.001 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-08-19 11:40:53.001 +0200]:
+    computeUnits: 17096
+INFO [2026-06-15 09:17:10.713 +0530]: Completed buildTransaction (setChainRateLimit)
+    durationMs: 338
+INFO [2026-06-15 09:17:10.713 +0530]:
+INFO [2026-06-15 09:17:10.713 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 09:17:10.713 +0530]:
+INFO [2026-06-15 09:17:10.713 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 09:17:10.713 +0530]:    Instruction: setChainRateLimit
+INFO [2026-06-15 09:17:10.713 +0530]:    Size: 253 bytes
+INFO [2026-06-15 09:17:10.713 +0530]:    Base58 length: 345 characters
+INFO [2026-06-15 09:17:10.720 +0530]:    Compute units: 17,096
+INFO [2026-06-15 09:17:10.720 +0530]:    Generated: 2026-06-15T03:47:10.712Z
+INFO [2026-06-15 09:17:10.720 +0530]:
+INFO [2026-06-15 09:17:10.720 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 09:17:10.720 +0530]:
+INFO [2026-06-15 09:17:10.721 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 09:17:10.721 +0530]:
+INFO [2026-06-15 09:17:10.721 +0530]: 📊 Account Information:
+INFO [2026-06-15 09:17:10.721 +0530]:    Total accounts: 3
+INFO [2026-06-15 09:17:10.721 +0530]:     1. 2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu (read-only)
+INFO [2026-06-15 09:17:10.721 +0530]:     2. A3TEVLHYCbBzncbmVtiZAsK9R281n9oe4DZwMZyKy5p2 (writable)
+INFO [2026-06-15 09:17:10.721 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 09:17:10.721 +0530]:
+INFO [2026-06-15 09:17:10.721 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 09:17:10.721 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 09:17:10.721 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 09:17:10.721 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 09:17:10.721 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 09:17:10.721 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 09:17:10.721 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 09:17:10.721 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 09:17:10.721 +0530]:
+INFO [2026-06-15 09:17:10.721 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 09:17:10.721 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 09:17:10.721 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 09:17:10.721 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 09:17:10.721 +0530]:    • Estimated compute units: 17,096
+INFO [2026-06-15 09:17:10.721 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 09:17:10.721 +0530]:
+INFO [2026-06-15 09:17:10.721 +0530]: setChainRateLimit command completed successfully
+    command: "burnmint-token-pool.set-chain-rate-limit"
+    transactionSize: "253 bytes"
+    computeUnits: 17096
 ```
 
 </Fragment>
@@ -1897,15 +2194,15 @@ INFO [2025-08-19 11:40:53.001 +0200]:
 
 | Account | Address                                        | Type                 | Purpose                                                           |
 | ------- | ---------------------------------------------- | -------------------- | ----------------------------------------------------------------- |
-| **#1**  | `2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M` | **Read-only**        | **Pool State PDA** - Main pool configuration account              |
-| **#2**  | `8zdWLvsAgLQkRmBDATR3j8xVQzcdwrRNZtPZH5kU37jg` | **Writable**         | **Chain Config PDA** - Chain-specific config (stores rate limits) |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Signer, Writable** | **Authority** - Your Squad vault that can modify rate limits      |
+| **#1**  | `2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu` | **Read-only**        | **Pool State PDA** - Main pool configuration account              |
+| **#2**  | `A3TEVLHYCbBzncbmVtiZAsK9R281n9oe4DZwMZyKy5p2` | **Writable**         | **Chain Config PDA** - Chain-specific config (stores rate limits) |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Signer, Writable** | **Authority** - Your Squad vault that can modify rate limits      |
 
 <Aside type="note" title="Squads Execution Required">
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -1930,9 +2227,9 @@ This command creates an **Address Lookup Table (ALT)** that stores frequently us
 ```bash
 # Generate address lookup table creation transaction
 pnpm bs58 router --env devnet --instruction create-lookup-table \
-  --program-id $CCIP_ROUTER_PROGRAM \
-  --fee-quoter-program-id $CCIP_FEE_QUOTER_PROGRAM \
-  --pool-program-id $CCIP_POOL_PROGRAM \
+  --program-id $SOL_CCIP_ROUTER \
+  --fee-quoter-program-id $SOL_CCIP_FEE_QUOTER_PROGRAM \
+  --pool-program-id $SOL_CCIP_POOL_PROGRAM \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --additional-addresses "[\"$SOL_SPL_MULTISIG\"]"
@@ -1943,44 +2240,78 @@ pnpm bs58 router --env devnet --instruction create-lookup-table \
 <Fragment slot="panel.2">
 
 ```bash
-📮 Derived Lookup Table Address: 2s6yx6xCBgEQBrv5h4dF7TQvvKUWTJBEsueqTnZZHLwY
-   ✅ Transaction simulation completed
+🔄 Generating create_lookup_table transaction...
+🔄 Building and simulating transaction...
 🎯 COPY TRANSACTION DATA BELOW:
 
-4Tv96e4E7ESPWQLmUo496tqU5fHzEJ11Baqk6FSZ4caP6KGA2zsYbdEXanTSaqUG8anjbxD9zHH6cV7BHePqwX5Nvgan4ZrFjqo1Vk9yYDaw5HhKmVgaB4JiGaJEtpe7aMvt9U9rUSfTBcAtXSaW2oPWphKHwqFD7ANH8eW2ybF9KMVEoXi2RJQDgtribNpMZvsh7pkVkWifYiTB4N6gFc4kXqxsSMqV3y9FtvsDFFnhvhSvDxLiRgCH5cp5puhsLFAxF87yCWsJiN5GA1iuHC1CYh3nDMVwcbowdZWQgbMJyyzijnzmXmczv1TWRF7g7VTDv9kULaNTTQDuswN9pUzTJeGPxDbnWwe31SKRjT3HiSCzPCQG67tcPzMnG14S3J2W2foUaMwcK7UHJaw7B1Wgd6dX4VduaJtFd2rELY6hXkfvdApy9dweL6UpuC1pkww3JETimnUCGdmcNGqpCSdrtbd4gpNfk4QNSit4uSiqRruv1ggaEKDTPoKA5GSFgYf14Aj9dpcwGTeAqcw3oXYAHmCRHEB5AGk6BqRCPe7FJkHjBBKq9mANGjf15G21dxAwpZx3FhnGXX7RB7UoQmDHNYorYRKNuHZpCuUmdQKyLDnkRPdvGCVPqpwnREZmMCpqC7gSMRs7wzy1Ed8AorCjTqWExc2ijrNbWfDEfGVHsoLfe6CmgEmfEZB3Ccr34hy8hhfUvCFiJwDHZKkmUPG1kv5Xu7AKbDkDpWafv4ngyQBGT3oRtRC1
+4Tv97PYyrMme7P36n8oAz29YxbpdKWYcAHQmjxpUgAh8wwU1E7Q5bnUqBzQp2xnXL6Z3kFaQhxtR4jj5YHs8yhFzELPrjRhWUuGZbQhyJrGsqDqsL3YGeycrgFhFSieJCjKv9qVfmNwhBwmvjLTcGRKNgwNmUXYB67pzkDwwj8xgN7mdg13wBxFNSGvbBsoBhFqNqDfq4p4who4JKxKHnx4GRi8LdeNgf2ctSi3XZTq2SFAp4yeqMKNyegXXzxV5D7LosUqxCt3umcrq7HG3RZfm4ctkJFAduZftvUcJ18MKgPNmTw4TBGC7HLBoYi8fp7m4EMSPiPgHK6vzxmt5QaAYk6PDpjG7tcE5bxF3LTMqXXA94GEhox79b3uVFKVutUCgAdtq3qCrnfBf5h3j1Md7ybGuQDV5AmKQg8DDGUDPybi2aDr8zTpXY8rBDisYysxvx6JoRyS4ZTxnFUYFLh1dHUXrbD2F8yEfEQpokkxw3oW5bTqwqCr3cA17vvTSo1dvbQYyNoJyuDqnmAGs2UvMDAxJxtQgxCPQcc1ZJzNQgmFai1wnohmPsVVWMVgXcARDbJvzHDeZxtQH99KfrTFvbLsaGgWAv6iqYKT1fhzoQsDpTPvhmUzQNYUoFgysCcDS5jKNZgtQ9M7oiBDV464HZfAbfq9K4erB9g71f4NHEgwohNUeTvKaMiMD6ubHdCQuM5y92Fc6NtMdgYW38rU1Q53NnzWnkD68d7kvCXGT3UJ41v7GuGBX
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-08-19 11:42:31.495 +0200]: Transaction built successfully
+📮 Derived Lookup Table Address: DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv
+   ✅ Transaction simulation completed
+
+⚠️  ALT CREATION TIMING CONSTRAINT
+   This transaction must be imported AND executed within 60-90 seconds
+   due to slot-dependent address derivation.
+
+💡 RECOMMENDED: Use the companion tool for immediate execution:
+   pnpm create-alt --keypair <EOA_KEYPAIR> --authority AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB \
+     --program-id Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C \
+     --fee-quoter-program-id FeeQPGkKDeRV1MgoYfMH6L8o3KeuYjwUZrgn4LRKfjHi \
+     --pool-program-id 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB \
+     --mint hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub \
+     --env devnet
+
+INFO [2026-06-15 09:37:03.045 +0530]: Detected SPL Token v1
+    mint: "hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+INFO [2026-06-15 09:37:03.321 +0530]: Transaction built successfully
     instructionName: "router.create_lookup_table"
     transactionSize: "557 bytes"
     base58Length: "760 characters"
     hexLength: "1114 characters"
     accountCount: 4
     signerCount: 2
-    computeUnits: 19728
-INFO [2025-08-19 11:42:31.496 +0200]: Completed buildTransaction (router.create_lookup_table)
-    durationMs: 481
-INFO [2025-08-19 11:42:31.496 +0200]:
-INFO [2025-08-19 11:42:31.496 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-08-19 11:42:31.496 +0200]:
-INFO [2025-08-19 11:42:31.496 +0200]: 📋 Transaction Details:
-INFO [2025-08-19 11:42:31.496 +0200]:    Instruction: router.create_lookup_table
-INFO [2025-08-19 11:42:31.496 +0200]:    Size: 557 bytes
-INFO [2025-08-19 11:42:31.496 +0200]:    Base58 length: 760 characters
-INFO [2025-08-19 11:42:31.515 +0200]:    Compute units: 19 728
-INFO [2025-08-19 11:42:31.515 +0200]:    Generated: 2025-08-19T09:42:31.495Z
-INFO [2025-08-19 11:42:31.515 +0200]:
-INFO [2025-08-19 11:42:31.515 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-08-19 11:42:31.515 +0200]:
-INFO [2025-08-19 11:42:31.516 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-08-19 11:42:31.516 +0200]:
-INFO [2025-08-19 11:42:31.516 +0200]: 📊 Account Information:
-INFO [2025-08-19 11:42:31.516 +0200]:    Total accounts: 4
-INFO [2025-08-19 11:42:31.516 +0200]:     1. 2s6yx6xCBgEQBrv5h4dF7TQvvKUWTJBEsueqTnZZHLwY (writable)
-INFO [2025-08-19 11:42:31.516 +0200]:     2. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer)
-INFO [2025-08-19 11:42:31.516 +0200]:     3. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-08-19 11:42:31.516 +0200]:     4. 11111111111111111111111111111111 (read-only)
-INFO [2025-08-19 11:42:31.516 +0200]:
+    computeUnits: 19521
+INFO [2026-06-15 09:37:03.321 +0530]: Completed buildTransaction (router.create_lookup_table)
+    durationMs: 183
+INFO [2026-06-15 09:37:03.322 +0530]:
+INFO [2026-06-15 09:37:03.322 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 09:37:03.322 +0530]:
+INFO [2026-06-15 09:37:03.322 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 09:37:03.322 +0530]:    Instruction: router.create_lookup_table
+INFO [2026-06-15 09:37:03.322 +0530]:    Size: 557 bytes
+INFO [2026-06-15 09:37:03.322 +0530]:    Base58 length: 760 characters
+INFO [2026-06-15 09:37:03.329 +0530]:    Compute units: 19,521
+INFO [2026-06-15 09:37:03.329 +0530]:    Generated: 2026-06-15T04:07:03.321Z
+INFO [2026-06-15 09:37:03.329 +0530]:
+INFO [2026-06-15 09:37:03.329 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 09:37:03.329 +0530]:
+INFO [2026-06-15 09:37:03.329 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 09:37:03.329 +0530]:
+INFO [2026-06-15 09:37:03.329 +0530]: 📊 Account Information:
+INFO [2026-06-15 09:37:03.329 +0530]:    Total accounts: 4
+INFO [2026-06-15 09:37:03.329 +0530]:     1. DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv (writable)
+INFO [2026-06-15 09:37:03.329 +0530]:     2. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer)
+INFO [2026-06-15 09:37:03.329 +0530]:     3. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 09:37:03.329 +0530]:     4. 11111111111111111111111111111111 (read-only)
+INFO [2026-06-15 09:37:03.329 +0530]:
+INFO [2026-06-15 09:37:03.329 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 09:37:03.329 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 09:37:03.329 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 09:37:03.329 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 09:37:03.329 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 09:37:03.329 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 09:37:03.329 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 09:37:03.329 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 09:37:03.329 +0530]:
+INFO [2026-06-15 09:37:03.330 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 09:37:03.330 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 09:37:03.330 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 09:37:03.330 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 09:37:03.330 +0530]:    • Estimated compute units: 19,521
+INFO [2026-06-15 09:37:03.330 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 09:37:03.330 +0530]:
 ```
 
 </Fragment>
@@ -1990,9 +2321,9 @@ INFO [2025-08-19 11:42:31.516 +0200]:
 
 | Account | Address                                        | Description                                               |
 | ------- | ---------------------------------------------- | --------------------------------------------------------- |
-| **#1**  | `2s6yx6xCBgEQBrv5h4dF7TQvvKUWTJBEsueqTnZZHLwY` | **ALT Account** (writable - being created)                |
-| **#2**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **ALT Authority** (signer - will own the table)           |
-| **#3**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Fee Payer** (signer, writable - pays creation costs)    |
+| **#1**  | `DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv` | **ALT Account** (writable - being created)                |
+| **#2**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **ALT Authority** (signer - will own the table)           |
+| **#3**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Fee Payer** (signer, writable - pays creation costs)    |
 | **#4**  | `11111111111111111111111111111111`             | **System Program** (read-only - handles account creation) |
 
 **What This Command Does:**
@@ -2001,7 +2332,7 @@ This command creates the ALT infrastructure needed for efficient CCIP operations
 
 **Transaction Flow:**
 
-1. **ALT Creation**: Creates lookup table account `2s6yx6x...` with Squad Vault as authority
+1. **ALT Creation**: Creates lookup table account `DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv` with Squad Vault as authority
 1. **Core Address Addition**: Adds essential CCIP accounts (programs, PDAs) to the table
 1. **SPL Multisig Addition**: Adds your SPL multisig `$SOL_SPL_MULTISIG` via `--additional-addresses`
 1. **Index Assignment**: Each address gets a unique 1-byte index for future reference
@@ -2016,17 +2347,17 @@ The created lookup table will contain indices for these accounts in this exact o
 
 | Index  | Account Address                                | Purpose                                               |
 | ------ | ---------------------------------------------- | ----------------------------------------------------- |
-| **0**  | `2s6yx6xCBgEQBrv5h4dF7TQvvKUWTJBEsueqTnZZHLwY` | **ALT Address (Self-Reference)**                      |
-| **1**  | `4maPuX2fcDmCkQv1Qa6RmQa2yGpeZLxiqKy9ybwazGft` | **Token Admin Registry PDA**                          |
+| **0**  | `DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv` | **ALT Address (Self-Reference)**                      |
+| **1**  | `6jWPxptvZKTiLFNdLT39uG1HHa1DXnUqFpi6VttNGrH3` | **Token Admin Registry PDA**                          |
 | **2**  | `41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB` | **Pool Program ID**                                   |
-| **3**  | `2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M` | **Pool State PDA**                                    |
-| **4**  | `BKkeydRQWKDc5dR7euwhYi47TDLV99o8pD83ncGA2LdZ` | **Pool Signer's Associated Token Account**            |
-| **5**  | `8NTqDH8dFj7aU5FBWeNMJwjsR1gZMR7criaEaDMEE24r` | **Pool Signer PDA**                                   |
+| **3**  | `2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu` | **Pool State PDA**                                    |
+| **4**  | `2Lzp4uRF6N2x65aMpKqFrajFukAbTCtQcG8thVgqcsEh` | **Pool Signer's Associated Token Account**            |
+| **5**  | `62So4PhmWWzMpVXKzsCXdNUfrrB4jGXTVda9BzS6HTeo` | **Pool Signer PDA**                                   |
 | **6**  | `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`  | **Token Program ID (SPL Token v1)**                   |
-| **7**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | **Token Mint**                                        |
+| **7**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | **Token Mint**                                        |
 | **8**  | `GTz54AfhMRkKzFVse8jX8rjAx21fA86ZmVBF1v5VUC3u` | **Fee Quoter Token Config PDA**                       |
 | **9**  | `H6ZviaabTYZqUPgiSoMDbeVthcNW9ULcAuUu3zRLFqDR` | **Router External Token Pools Signer PDA**            |
-| **10** | `6c5UGRRQzPvZY4ZJZJiPGRYMw5e32uX8GfFzvm35k3jK` | **SPL Token Multisig** ← **Your Additional Address!** |
+| **10** | `3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX` | **SPL Token Multisig** ← **Your Additional Address!** |
 
 **Transaction Efficiency Impact:**
 
@@ -2038,7 +2369,7 @@ The created lookup table will contain indices for these accounts in this exact o
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -2071,7 +2402,7 @@ echo "✅ Address Lookup Table: $SOL_ADDRESS_LOOKUP_TABLE"
 <Fragment slot="panel.2">
 
 ```bash
-✅ Address Lookup Table: 2s6yx6xCBgEQBrv5h4dF7TQvvKUWTJBEsueqTnZZHLwY
+✅ Address Lookup Table: DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv
 ```
 
 </Fragment>
@@ -2096,7 +2427,7 @@ Register your token pool with the CCIP Router using [set_pool](/ccip/api-referen
 ```bash
 # Generate pool registration transaction
 pnpm bs58 router --env devnet --instruction set-pool \
-  --program-id $CCIP_ROUTER_PROGRAM \
+  --program-id $SOL_CCIP_ROUTER \
   --mint $SOL_TOKEN_MINT \
   --authority $SOL_SQUAD_VAULT_MULTISIG \
   --pool-lookup-table $SOL_ADDRESS_LOOKUP_TABLE \
@@ -2108,44 +2439,62 @@ pnpm bs58 router --env devnet --instruction set-pool \
 <Fragment slot="panel.2">
 
 ```bash
-   ✅ Transaction simulation completed
+🔄 Generating set_pool transaction...
+🔄 Building and simulating transaction...
 🎯 COPY TRANSACTION DATA BELOW:
 
-QmCar77mNEqzAzGvMRsXQY9UpezF7qcPt7iURnmpvC88c6KwfUn7EV6zzYacufykzKm9Tix1Pgf8mR7fbMQMuzqRHRkcqTYE5qFvjEBZ3WeWgdr3wJHrRt4AXLT7B4PNUDV8jhPMNNahL3NJMQmz6VjA9dRxJ2qLGQEFvGaN4qgTbstuwniy93gJvzjhZzTpa7qi8CedKWb4wni5xX9MjKGbQV4pxdXHuFiuYv9uxXJWFTJjFMvH1jrnsAnUJEqu6V5SZjSCYGGrnXm4PoifNadCwnCBYLhX1p9GtrA3S6zUG2YcsLDMCbKzM2Ge5FLfn4mDMp2QQn2UrDFtstRq4pN
+QmCawFUFrWLVf4xbxo2fJyttTDxiAsdLTbZfn4tgZUjn1TcfyExg71Uugx2fD6A4L38xjLemqiRRAaZy18w67UgpHw7KZvDp1YRGtWyYbZifpMcvXDqu6L8iMX9f8MqPLT1eFKwwBFxNmksaCC8KrSTMVaXeWATpMGEz9nDdXJdt4GvvoxJSjwdmLt2UQEEHtctnPPG6iL3iWidCcQDGoJeLnTfnwAT3KG89UAuFwxxiqF8Ub6Yqbesy1jm18yXvdeiVmuAYAeLCWmZzeUPKGkGccKv3dvY4xGX8LwJQLzfhDGKapDz533cKHXStjkhyEmwF5FHbEQk9URGQYNuL5Dg
 
 ────────────────────────────────────────────────────────────────────────────────
-INFO [2025-08-19 11:47:34.577 +0200]: Transaction built successfully
+   ✅ Transaction simulation completed
+INFO [2026-06-15 09:41:01.361 +0530]: Transaction built successfully
     instructionName: "router.set_pool"
     transactionSize: "252 bytes"
     base58Length: "343 characters"
     hexLength: "504 characters"
     accountCount: 5
     signerCount: 1
-    computeUnits: 40367
-INFO [2025-08-19 11:47:34.578 +0200]: Completed buildTransaction (router.set_pool)
-    durationMs: 732
-INFO [2025-08-19 11:47:34.578 +0200]:
-INFO [2025-08-19 11:47:34.578 +0200]: 🎉 Transaction generated successfully!
-INFO [2025-08-19 11:47:34.578 +0200]:
-INFO [2025-08-19 11:47:34.579 +0200]: 📋 Transaction Details:
-INFO [2025-08-19 11:47:34.579 +0200]:    Instruction: router.set_pool
-INFO [2025-08-19 11:47:34.579 +0200]:    Size: 252 bytes
-INFO [2025-08-19 11:47:34.579 +0200]:    Base58 length: 343 characters
-INFO [2025-08-19 11:47:34.593 +0200]:    Compute units: 40 367
-INFO [2025-08-19 11:47:34.593 +0200]:    Generated: 2025-08-19T09:47:34.576Z
-INFO [2025-08-19 11:47:34.593 +0200]:
-INFO [2025-08-19 11:47:34.593 +0200]: 🔗 Transaction Data (Base58):
-INFO [2025-08-19 11:47:34.593 +0200]:
-INFO [2025-08-19 11:47:34.594 +0200]: 💡 Triple-click the line above to select the entire transaction data
-INFO [2025-08-19 11:47:34.594 +0200]:
-INFO [2025-08-19 11:47:34.594 +0200]: 📊 Account Information:
-INFO [2025-08-19 11:47:34.594 +0200]:    Total accounts: 5
-INFO [2025-08-19 11:47:34.594 +0200]:     1. 3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3 (read-only)
-INFO [2025-08-19 11:47:34.594 +0200]:     2. 4maPuX2fcDmCkQv1Qa6RmQa2yGpeZLxiqKy9ybwazGft (writable)
-INFO [2025-08-19 11:47:34.594 +0200]:     3. 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci (read-only)
-INFO [2025-08-19 11:47:34.594 +0200]:     4. 2s6yx6xCBgEQBrv5h4dF7TQvvKUWTJBEsueqTnZZHLwY (read-only)
-INFO [2025-08-19 11:47:34.594 +0200]:     5. 59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY (signer, writable)
-INFO [2025-08-19 11:47:34.594 +0200]:
+    computeUnits: 37367
+INFO [2026-06-15 09:41:01.361 +0530]: Completed buildTransaction (router.set_pool)
+    durationMs: 326
+INFO [2026-06-15 09:41:01.361 +0530]:
+INFO [2026-06-15 09:41:01.361 +0530]: 🎉 Transaction generated successfully!
+INFO [2026-06-15 09:41:01.361 +0530]:
+INFO [2026-06-15 09:41:01.361 +0530]: 📋 Transaction Details:
+INFO [2026-06-15 09:41:01.361 +0530]:    Instruction: router.set_pool
+INFO [2026-06-15 09:41:01.361 +0530]:    Size: 252 bytes
+INFO [2026-06-15 09:41:01.361 +0530]:    Base58 length: 343 characters
+INFO [2026-06-15 09:41:01.372 +0530]:    Compute units: 37,367
+INFO [2026-06-15 09:41:01.372 +0530]:    Generated: 2026-06-15T04:11:01.360Z
+INFO [2026-06-15 09:41:01.372 +0530]:
+INFO [2026-06-15 09:41:01.372 +0530]: 🔗 Transaction Data (Base58):
+INFO [2026-06-15 09:41:01.372 +0530]:
+INFO [2026-06-15 09:41:01.372 +0530]: 💡 Triple-click the line above to select the entire transaction data
+INFO [2026-06-15 09:41:01.372 +0530]:
+INFO [2026-06-15 09:41:01.372 +0530]: 📊 Account Information:
+INFO [2026-06-15 09:41:01.372 +0530]:    Total accounts: 5
+INFO [2026-06-15 09:41:01.372 +0530]:     1. 3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3 (read-only)
+INFO [2026-06-15 09:41:01.372 +0530]:     2. 6jWPxptvZKTiLFNdLT39uG1HHa1DXnUqFpi6VttNGrH3 (writable)
+INFO [2026-06-15 09:41:01.372 +0530]:     3. hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub (read-only)
+INFO [2026-06-15 09:41:01.372 +0530]:     4. DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv (read-only)
+INFO [2026-06-15 09:41:01.372 +0530]:     5. AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB (signer, writable)
+INFO [2026-06-15 09:41:01.372 +0530]:
+INFO [2026-06-15 09:41:01.372 +0530]: 💡 Usage Instructions:
+INFO [2026-06-15 09:41:01.372 +0530]:    1. 📋 Copy the Base58 transaction data from the box above
+INFO [2026-06-15 09:41:01.372 +0530]:    2. 🔗 Open your Squads multisig interface
+INFO [2026-06-15 09:41:01.372 +0530]:    3. ➕ Create a "Custom Transaction" or "Raw Transaction"
+INFO [2026-06-15 09:41:01.372 +0530]:    4. 📝 Paste the Base58 data into the transaction field
+INFO [2026-06-15 09:41:01.372 +0530]:    5. ✅ Review all accounts and parameters carefully
+INFO [2026-06-15 09:41:01.372 +0530]:    6. 👥 Get required signatures from multisig members
+INFO [2026-06-15 09:41:01.372 +0530]:    7. 🚀 Execute the transaction on Solana
+INFO [2026-06-15 09:41:01.372 +0530]:
+INFO [2026-06-15 09:41:01.372 +0530]: 🔍 Important Notes:
+INFO [2026-06-15 09:41:01.372 +0530]:    • Transaction was simulated and validated before generation
+INFO [2026-06-15 09:41:01.372 +0530]:    • All public keys and accounts have been verified
+INFO [2026-06-15 09:41:01.372 +0530]:    • Always double-check the transaction details in your multisig
+INFO [2026-06-15 09:41:01.372 +0530]:    • Estimated compute units: 37,367
+INFO [2026-06-15 09:41:01.372 +0530]:    • This transaction is valid until the blockhash expires (~2 minutes)
+INFO [2026-06-15 09:41:01.372 +0530]:
 ```
 
 </Fragment>
@@ -2156,10 +2505,10 @@ INFO [2025-08-19 11:47:34.594 +0200]:
 | Account | Address                                        | Description                                                 |
 | ------- | ---------------------------------------------- | ----------------------------------------------------------- |
 | **#1**  | `3Yrg9E4ySAeRezgQY99NNarAmFLtixapga9MZb6y2dt3` | **Router Config PDA** (read-only - configuration reference) |
-| **#2**  | `4maPuX2fcDmCkQv1Qa6RmQa2yGpeZLxiqKy9ybwazGft` | **Token Admin Registry PDA** (writable - pool registration) |
-| **#3**  | `3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci` | **Token Mint** (read-only - token identification)           |
-| **#4**  | `2s6yx6xCBgEQBrv5h4dF7TQvvKUWTJBEsueqTnZZHLwY` | **Address Lookup Table** (read-only - ALT registration)     |
-| **#5**  | `59eNrRrxrZMdqJxS7J3WGaV4MLLog2er14kePiWVjXtY` | **Squad Vault Authority** (signer, writable - admin & fees) |
+| **#2**  | `6jWPxptvZKTiLFNdLT39uG1HHa1DXnUqFpi6VttNGrH3` | **Token Admin Registry PDA** (writable - pool registration) |
+| **#3**  | `hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub`  | **Token Mint** (read-only - token identification)           |
+| **#4**  | `DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv` | **Address Lookup Table** (read-only - ALT registration)     |
+| **#5**  | `AgPSS5TVRimXPx2bv7Cs2CnuD6pVGPZkrPxjnZ8tLtgB` | **Squad Vault Authority** (signer, writable - admin & fees) |
 
 **What This Command Does:**
 
@@ -2167,7 +2516,7 @@ This command **registers your token pool** with the CCIP Router. It configures t
 
 **Key Configuration:**
 
-- **ALT Integration**: Uses the lookup table `2s6yx6x...` you just created
+- **ALT Integration**: Uses the lookup table `DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv` you just created
 - **Writable Indexes**: `[3,4,7]` - Specific accounts from the ALTthat need write access during CCIP operations
 
 **Transaction Flow:**
@@ -2191,7 +2540,7 @@ Based on the ALT order established earlier:
 
 **Execute this base58 transaction in Squads UI:**
 
-- **Import**: Copy the base58 output → Squads UI → "Add instruction" → "Import base58 encoded tx"
+- **Import**: Copy the base58 output → Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx**
 - **Review**: Verify transaction details and parameters
 - **Simulate**: Simulate the transaction to ensure it will succeed
 - **Approve**: Obtain required threshold signatures
@@ -2216,8 +2565,8 @@ export ETH_POOL_ADDRESS="$ETH_POOL_ADDRESS"
 
 # Phase 2 - Solana
 
-export CCIP_POOL_PROGRAM="$CCIP_POOL_PROGRAM"
-export CCIP_ROUTER_PROGRAM="$CCIP_ROUTER_PROGRAM"
+export SOL_CCIP_POOL_PROGRAM="$SOL_CCIP_POOL_PROGRAM"
+export SOL_CCIP_ROUTER="$SOL_CCIP_ROUTER"
 export SOL_SQUAD_VAULT_MULTISIG="$SOL_SQUAD_VAULT_MULTISIG"
 export SOL_WALLET_ADDRESS="$SOL_WALLET_ADDRESS"
 export SOL_TOKEN_MINT="$SOL_TOKEN_MINT"
@@ -2243,7 +2592,7 @@ echo "✅ All variables saved to ~/.all_vars"
 
 ```bash
 === Phase 3 Complete - Cross-Chain Configuration ===
-✅ Address Lookup Table: 2s6yx6xCBgEQBrv5h4dF7TQvvKUWTJBEsueqTnZZHLwY
+✅ Address Lookup Table: DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv
 ✅ Cross-chain connection configured
 ✅ All variables saved to ~/.all_vars
 ```
@@ -2291,11 +2640,11 @@ echo "✅ SOL ALT: $SOL_ADDRESS_LOOKUP_TABLE"
 
 ```bash
 /.../smart-contract-examples/ccip/cct/hardhat
-✅ ETH Token: 0x7c57A9d966c3E6e344621C512d510f76575640ED
-✅ ETH Pool: 0x88965fF139bbA53D6e02a49a80c29d8c65645bA7
-✅ SOL Token: 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci
-✅ SOL Pool: 2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M
-✅ SOL ALT: 2s6yx6xCBgEQBrv5h4dF7TQvvKUWTJBEsueqTnZZHLwY
+✅ ETH Token: 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184
+✅ ETH Pool: 0x7115d906b67f9bc1a70ab16a8e38c603d9669749
+✅ SOL Token: hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub
+✅ SOL Pool: 2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu
+✅ SOL ALT: DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv
 ```
 
 </Fragment>
@@ -2343,7 +2692,7 @@ npx hardhat applyChainUpdates \
   --inboundratelimitenabled true \
   --inboundratelimitcapacity 20000000000000000000 \
   --inboundratelimitrate 100000000000000000 \
- --network sepolia
+ --network ethereumSepolia
 ```
 
 </Fragment>
@@ -2357,7 +2706,7 @@ npx hardhat applyChainUpdates \
   --remotechain solanaDevnet \
   --remotepooladdresses $SOL_POOL_ADDRESS \
   --remotetokenaddress $SOL_TOKEN_MINT \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 </Fragment>
@@ -2365,30 +2714,27 @@ npx hardhat applyChainUpdates \
 <Fragment slot="panel.3">
 
 ```bash
-2025-08-19T09:50:51.952Z info: === Starting Chain Update Configuration ===
-2025-08-19T09:50:51.952Z info: 🔹 Local network: sepolia
-2025-08-19T09:50:51.953Z info: 🔹 Pool address: 0x88965fF139bbA53D6e02a49a80c29d8c65645bA7
-2025-08-19T09:50:51.953Z info: 🔹 Remote chain: solanaDevnet
-2025-08-19T09:50:51.953Z info: 🔹 Remote chain type detected: svm
-2025-08-19T09:50:51.953Z info: 🔹 Remote chain selector: 16423721717087811551
-2025-08-19T09:50:51.953Z info: 🔹 Parsed 1 remote pool addresses
-2025-08-19T09:50:51.972Z info: ✅ All addresses validated successfully
-2025-08-19T09:50:52.333Z info: 🔹 Using signer: 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-19T09:50:52.735Z info: ✅ Connected to pool contract
-2025-08-19T09:50:52.735Z info: 🔹 Remote pool address 1: 2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M → 0x1af78d7e2c946d8b44252005f2fa4051109b366b8b86e3d9dd718fbd76e1bb6e
-2025-08-19T09:50:52.736Z info: 🔹 Remote token address: 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci → 0x246189812d1a095f17334822baca43823b37b7e372c96ffd0864a03e10d2afaf
-2025-08-19T09:50:52.736Z info: === Rate Limiter Configuration ===
-2025-08-19T09:50:52.736Z info: 🔹 Outbound enabled: true
-2025-08-19T09:50:52.736Z info: 🔹 Outbound capacity: 18000000000000000000
-2025-08-19T09:50:52.736Z info: 🔹 Outbound rate: 100000000000000000
-2025-08-19T09:50:52.736Z info: 🔹 Inbound enabled: true
-2025-08-19T09:50:52.736Z info: 🔹 Inbound capacity: 20000000000000000000
-2025-08-19T09:50:52.736Z info: 🔹 Inbound rate: 100000000000000000
-2025-08-19T09:50:52.736Z info: === Executing Transaction ===
-2025-08-19T09:50:52.736Z info: 🔹 Sending applyChainUpdates transaction...
-2025-08-19T09:50:53.839Z info: 🔹 Transaction sent: 0xd5a86cad37e489ef1557ef75ba046087b1b9ad647934ec48e3cb5d3b3f38da08
-2025-08-19T09:50:53.839Z info: 🔹 Waiting for 3 confirmations...
-2025-08-19T09:51:25.094Z info: ✅ Chain update applied successfully!
+2026-06-15T04:20:46.391Z info: === Starting Chain Update Configuration ===
+2026-06-15T04:20:46.392Z info: 🔹 Local network: ethereumSepolia
+2026-06-15T04:20:46.392Z info: 🔹 Pool address: 0x7115d906b67f9bc1a70ab16a8e38c603d9669749
+2026-06-15T04:20:46.393Z info: 🔹 Remote chain: solanaDevnet
+2026-06-15T04:20:46.393Z info: 🔹 Remote chain family: svm
+2026-06-15T04:20:46.393Z info: 🔹 Remote chain selector: 16423721717087811551
+2026-06-15T04:20:47.891Z info: ✅ All addresses validated successfully
+2026-06-15T04:20:48.336Z info: ✅ Using signer: 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-15T04:20:48.589Z info: ✅ Connected to TokenPool contract
+2026-06-15T04:20:48.590Z info:   Remote pool 1: 2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu → 0x1cc091f29ab8f1bd3c6d04a7f33ffdfb1efd2f803f33558762502af90a58ce32
+2026-06-15T04:20:48.591Z info: === Rate Limiter Configuration ===
+2026-06-15T04:20:48.591Z info: Outbound enabled: true
+2026-06-15T04:20:48.591Z info:   capacity: 18000000000000000000
+2026-06-15T04:20:48.591Z info:   rate: 100000000000000000
+2026-06-15T04:20:48.591Z info: Inbound enabled: true
+2026-06-15T04:20:48.591Z info:   capacity: 20000000000000000000
+2026-06-15T04:20:48.591Z info:   rate: 100000000000000000
+2026-06-15T04:20:48.591Z info: === Executing applyChainUpdates() ===
+2026-06-15T04:20:50.227Z info: 📤 TX sent: 0x0a485bde9eca53e5d9acaa5edaf25e28375129cd98d130230fd107faf5195600
+2026-06-15T04:20:50.227Z info: Waiting for 3 confirmations...
+2026-06-15T04:21:24.518Z info: ✅ Chain update applied successfully on ethereumSepolia (3 confirmations)!
 ```
 
 </Fragment>
@@ -2396,39 +2742,42 @@ npx hardhat applyChainUpdates \
 <Fragment slot="panel.4">
 
 ```bash
-2025-08-19T09:51:25.322Z info: === Starting Chain Update Configuration ===
-2025-08-19T09:51:25.323Z info: 🔹 Local network: sepolia
-2025-08-19T09:51:25.323Z info: 🔹 Pool address: 0x88965fF139bbA53D6e02a49a80c29d8c65645bA7
-2025-08-19T09:51:25.323Z info: 🔹 Remote chain: solanaDevnet
-2025-08-19T09:51:25.324Z info: 🔹 Remote chain type detected: svm
-2025-08-19T09:51:25.324Z info: 🔹 Remote chain selector: 16423721717087811551
-2025-08-19T09:51:25.324Z info: 🔹 Parsed 1 remote pool addresses
-2025-08-19T09:51:25.381Z info: ✅ All addresses validated successfully
-2025-08-19T09:51:25.836Z info: 🔹 Using signer: 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-19T09:51:26.249Z info: ✅ Connected to pool contract
-2025-08-19T09:51:26.250Z info: 🔹 Remote pool address 1: 2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M → 0x0a2515d8f6ec3b58297031a08a2736defe792239608d920214c91a0474705854
-2025-08-19T09:51:26.250Z info: 🔹 Remote token address: 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci → 0xca1558e396f86b9fbd3a5219af4207e2624d5acd0bcf272fb8713bf1f7c32a2e
-2025-08-19T09:51:26.250Z info: === Rate Limiter Configuration ===
-2025-08-19T09:51:26.250Z info: 🔹 No rate limits configured (unlimited transfers)
-2025-08-19T09:51:26.250Z info: === Executing Transaction ===
-2025-08-19T09:51:26.250Z info: 🔹 Sending applyChainUpdates transaction...
-2025-08-19T09:51:26.762Z info: 🔹 Transaction sent: 0x7f89ab2c3d4e5f6789abc123def4567890abcdef1234567890abcdef12345678
-2025-08-19T09:51:26.762Z info: 🔹 Waiting for 3 confirmations...
-2025-08-19T09:51:27.168Z info: ✅ Chain update applied successfully!
+2026-06-15T04:23:15.391Z info: === Starting Chain Update Configuration ===
+2026-06-15T04:23:15.392Z info: 🔹 Local network: ethereumSepolia
+2026-06-15T04:23:15.392Z info: 🔹 Pool address: 0x7115d906b67f9bc1a70ab16a8e38c603d9669749
+2026-06-15T04:23:15.393Z info: 🔹 Remote chain: solanaDevnet
+2026-06-15T04:23:15.393Z info: 🔹 Remote chain family: svm
+2026-06-15T04:23:15.393Z info: 🔹 Remote chain selector: 16423721717087811551
+2026-06-15T04:23:16.891Z info: ✅ All addresses validated successfully
+2026-06-15T04:23:17.336Z info: ✅ Using signer: 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-15T04:23:17.589Z info: ✅ Connected to TokenPool contract
+2026-06-15T04:23:17.590Z info:   Remote pool 1: 2wEj5e6gpdsEu6DxMQyGbvgRvTe8ZsQmfPbJWV8HUNEu → 0x1cc091f29ab8f1bd3c6d04a7f33ffdfb1efd2f803f33558762502af90a58ce32
+2026-06-15T04:23:17.591Z info: === Rate Limiter Configuration ===
+2026-06-15T04:23:17.591Z info: Outbound enabled: false
+2026-06-15T04:23:17.591Z info: Inbound enabled: false
+2026-06-15T04:23:17.591Z info: === Executing applyChainUpdates() ===
+2026-06-15T04:23:19.227Z info: 📤 TX sent: 0xc4e8a1f92b3d5678e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2
+2026-06-15T04:23:19.227Z info: Waiting for 3 confirmations...
+2026-06-15T04:23:53.518Z info: ✅ Chain update applied successfully on ethereumSepolia (3 confirmations)!
 ```
 
 </Fragment>
 </Tabs>
 
-## Phase 5: Testing and Validation
+## Phase 5: Pre-Transfer Setup, Validation, and Testing
 
 <Aside type="note" title="Terminal Context Check">
-  **Current Focus: Terminal 3 (Solana Testing)** Switch to the Solana Starter Kit repository for comprehensive testing.
+  **Current Focus: Terminal 1 (CCIP Solana BS58 Generator)** Complete pre-transfer setup and validate your
+  configuration. Governance steps use Squads; delegation and verification use your local wallet with `--execute`.
 </Aside>
 
-### Step 1: Load Phase 4 Variables
+<Aside type="note" title="Cross-Chain Transfers with CCIP CLI">
 
-Before testing cross-chain transfers, ensure your terminal environment is properly configured:
+Use [`@chainlink/ccip-cli`](https://github.com/smartcontractkit/ccip-tools-ts) for bidirectional token transfers. Run Solana → EVM sends from Terminal 1 and EVM → Solana sends from Terminal 2. See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for full options.
+
+</Aside>
+
+### Step 1: Load Configuration
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Command</Fragment>
@@ -2437,29 +2786,19 @@ Before testing cross-chain transfers, ensure your terminal environment is proper
 <Fragment slot="panel.1">
 
 ```bash
-# Check current directory
-# This should be the solana-starter-kit directory (Terminal 3)
+# Check current directory (Terminal 1)
 pwd
-```
+# Should show: .../ccip-solana-bs58-generator
 
-Load all environment variables
-
-```bash
+# Load all environment variables
 source ~/.all_vars
-```
 
-Set Ethereum receiver for testing
-
-```bash
-export ETH_RECEIVER_ADDRESS="<YOUR_ETH_RECEIVER_ADDRESS>"
-```
-
-Verify critical variables for Solana Starter Kit
-
-```bash
+# Verify critical variables
 echo "SOL_TOKEN_MINT: $SOL_TOKEN_MINT"
 echo "ETH_TOKEN_ADDRESS: $ETH_TOKEN_ADDRESS"
-echo "ETH_RECEIVER_ADDRESS: $ETH_RECEIVER_ADDRESS"
+echo "SOL_POOL_SIGNER_PDA: $SOL_POOL_SIGNER_PDA"
+echo "SOL_SPL_MULTISIG: $SOL_SPL_MULTISIG"
+echo "SOL_ADDRESS_LOOKUP_TABLE: $SOL_ADDRESS_LOOKUP_TABLE"
 echo "SOL_WALLET_ADDRESS: $SOL_WALLET_ADDRESS"
 ```
 
@@ -2468,25 +2807,23 @@ echo "SOL_WALLET_ADDRESS: $SOL_WALLET_ADDRESS"
 <Fragment slot="panel.2">
 
 ```bash
-/.../solana-starter-kit
-SOL_TOKEN_MINT: 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci
-ETH_TOKEN_ADDRESS: 0x7c57A9d966c3E6e344621C512d510f76575640ED
-ETH_RECEIVER_ADDRESS: 0x9d087fC03ae39b088326b67fA3C788236645b717
-SOL_WALLET_ADDRESS: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
+/.../ccip-solana-bs58-generator
+SOL_TOKEN_MINT: hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub
+ETH_TOKEN_ADDRESS: 0x8b7ce78b89f05eaec2e803e638ff5b0f6f009184
+SOL_POOL_SIGNER_PDA: 62So4PhmWWzMpVXKzsCXdNUfrrB4jGXTVda9BzS6HTeo
+SOL_SPL_MULTISIG: 3cKsjnEtGtH47n5wzzA2GKGTTTFWby6n4nWSQDEJU1MX
+SOL_ADDRESS_LOOKUP_TABLE: DtbZ7Py3pmH5azq4HTqc4axfKwj8zLApkFzueouKg9Zv
+SOL_WALLET_ADDRESS: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
 ```
 
 </Fragment>
 </Tabs>
 
-### Transfer Direction 1: Solana → Ethereum
+### Step 2: Pre-Transfer Setup
 
-Test the production multisig setup with a cross-chain transfer from Solana Devnet to Ethereum Sepolia:
+Before cross-chain transfers (when available), complete token delegation so CCIP can move tokens from your wallet.
 
-#### Prepare for Testing
-
-Before testing cross-chain transfers, you need to create the pool's Associated Token Account (ATA) and prepare your tokens:
-
-##### Check Token Balance
+#### Check Token Balance
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Command</Fragment>
@@ -2495,20 +2832,23 @@ Before testing cross-chain transfers, you need to create the pool's Associated T
 <Fragment slot="panel.1">
 
 ```bash
-# Check your current token balance
 spl-token balance $SOL_TOKEN_MINT
 ```
 
 </Fragment>
 
 <Fragment slot="panel.2">
+
 ```bash
 5001
 ```
+
 </Fragment>
 </Tabs>
 
-##### Create Pool Associated Token Account
+#### Create Pool Associated Token Account
+
+If not created during pool setup, create the pool's ATA:
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Command</Fragment>
@@ -2517,11 +2857,10 @@ spl-token balance $SOL_TOKEN_MINT
 <Fragment slot="panel.1">
 
 ```bash
-# Create Associated Token Account for the Pool Signer PDA
-
-yarn svm:pool:create-token-account \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM
+# Create ATA owned by the Pool Signer PDA
+spl-token create-account $SOL_TOKEN_MINT \
+  --owner $SOL_POOL_SIGNER_PDA \
+  --fee-payer $HOME/.config/solana/id.json
 ```
 
 </Fragment>
@@ -2529,70 +2868,27 @@ yarn svm:pool:create-token-account \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-19T09:55:22.737Z] 🏊 CCIP Pool Token Account Creation
-[2025-08-19T09:55:22.740Z] ==========================================
-[2025-08-19T09:55:22.783Z] Network: solana-devnet
-[2025-08-19T09:55:22.784Z] Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-19T09:55:22.784Z]
-[2025-08-19T09:55:22.784Z] 💰 WALLET BALANCE
-[2025-08-19T09:55:22.784Z] ==========================================
-[2025-08-19T09:55:23.399Z] SOL Balance: 58365718274 lamports (58.365718274 SOL)
-[2025-08-19T09:55:23.399Z]
-[2025-08-19T09:55:23.399Z] 📋 ACCOUNT CREATION CONFIGURATION
-[2025-08-19T09:55:23.399Z] ==========================================
-[2025-08-19T09:55:23.400Z] Token Mint: 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci
-[2025-08-19T09:55:23.400Z] Burn-Mint Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-19T09:55:23.401Z]
-[2025-08-19T09:55:23.401Z] 🔍 VERIFYING POOL EXISTENCE
-[2025-08-19T09:55:23.401Z] ==========================================
-[2025-08-19T09:55:23.405Z] 📍 Pool Config PDA: 2pGY9WAjanpR3RnY5hQ1a23uDNomzFCAD5HMBgo8nH6M
-[2025-08-19T09:55:23.506Z] ✅ Pool exists
-[2025-08-19T09:55:23.506Z] Current pool token account: BKkeydRQWKDc5dR7euwhYi47TDLV99o8pD83ncGA2LdZ
-[2025-08-19T09:55:23.506Z] Getting mint account info for 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci to determine token program ID...
-[2025-08-19T09:55:23.619Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-19T09:55:23.620Z] Pool signer PDA: 8NTqDH8dFj7aU5FBWeNMJwjsR1gZMR7criaEaDMEE24r
-[2025-08-19T09:55:23.620Z] Expected pool token account (ATA): BKkeydRQWKDc5dR7euwhYi47TDLV99o8pD83ncGA2LdZ
-[2025-08-19T09:55:23.620Z]
-[2025-08-19T09:55:23.620Z] 🔍 CHECKING EXISTING ACCOUNT
-[2025-08-19T09:55:23.620Z] ==========================================
-[2025-08-19T09:55:23.717Z]
-[2025-08-19T09:55:23.718Z] 🔧 CREATING POOL TOKEN ACCOUNT
-[2025-08-19T09:55:23.718Z] ==========================================
-[2025-08-19T09:55:23.718Z] Creating pool token account (ATA)...
-[2025-08-19T09:55:25.993Z]
-[2025-08-19T09:55:25.994Z] ✅ POOL TOKEN ACCOUNT CREATED SUCCESSFULLY
-[2025-08-19T09:55:25.994Z] ==========================================
-[2025-08-19T09:55:25.994Z] Transaction Signature: ngm3gZxYpgR5qsncrZRWrS1ypYBpyYHvqCweVK7Q9DdpwJQNoyEZRHMMmr4s7mMYzAZAe8DmKqASe86yPaAjK25
-[2025-08-19T09:55:25.994Z] Pool Token Account Address: BKkeydRQWKDc5dR7euwhYi47TDLV99o8pD83ncGA2LdZ
-[2025-08-19T09:55:25.994Z]
-[2025-08-19T09:55:25.994Z] 🔍 EXPLORER URLS
-[2025-08-19T09:55:25.995Z] ==========================================
-[2025-08-19T09:55:25.995Z] Transaction: https://explorer.solana.com/tx/ngm3gZxYpgR5qsncrZRWrS1ypYBpyYHvqCweVK7Q9DdpwJQNoyEZRHMMmr4s7mMYzAZAe8DmKqASe86yPaAjK25?cluster=devnet
-[2025-08-19T09:55:25.995Z]
-[2025-08-19T09:55:25.995Z] 🔍 VERIFYING ACCOUNT CREATION
-[2025-08-19T09:55:25.995Z] ==========================================
-[2025-08-19T09:55:26.305Z] ✅ Account creation verified!
-[2025-08-19T09:55:26.305Z]
-[2025-08-19T09:55:26.305Z] 🎉 Pool Token Account Setup Complete!
-[2025-08-19T09:55:26.306Z] ✅ ATA Address: BKkeydRQWKDc5dR7euwhYi47TDLV99o8pD83ncGA2LdZ
-[2025-08-19T09:55:26.306Z] ✅ Owner: 8NTqDH8dFj7aU5FBWeNMJwjsR1gZMR7criaEaDMEE24r (Pool Signer PDA)
-[2025-08-19T09:55:26.306Z] ✅ Ready for cross-chain token operations
+Creating account 2Lzp4uRF6N2x65aMpKqFrajFukAbTCtQcG8thVgqcsEh
+
+Signature: 2iH5vhcB2iNtez9HgtgqNCZFF1zdBiE8FdnhD5n9gbEdwL1ucLLc8os9ipCTKhVjLMYkPT3KD5KovrS8K59CJzS4
 ```
 
 </Fragment>
 </Tabs>
 
-##### Delegate Token Authority
+#### Delegate Token Authority
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Command</Fragment>
+<Fragment slot="tab.1">Derive Fee-Billing Signer</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Delegate tokens for CCIP transfers
-yarn svm:token:delegate --token-mint $SOL_TOKEN_MINT
+# Derive the CCIP fee-billing signer PDA
+export SOL_CCIP_FEE_BILLING_SIGNER=$(solana find-program-derived-address $SOL_CCIP_ROUTER string:fee_billing_signer | head -1)
+
+echo "SOL_CCIP_FEE_BILLING_SIGNER=$SOL_CCIP_FEE_BILLING_SIGNER"
 ```
 
 </Fragment>
@@ -2600,53 +2896,28 @@ yarn svm:token:delegate --token-mint $SOL_TOKEN_MINT
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-19T09:56:28.990Z] CCIP Token Authority Delegator
-[2025-08-19T09:56:28.992Z] =============================================
-[2025-08-19T09:56:29.020Z] Network: solana-devnet
-[2025-08-19T09:56:29.021Z] Router Program: Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
-[2025-08-19T09:56:29.021Z] Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-19T09:56:29.021Z]
-[2025-08-19T09:56:29.021Z] 💰 WALLET BALANCE
-[2025-08-19T09:56:29.021Z] =============================================
-[2025-08-19T09:56:29.659Z] SOL Balance: 58.363673994 SOL (58363673994 lamports)
-[2025-08-19T09:56:29.660Z]
-[2025-08-19T09:56:29.660Z] 🔐 PROCESSING TOKEN DELEGATIONS
-[2025-08-19T09:56:29.660Z] =============================================
-[2025-08-19T09:56:29.660Z] Custom token mints provided: 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci
-[2025-08-19T09:56:29.660Z] Using 'fee-billing' delegation type for ccip_send compatibility
-[2025-08-19T09:56:29.660Z] Added custom token delegation for: 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci
-[2025-08-19T09:56:29.660Z]
-[1/1] Processing delegation for mint: 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci
-[2025-08-19T09:56:29.661Z] Getting mint account info for 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci to determine token program ID...
-[2025-08-19T09:56:29.765Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-19T09:56:29.767Z] Token Program ID: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-19T09:56:29.767Z] Delegation Type: fee-billing
-[2025-08-19T09:56:29.767Z] Delegate Address: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
-[2025-08-19T09:56:29.767Z] Amount to delegate: 18446744073709551615
-[2025-08-19T09:56:29.768Z] User Token Account: 84FvKxAQpHtSaFLguFygoPPEaRorZpTjs8rmMCxuwqUF
-[2025-08-19T09:56:29.876Z] Token account 84FvKxAQpHtSaFLguFygoPPEaRorZpTjs8rmMCxuwqUF exists.
-[2025-08-19T09:56:29.976Z] Sending transaction to delegate token authority...
-[2025-08-19T09:56:31.352Z] ✅ Token delegation successful!
-[2025-08-19T09:56:31.352Z] Transaction signature: 2mWGmy1S722SShBX1Qg2raKNWF5Rfhue91vcJ3fpqm5qnq9v2Aa7geQQYd1nnWdBwLSoHosj9zifU5RTNwEnyKbY
-[2025-08-19T09:56:31.352Z] Explorer URL: https://explorer.solana.com/tx/2mWGmy1S722SShBX1Qg2raKNWF5Rfhue91vcJ3fpqm5qnq9v2Aa7geQQYd1nnWdBwLSoHosj9zifU5RTNwEnyKbY?cluster=devnet
-[2025-08-19T09:56:31.352Z]
-[2025-08-19T09:56:31.352Z] ✅ All delegations processed successfully
+SOL_CCIP_FEE_BILLING_SIGNER=2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
 ```
 
 </Fragment>
 </Tabs>
 
-#### Transfer tokens from Solana Devnet to Ethereum Sepolia
+Approve the fee-billing signer to transfer tokens from your ATA:
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Transfer Command</Fragment>
+<Fragment slot="tab.1">Delegate Authority</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Execute cross-chain transfer from Solana to Ethereum
-yarn svm:token-transfer --token-mint $SOL_TOKEN_MINT --token-amount 1000000 --receiver $ETH_RECEIVER_ADDRESS
+# --amount is u64 max (2^64 - 1): max delegation for CCIP fee billing
+pnpm bs58 --env devnet --execute spl-token \
+  --instruction approve \
+  --authority $SOL_WALLET_ADDRESS \
+  --mint $SOL_TOKEN_MINT \
+  --delegate $SOL_CCIP_FEE_BILLING_SIGNER \
+  --amount 18446744073709551615
 ```
 
 </Fragment>
@@ -2654,109 +2925,252 @@ yarn svm:token-transfer --token-mint $SOL_TOKEN_MINT --token-amount 1000000 --re
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-19T09:58:06.935Z] 🚀 CCIP Token Transfer
-[2025-08-19T09:58:06.937Z] =======================================
-[2025-08-19T09:58:06.969Z] Network: devnet
-[2025-08-19T09:58:06.969Z] Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-19T09:58:06.969Z]
-[2025-08-19T09:58:06.969Z] 💰 WALLET BALANCE
-[2025-08-19T09:58:06.969Z] =======================================
-[2025-08-19T09:58:07.509Z] SOL Balance: 58363668994 lamports (58.363668994 SOL)
-[2025-08-19T09:58:07.509Z]
-[2025-08-19T09:58:07.510Z] 🌉 CCIP ROUTER INFORMATION
-[2025-08-19T09:58:07.510Z] =======================================
-[2025-08-19T09:58:07.510Z] CCIP Router Program ID: Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
-[2025-08-19T09:58:07.510Z] Fee Quoter Program ID: FeeQPGkKDeRV1MgoYfMH6L8o3KeuYjwUZrgn4LRKfjHi
-[2025-08-19T09:58:07.510Z] RMN Remote Program ID: RmnXLft1mSEwDgMKu2okYuHkiazxntFFcZFrrcXxYg7
-[2025-08-19T09:58:07.510Z] Using native SOL as fee token
-[2025-08-19T09:58:07.510Z]
-[2025-08-19T09:58:07.510Z] 📋 TOKEN TRANSFER PARAMETERS
-[2025-08-19T09:58:07.510Z] ===========================================
-[2025-08-19T09:58:07.510Z] Destination Chain: ethereum-sepolia
-[2025-08-19T09:58:07.510Z] Destination Chain Selector: 16015286601757825753
-[2025-08-19T09:58:07.510Z] EVM Receiver Address: 0x9d087fC03ae39b088326b67fA3C788236645b717
-[2025-08-19T09:58:07.511Z] Token Mint: 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci
-[2025-08-19T09:58:07.511Z] Token Amount: 1000000
-[2025-08-19T09:58:07.511Z] Fee Token: 11111111111111111111111111111111
-[2025-08-19T09:58:07.511Z] Gas Limit: 0
-[2025-08-19T09:58:07.511Z] Allow Out Of Order Execution: true
-[2025-08-19T09:58:07.513Z]
-[2025-08-19T09:58:07.513Z] 🔄 SENDING TOKEN TRANSFER
-[2025-08-19T09:58:07.513Z] =======================================
-[2025-08-19T09:58:07.513Z] Preparing CCIP message...
-[2025-08-19T09:58:07.514Z] Sending CCIP message to destination chain 16015286601757825753
-[2025-08-19T09:58:07.514Z] Building accounts for CCIP send to chain 16015286601757825753
-[2025-08-19T09:58:07.520Z] Getting mint account info for 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci to determine token program ID...
-[2025-08-19T09:58:07.633Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-19T09:58:21.295Z] CCIP message sent successfully: 4T6coWNspJ7TDhsUFVZ7S1huzVxy6dSjbPfrFw4THGRBEt8X9UYfFggrxYLD4Hnm11Hqdnzg9vJTbrNSjp7ycRvf
-[2025-08-19T09:58:21.295Z] Parsing CCIP message sent event for transaction: 4T6coWNspJ7TDhsUFVZ7S1huzVxy6dSjbPfrFw4THGRBEt8X9UYfFggrxYLD4Hnm11Hqdnzg9vJTbrNSjp7ycRvf
-[2025-08-19T09:58:21.431Z] Successfully extracted messageId: 0x21d6ca53d5ab59caa9d5a1d58a5f8040f9695043dcad5ddc0059710dff0113c3
-[2025-08-19T09:58:21.431Z]
-[2025-08-19T09:58:21.431Z] ✅ TOKEN TRANSFER SENT SUCCESSFULLY
-[2025-08-19T09:58:21.431Z] =======================================
-[2025-08-19T09:58:21.431Z] Transaction Signature: 4T6coWNspJ7TDhsUFVZ7S1huzVxy6dSjbPfrFw4THGRBEt8X9UYfFggrxYLD4Hnm11Hqdnzg9vJTbrNSjp7ycRvf
-[2025-08-19T09:58:21.431Z] CCIP Message ID: 0x21d6ca53d5ab59caa9d5a1d58a5f8040f9695043dcad5ddc0059710dff0113c3
-[2025-08-19T09:58:21.431Z]
-[2025-08-19T09:58:21.431Z] 🔍 EXPLORER URLS
-[2025-08-19T09:58:21.431Z] =======================================
-[2025-08-19T09:58:21.432Z] Solana Transaction: https://explorer.solana.com/tx/4T6coWNspJ7TDhsUFVZ7S1huzVxy6dSjbPfrFw4THGRBEt8X9UYfFggrxYLD4Hnm11Hqdnzg9vJTbrNSjp7ycRvf?cluster=devnet
-[2025-08-19T09:58:21.432Z] CCIP Explorer: https://ccip.chain.link/msg/0x21d6ca53d5ab59caa9d5a1d58a5f8040f9695043dcad5ddc0059710dff0113c3
-[2025-08-19T09:58:21.432Z]
-[2025-08-19T09:58:21.432Z] 🎉 Transfer Complete!
-[2025-08-19T09:58:21.432Z] ✅ Sent 1000000 tokens to 0x9d087fC03ae39b088326b67fA3C788236645b717
-[2025-08-19T09:58:21.432Z] ✅ Message ID: 0x21d6ca53d5ab59caa9d5a1d58a5f8040f9695043dcad5ddc0059710dff0113c3
-[2025-08-19T09:58:21.432Z] ✅ Monitor progress on CCIP Explorer: https://ccip.chain.link/msg/0x21d6ca53d5ab59caa9d5a1d58a5f8040f9695043dcad5ddc0059710dff0113c3
+🔍 Detecting token program...
+INFO [2026-06-15 09:58:35.097 +0530]: Starting approve command
+    command: "spl-token.approve"
+    mint: "hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub"
+    delegate: "2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG"
+    authority: "GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN"
+    amount: "18446744073709551615"
+    globalOptions: {
+      "environment": "devnet",
+      "execute": true,
+      "resolvedRpcUrl": "https://api.devnet.solana.com",
+      "keypair": "/Users/syed-cll/.config/solana/id.json",
+      "_signerKeypair": {
+        "_keypair": {
+          "publicKey": {
+            "0": 230,
+            "1": 211,
+            "2": 30,
+            ...
+            "29": 179,
+            "30": 114,
+            "31": 73
+          },
+          "secretKey": {
+            "0": 191,
+            "1": 198,
+            "2": 244,
+            ...
+            "61": 179,
+            "62": 114,
+            "63": 73
+          }
+        }
+      }
+    }
+   ✅ Detected token program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+🔍 Auto-deriving Associated Token Account...
+   ✅ Derived ATA: gKhGBvVGw62EdjfdNQFvVvvbg8CqdepTrdmSdVsEDBS
+🔄 Generating approve transaction...
+   RPC URL: https://api.devnet.solana.com
+   Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+   Mint: hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub
+   Token Account: gKhGBvVGw62EdjfdNQFvVvvbg8CqdepTrdmSdVsEDBS
+   Delegate: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
+   Authority (Token Account Owner): GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+   Amount: 18446744073709551615
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-15 09:58:35.357 +0530]: Detected SPL Token v1
+    mint: "hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+INFO [2026-06-15 09:58:35.514 +0530]: Transaction built successfully
+    instructionName: "approve"
+    transactionSize: "180 bytes"
+    base58Length: "245 characters"
+    hexLength: "360 characters"
+    accountCount: 3
+    signerCount: 1
+    computeUnits: 123
+INFO [2026-06-15 09:58:35.514 +0530]: Completed buildTransaction (approve)
+    durationMs: 155
+INFO [2026-06-15 09:58:35.668 +0530]:
+INFO [2026-06-15 09:58:35.668 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-15 09:58:35.668 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 09:58:35.668 +0530]:    Instruction: approve
+INFO [2026-06-15 09:58:35.668 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-15 09:58:35.668 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-15 09:58:36.528 +0530]: Transaction confirmed successfully
+    signature: "3D5wGk6nf3ZnWx7ymBZQ4QxFMSLNRTwwDCok1zhNjpv7byJKVW8SzsHanmdS5ua899JtD2yBsgEgu5f257JBN4Rg"
+    attempt: 1
+INFO [2026-06-15 09:58:36.528 +0530]:
+INFO [2026-06-15 09:58:36.528 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-15 09:58:36.528 +0530]:
+INFO [2026-06-15 09:58:36.528 +0530]: 📋 Execution Details:
+INFO [2026-06-15 09:58:36.528 +0530]:    Instruction: approve
+INFO [2026-06-15 09:58:36.528 +0530]:    Signature:   3D5wGk6nf3ZnWx7ymBZQ4QxFMSLNRTwwDCok1zhNjpv7byJKVW8SzsHanmdS5ua899JtD2yBsgEgu5f257JBN4Rg
+INFO [2026-06-15 09:58:36.528 +0530]:    Explorer:    https://explorer.solana.com/tx/3D5wGk6nf3ZnWx7ymBZQ4QxFMSLNRTwwDCok1zhNjpv7byJKVW8SzsHanmdS5ua899JtD2yBsgEgu5f257JBN4Rg?cluster=devnet
+INFO [2026-06-15 09:58:36.528 +0530]:
+INFO [2026-06-15 09:58:36.528 +0530]: approve command completed successfully
+    command: "spl-token.approve"
+    transactionSize: "180 bytes"
+    computeUnits: 123
 ```
 
 </Fragment>
 </Tabs>
 
-#### Monitor and Verify Transaction
+#### Verify Delegation
 
-Upon successful execution, the system generates critical tracking identifiers for transaction monitoring and verification.
+Check that your token account is delegated to the fee-billing signer:
 
-**Transaction Identifiers:**
+<Tabs client:visible>
+<Fragment slot="tab.1">Find Token Account</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
 
-- **Transaction Signature**: `4T6coWNspJ7TDhsUFVZ7S1huzVxy6dSjbPfrFw4THGRBEt8X9UYfFggrxYLD4Hnm11Hqdnzg9vJTbrNSjp7ycRvf`
-- **CCIP Message ID**: `0x21d6ca53d5ab59caa9d5a1d58a5f8040f9695043dcad5ddc0059710dff0113c3`
+<Fragment slot="panel.1">
 
-**CCIP Explorer** (Primary monitoring interface):
+```bash
+# Find your Associated Token Account (ATA) address
+export SOL_TOKEN_ACCOUNT=$(spl-token accounts $SOL_TOKEN_MINT --owner $SOL_WALLET_ADDRESS --addresses-only)
 
-```
-https://ccip.chain.link/msg/0x21d6ca53d5ab59caa9d5a1d58a5f8040f9695043dcad5ddc0059710dff0113c3
-```
-
-The CCIP Explorer provides comprehensive transaction visibility:
-
-- Source chain (Solana) transaction confirmation
-- CCIP message processing and routing
-- Destination chain (Ethereum) message delivery
-- Token minting completion on Ethereum
-
-**Solana Explorer** (Source chain verification):
-
-```
-https://explorer.solana.com/tx/4T6coWNspJ7TDhsUFVZ7S1huzVxy6dSjbPfrFw4THGRBEt8X9UYfFggrxYLD4Hnm11Hqdnzg9vJTbrNSjp7ycRvf?cluster=devnet
+echo "SOL_TOKEN_ACCOUNT=$SOL_TOKEN_ACCOUNT"
 ```
 
-### Transfer Direction 2: Ethereum → Solana
+</Fragment>
 
-<Aside type="note" title="Terminal Environment">
-  **Continue in Terminal 3** (Solana Starter Kit directory). No need to switch terminals - the Solana Starter Kit
-  handles Ethereum → Solana transfers as well.
+<Fragment slot="panel.2">
+
+```bash
+SOL_TOKEN_ACCOUNT=gKhGBvVGw62EdjfdNQFvVvvbg8CqdepTrdmSdVsEDBS
+```
+
+</Fragment>
+</Tabs>
+
+Display token account and delegation status:
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Check Delegation</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+spl-token display $SOL_TOKEN_ACCOUNT
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+SPL Token Account
+  Address: gKhGBvVGw62EdjfdNQFvVvvbg8CqdepTrdmSdVsEDBS
+  Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+  Balance: 5001
+  Decimals: 9
+  Mint: hdTyFD4Pv5vLRvGVAQqs1ZSedNvTM1iu5Y5Rwur5gub
+  Owner: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+  State: Initialized
+  Delegation:
+    Delegate: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
+    Allowance: 18446744073.709551615
+  Close authority: (not set)
+```
+
+</Fragment>
+</Tabs>
+
+### Step 3: Verify Solana Pool and Chain Config
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Verification Commands</Fragment>
+<Fragment slot="tab.2">What to Confirm</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+# Verify pool state
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-state \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT
+
+# Verify Ethereum Sepolia remote chain config
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-chain-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --remote-chain-selector $ETHEREUM_SEPOLIA_CHAIN_SELECTOR
+
+# Verify mint authority is the SPL multisig
+spl-token display $SOL_TOKEN_MINT
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+Confirm the following:
+
+- Pool owner matches your Squads vault (`$SOL_SQUAD_VAULT_MULTISIG`)
+- Mint authority is the SPL token multisig (`$SOL_SPL_MULTISIG`) with Pool Signer PDA as a signer
+- Remote chain config includes `$ETH_POOL_ADDRESS` and `$ETH_TOKEN_ADDRESS`
+- Rate limit settings match your Phase 3 configuration (if enabled)
+- Token delegation is set to the fee-billing signer
+
+</Fragment>
+</Tabs>
+
+### Step 4: Verify Ethereum Pool (Terminal 2)
+
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
+
+```bash
+npx hardhat getPoolConfig \
+  --pooladdress $ETH_POOL_ADDRESS \
+  --network ethereumSepolia
+```
+
+Confirm the Ethereum pool recognizes Solana Devnet with your `$SOL_POOL_ADDRESS` and `$SOL_TOKEN_MINT`.
+
+### Configure CCIP CLI
+
+Export these RPC URLs once before your first transfer:
+
+```bash
+export SOLANA_DEVNET_RPC="https://api.devnet.solana.com"
+export ETHEREUM_SEPOLIA_RPC_URL="<YOUR_ETHEREUM_SEPOLIA_RPC_URL>"
+
+export ETH_CCIP_ROUTER="0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59"
+```
+
+Use the same `ETHEREUM_SEPOLIA_RPC_URL` from your env-enc setup in Terminal 2 (`npx env-enc view`). On `ccip-cli send`, the source chain RPC quotes fees and submits the transaction; for token-only transfers in this tutorial, that is the only RPC strictly required to send. Pass both RPCs on cross-chain commands anyway: the destination RPC is required for `ccip-cli show --wait` and for optional send features such as `--estimate-gas-limit` or `send --wait`.
+
+<Aside type="note" title="RPC and wallet configuration">
+  Repeat `--rpc` for multiple networks, or use `--rpcs` with comma-separated URLs. Alternatively, set `RPC_*` environment variables or a `.env` file — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration). Solana sends use `--wallet ~/.config/solana/id.json`. EVM sends: prefer `--wallet hardhat:<name>` from the Hardhat project directory ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)); alternatively export `PRIVATE_KEY` manually after `npx env-enc view` (Hardhat tasks load env-enc automatically, but `ccip-cli` does not). See [CCIP CLI wallet configuration](https://docs.chain.link/ccip/tools/cli/configuration#wallet-configuration).
 </Aside>
 
-#### Transfer tokens from Ethereum Sepolia to Solana Devnet
+### Transfer Solana → Ethereum
+
+**Terminal 1** (CCIP Solana BS58 Generator):
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Transfer Command</Fragment>
+<Fragment slot="tab.1">Send Command</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Execute cross-chain transfer from Ethereum to Solana
-yarn evm:transfer --token $ETH_TOKEN_ADDRESS --amount 1000000000000000000 --token-receiver $SOL_WALLET_ADDRESS
+source ~/.all_vars
+
+export ETH_RECEIVER_ADDRESS="<YOUR_ETHEREUM_RECEIVER_ADDRESS>"
+
+
+ccip-cli send \
+  -s solana-devnet \
+  -r $SOL_CCIP_ROUTER \
+  -d ethereum-testnet-sepolia \
+  --to $ETH_RECEIVER_ADDRESS \
+  -t $SOL_TOKEN_MINT=0.001 \
+  --wallet ~/.config/solana/id.json \
+  --rpc $SOLANA_DEVNET_RPC \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL
 ```
 
 </Fragment>
@@ -2764,141 +3178,215 @@ yarn evm:transfer --token $ETH_TOKEN_ADDRESS --amount 1000000000000000000 --toke
 <Fragment slot="panel.2">
 
 ```bash
-[token-transfer] [INFO] 🚀 EVM to Solana CCIP Token Transfer
-[token-transfer] [INFO] =========================================
-chainId ethereum-sepolia
-[token-transfer] [INFO] Source Chain: ethereum-sepolia
-[token-transfer] [INFO] Fee Token: link
-[token-transfer] [INFO] Token Receiver: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[token-transfer] [INFO] Compute Units: 0
-[token-transfer] [INFO]
-==== Environment Information ====
-chainId ethereum-sepolia
-[token-transfer] [INFO] Router Address: 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59
-[ccip-messenger] [INFO] Creating client for chain: Ethereum Sepolia (ethereum-sepolia)
-[token-transfer] [INFO] Wallet Address: 0x9d087fC03ae39b088326b67fA3C788236645b717
-[token-transfer] [INFO] Native Balance: 592.730131579314728831 ETH
-[token-transfer] [INFO]
-🔍 Validating Token Transfer
-[token-transfer] [INFO] =========================================
-[token-transfer] [INFO] Token: BnmAEM (0x7c57A9d966c3E6e344621C512d510f76575640ED)
-[token-transfer] [INFO] Token Balance: 1000.0 BnmAEM
-[token-transfer] [INFO] Token: BnmAEM (0x7c57A9d966c3E6e344621C512d510f76575640ED)
-[token-transfer] [INFO] Token Balance: 1000.0 BnmAEM
-[token-transfer] [INFO] Transfer Amount: 1.0 BnmAEM
-[token-transfer] [INFO] ✅ Token validation successful
-[token-transfer] [INFO] Using fee token: 0x779877A7B0D9E8603169DdbD7836e478b4624789
-[token-transfer] [INFO] Creating CCIP message request
-[token-transfer] [INFO]
-📋 Transfer Summary
-[token-transfer] [INFO] =========================================
-[token-transfer] [INFO]
-==== Transfer Summary ====
-[token-transfer] [INFO] Source Chain: Ethereum Sepolia
-[token-transfer] [INFO] Destination Chain: Solana Devnet (16423721717087811551)
-[token-transfer] [INFO] Sender: 0x9d087fC03ae39b088326b67fA3C788236645b717
-[token-transfer] [INFO] Receiver: 11111111111111111111111111111111
-[token-transfer] [INFO] Token Receiver: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[token-transfer] [INFO] Fee Token: 0x779877A7B0D9E8603169DdbD7836e478b4624789
-[token-transfer] [INFO]
-Token Transfers:
-[token-transfer] [INFO]   1. 1000000000000000000 raw units (0x7c57A9d966c3E6e344621C512d510f76575640ED)
-[token-transfer] [INFO]
-Extra Args: Solana-specific, 228 bytes
-[token-transfer] [INFO]
-🚀 Executing Token Transfer
-[token-transfer] [INFO] =========================================
-[token-transfer] [INFO] Sending CCIP message...
-[ccip-messenger] [INFO] Estimated fee: 13079906629732765
-[ccip-messenger] [INFO] LINK already has sufficient allowance: 0.016317549010854859 (needed: 0.015695887955679318, surplus: 0.000621661055175541)
-[ccip-messenger] [INFO] Using existing allowance for fee token
-[ccip-messenger] [INFO] Approving 1.0 BnmAEM for CCIP Router
-[ccip-messenger] [INFO] Approving 1.0 tokens for 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59
-[ccip-messenger] [INFO] BnmAEM approved for CCIP Router
-[ccip-messenger] [INFO] ✅ Verified on-chain allowance for BnmAEM: 1.0 (required: 1.0)
-[ccip-messenger] [INFO] Sending CCIP message...
-[ccip-messenger] [INFO] Sending CCIP message...
-[ccip-messenger] [INFO] Transaction sent: 0x55e6e9c295c7d32bc0d708f3363e42aad37298f9f30b4db0889e06bfac761157
-[ccip-messenger] [INFO] Transaction sent: 0x55e6e9c295c7d32bc0d708f3363e42aad37298f9f30b4db0889e06bfac761157
-[ccip-messenger] [INFO] Message ID: 0x11ef3640d8030bae75c2e4ca863a122bbf28fbbcd1dc83be0f77a25091442c72
-[token-transfer] [INFO]
-🎉 Transfer Results
-[token-transfer] [INFO] =========================================
-[token-transfer] [INFO]
-==== Transfer Results ====
-[token-transfer] [INFO] Transaction Hash: 0x55e6e9c295c7d32bc0d708f3363e42aad37298f9f30b4db0889e06bfac761157
-[token-transfer] [INFO] Transaction URL: https://sepolia.etherscan.io/tx/0x55e6e9c295c7d32bc0d708f3363e42aad37298f9f30b4db0889e06bfac761157
-[token-transfer] [INFO] Message ID: 0x11ef3640d8030bae75c2e4ca863a122bbf28fbbcd1dc83be0f77a25091442c72
-[token-transfer] [INFO] 👉 CCIP Explorer: https://ccip.chain.link/msg/0x11ef3640d8030bae75c2e4ca863a122bbf28fbbcd1dc83be0f77a25091442c72
-[token-transfer] [INFO] Destination Chain Selector: 16423721717087811551
-[token-transfer] [INFO] Sequence Number: 669
-[token-transfer] [INFO]
-Message tracking for Solana destinations:
-[token-transfer] [INFO] Please check the CCIP Explorer link to monitor your message status.
-[token-transfer] [INFO]
-✅ Transaction completed on the source chain
-[token-transfer] [INFO]
-✅ Token Transfer Complete!
-[token-transfer] [INFO] 🔗 Your tokens are being bridged to Solana
+Using rate-limited fetch for public solana nodes, commands may be slow
+Fee: 133805598n = 0.133805598 SOL
+🚀 Sending message to 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca @ ethereum-testnet-sepolia , tx => 2PaRwTZcUPwMz4Y3wmCbYA57w6jgQdM8WuNHyMy3N4o4eSdnxH2oQo1WEKpHDHQMka6gSSK8vdaz2UHp2MY8AFiA, messageId => 0xe36a4b5d82dd8071cf132918b55ad59e53d985872ad9d182305803f37a61ec98
+Using rate-limited fetch for public solana nodes, commands may be slow
+Lane:
+┌────────────────┬────────────────────────────────────────────────┬────────────────────────────┐
+│ (index)        │ source                                         │ dest                       │
+├────────────────┼────────────────────────────────────────────────┼────────────────────────────┤
+│ name           │ 'solana-devnet'                                │ 'ethereum-testnet-sepolia' │
+│ chainId        │ 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' │ 11155111                   │
+│ chainSelector  │ 16423721717087811551n                          │ 16015286601757825753n      │
+│ onRamp/version │ 'Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C' │ '1.6.0'                    │
+└────────────────┴────────────────────────────────────────────────┴────────────────────────────┘
+Request (source):
+┌──────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)                  │ Values                                                                                     │
+├──────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ messageId                │ '0xe36a4b5d82dd8071cf132918b55ad59e53d985872ad9d182305803f37a61ec98'                       │
+│ origin                   │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ sender                   │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ receiver                 │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ sequenceNumber           │ 3077                                                                                       │
+│ nonce                    │ '0 => allow out-of-order exec'                                                             │
+│ gasLimit                 │ 0n                                                                                         │
+│ transactionHash          │ '2PaRwTZcUPwMz4Y3wmCbYA57w6jgQdM8WuNHyMy3N4o4eSdnxH2oQo1WEKpHDHQMka6gSSK8vdaz2UHp2MY8AFiA' │
+│ logIndex                 │ 35                                                                                         │
+│ blockNumber              │ 469529662                                                                                  │
+│ timestamp                │ '2026-06-15 04:34:55 (2s ago)'                                                             │
+│ finalized                │ '12s left'                                                                                 │
+│ fee                      │ '0.133805598 SOL'                                                                          │
+│ tokens                   │ '0.001 CCIP-AEM'                                                                           │
+│ data                     │ '0x'                                                                                       │
+│ feeValueJuels            │ 1159415351000000000n                                                                       │
+│ allowOutOfOrderExecution │ true                                                                                       │
+└──────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
+CCIP Explorer: https://ccip.chain.link/msg/0xe36a4b5d82dd8071cf132918b55ad59e53d985872ad9d182305803f37a61ec98
 ```
 
 </Fragment>
 </Tabs>
 
-#### Monitor and Verify Transaction
+The `-t` flag uses human-readable amounts (0.001 tokens with 9 decimals = 1,000,000 smallest units).
 
-Upon successful execution, the system generates distinct tracking identifiers for comprehensive monitoring across both blockchain networks.
+<Tabs client:visible>
+<Fragment slot="tab.1">Monitor Transfer</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
 
-**Transaction Identifiers:**
+<Fragment slot="panel.1">
 
-- **Ethereum Transaction Hash**: `0x55e6e9c295c7d32bc0d708f3363e42aad37298f9f30b4db0889e06bfac761157`
-- **CCIP Message ID**: `0x11ef3640d8030bae75c2e4ca863a122bbf28fbbcd1dc83be0f77a25091442c72`
-
-**CCIP Explorer** (Primary monitoring interface):
-
-```
-https://ccip.chain.link/msg/0x11ef3640d8030bae75c2e4ca863a122bbf28fbbcd1dc83be0f77a25091442c72
-```
-
-The CCIP Explorer provides comprehensive transaction visibility:
-
-- Source chain (Ethereum) transaction confirmation
-- CCIP message processing and routing
-- Destination chain (Solana) message delivery
-- Token minting completion on Solana network
-
-**Ethereum Sepolia Explorer** (Source chain verification):
-
-```
-https://sepolia.etherscan.io/tx/0x55e6e9c295c7d32bc0d708f3363e42aad37298f9f30b4db0889e06bfac761157
+```bash
+# Replace with the transaction hash or message ID from the send output
+ccip-cli show <TX_HASH_OR_MESSAGE_ID> --wait \
+  --rpc $SOLANA_DEVNET_RPC \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL
 ```
 
-### Test Solana Rate Limit Enforcement (Optional)
+</Fragment>
 
-<Aside type="note" title="Rate Limit Configuration Reminder">
+<Fragment slot="panel.2">
 
-**Current Rate Limits**: If you followed Phase 3 with rate limits enabled:
+```bash
+Using rate-limited fetch for public solana nodes, commands may be slow
+Lane:
+┌────────────────┬────────────────────────────────────────────────┬────────────────────────────┐
+│ (index)        │ source                                         │ dest                       │
+├────────────────┼────────────────────────────────────────────────┼────────────────────────────┤
+│ name           │ 'solana-devnet'                                │ 'ethereum-testnet-sepolia' │
+│ chainId        │ 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' │ 11155111                   │
+│ chainSelector  │ 16423721717087811551n                          │ 16015286601757825753n      │
+│ onRamp/version │ 'Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C' │ '1.6.2'                    │
+└────────────────┴────────────────────────────────────────────────┴────────────────────────────┘
+Request (source):
+┌────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)                            │ Values                                                                                     │
+├────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ messageId                          │ '0xe36a4b5d82dd8071cf132918b55ad59e53d985872ad9d182305803f37a61ec98'                       │
+│ origin                             │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ sender                             │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ receiver                           │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ sequenceNumber                     │ 3077                                                                                       │
+│ nonce                              │ '0 => allow out-of-order exec'                                                             │
+│ gasLimit                           │ 0n                                                                                         │
+│ transactionHash                    │ '2PaRwTZcUPwMz4Y3wmCbYA57w6jgQdM8WuNHyMy3N4o4eSdnxH2oQo1WEKpHDHQMka6gSSK8vdaz2UHp2MY8AFiA' │
+│ logIndex                           │ 2                                                                                          │
+│ blockNumber                        │ 469529662                                                                                  │
+│ timestamp                          │ '2026-06-15 04:34:55 (58s ago)'                                                            │
+│ finalized                          │ true                                                                                       │
+│ fee                                │ '0.133805598 SOL'                                                                          │
+│ tokens                             │ '0.001 CCIP-AEM'                                                                           │
+│ fees.fixedFeesDetails.tokenAddress │ 'So11111111111111111111111111111111111111112'                                              │
+│ fees.fixedFeesDetails.totalAmount  │ 133805598n                                                                                 │
+│ finality                           │ 0n                                                                                         │
+│ finalityType                       │ 'FINALIZED'                                                                                │
+│ routerAddress                      │ 'Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C'                                             │
+│ allowOutOfOrderExecution           │ true                                                                                       │
+│ status                             │ 'COMMITTED'                                                                                │
+│ readyForManualExecution            │ false                                                                                      │
+│ receiptTransactionHash             │ null                                                                                       │
+│ receiptTimestamp                   │ undefined                                                                                  │
+│ deliveryTime                       │ null                                                                                       │
+│ offRamp                            │ '0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0'                                               │
+└────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
+CCIP Explorer: https://ccip.chain.link/msg/0xe36a4b5d82dd8071cf132918b55ad59e53d985872ad9d182305803f37a61ec98
+[SENT] Waiting for source chain finalization...
+[SOURCE_FINALIZED] Source chain finalized
+[SOURCE_FINALIZED] Waiting for commit on destination chain...
+[COMMITTED] Commit report accepted on destination chain
+┌─────────────────┬──────────────────────────────────────────────────────────────────────┐
+│ (index)         │ Values                                                               │
+├─────────────────┼──────────────────────────────────────────────────────────────────────┤
+│ merkleRoot      │ '0xdce4e8a082a45983a5ad0ce37abe06fb4f72dcc7e1c624b2e8dbf0f47590c909' │
+│ min             │ 3077                                                                 │
+│ max             │ 3077                                                                 │
+│ origin          │ '0x3d4990B971284fEbfb476710baF873fc5b65ee3e'                         │
+│ contract        │ '0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0'                         │
+│ transactionHash │ '0xed981056b3ad340d799bf5019fd4f2ef064cd05ab58c5fa99c0cccf03c73d1af' │
+│ blockNumber     │ 11063152                                                             │
+│ timestamp       │ '2026-06-15 04:35:36 (41s after request)'                            │
+└─────────────────┴──────────────────────────────────────────────────────────────────────┘
+[BLESSED] Waiting for execution on destination chain...
+[SUCCESS] Message executed on destination chain
+┌─────────────────┬──────────────────────────────────────────────────────────────────────┐
+│ (index)         │ Values                                                               │
+├─────────────────┼──────────────────────────────────────────────────────────────────────┤
+│ state           │ '✅ success'                                                         │
+│ gasUsed         │ 87342                                                                │
+│ origin          │ '0xc03BfDf1C576bc3720DcD45B6B4EF6A0aEf4dfe6'                         │
+│ contract        │ '0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0'                         │
+│ transactionHash │ '0x3d1e483eeca0bef62b7a760111e7c6d5f4186c68862101d958784a2b504aea73' │
+│ logIndex        │ 712                                                                  │
+│ blockNumber     │ 11063155                                                             │
+│ timestamp       │ '2026-06-15 04:36:12 (1m17s after request)'                          │
+└─────────────────┴──────────────────────────────────────────────────────────────────────┘
+```
 
-- **Solana Outbound**: 18 tokens capacity, 0.1 tokens/second rate
-- **Solana Inbound**: 20 tokens capacity, 0.1 tokens/second rate
-- **Ethereum**: Similar limits (18-decimal equivalent: 18/20 ETH tokens)
+</Fragment>
+</Tabs>
 
-**Testing Strategy**: Attempt to transfer 25 tokens (exceeds 20-token inbound capacity).
+### Transfer Ethereum → Solana
 
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
+
+`ccip-cli` does not load Hardhat env-enc automatically. Run these commands from the Hardhat project directory. Prefer [Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore) over exporting a private key in plain text.
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Hardhat keystore (Recommended)</Fragment>
+<Fragment slot="tab.2">PRIVATE_KEY (Alternative)</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+source ~/.all_vars
+
+ccip-cli send \
+  -s ethereum-testnet-sepolia \
+  -r $ETH_CCIP_ROUTER \
+  -d solana-devnet \
+  --to $SOL_WALLET_ADDRESS \
+  -t $ETH_TOKEN_ADDRESS=1.0 \
+  --wallet hardhat:<YOUR_KEYSTORE_ACCOUNT_NAME> \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
+```
+
+Use the keystore account name from your Hardhat project (see [Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)). This keeps the signing key encrypted instead of in shell history.
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+source ~/.all_vars
+
+# ccip-cli does not read env-enc — view and export the same key used in Phase 1
+npx env-enc view
+export PRIVATE_KEY="<YOUR_PRIVATE_KEY_FROM_ENV_ENC>"
+
+ccip-cli send \
+  -s ethereum-testnet-sepolia \
+  -r $ETH_CCIP_ROUTER \
+  -d solana-devnet \
+  --to $SOL_WALLET_ADDRESS \
+  -t $ETH_TOKEN_ADDRESS=1.0 \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
+```
+
+Do not commit or share the exported key. Prefer the Hardhat keystore tab for production-like workflows.
+
+</Fragment>
+</Tabs>
+
+For token-only transfers to Solana, `--to` is the destination wallet that receives minted tokens. CCIP fees are paid in native Sepolia ETH by default — ensure your wallet has sufficient ETH for gas and fees.
+
+<Aside type="note" title="Pay fees in LINK (optional)">
+  Add `--fee-token LINK` to pay CCIP fees in LINK instead of ETH (Sepolia LINK:
+  `0x779877A7B0D9E8603169DdbD7836e478b4624789`).
 </Aside>
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Test Command</Fragment>
-<Fragment slot="tab.2">Expected Failure</Fragment>
+<Fragment slot="tab.1">Monitor Transfer</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Attempt to transfer 25 tokens (exceeds rate limit capacity of 20)
-yarn svm:token-transfer \
-  --token-mint $SOL_TOKEN_MINT \
-  --token-amount 25000000000 \
-  --receiver $ETH_RECEIVER_ADDRESS
+ccip-cli show <TX_HASH_OR_MESSAGE_ID> --wait \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
 ```
 
 </Fragment>
@@ -2906,100 +3394,138 @@ yarn svm:token-transfer \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-19T10:02:56.319Z] 🔄 SENDING TOKEN TRANSFER
-[2025-08-19T10:02:56.319Z] =======================================
-[2025-08-19T10:02:56.319Z] Preparing CCIP message...
-[2025-08-19T10:02:56.333Z] Sending CCIP message to destination chain 16015286601757825753
-[2025-08-19T10:02:56.410Z] Building accounts for CCIP send to chain 16015286601757825753
-[2025-08-19T10:02:56.488Z] Getting mint account info for 3T1wVJporm2JpGojRV831TTQ1nexkBqFWhKnE5Lwedci to determine token program ID...
-[2025-08-19T10:02:56.807Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-19T10:02:57.848Z] ❌ Failed to send token transfer: Simulation failed.
-Message: Transaction simulation failed: Error processing Instruction 1: custom program error: 0x177f.
-Logs:
-[
-  "Program log: Instruction: LockOrBurnTokens",
-  "Program RmnXLft1mSEwDgMKu2okYuHkiazxntFFcZFrrcXxYg7 invoke [3]",
-  "Program log: Instruction: VerifyNotCursed",
-  "Program RmnXLft1mSEwDgMKu2okYuHkiazxntFFcZFrrcXxYg7 consumed 6856 of 1185613 compute units",
-  "Program RmnXLft1mSEwDgMKu2okYuHkiazxntFFcZFrrcXxYg7 success",
-  "Program log: AnchorError thrown in programs/base-token-pool/src/rate_limiter.rs:48. Error Code: RLMaxCapacityExceeded. Error Number: 6015. Error Message: RateLimit: max capacity exceeded.",
-  "Program 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB consumed 38998 of 1214906 compute units",
-  "Program 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB failed: custom program error: 0x177f",
-  "Program Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C consumed 223942 of 1399850 compute units",
-  "Program Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C failed: custom program error: 0x177f"
-].
-Catch the `SendTransactionError` and call `getLogs()` on it for full details.
-[2025-08-19T10:02:57.881Z]
-❌ Command failed:
-[2025-08-19T10:02:57.881Z] Simulation failed.
-Message: Transaction simulation failed: Error processing Instruction 1: custom program error: 0x177f.
-Logs:
-[
-  "Program log: Instruction: LockOrBurnTokens",
-  "Program RmnXLft1mSEwDgMKu2okYuHkiazxntFFcZFrrcXxYg7 invoke [3]",
-  "Program log: Instruction: VerifyNotCursed",
-  "Program RmnXLft1mSEwDgMKu2okYuHkiazxntFFcZFrrcXxYg7 consumed 6856 of 1185613 compute units",
-  "Program RmnXLft1mSEwDgMKu2okYuHkiazxntFFcZFrrcXxYg7 success",
-  "Program log: AnchorError thrown in programs/base-token-pool/src/rate_limiter.rs:48. Error Code: RLMaxCapacityExceeded. Error Number: 6015. Error Message: RateLimit: max capacity exceeded.",
-  "Program 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB consumed 38998 of 1214906 compute units",
-  "Program 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB failed: custom program error: 0x177f",
-  "Program Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C consumed 223942 of 1399850 compute units",
-  "Program Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C failed: custom program error: 0x177f"
-].
+Lane:
+┌────────────────┬──────────────────────────────────────────────┬────────────────────────────────────────────────┐
+│ (index)        │ source                                       │ dest                                           │
+├────────────────┼──────────────────────────────────────────────┼────────────────────────────────────────────────┤
+│ name           │ 'ethereum-testnet-sepolia'                   │ 'solana-devnet'                                │
+│ chainId        │ 11155111                                     │ 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' │
+│ chainSelector  │ 16015286601757825753n                        │ 16423721717087811551n                          │
+│ onRamp/version │ '0x23a5084Fa78104F3DF11C63Ae59fcac4f6AD9DeE' │ '1.6.0'                                        │
+└────────────────┴──────────────────────────────────────────────┴────────────────────────────────────────────────┘
+Request (source):
+┌────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)                            │ Values                                                                                     │
+├────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ messageId                          │ '0x62d00e2bd81645ea26d8ad804a97d4cdd9724d15a4881ae6f0ff5aeacb8d95ae'                       │
+│ origin                             │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ sender                             │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ receiver                           │ '11111111111111111111111111111111'                                                         │
+│ sequenceNumber                     │ 10201                                                                                      │
+│ nonce                              │ '0 => allow out-of-order exec'                                                             │
+│ computeUnits                       │ 0n                                                                                         │
+│ transactionHash                    │ '0xd010ae34f97985e8aadf7910482ad8b311a76491a5077f1ff929c072fcb0d620'                       │
+│ logIndex                           │ 1053                                                                                       │
+│ blockNumber                        │ 11063166                                                                                   │
+│ timestamp                          │ '2026-06-15 04:38:24 (19m12s ago)'                                                         │
+│ finalized                          │ true                                                                                       │
+│ fee                                │ '0.000350949027443669 WETH'                                                                │
+│ tokens                             │ '1.0 BnmAEM'                                                                               │
+│ accounts                           │ undefined                                                                                  │
+│ fees.fixedFeesDetails.tokenAddress │ '0x097D90c9d3E0B50Ca60e1ae45F6A81010f9FB534'                                               │
+│ fees.fixedFeesDetails.totalAmount  │ 350949027443669n                                                                           │
+│ finality                           │ 0n                                                                                         │
+│ finalityType                       │ 'FINALIZED'                                                                                │
+│ routerAddress                      │ '0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59'                                               │
+│ accountIsWritableBitmap            │ 0n                                                                                         │
+│ allowOutOfOrderExecution           │ true                                                                                       │
+│ tokenReceiver                      │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ status                             │ 'SUCCESS'                                                                                  │
+│ readyForManualExecution            │ false                                                                                      │
+│ receiptTransactionHash             │ '64SNgMXWoakBk7SZVcKUnBZFyWiGqTZUaRfSGk9ZeiAfBY4oysaVzZnq7KYR8KwyVjFtomao5hjXNGgaoqQjCDp2' │
+│ receiptTimestamp                   │ '2026-06-15 04:57:10'                                                                      │
+│ deliveryTime                       │ 1126000n                                                                                   │
+│ offRamp                            │ 'offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm'                                              │
+└────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
+CCIP Explorer: https://ccip.chain.link/msg/0x62d00e2bd81645ea26d8ad804a97d4cdd9724d15a4881ae6f0ff5aeacb8d95ae
+[SENT] Waiting for source chain finalization...
+Using rate-limited fetch for public solana nodes, commands may be slow
+[SOURCE_FINALIZED] Source chain finalized
+[SOURCE_FINALIZED] Waiting for commit on destination chain...
+[SUCCESS] Message executed on destination chain
+┌─────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)         │ Values                                                                                     │
+├─────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ state           │ '✅ success'                                                                               │
+│ origin          │ 'GedMetJrF1cYn3FqS7e1huH8bb4cVxXkVdqhSNdgz5K6'                                             │
+│ contract        │ 'offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm'                                              │
+│ transactionHash │ '64SNgMXWoakBk7SZVcKUnBZFyWiGqTZUaRfSGk9ZeiAfBY4oysaVzZnq7KYR8KwyVjFtomao5hjXNGgaoqQjCDp2' │
+│ logIndex        │ 24                                                                                         │
+│ blockNumber     │ 469533190                                                                                  │
+│ timestamp       │ '2026-06-15 04:57:10 (18m46s after request)'                                               │
+└─────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 </Fragment>
 </Tabs>
 
-The transaction correctly failed with `RLMaxCapacityExceeded` error because:
+### Optional: Test Rate Limit Enforcement
 
-- **Attempted**: 25 tokens (`25000000000` in smallest units)
-- **Limit**: 20 tokens maximum capacity (`20000000000`)
-- **Result**: Rate limiter blocked the excessive transfer
-
-**Key Error Details:**
-
-- **Error Code**: `RLMaxCapacityExceeded` (Error Number: 6015)
-- **Source**: `programs/base-token-pool/src/rate_limiter.rs:48`
-- **Meaning**: The token bucket capacity was exceeded
-
-This demonstrates that your rate limits are properly configured and actively protecting against transfers that exceed the configured limits.
-
-### Test EVM Rate Limit Enforcement (Optional)
-
-Test rate limits from the EVM side (Ethereum to Solana) using the same 25-token limit.
+If you configured rate limits in Phase 3, attempt a transfer that exceeds capacity (25 tokens vs 20-token limit):
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Test Command</Fragment>
-<Fragment slot="tab.2">Expected Failure</Fragment>
+<Fragment slot="tab.1">Solana → EVM (expect failure)</Fragment>
+<Fragment slot="tab.2">EVM → Solana (expect failure)</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Attempt to transfer 25 tokens from Ethereum (exceeds rate limit capacity of 20)
-yarn evm:transfer \
-  --token $ETH_TOKEN_ADDRESS \
-  --amount 25000000000000000000 \
-  --token-receiver $SOL_WALLET_ADDRESS
+# Terminal 1
+
+ccip-cli send \
+  -s solana-devnet \
+  -r $SOL_CCIP_ROUTER \
+  -d ethereum-testnet-sepolia \
+  --to $ETH_RECEIVER_ADDRESS \
+  -t $SOL_TOKEN_MINT=25 \
+  --wallet ~/.config/solana/id.json \
+  --rpc $SOLANA_DEVNET_RPC \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL
 ```
+
+Expect `RLMaxCapacityExceeded` (Error 6015) when limits are enabled.
 
 </Fragment>
 
 <Fragment slot="panel.2">
 
 ```bash
-[ccip-messenger] [INFO] Sending CCIP message...
-[ccip-messenger] [ERROR] Error sending CCIP message: Error: execution reverted (unknown custom error) (action="estimateGas", data="0x1a76572a000000000000000000000000000000000000000000000000f9ccd8a1c50800000000000000000000000000000000000000000000000000015af1d78b58c400000000000000000000000000007c57a9d966c3e6e344621c512d510f76575640ed", reason=null, transaction={ "data": "0x96f4e9f9000000000000000000000000000000000000000000000000e3ecc7e294e337df000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000100000000000000000000000000779877a7b0d9e8603169ddbd7836e478b4624789000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000007c57a9d966c3e6e344621c512d510f76575640ed0000000000000000000000000000000000000000000000015af1d78b58c4000000000000000000000000000000000000000000000000000000000000000000e41f3b3aba0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001c6ea0f22160ac820ce7cd983587acd07557c7d9c79cc15dd818f50d2c554e84800000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", "from": "0x9d087fC03ae39b088326b67fA3C788236645b717", "to": "0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59" }, invocation=null, revert=null, code=CALL_EXCEPTION, version=6.13.5)
+# Terminal 2 — use the same wallet option as the E→S transfer above
+
+ccip-cli send \
+  -s ethereum-testnet-sepolia \
+  -r $ETH_CCIP_ROUTER \
+  -d solana-devnet \
+  --to $SOL_WALLET_ADDRESS \
+  -t $ETH_TOKEN_ADDRESS=25 \
+  --wallet hardhat:<YOUR_KEYSTORE_ACCOUNT_NAME> \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
 ```
+
+Expect `TokenMaxCapacityExceeded` (selector `0x1a76572a`) when limits are enabled.
 
 </Fragment>
 </Tabs>
 
-The transaction correctly failed because:
+### Optional: Verify Rate Limit Configuration
 
-- **Attempted**: 25 tokens (`25000000000000000000` wei - 18 decimals)
-- **Limit**: 18 tokens maximum capacity
-- **Error Selector**: [`0x1a76572a` (TokenMaxCapacityExceeded)](/ccip/api-reference/evm/v1.6.1/errors#rate-limiter-errors)
-- **Decoded Values**: Capacity: `18000000000000000000`, Attempted: `25000000000000000000`, Token: `0x9cE471d0a7bE21ee32276dde49104fe02c812906`
+If you configured rate limits in Phase 3, confirm they appear in your chain configuration:
 
-This demonstrates that rate limits are enforced on both chains, protecting the cross-chain bridge from excessive transfers. The EVM error selector corresponds to the `TokenMaxCapacityExceeded` error in the [CCIP EVM v1.6.0 errors reference](/ccip/api-reference/evm/v1.6.1/errors).
+```bash
+# Terminal 1 — inspect Solana outbound/inbound rate limits
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-chain-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --remote-chain-selector $ETHEREUM_SEPOLIA_CHAIN_SELECTOR
+```
+
+```bash
+# Terminal 2 — inspect EVM rate limit settings
+npx hardhat getPoolConfig \
+  --pooladdress $ETH_POOL_ADDRESS \
+  --network ethereumSepolia
+```
+
+**Congratulations!** Your production cross-chain token infrastructure with Squads governance is fully configured on both chains.

--- a/src/content/ccip/tutorials/svm/cross-chain-tokens/spl-token-multisig-tutorial.mdx
+++ b/src/content/ccip/tutorials/svm/cross-chain-tokens/spl-token-multisig-tutorial.mdx
@@ -9,7 +9,7 @@ metadata:
   description: "Learn SPL token multisig architecture for cross-chain tokens. Learn governance concepts and multisig patterns before building production systems with CCIP."
   excerpt: "ccip cross-chain token tutorial solana ethereum burnmint pools path-a multisig educational spl token token-2022 multisig architecture learning self-service registration svm evm bidirectional token pools address lookup tables transaction monitoring solana devnet ethereum sepolia pool signer pda token admin registry multisig concepts tutorial governance foundation"
   datePublished: "2025-08-13T00:53:46Z"
-  lastModified: "2025-08-13T00:53:46Z"
+  lastModified: "2026-06-15T00:53:46Z"
   estimatedTime: "45 minutes"
   difficulty: "intermediate"
 ---
@@ -76,16 +76,16 @@ This tutorial implements the **[Burn and Mint](/ccip/concepts/cross-chain-token/
 
 ## Tutorial Approach
 
-This tutorial provides step-by-step instructions with detailed explanations of what each command does and why. You'll work primarily in Terminal 1 (Solana) with occasional switches to Terminal 2 (EVM).
+This tutorial provides step-by-step instructions with detailed explanations of what each command does and why. You'll work primarily in Terminal 1 (CCIP Solana BS58 Generator) with occasional switches to Terminal 2 (EVM).
 
 **Environment Variable Management**: This tutorial uses phase-based variable files (e.g., `~/.phase1_vars`, `~/.ccip_complete_vars`) to eliminate manual variable re-entry when switching between terminals. Each phase saves its variables to files that subsequent phases can load automatically.
 
-For detailed implementation code explanations, refer to the comprehensive READMEs in both repositories:
+For detailed implementation code explanations, refer to:
 
-- **[Solana Starter Kit README](https://github.com/smartcontractkit/solana-starter-kit/blob/main/README.md)**: Detailed explanations of all SVM commands and implementation
-- **[Smart Contract Examples README](https://github.com/smartcontractkit/smart-contract-examples/blob/main/ccip/cct/hardhat/README.md)**: Comprehensive EVM implementation guide
+- **[CCIP Solana BS58 Generator README](https://github.com/smartcontractkit/ccip-solana-bs58-generator/blob/main/README.md)**: Solana CLI command details, `--execute` EOA workflow, and options
+- **[Smart Contract Examples README](https://github.com/smartcontractkit/smart-contract-examples/blob/main/ccip/cct/hardhat/README.md)**: EVM implementation guide
 
-The READMEs contain detailed technical explanations, troubleshooting guides, and advanced configuration options.
+**EOA execution**: In Terminal 1, append `--execute` to each `pnpm bs58` command so your local Solana wallet signs and sends transactions directly. Set `--authority` to your wallet address (`$SOL_ADMIN_WALLET`). Read-only commands (`get-state`, `get-chain-config`, `derive-accounts`) do not use `--execute`.
 
 ## Phase 1: Ethereum Sepolia Token Setup
 
@@ -113,23 +113,30 @@ npx hardhat deployToken \
  --name "BnM AEM Token" \
  --symbol BnMAEM \
  --decimals 18 \
- --verifycontract true \
- --network sepolia
+ --verifycontract \
+ --network ethereumSepolia
 ```
 
 </Fragment>
 
 <Fragment slot="panel.2">
 ```bash
-2025-08-22T09:13:58.531Z info: Deploying BurnMintERC20 contract to sepolia
-2025-08-22T09:13:58.532Z info: Waiting 3 blocks for transaction 0x8fc04d92a0195c785fd5776f1b03bb4a6c416fadbc9ee11b18860b7e4644f068 to be confirmed...
-2025-08-22T09:14:36.690Z info: Token deployed to: 0x84426E21208D73E8D3760d9cbc4FaEFa279d3720
-2025-08-22T09:14:36.759Z info: Granting mint and burn roles to 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-22T09:15:13.003Z info: Verifying contract...
-The contract 0x84426E21208D73E8D3760d9cbc4FaEFa279d3720 has already been verified on the block explorer. If you're trying to verify a partially verified contract, please use the --force flag.
-https://sepolia.etherscan.io/address/0x84426E21208D73E8D3760d9cbc4FaEFa279d3720#code
+2026-06-15T00:17:28.926Z info: 🚀 Deploying BurnMintERC20 to ethereumSepolia...
+2026-06-15T00:17:28.927Z info:    name: BnM AEM Token, symbol: BnMAEM
+2026-06-15T00:17:32.119Z info: ⏳ Deployment tx: 0x12333b3fcf22399e49809fd1c0b7f83106f571569b3c03ecb5665fcab8c21f81
+2026-06-15T00:17:32.120Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T00:18:02.183Z info: ✅ Token deployed at: 0x45cfb05d6278715716023ebeec733c081ce9f822
+2026-06-15T00:18:02.659Z info: Granting mint and burn roles to 0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA...
+2026-06-15T00:18:03.729Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T00:18:37.999Z info: ✅ Mint/Burn roles granted.
+2026-06-15T00:18:38.000Z info: Verifying contract...
 
-2025-08-22T09:15:13.627Z info: Token contract deployed and verified
+The contract at 0x45cfb05d6278715716023ebeec733c081ce9f822 has already been verified on Etherscan.
+
+If you need to verify a partially verified contract, please use the --force flag.
+
+Explorer: https://sepolia.etherscan.io/address/0x45cfb05d6278715716023ebeec733c081ce9f822#code
+2026-06-15T00:18:40.891Z info: ✅ Token contract verified successfully
 
 ````
 
@@ -160,7 +167,7 @@ echo "Token Address: $ETH_TOKEN_ADDRESS"
 <Fragment slot="panel.2">
 
 ```bash
-Token Address: 0x84426E21208D73E8D3760d9cbc4FaEFa279d3720
+Token Address: 0x45cfb05d6278715716023ebeec733c081ce9f822
 ```
 
 </Fragment>
@@ -182,8 +189,8 @@ npx hardhat deployTokenPool \
  --tokenaddress $ETH_TOKEN_ADDRESS \
  --localtokendecimals 18 \
  --pooltype burnMint \
- --verifycontract true \
- --network sepolia
+ --verifycontract \
+ --network ethereumSepolia
 ```
 
 </Fragment>
@@ -191,14 +198,24 @@ npx hardhat deployTokenPool \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-22T09:20:00.202Z info: Waiting 3 blocks for transaction 0xfe63c43556e33c77b06c352cbd36350e851965d1466248a8d6486d898ce67674 to be confirmed...
-2025-08-22T09:29:37.031Z info: Token pool deployed to: 0x22d99DF2246eD52063B0d2d0f24E03d7319b9299
-2025-08-22T09:29:37.036Z info: Granting mint and burn roles to 0x22d99DF2246eD52063B0d2d0f24E03d7319b9299 on token 0x84426E21208D73E8D3760d9cbc4FaEFa279d3720
-2025-08-22T09:30:12.768Z info: Verifying contract...
-The contract 0x22d99DF2246eD52063B0d2d0f24E03d7319b9299 has already been verified on the block explorer. If you're trying to verify a partially verified contract, please use the --force flag.
-https://sepolia.etherscan.io/address/0x22d99DF2246eD52063B0d2d0f24E03d7319b9299#code
+2026-06-15T00:20:36.040Z info: 🚀 Deploying burnMint pool on ethereumSepolia
+2026-06-15T00:20:36.041Z info:    Token: 0x45cfb05d6278715716023ebeec733c081ce9f822
+2026-06-15T00:20:36.041Z info:    Decimals: 18
+2026-06-15T00:20:36.041Z info:    Allowlist: None
+2026-06-15T00:20:39.071Z info: ⏳ Deployment tx: 0x9a186e27de847cbb27e47d5bdabe352e18068a17c4fb259e40e8c2ec08532d0c
+2026-06-15T00:20:39.072Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T00:21:13.340Z info: ✅ Token pool deployed at: 0x1df7ede88286c1ef95d024b311e12dc4b3106f1f
+2026-06-15T00:21:13.341Z info: Granting mint and burn roles to 0x1df7ede88286c1ef95d024b311e12dc4b3106f1f on token 0x45cfb05d6278715716023ebeec733c081ce9f822
+2026-06-15T00:21:14.730Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T00:21:49.003Z info: ✅ Mint/Burn roles granted
+2026-06-15T00:21:49.003Z info: Verifying contract...
 
-2025-08-22T09:30:13.374Z info: Token pool contract deployed and verified
+The contract at 0x1df7ede88286c1ef95d024b311e12dc4b3106f1f has already been verified on Etherscan.
+
+If you need to verify a partially verified contract, please use the --force flag.
+
+Explorer: https://sepolia.etherscan.io/address/0x1df7ede88286c1ef95d024b311e12dc4b3106f1f#code
+2026-06-15T00:21:52.270Z info: ✅ Token pool contract verified successfully
 ```
 
 </Fragment>
@@ -228,7 +245,7 @@ echo "Pool Address: $ETH_POOL_ADDRESS"
 <Fragment slot="panel.2">
 
 ```bash
-Pool Address: 0x22d99DF2246eD52063B0d2d0f24E03d7319b9299
+Pool Address: 0x1df7ede88286c1ef95d024b311e12dc4b3106f1f
 ```
 
 </Fragment>
@@ -248,16 +265,18 @@ In this step, you will use the `mintTokens` task to mint tokens on Ethereum Sepo
 npx hardhat mintTokens \
   --tokenaddress $ETH_TOKEN_ADDRESS \
   --amount 1000000000000000000000 \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 </Fragment>
 
 <Fragment slot="panel.2">
 ```bash
-2025-08-22T09:38:02.533Z info: Minting 1000000000000000000000 of BnMAEM tokens to 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-22T09:38:37.383Z info: Minted 1000000000000000000000 of BnMAEM tokens to 0x9d087fC03ae39b088326b67fA3C788236645b717 - transaction hash: 0x4648cf405b8847a57bfa84aa0b4b2f38be3a25eaddf21432356d513aa151fbb0
-2025-08-22T09:38:37.492Z info: Current balance of 0x9d087fC03ae39b088326b67fA3C788236645b717 is 1000000000000000000000 BnMAEM
+2026-06-15T00:23:17.116Z info: 🪙 Minting 1000000000000000000000 BnMAEM to 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca...
+2026-06-15T00:23:18.710Z info: ⏳ Mint tx: 0x7b02fe02f07744b977d4f099b734fa98f0e56bcf516c48c265cc393a7c5c7c8d
+2026-06-15T00:23:18.710Z info:    Waiting for 3 confirmation(s)...
+2026-06-15T00:23:48.959Z info: ✅ Minted 1000000000000000000000 BnMAEM to 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-15T00:23:48.960Z info:    Current balance of 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca: 1000000000000000000000 BnMAEM
 ```
 
 </Fragment>
@@ -276,17 +295,17 @@ In this step, you will use the `claimAdmin` task to register your EOA as the adm
 # Claim admin role
 npx hardhat claimAdmin \
   --tokenaddress $ETH_TOKEN_ADDRESS \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 </Fragment>
 
 <Fragment slot="panel.2">
 ```bash
-2025-08-22T09:39:05.315Z info: 🎯 Attempting to claim admin for token 0x84426E21208D73E8D3760d9cbc4FaEFa279d3720 using getCCIPAdmin mode
-2025-08-22T09:39:06.052Z info: Current token CCIP admin: 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-22T09:39:06.052Z info: Claiming admin of 0x84426E21208D73E8D3760d9cbc4FaEFa279d3720 via getCCIPAdmin() for CCIP admin 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-22T09:42:36.924Z info: ✅ Successfully claimed admin of 0x84426E21208D73E8D3760d9cbc4FaEFa279d3720 using getCCIPAdmin mode. Transaction: 0x5938a38e68f76c02e3da4542654466f0ce2b23dd5191b9b257676f005e7ffc4b
+2026-06-15T00:24:51.426Z info: 🎯 Claiming admin for 0x45cfb05d6278715716023ebeec733c081ce9f822 using getCCIPAdmin mode
+2026-06-15T00:24:54.359Z info: ✅ Current wallet 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca is CCIP admin
+2026-06-15T00:24:55.884Z info: 📤 TX sent: 0x59ee4f9880d5ee36187d7c89d3cca19b6f478fd58a9a7a35a9bfe0a77a8ea33f. Waiting for 3 confirmations...
+2026-06-15T00:25:25.930Z info: ✅ Admin claimed for 0x45cfb05d6278715716023ebeec733c081ce9f822 on ethereumSepolia (3 confirmations)
 ```
 
 </Fragment>
@@ -305,14 +324,19 @@ In this step, you will use the `acceptAdminRole` task to accept the admin role f
 # Accept admin role
 npx hardhat acceptAdminRole \
  --tokenaddress $ETH_TOKEN_ADDRESS \
- --network sepolia
+ --network ethereumSepolia
 ```
 
 </Fragment>
 
 <Fragment slot="panel.2">
 ```bash
-2025-08-22T09:44:00.851Z info: Accepted admin role for token 0x84426E21208D73E8D3760d9cbc4FaEFa279d3720 tx: 0xce1554bb5d281a70a8f3be97fbfb3bd4b9a484ff76b1a37b7bc631aff94bae86
+2026-06-15T00:26:00.427Z info: 🔄 Accepting admin role for 0x45cfb05d6278715716023ebeec733c081ce9f822 on ethereumSepolia...
+2026-06-15T00:26:02.466Z info: Checking pending admin for 0x45cfb05d6278715716023ebeec733c081ce9f822...
+2026-06-15T00:26:02.696Z info: ✅ Current wallet 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca is the pending admin
+2026-06-15T00:26:02.696Z info: Accepting admin role...
+2026-06-15T00:26:04.269Z info: 📤 TX sent: 0x2215a67879d31cde69e35516244395a115f7d24d42d94052c0c0f87a32b20130. Waiting for 3 confirmations...
+2026-06-15T00:26:38.526Z info: ✅ Admin role accepted for 0x45cfb05d6278715716023ebeec733c081ce9f822 on ethereumSepolia (3 confirmations)
 ```
 
 </Fragment>
@@ -344,8 +368,9 @@ echo "✅ Variables saved to ~/.phase1_vars"
 <Fragment slot="panel.2">
 
 ```bash
-✅ ETH Token: 0x84426E21208D73E8D3760d9cbc4FaEFa279d3720
-✅ ETH Pool: 0x22d99DF2246eD52063B0d2d0f24E03d7319b9299
+=== Phase 1 Complete - EVM Setup ===
+✅ ETH Token: 0x45cfb05d6278715716023ebeec733c081ce9f822
+✅ ETH Pool: 0x1df7ede88286c1ef95d024b311e12dc4b3106f1f
 ✅ Variables saved to ~/.phase1_vars
 ```
 
@@ -356,23 +381,49 @@ echo "✅ Variables saved to ~/.phase1_vars"
 
 In this phase, you will create an SPL token, initialize the CCIP token pool, and complete CCIP registration **before\*\*** setting up the SPL token multisig. This sequence is critical because the self-service registration requires you to hold the mint authority.
 
-**Switch to Terminal 1** (Solana Starter Kit) Verify your location:
+**Switch to Terminal 1** (CCIP Solana BS58 Generator) Verify your location:
 
 ```bash
 pwd
-# Should show: .../solana-starter-kit
+# Should show: .../ccip-solana-bs58-generator
 ```
 
-Load the Ethereum addresses from Phase 1:
+Load the Ethereum addresses from Phase 1 and set CCIP constants:
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Setup Command</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
 
 ```bash
 source ~/.phase1_vars
-echo "Loaded Phase 1 variables: ETH_TOKEN_ADDRESS=$ETH_TOKEN_ADDRESS, ETH_POOL_ADDRESS=$ETH_POOL_ADDRESS"
+
+export SOL_ADMIN_WALLET=$(solana address)
+export SOL_CCIP_POOL_PROGRAM="41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
+export SOL_CCIP_ROUTER="Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C"
+export SOL_CCIP_FEE_QUOTER_PROGRAM="FeeQPGkKDeRV1MgoYfMH6L8o3KeuYjwUZrgn4LRKfjHi"
+export ETH_SEPOLIA_CHAIN_SELECTOR="16015286601757825753"
+
+echo "Loaded Phase 1: ETH_TOKEN_ADDRESS=$ETH_TOKEN_ADDRESS"
+echo "Admin Wallet: $SOL_ADMIN_WALLET"
 ```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+Loaded Phase 1: ETH_TOKEN_ADDRESS=0x45cfb05d6278715716023ebeec733c081ce9f822
+Admin Wallet: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+```
+
+</Fragment>
+</Tabs>
 
 ### Step 1: Create SPL Token
 
-In this step, you will use the `svm:token:create` script to create an SPL token with Metaplex metadata support on Solana Devnet. This script leverages the TokenManager library to create a comprehensive token with metadata, initial supply, and proper configuration for CCIP integration.
+Create an SPL token with Metaplex metadata and initial supply using direct EOA execution:
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Create Token</Fragment>
@@ -380,25 +431,22 @@ In this step, you will use the `svm:token:create` script to create an SPL token 
 
 <Fragment slot="panel.1">
 ```bash
-# Create SPL token with default configuration
-yarn svm:token:create
+# Create SPL token with Metaplex metadata and initial supply
+pnpm bs58 --env devnet --execute spl-token \
+  --instruction create-mint \
+  --authority $SOL_ADMIN_WALLET \
+  --decimals 9 \
+  --with-metaplex true \
+  --name "AEM" \
+  --symbol "CCIP-AEM" \
+  --uri "https://cyan-pleasant-anteater-613.mypinata.cloud/ipfs/bafkreieirlwjqbtzniqsgcjebzexlcspcmvd4woh3ajvf2p4fuivkenw6i" \
+  --initial-supply 1000000000000 \
+  --recipient $SOL_ADMIN_WALLET
 ```
 
 <Aside type="note" title="Custom Configuration">
-  You can customize the token by adding parameters:
-  
-  
-  ```bash
-  yarn svm:token:create \
-    --name "Cross Chain Token Production" \
-    --symbol "CCTP" \
-    --uri "https://your-ipfs-url/metadata.json"
-  ```
-
-You can reuse this metadata or create your own to IPFS or another decentralized storage solution and update the
-`create-token-metaplex.ts` script to ensure your metadata file and token configuration are compatible. The default
-metadata URI provided is for demonstration purposes only.
-
+  You can customize the token by updating `--name`, `--symbol`, and `--uri`. Upload your metadata to IPFS or another
+  decentralized storage solution.
 </Aside>
 
 </Fragment>
@@ -406,89 +454,76 @@ metadata URI provided is for demonstration purposes only.
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-22T09:52:33.774Z] 🏭 CREATING SPL TOKEN
-[2025-08-22T09:52:33.774Z] ===============================================
-[2025-08-22T09:52:33.774Z] Starting spl-token creation with metadata {
-  name: 'AEM',
-  symbol: 'CCIP-AEM',
-  decimals: 9,
-  uri: 'https://cyan-pleasant-anteater-613.mypinata.cloud/ipfs/bafkreieirlwjqbtzniqsgcjebzexlcspcmvd4woh3ajvf2p4fuivkenw6i',
-  initialSupply: '1000000000000',
-  sellerFeeBasisPoints: 0,
-  tokenProgram: 'spl-token'
-}
-[2025-08-22T09:52:47.422Z] spl-token token created successfully {
-  mint: '8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS',
-  signature: 'i3svbchAskKnVFQJzHXeEg6KVGTa1m43USW1mdZQeYLRvjvKgVNBmauiYMMdaPnSAA79mz9XPL3mkvFWbPgx9U2'
-}
-[2025-08-22T09:52:47.425Z] Starting token mint operation {
-  mint: '8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS',
-  amount: '1000000000000',
-  recipient: 'EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB'
-}
-[2025-08-22T09:53:01.694Z] ATA created successfully {
-  tokenAccount: '4k3FoESSV3MHg1iKScE1Ccqeb3PfHiz71nX5PgkaL1kz',
-  signature: '3eLGA18SbGmfPJNcEfrJqiDUsuyDrRMN8Y61oupGxkZnVjXvuEucEnH2UZGNzjAzUafKQrR7KaWAiuPrYesFD2K9'
-}
-[2025-08-22T09:53:15.908Z] Tokens minted successfully {
-  signature: '3N6YhEfedAtucAXoadgeg11BcDbdGJhiD1hva4Zk15QAsDjiq1LJPwD485f8BN7zrVtbQ81yw3ecruC2p5opTGp3',
-  amount: '1000000000000',
-  tokenAccount: '4k3FoESSV3MHg1iKScE1Ccqeb3PfHiz71nX5PgkaL1kz',
-  newBalance: '1000000000000'
-}
-[2025-08-22T09:53:15.908Z] Initial supply minted {
-  tokenAccount: '4k3FoESSV3MHg1iKScE1Ccqeb3PfHiz71nX5PgkaL1kz',
-  amount: '1000000000000'
-}
-[2025-08-22T09:53:15.909Z]
-[2025-08-22T09:53:15.909Z] ✅ SPL TOKEN CREATED SUCCESSFULLY
-[2025-08-22T09:53:15.909Z] ===============================================
-[2025-08-22T09:53:15.909Z] Mint Address: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T09:53:15.911Z] Transaction Signature: i3svbchAskKnVFQJzHXeEg6KVGTa1m43USW1mdZQeYLRvjvKgVNBmauiYMMdaPnSAA79mz9XPL3mkvFWbPgx9U2
-[2025-08-22T09:53:15.911Z] Token Account: 4k3FoESSV3MHg1iKScE1Ccqeb3PfHiz71nX5PgkaL1kz
-[2025-08-22T09:53:15.911Z]
+INFO [2026-06-15 06:00:21.843 +0530]: 🔍 Validating create mint parameters...
+INFO [2026-06-15 06:00:21.844 +0530]: 📋 Token Program: spl-token (TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA)
+INFO [2026-06-15 06:00:21.844 +0530]: 📋 Decimals: 9
+INFO [2026-06-15 06:00:21.844 +0530]: 📋 Metaplex metadata enabled
+INFO [2026-06-15 06:00:21.844 +0530]:    Name: "AEM"
+INFO [2026-06-15 06:00:21.844 +0530]:    Symbol: "CCIP-AEM"
+INFO [2026-06-15 06:00:21.844 +0530]:    URI: https://cyan-pleasant-anteater-613.mypinata.cloud/ipfs/bafkreieirlwjqbtzniqsgcjebzexlcspcmvd4woh3ajvf2p4fuivkenw6i
+INFO [2026-06-15 06:00:21.844 +0530]: 📋 Initial supply: 1000000000000 smallest units
+INFO [2026-06-15 06:00:21.844 +0530]: 📋 Recipient: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 06:00:21.844 +0530]: ✅ Parameter validation completed
+INFO [2026-06-15 06:00:21.844 +0530]: 🎨 Creating mint with Metaplex metadata...
+INFO [2026-06-15 06:00:21.845 +0530]: 📋 Generated mint address: AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
+INFO [2026-06-15 06:00:21.845 +0530]: 📋 Mint seed: mint_1781483421844_6ifalj
+INFO [2026-06-15 06:00:21.845 +0530]: 📋 Using token program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+INFO [2026-06-15 06:00:22.230 +0530]: 📋 Generated 3 instructions for mint + metadata creation
+INFO [2026-06-15 06:00:22.230 +0530]: 💰 Adding initial supply mint instructions...
+INFO [2026-06-15 06:00:22.232 +0530]: 📋 Creating ATA for recipient: 9Xv8WtoN9EpBfSjqWVoQfrf4qc5CMSvBmM5Hu9jApYhc
+INFO [2026-06-15 06:00:22.232 +0530]: 📋 Will mint 1000000000000 smallest units to 9Xv8WtoN9EpBfSjqWVoQfrf4qc5CMSvBmM5Hu9jApYhc
+INFO [2026-06-15 06:00:22.232 +0530]: 🔄 Building and simulating transaction...
+INFO [2026-06-15 06:00:22.232 +0530]: 📋 Metadata PDA: AaBhXgiCdKj3gfjDn5fwg58unUcF8Q7wRwHbfdxLu1os
+INFO [2026-06-15 06:00:22.425 +0530]: Transaction built successfully
+    instructionName: "spl-token.create_mint_with_metaplex"
+    transactionSize: "778 bytes"
+    base58Length: "1062 characters"
+    hexLength: "1556 characters"
+    accountCount: 2
+    signerCount: 1
+    computeUnits: 68049
+INFO [2026-06-15 06:00:22.425 +0530]: Completed buildTransaction (spl-token.create_mint_with_metaplex)
+    durationMs: 193
+INFO [2026-06-15 06:00:22.615 +0530]:
+INFO [2026-06-15 06:00:22.615 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-15 06:00:22.615 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 06:00:22.615 +0530]:    Instruction: spl-token.create_mint_with_metaplex
+INFO [2026-06-15 06:00:22.615 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-15 06:00:22.615 +0530]:
+INFO [2026-06-15 06:00:23.574 +0530]: Transaction confirmed successfully
+    signature: "2ETpQBQSCe5bYN7dXoyhhpwwrDz3P3SmsnVYsFMPuYddTk7qi8mneAJrpTRFoHDmWbv9ED1o7fHnnSz1ThsV8QS5"
+    attempt: 1
+INFO [2026-06-15 06:00:23.574 +0530]:
+INFO [2026-06-15 06:00:23.574 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-15 06:00:23.574 +0530]:
+INFO [2026-06-15 06:00:23.574 +0530]: 📋 Execution Details:
+INFO [2026-06-15 06:00:23.574 +0530]:    Instruction: spl-token.create_mint_with_metaplex
+INFO [2026-06-15 06:00:23.574 +0530]:    Signature:   2ETpQBQSCe5bYN7dXoyhhpwwrDz3P3SmsnVYsFMPuYddTk7qi8mneAJrpTRFoHDmWbv9ED1o7fHnnSz1ThsV8QS5
+INFO [2026-06-15 06:00:23.574 +0530]:    Explorer:    https://explorer.solana.com/tx/2ETpQBQSCe5bYN7dXoyhhpwwrDz3P3SmsnVYsFMPuYddTk7qi8mneAJrpTRFoHDmWbv9ED1o7fHnnSz1ThsV8QS5?cluster=devnet
+INFO [2026-06-15 06:00:23.574 +0530]:
+INFO [2026-06-15 06:00:23.574 +0530]: ✅ Transaction simulation completed
 ```
 
 </Fragment>
 </Tabs>
 
-### Set Environment Variables
-
-Set up environment variables for easier reference throughout the tutorial:
+Set the token mint variable:
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Set Environment Variables</Fragment>
+<Fragment slot="tab.1">Set Token Mint</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
-<Aside type="note" title="CCIP BurnMint Pool Program">
-  The CCIP BurnMint pool program is a self-service pool program that allows you to create a pool for your token.
-  You can find the program ID in the CCIP Directory for:
-
-     - [Solana Devnet](/ccip/directory/testnet/chain/solana-devnet)
-     - [Solana Mainnet](/ccip/directory/mainnet/chain/solana-mainnet)
-
-</Aside>
-
 ```bash
-# Set your token mint address from the previous output
+# Copy the mint address from the command output above
 export SOL_TOKEN_MINT="<REPLACE_WITH_YOUR_TOKEN_MINT_ADDRESS>"
-
-# Set your admin wallet (tutorial simplification - use governance multisig in production)
-export SOL_ADMIN_WALLET=$(solana address)
-
-# Set pool program (Chainlink self-service BurnMint pool program)
-export CCIP_POOL_PROGRAM=41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
 ```
 
-Verify your environment variables:
+Verify the variable:
 
 ```bash
-# Display for verification
 echo "Token Mint: $SOL_TOKEN_MINT"
-echo "Admin Wallet: $SOL_ADMIN_WALLET"
-echo "Pool Program: $CCIP_POOL_PROGRAM"
 ```
 
 </Fragment>
@@ -496,9 +531,7 @@ echo "Pool Program: $CCIP_POOL_PROGRAM"
 <Fragment slot="panel.2">
 
 ```bash
-Token Mint: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-Admin Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
+Token Mint: AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
 ```
 
 </Fragment>
@@ -506,7 +539,7 @@ Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
 
 ### Step 2: Initialize CCIP Token Pool
 
-In this step, you will use the `svm:pool:initialize` script to initialize a CCIP token pool for your SPL token. This process creates the necessary on-chain state for cross-chain operations and establishes the Pool Signer PDA that will manage token operations.
+Initialize a CCIP token pool for your SPL token. This creates the on-chain state for cross-chain operations and establishes the Pool Signer PDA that will become a multisig member.
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Initialize Pool</Fragment>
@@ -515,9 +548,11 @@ In this step, you will use the `svm:pool:initialize` script to initialize a CCIP
 <Fragment slot="panel.1">
 ```bash
 # Initialize pool for your token
-yarn svm:pool:initialize \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM
+pnpm bs58 --env devnet --execute burnmint-token-pool \
+  --instruction initialize-pool \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_ADMIN_WALLET
 ```
 
 </Fragment>
@@ -525,36 +560,36 @@ yarn svm:pool:initialize \
 <Fragment slot="panel.2">
 
 ```bash
-🎯 Pool Initialization Summary:
-[2025-08-22T10:00:57.305Z]    Token Mint:       8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:00:57.305Z]    Pool State PDA:   DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE
-[2025-08-22T10:00:57.305Z]    Pool Signer PDA:  GLgULP9HDnQy5kQkeEdJJeLXTW1qK7NAbQRJ8xNniNFo
-[2025-08-22T10:00:57.305Z]    Program ID:       41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-22T10:00:57.305Z]    Transaction:      4EBzqsc9JHnBF9yDGwoJWZzd6zXyxBB8zcSpw264mAzwi6enEj32vDeesFh16z6BuR5dnmd98iniR9jfNckKQezK
-[2025-08-22T10:00:57.305Z]
-[2025-08-22T10:00:57.306Z] ✅ POOL INITIALIZED SUCCESSFULLY
-[2025-08-22T10:00:57.306Z] ===========================================
-[2025-08-22T10:00:57.306Z] Transaction Signature: 4EBzqsc9JHnBF9yDGwoJWZzd6zXyxBB8zcSpw264mAzwi6enEj32vDeesFh16z6BuR5dnmd98iniR9jfNckKQezK
-[2025-08-22T10:00:57.306Z] 📍 Pool State PDA: DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE
-[2025-08-22T10:00:57.306Z]
-[2025-08-22T10:00:57.306Z] 🔍 EXPLORER URLS
-[2025-08-22T10:00:57.306Z] ===========================================
-[2025-08-22T10:00:57.307Z] Transaction: https://explorer.solana.com/tx/4EBzqsc9JHnBF9yDGwoJWZzd6zXyxBB8zcSpw264mAzwi6enEj32vDeesFh16z6BuR5dnmd98iniR9jfNckKQezK?cluster=devnet
-[2025-08-22T10:00:57.307Z]
-[2025-08-22T10:00:57.307Z] 🔍 VERIFICATION
-[2025-08-22T10:00:57.307Z] ===========================================
-[2025-08-22T10:00:57.307Z] Verifying pool initialization...
-[2025-08-22T10:00:57.309Z] 📍 Pool Config PDA: DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE
-[2025-08-22T10:00:57.552Z] ✅ Pool initialization verified successfully!
-[2025-08-22T10:00:57.552Z] ✅ State PDA confirmed active: DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE
-[2025-08-22T10:00:57.552Z]
-[2025-08-22T10:00:57.552Z] 🎯 POOL CREATION SUMMARY
-[2025-08-22T10:00:57.552Z] ===============================================
-[2025-08-22T10:00:57.552Z] Token Mint: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:00:57.552Z] State PDA: DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE
-[2025-08-22T10:00:57.553Z] Owner: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-22T10:00:57.553Z] Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-22T10:00:57.553Z]
+🔄 Generating initialize (pool) transaction...
+🔄 Building and simulating transaction...
+INFO [2026-06-15 06:05:05.108 +0530]: Transaction built successfully
+    instructionName: "burnmint-token-pool.initialize"
+    transactionSize: "279 bytes"
+    base58Length: "380 characters"
+    hexLength: "558 characters"
+    accountCount: 7
+    signerCount: 1
+    computeUnits: 24318
+INFO [2026-06-15 06:05:05.108 +0530]: Completed buildTransaction (burnmint-token-pool.initialize)
+    durationMs: 347
+INFO [2026-06-15 06:05:05.266 +0530]:
+INFO [2026-06-15 06:05:05.266 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-15 06:05:05.266 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 06:05:05.266 +0530]:    Instruction: burnmint-token-pool.initialize
+INFO [2026-06-15 06:05:05.266 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-15 06:05:05.266 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-15 06:05:06.299 +0530]: Transaction confirmed successfully
+    signature: "2FDvLxkNdTENjLWDkXrDtNYTWqCQwsRGJ7MkagY2B3teWdRxnPZyh1fgt4wihDkZQ7NxzXZ5e5DhQGi5p9oG3UMx"
+    attempt: 1
+INFO [2026-06-15 06:05:06.299 +0530]:
+INFO [2026-06-15 06:05:06.299 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-15 06:05:06.299 +0530]:
+INFO [2026-06-15 06:05:06.299 +0530]: 📋 Execution Details:
+INFO [2026-06-15 06:05:06.299 +0530]:    Instruction: burnmint-token-pool.initialize
+INFO [2026-06-15 06:05:06.299 +0530]:    Signature:   2FDvLxkNdTENjLWDkXrDtNYTWqCQwsRGJ7MkagY2B3teWdRxnPZyh1fgt4wihDkZQ7NxzXZ5e5DhQGi5p9oG3UMx
+INFO [2026-06-15 06:05:06.299 +0530]:    Explorer:    https://explorer.solana.com/tx/2FDvLxkNdTENjLWDkXrDtNYTWqCQwsRGJ7MkagY2B3teWdRxnPZyh1fgt4wihDkZQ7NxzXZ5e5DhQGi5p9oG3UMx?cluster=devnet
+INFO [2026-06-15 06:05:06.299 +0530]:
 ```
 
 </Fragment>
@@ -562,19 +597,21 @@ yarn svm:pool:initialize \
 
 ### Step 3: Verify Pool Creation
 
-In this step, you will use the `svm:pool:get-info` script to verify that your token pool was initialized correctly. This command queries the on-chain state and displays comprehensive information about your pool configuration, including the Pool Signer PDA and current ownership.
+Derive pool accounts using the read-only `derive-accounts` command:
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Verify Pool</Fragment>
+<Fragment slot="tab.1">Derive Pool Accounts</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Verify pool creation
-yarn svm:pool:get-info \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM
+# Derive Pool Signer PDA and Pool State PDA
+pnpm bs58 --env devnet utils \
+  --instruction derive-accounts \
+  --program-type burnmint-token-pool \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT
 ```
 
 </Fragment>
@@ -582,61 +619,83 @@ yarn svm:pool:get-info \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-22T10:01:49.699Z] 🔍 POOL EXISTENCE CHECK
-[2025-08-22T10:01:49.699Z] ===========================================
-[2025-08-22T10:01:49.699Z] Checking if pool exists...
-[2025-08-22T10:01:49.700Z] 📍 Pool Config PDA: DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE
-[2025-08-22T10:01:50.075Z]
-[2025-08-22T10:01:50.075Z] 📊 FETCHING POOL DATA
-[2025-08-22T10:01:50.075Z] ===========================================
-[2025-08-22T10:01:50.075Z] Fetching pool information...
-[2025-08-22T10:01:50.075Z] 📍 Pool Config PDA: DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE
-[2025-08-22T10:01:50.247Z] 📍 Global Config PDA: E4Bsi43kX3iwXAFia2ebm1mS5Xkmmdv3minZDnfo7Zzf
-[2025-08-22T10:01:50.343Z] \n================================================================================
-[2025-08-22T10:01:50.343Z] 🏊 BURN-MINT TOKEN POOL INFORMATION
-[2025-08-22T10:01:50.343Z] ================================================================================
-[2025-08-22T10:01:50.343Z] \n🌍 GLOBAL CONFIGURATION
-[2025-08-22T10:01:50.343Z] ----------------------------------------
-[2025-08-22T10:01:50.343Z] Program Version: 1
-[2025-08-22T10:01:50.343Z] Self-Served Pools: ✅ Enabled
-[2025-08-22T10:01:50.343Z] \n📋 BASIC INFORMATION
-[2025-08-22T10:01:50.343Z] ----------------------------------------
-[2025-08-22T10:01:50.343Z] Pool Type: burn-mint
-[2025-08-22T10:01:50.343Z] Version: 1
-[2025-08-22T10:01:50.343Z] Token Mint: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:01:50.343Z] Decimals: 9
-[2025-08-22T10:01:50.343Z] \n👥 OWNERSHIP & PERMISSIONS
-[2025-08-22T10:01:50.343Z] ----------------------------------------
-[2025-08-22T10:01:50.343Z] Current Owner: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-22T10:01:50.343Z] Proposed Owner: 11111111111111111111111111111111 (default/unset)
-[2025-08-22T10:01:50.343Z] Rate Limit Admin: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-22T10:01:50.343Z] \n🪙 TOKEN CONFIGURATION
-[2025-08-22T10:01:50.344Z] ----------------------------------------
-[2025-08-22T10:01:50.344Z] Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-22T10:01:50.344Z] Pool Signer PDA: GLgULP9HDnQy5kQkeEdJJeLXTW1qK7NAbQRJ8xNniNFo
-[2025-08-22T10:01:50.344Z] Pool Token Account: HaBXCZtWkJLAgagxeemKWoXmGYqP2fNQqtazuj6uJrxX
-[2025-08-22T10:01:50.344Z] \n🌉 CCIP INTEGRATION
-[2025-08-22T10:01:50.344Z] ----------------------------------------
-[2025-08-22T10:01:50.344Z] CCIP Router: Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
-[2025-08-22T10:01:50.344Z] Router Onramp Authority: H6ZviaabTYZqUPgiSoMDbeVthcNW9ULcAuUu3zRLFqDR
-[2025-08-22T10:01:50.344Z] RMN Remote: RmnXLft1mSEwDgMKu2okYuHkiazxntFFcZFrrcXxYg7
-[2025-08-22T10:01:50.344Z] \n🔒 SECURITY & CONTROLS
-[2025-08-22T10:01:50.344Z] ----------------------------------------
-[2025-08-22T10:01:50.344Z] Allowlist: ❌ Disabled
-[2025-08-22T10:01:50.344Z] \n⚖️ REBALANCING (Lock/Release Only)
-[2025-08-22T10:01:50.344Z] ----------------------------------------
-[2025-08-22T10:01:50.344Z] Rebalancer: 11111111111111111111111111111111 (default/unset)
-[2025-08-22T10:01:50.344Z] Can Accept Liquidity: ❌ Disabled
-[2025-08-22T10:01:50.344Z] \n📍 ADDRESS SUMMARY
-[2025-08-22T10:01:50.344Z] ----------------------------------------
-[2025-08-22T10:01:50.344Z] Token Mint:           8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:01:50.344Z] Pool Program:         41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-22T10:01:50.344Z] Pool Config PDA:      DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE  (Pool state account)
-[2025-08-22T10:01:50.344Z] Global Config PDA:    E4Bsi43kX3iwXAFia2ebm1mS5Xkmmdv3minZDnfo7Zzf  (Program global config)
-[2025-08-22T10:01:50.344Z] Pool Owner:           EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-22T10:01:50.345Z] Pool Signer PDA:      GLgULP9HDnQy5kQkeEdJJeLXTW1qK7NAbQRJ8xNniNFo  (Token authority)
-[2025-08-22T10:01:50.345Z] \n================================================================================
-[2025-08-22T10:01:50.345Z] ✅ Pool information retrieved successfully!
+🔍 Deriving burnmint-token-pool accounts...
+INFO [2026-06-15 06:10:15.947 +0530]: Starting deriveAccounts command
+    command: "derive-accounts"
+    programType: "burnmint-token-pool"
+    programId: "41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
+    mint: "AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7"
+    globalOptions: {
+      "environment": "devnet",
+      "resolvedRpcUrl": "https://api.devnet.solana.com"
+    }
+
+📊 Derived Accounts:
+
+1. Pool State PDA
+   Address: Fuu3EwnQkV4WUrcLj1atwEq4xbfkpgvXF5tMRYPg3nCm
+   Seeds: ["ccip_tokenpool_config", mint]
+   Bump: 255
+   Description: Main pool configuration account (created by initialize-pool)
+
+2. Pool Signer PDA
+   Address: 5LZUPpzMudPAX6BNaDrzjPE28YuGbQArvJucM2f7JJMe
+   Seeds: ["ccip_tokenpool_signer", mint]
+   Bump: 255
+   Description: 🎯 CRITICAL: Autonomous mint/burn authority for cross-chain operations
+
+3. Global Config PDA
+   Address: E4Bsi43kX3iwXAFia2ebm1mS5Xkmmdv3minZDnfo7Zzf
+   Seeds: ["config"]
+   Bump: 255
+   Description: Program-wide configuration settings
+
+4. Pool Token ATA
+   Address: 5FbZe44bPUK5HZHcZF84Jy6uutQS3PpWCDCr8yuKCpqv
+   Seeds: [mint, pool_signer_pda, token_program]
+   Description: Pool's token account (owned by Pool Signer PDA)
+
+🎯 CRITICAL ADDRESS FOR CROSS-CHAIN OPERATIONS:
+   Pool Signer PDA: 5LZUPpzMudPAX6BNaDrzjPE28YuGbQArvJucM2f7JJMe
+   ↳ This address signs all mint/burn transactions autonomously
+
+INFO [2026-06-15 06:10:16.348 +0530]: Detected SPL Token v1
+    mint: "AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+INFO [2026-06-15 06:10:16.350 +0530]: ✅ Account derivation completed successfully
+    command: "derive-accounts"
+```
+
+</Fragment>
+</Tabs>
+
+Copy the **Pool Signer PDA** and **Pool State PDA** from the output, then export them:
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Set Pool Variables</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+export SOL_POOL_SIGNER_PDA="<REPLACE_WITH_YOUR_POOL_SIGNER_PDA>"
+export SOL_POOL_CONFIG_PDA="<REPLACE_WITH_YOUR_POOL_STATE_PDA>"
+```
+
+Verify the variables:
+
+```bash
+echo "Pool Signer PDA: $SOL_POOL_SIGNER_PDA"
+echo "Pool Config PDA: $SOL_POOL_CONFIG_PDA"
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+Pool Signer PDA: 5LZUPpzMudPAX6BNaDrzjPE28YuGbQArvJucM2f7JJMe
+Pool Config PDA: Fuu3EwnQkV4WUrcLj1atwEq4xbfkpgvXF5tMRYPg3nCm
 ```
 
 </Fragment>
@@ -644,7 +703,7 @@ yarn svm:pool:get-info \
 
 ### Step 4: Create Pool Token Account
 
-In this step, you will use the `svm:pool:create-token-account` script to create an Associated Token Account (ATA) for the Pool Signer PDA. This ATA is required for the pool to hold and manage tokens during cross-chain transfer operations.
+Create an Associated Token Account (ATA) for the Pool Signer PDA. This ATA is required for the pool to hold and manage tokens during cross-chain transfer operations.
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Create Token Account</Fragment>
@@ -654,9 +713,9 @@ In this step, you will use the `svm:pool:create-token-account` script to create 
 
 ```bash
 # Create ATA for Pool Signer PDA
-yarn svm:pool:create-token-account \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM
+spl-token create-account $SOL_TOKEN_MINT \
+  --owner $SOL_POOL_SIGNER_PDA \
+  --fee-payer $HOME/.config/solana/id.json
 ```
 
 </Fragment>
@@ -664,83 +723,17 @@ yarn svm:pool:create-token-account \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-22T10:03:03.718Z] 🔍 VERIFYING POOL EXISTENCE
-[2025-08-22T10:03:03.718Z] ==========================================
-[2025-08-22T10:03:03.720Z] 📍 Pool Config PDA: DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE
-[2025-08-22T10:03:03.819Z] ✅ Pool exists
-[2025-08-22T10:03:03.820Z] Current pool token account: HaBXCZtWkJLAgagxeemKWoXmGYqP2fNQqtazuj6uJrxX
-[2025-08-22T10:03:03.820Z] Getting mint account info for 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS to determine token program ID...
-[2025-08-22T10:03:03.916Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-22T10:03:03.917Z] Pool signer PDA: GLgULP9HDnQy5kQkeEdJJeLXTW1qK7NAbQRJ8xNniNFo
-[2025-08-22T10:03:03.918Z] Expected pool token account (ATA): HaBXCZtWkJLAgagxeemKWoXmGYqP2fNQqtazuj6uJrxX
-[2025-08-22T10:03:03.918Z]
-[2025-08-22T10:03:03.918Z] 🔍 CHECKING EXISTING ACCOUNT
-[2025-08-22T10:03:03.918Z] ==========================================
-[2025-08-22T10:03:04.012Z]
-[2025-08-22T10:03:04.012Z] 🔧 CREATING POOL TOKEN ACCOUNT
-[2025-08-22T10:03:04.012Z] ==========================================
-[2025-08-22T10:03:04.012Z] Creating pool token account (ATA)...
-[2025-08-22T10:03:05.348Z]
-[2025-08-22T10:03:05.348Z] ✅ POOL TOKEN ACCOUNT CREATED SUCCESSFULLY
-[2025-08-22T10:03:05.348Z] ==========================================
-[2025-08-22T10:03:05.349Z] Transaction Signature: 2Coz7UvAbQdCDbqbCxFNky9GoGek7ispM2FQrydVoww8Bk4QGgUyMcxPuDiat1sTQwtcAcFsze4ogHkJ42N7E3RE
-[2025-08-22T10:03:05.349Z] Pool Token Account Address: HaBXCZtWkJLAgagxeemKWoXmGYqP2fNQqtazuj6uJrxX
-[2025-08-22T10:03:05.349Z]
-[2025-08-22T10:03:05.349Z] 🔍 EXPLORER URLS
-[2025-08-22T10:03:05.349Z] ==========================================
-[2025-08-22T10:03:05.349Z] Transaction: https://explorer.solana.com/tx/2Coz7UvAbQdCDbqbCxFNky9GoGek7ispM2FQrydVoww8Bk4QGgUyMcxPuDiat1sTQwtcAcFsze4ogHkJ42N7E3RE?cluster=devnet
-[2025-08-22T10:03:05.349Z]
-[2025-08-22T10:03:05.349Z] 🔍 VERIFYING ACCOUNT CREATION
-[2025-08-22T10:03:05.349Z] ==========================================
-[2025-08-22T10:03:05.477Z] ✅ Account creation verified!
-[2025-08-22T10:03:05.477Z]
-[2025-08-22T10:03:05.477Z] 🎉 Pool Token Account Setup Complete!
-[2025-08-22T10:03:05.477Z] ✅ ATA Address: HaBXCZtWkJLAgagxeemKWoXmGYqP2fNQqtazuj6uJrxX
-[2025-08-22T10:03:05.477Z] ✅ Owner: GLgULP9HDnQy5kQkeEdJJeLXTW1qK7NAbQRJ8xNniNFo (Pool Signer PDA)
+Creating account 5FbZe44bPUK5HZHcZF84Jy6uutQS3PpWCDCr8yuKCpqv
+
+Signature: 2TPHNUMP5bxHfMuJd1xUo2oNgg9wSmStivpKXXkjumQpfLok68uQ4CvN9NZm1bLzuXAUpxbhsuwKVcdNuCzvVDQG
 ```
 
 </Fragment>
 </Tabs>
 
-### Step 5: Set Pool Environment Variables
+### Step 5: Claim Admin
 
-Set the Pool Signer PDA and Pool Config PDA from the Step 3 output above:
-
-<Tabs client:visible>
-<Fragment slot="tab.1">Set Pool Env Variables</Fragment>
-<Fragment slot="tab.2">Expected Output</Fragment>
-
-<Fragment slot="panel.1">
-
-```bash
-# Set Pool Signer PDA from the Step 3 output above
-export SOL_POOL_SIGNER_PDA="<REPLACE_WITH_YOUR_POOL_SIGNER_PDA>"
-
-# Set Pool Config PDA from the Step 3 output above
-export SOL_POOL_CONFIG_PDA="<REPLACE_WITH_YOUR_CONFIG_PDA>"
-```
-
-Verify output:
-
-```bash
-echo "Pool Signer PDA: $SOL_POOL_SIGNER_PDA"
-echo "Pool Config PDA: $SOL_POOL_CONFIG_PDA"
-```
-
-</Fragment>
-<Fragment slot="panel.2">
-
-```bash
-Pool Signer PDA: GLgULP9HDnQy5kQkeEdJJeLXTW1qK7NAbQRJ8xNniNFo
-Pool Config PDA: DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE
-```
-
-</Fragment>
-</Tabs>
-
-### Step 6: Claim Admin
-
-In this step, you will use the `svm:admin:propose-administrator` and `svm:admin:accept-admin-role` scripts to register yourself as the CCIP administrator for the Solana token. This process establishes your control over the token's CCIP configuration on Solana.
+Register yourself as the CCIP administrator for the Solana token. This must be completed while you still hold the mint authority.
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Propose Admin</Fragment>
@@ -750,45 +743,57 @@ In this step, you will use the `svm:admin:propose-administrator` and `svm:admin:
 
 ```bash
 # Propose yourself as CCIP administrator (requires mint authority)
-
-yarn svm:admin:propose-administrator \
- --token-mint $SOL_TOKEN_MINT
-
+pnpm bs58 --env devnet --execute router \
+  --instruction owner-propose-administrator \
+  --program-id $SOL_CCIP_ROUTER \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_ADMIN_WALLET \
+  --token-admin-registry-admin $SOL_ADMIN_WALLET
 ```
-
-<Aside type="caution" title="Mint Authority Required">
-  **Critical Sequence**: This step MUST be completed while you still hold the mint authority. The Router's
-  `owner_propose_administrator` instruction verifies that the caller is the token's mint authority holder.
-</Aside>
 
 </Fragment>
 
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-22T10:22:08.424Z] ✅ ADMINISTRATOR PROPOSAL SUCCESSFUL!
-[2025-08-22T10:22:08.424Z] =========================================================
-[2025-08-22T10:22:08.424Z] Transaction Signature: 4hcxmjWdMX91qWxKRs4RAGAo3eYZm5QXahEfHa118D69RyddPqgaReJyAPtcNzaxomuSKMd6Tb4k5DMSCWKP1vUH
-[2025-08-22T10:22:08.424Z] Explorer URL: https://explorer.solana.com/tx/4hcxmjWdMX91qWxKRs4RAGAo3eYZm5QXahEfHa118D69RyddPqgaReJyAPtcNzaxomuSKMd6Tb4k5DMSCWKP1vUH?cluster=devnet
-[2025-08-22T10:22:08.425Z]
-[2025-08-22T10:22:08.425Z] 📋 REGISTRY INFORMATION
-[2025-08-22T10:22:08.425Z] =========================================================
-[2025-08-22T10:22:08.425Z] Token Mint: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:22:08.425Z] Proposed Administrator: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-22T10:22:08.425Z] Registry Created/Updated By: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-22T10:22:08.425Z]
-[2025-08-22T10:22:08.425Z] 🎉 SUCCESS!
-[2025-08-22T10:22:08.426Z] Administrator proposal completed successfully!
-[2025-08-22T10:22:08.426Z] Since you proposed yourself, you can now accept the role.
-[2025-08-22T10:22:08.426Z]
+🔄 Generating owner_propose_administrator transaction...
+🔄 Building and simulating transaction...
+INFO [2026-06-15 06:21:05.087 +0530]: Transaction built successfully
+    instructionName: "router.owner_propose_administrator"
+    transactionSize: "277 bytes"
+    base58Length: "377 characters"
+    hexLength: "554 characters"
+    accountCount: 5
+    signerCount: 1
+    computeUnits: 25731
+INFO [2026-06-15 06:21:05.088 +0530]: Completed buildTransaction (router.owner_propose_administrator)
+    durationMs: 379
+INFO [2026-06-15 06:21:05.251 +0530]:
+INFO [2026-06-15 06:21:05.252 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-15 06:21:05.252 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 06:21:05.252 +0530]:    Instruction: router.owner_propose_administrator
+INFO [2026-06-15 06:21:05.252 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-15 06:21:05.252 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-15 06:21:06.039 +0530]: Transaction confirmed successfully
+    signature: "28884ViTfXiCsGh5dQAbA8WCNvyGf8XgFiTDFT7CnzzsjBteAR9yDVrkAtwo6Jn66vmPH2Cz55CUM7cSqprdGy1i"
+    attempt: 1
+INFO [2026-06-15 06:21:06.039 +0530]:
+INFO [2026-06-15 06:21:06.039 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-15 06:21:06.039 +0530]:
+INFO [2026-06-15 06:21:06.039 +0530]: 📋 Execution Details:
+INFO [2026-06-15 06:21:06.039 +0530]:    Instruction: router.owner_propose_administrator
+INFO [2026-06-15 06:21:06.039 +0530]:    Signature:   28884ViTfXiCsGh5dQAbA8WCNvyGf8XgFiTDFT7CnzzsjBteAR9yDVrkAtwo6Jn66vmPH2Cz55CUM7cSqprdGy1i
+INFO [2026-06-15 06:21:06.039 +0530]:    Explorer:    https://explorer.solana.com/tx/28884ViTfXiCsGh5dQAbA8WCNvyGf8XgFiTDFT7CnzzsjBteAR9yDVrkAtwo6Jn66vmPH2Cz55CUM7cSqprdGy1i?cluster=devnet
+INFO [2026-06-15 06:21:06.039 +0530]:
 ```
 
 </Fragment>
 </Tabs>
 
-### Step 7: Accept Admin Role
+### Step 6: Accept Admin Role
 
-In this step, you will use the `svm:admin:accept-admin-role` script to accept the proposed administrator role. This process establishes your control over the token's CCIP configuration on Solana.
+Accept the proposed administrator role to establish CCIP admin control:
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Accept Admin Role</Fragment>
@@ -798,8 +803,11 @@ In this step, you will use the `svm:admin:accept-admin-role` script to accept th
 
 ```bash
 # Accept the proposed administrator role
-yarn svm:admin:accept-admin-role \
-  --token-mint $SOL_TOKEN_MINT
+pnpm bs58 --env devnet --execute router \
+  --instruction accept-admin-role \
+  --program-id $SOL_CCIP_ROUTER \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_ADMIN_WALLET
 ```
 
 </Fragment>
@@ -807,32 +815,42 @@ yarn svm:admin:accept-admin-role \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-22T10:23:08.598Z] 🎯 ACCEPTING ADMINISTRATOR ROLE
-[2025-08-22T10:23:08.598Z] ======================================================
-[2025-08-22T10:23:08.598Z] Preparing to accept administrator role...
-[2025-08-22T10:23:08.598Z] Token: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:23:08.598Z] New Administrator (you): EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-22T10:23:08.598Z] Previous Administrator: 11111111111111111111111111111111
-[2025-08-22T10:23:08.598Z] Accepting admin role for token: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:23:22.425Z] Admin role accepted successfully. Tx signature: 445fREW1ipPSSnp57hvVo31DU69LVaxbhvRbvgsgCQfzk1agg4wbu2Z9iP5W6pHCW4qZXFukNuhsE1n7VjVgHZ86
-[2025-08-22T10:23:22.425Z]
-[2025-08-22T10:23:22.425Z] ✅ ROLE ACCEPTANCE SUCCESSFUL!
-[2025-08-22T10:23:22.425Z] ======================================================
-[2025-08-22T10:23:22.426Z] Transaction Signature: 445fREW1ipPSSnp57hvVo31DU69LVaxbhvRbvgsgCQfzk1agg4wbu2Z9iP5W6pHCW4qZXFukNuhsE1n7VjVgHZ86
-[2025-08-22T10:23:22.426Z] Explorer URL: https://explorer.solana.com/tx/445fREW1ipPSSnp57hvVo31DU69LVaxbhvRbvgsgCQfzk1agg4wbu2Z9iP5W6pHCW4qZXFukNuhsE1n7VjVgHZ86?cluster=devnet
-[2025-08-22T10:23:22.426Z]
-[2025-08-22T10:23:22.426Z] 📋 UPDATED REGISTRY INFORMATION
-[2025-08-22T10:23:22.426Z] ======================================================
-[2025-08-22T10:23:22.428Z] Token Mint: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:23:22.429Z] New Administrator: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-22T10:23:22.429Z] Previous Administrator: 11111111111111111111111111111111
-[2025-08-22T10:23:22.429Z]
+🔄 Generating accept_admin_role_token_admin_registry transaction...
+🔄 Building and simulating transaction...
+INFO [2026-06-15 06:23:30.001 +0530]: Transaction built successfully
+    instructionName: "router.accept_admin_role_token_admin_registry"
+    transactionSize: "212 bytes"
+    base58Length: "289 characters"
+    hexLength: "424 characters"
+    accountCount: 4
+    signerCount: 1
+    computeUnits: 21454
+INFO [2026-06-15 06:23:30.001 +0530]: Completed buildTransaction (router.accept_admin_role_token_admin_registry)
+    durationMs: 398
+INFO [2026-06-15 06:23:30.188 +0530]:
+INFO [2026-06-15 06:23:30.188 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-15 06:23:30.188 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 06:23:30.188 +0530]:    Instruction: router.accept_admin_role_token_admin_registry
+INFO [2026-06-15 06:23:30.188 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-15 06:23:30.188 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-15 06:23:31.062 +0530]: Transaction confirmed successfully
+    signature: "TzYbpW9M463X9j3ut7VUZ4KRcphUYqRPYJCTsLthgEcJvQhQXtekEbLChDk4VN1xPJxLW7MGqDGSYRdsfruC1Xe"
+    attempt: 1
+INFO [2026-06-15 06:23:31.062 +0530]:
+INFO [2026-06-15 06:23:31.062 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-15 06:23:31.062 +0530]:
+INFO [2026-06-15 06:23:31.062 +0530]: 📋 Execution Details:
+INFO [2026-06-15 06:23:31.062 +0530]:    Instruction: router.accept_admin_role_token_admin_registry
+INFO [2026-06-15 06:23:31.062 +0530]:    Signature:   TzYbpW9M463X9j3ut7VUZ4KRcphUYqRPYJCTsLthgEcJvQhQXtekEbLChDk4VN1xPJxLW7MGqDGSYRdsfruC1Xe
+INFO [2026-06-15 06:23:31.062 +0530]:    Explorer:    https://explorer.solana.com/tx/TzYbpW9M463X9j3ut7VUZ4KRcphUYqRPYJCTsLthgEcJvQhQXtekEbLChDk4VN1xPJxLW7MGqDGSYRdsfruC1Xe?cluster=devnet
+INFO [2026-06-15 06:23:31.062 +0530]:
 ```
 
 </Fragment>
 </Tabs>
 
-### Step 8: Create SPL Token Multisig
+### Step 7: Create SPL Token Multisig
 
 Now that CCIP registration is complete, create the SPL token multisig that will serve as the mint authority:
 
@@ -844,18 +862,21 @@ Now that CCIP registration is complete, create the SPL token multisig that will 
 
 ```bash
 # Create 1-of-2 multisig with Pool Signer PDA and admin wallet (tutorial setup)
-spl-token create-multisig 1 $SOL_POOL_SIGNER_PDA $SOL_ADMIN_WALLET
+pnpm bs58 --env devnet --execute spl-token \
+  --instruction create-multisig \
+  --authority $SOL_ADMIN_WALLET \
+  --seed "ccip-multisig-001" \
+  --mint $SOL_TOKEN_MINT \
+  --signers "[\"$SOL_POOL_SIGNER_PDA\",\"$SOL_ADMIN_WALLET\"]" \
+  --threshold 1
 ```
 
-<Aside type="note" title="Mutlisig Command details">
+<Aside type="note" title="Multisig Command Details">
 
-The `spl-token create-multisig` command creates a multisig account that can be used as the mint authority for the token.
+The `create-multisig` instruction creates a deterministic SPL token multisig account using `createAccountWithSeed`. The CLI derives the multisig address from your authority, seed, and mint. See the [CCIP Solana BS58 Generator README](https://github.com/smartcontractkit/ccip-solana-bs58-generator#create-multisig) for full options.
 
-The command takes the following arguments:
-
-- `1`: The number of signers required to authorize a transaction.
-- `$SOL_POOL_SIGNER_PDA`: The PDA of the pool signer.
-- `$SOL_ADMIN_WALLET`: The wallet address of the admin.
+- `--threshold 1`: One signature required (1-of-2 for this tutorial)
+- `--signers`: Pool Signer PDA (autonomous CCIP operations) and Admin Wallet (governance)
 
 </Aside>
 
@@ -864,9 +885,40 @@ The command takes the following arguments:
 <Fragment slot="panel.2">
 
 ```bash
-Creating 1/2 multisig 555G9UPbWGpDAcbpLbvhe793fLHVT72hBU9xWP2pJNxm under program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-
-Signature: 3Ds6bZgQ5s8BjiKHzCPb32ro916y653tNUcSarwvbcLuzXK4gDtpUxAzwFF5Z4st35fEfvfF8ppLPi9X58K6kn8W
+INFO [2026-06-15 06:28:57.267 +0530]: Detected SPL Token v1
+    mint: "AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+📮 Derived SPL Token Multisig Address: A4SnwAxQnfuMn5DcZbipwawAfDz3aAosw81ujdSq543C
+💡 Address derived from: authority + sha256("ccip-multisig-001" + mint).hex().slice(0,32) + tokenProgram
+INFO [2026-06-15 06:28:57.359 +0530]: 🔄 Building and simulating transaction...
+INFO [2026-06-15 06:28:57.544 +0530]: Transaction built successfully
+    instructionName: "spl.create_multisig"
+    transactionSize: "367 bytes"
+    base58Length: "500 characters"
+    hexLength: "734 characters"
+    accountCount: 2
+    signerCount: 1
+    computeUnits: 317
+INFO [2026-06-15 06:28:57.544 +0530]: Completed buildTransaction (spl.create_multisig)
+    durationMs: 185
+INFO [2026-06-15 06:28:57.727 +0530]:
+INFO [2026-06-15 06:28:57.727 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-15 06:28:57.727 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 06:28:57.727 +0530]:    Instruction: spl.create_multisig
+INFO [2026-06-15 06:28:57.727 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-15 06:28:57.727 +0530]:
+INFO [2026-06-15 06:28:58.428 +0530]: Transaction confirmed successfully
+    signature: "4JCXtsukV7f4ggfWPRrrVA6kgoaMvwtR1gqAXNBYM9vHdNKKqqidF4rkKPMrURgCdL1yY4TMaU8KibkZm3836FwL"
+    attempt: 1
+INFO [2026-06-15 06:28:58.428 +0530]:
+INFO [2026-06-15 06:28:58.428 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-15 06:28:58.428 +0530]:
+INFO [2026-06-15 06:28:58.428 +0530]: 📋 Execution Details:
+INFO [2026-06-15 06:28:58.428 +0530]:    Instruction: spl.create_multisig
+INFO [2026-06-15 06:28:58.428 +0530]:    Signature:   4JCXtsukV7f4ggfWPRrrVA6kgoaMvwtR1gqAXNBYM9vHdNKKqqidF4rkKPMrURgCdL1yY4TMaU8KibkZm3836FwL
+INFO [2026-06-15 06:28:58.428 +0530]:    Explorer:    https://explorer.solana.com/tx/4JCXtsukV7f4ggfWPRrrVA6kgoaMvwtR1gqAXNBYM9vHdNKKqqidF4rkKPMrURgCdL1yY4TMaU8KibkZm3836FwL?cluster=devnet
+INFO [2026-06-15 06:28:58.428 +0530]:
+INFO [2026-06-15 06:28:58.428 +0530]: ✅ Transaction simulation completed
 ```
 
 </Fragment>
@@ -896,13 +948,13 @@ echo "Multisig Address: $SOL_MULTISIG_ADDRESS"
 <Fragment slot="panel.2">
 
 ```bash
-Multisig Address: 555G9UPbWGpDAcbpLbvhe793fLHVT72hBU9xWP2pJNxm
+Multisig Address: A4SnwAxQnfuMn5DcZbipwawAfDz3aAosw81ujdSq543C
 ```
 
 </Fragment>
 </Tabs>
 
-### Step 9: Transfer Mint Authority to Multisig
+### Step 8: Transfer Mint Authority to Multisig
 
 Now transfer the mint authority from your wallet to the multisig:
 
@@ -913,7 +965,11 @@ Now transfer the mint authority from your wallet to the multisig:
 <Fragment slot="panel.1">
 ```bash
 # Transfer mint authority to multisig
-spl-token authorize $SOL_TOKEN_MINT mint $SOL_MULTISIG_ADDRESS
+pnpm bs58 --env devnet --execute spl-token \
+  --instruction transfer-mint-authority \
+  --authority $SOL_ADMIN_WALLET \
+  --mint $SOL_TOKEN_MINT \
+  --new-mint-authority $SOL_MULTISIG_ADDRESS
 ```
 
 </Fragment>
@@ -921,17 +977,44 @@ spl-token authorize $SOL_TOKEN_MINT mint $SOL_MULTISIG_ADDRESS
 <Fragment slot="panel.2">
 
 ```bash
-Updating 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-  Current mint: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-  New mint: 555G9UPbWGpDAcbpLbvhe793fLHVT72hBU9xWP2pJNxm
-
-Signature: 2SowgDgySvC1Mz42j5ScReqWWdjPV6sk8GbTqB6mL9m7AMpiton1oR2WHhEtJbwsbuRV7HRUttgqLA54RNYCGrxE
+INFO [2026-06-15 06:31:24.796 +0530]: Detected SPL Token v1
+    mint: "AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+INFO [2026-06-15 06:31:24.796 +0530]: 🔄 Building and simulating transaction...
+INFO [2026-06-15 06:31:24.968 +0530]: Transaction built successfully
+    instructionName: "spl.transfer_mint_authority"
+    transactionSize: "173 bytes"
+    base58Length: "235 characters"
+    hexLength: "346 characters"
+    accountCount: 2
+    signerCount: 1
+    computeUnits: 125
+INFO [2026-06-15 06:31:24.968 +0530]: Completed buildTransaction (spl.transfer_mint_authority)
+    durationMs: 171
+INFO [2026-06-15 06:31:25.137 +0530]:
+INFO [2026-06-15 06:31:25.137 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-15 06:31:25.137 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 06:31:25.137 +0530]:    Instruction: spl.transfer_mint_authority
+INFO [2026-06-15 06:31:25.137 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-15 06:31:25.137 +0530]:
+INFO [2026-06-15 06:31:25.879 +0530]: Transaction confirmed successfully
+    signature: "3e1hdrQuhNfMYMYf3eNHVgajUoRmi9d9ajvyksKiJKnCoU6bTs5o5m2mToXrB3qe28WQSsnCZs2mMUAfWd2DV2m"
+    attempt: 1
+INFO [2026-06-15 06:31:25.879 +0530]:
+INFO [2026-06-15 06:31:25.879 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-15 06:31:25.879 +0530]:
+INFO [2026-06-15 06:31:25.879 +0530]: 📋 Execution Details:
+INFO [2026-06-15 06:31:25.879 +0530]:    Instruction: spl.transfer_mint_authority
+INFO [2026-06-15 06:31:25.879 +0530]:    Signature:   3e1hdrQuhNfMYMYf3eNHVgajUoRmi9d9ajvyksKiJKnCoU6bTs5o5m2mToXrB3qe28WQSsnCZs2mMUAfWd2DV2m
+INFO [2026-06-15 06:31:25.879 +0530]:    Explorer:    https://explorer.solana.com/tx/3e1hdrQuhNfMYMYf3eNHVgajUoRmi9d9ajvyksKiJKnCoU6bTs5o5m2mToXrB3qe28WQSsnCZs2mMUAfWd2DV2m?cluster=devnet
+INFO [2026-06-15 06:31:25.879 +0530]:
+INFO [2026-06-15 06:31:25.879 +0530]: ✅ Transaction simulation completed
 ```
 
 </Fragment>
 </Tabs>
 
-### Step 10: Verify Multisig Configuration
+### Step 9: Verify Multisig Configuration
 
 Verify that the multisig has been properly configured and the mint authority has been transferred:
 
@@ -955,27 +1038,33 @@ spl-token display $SOL_MULTISIG_ADDRESS
 
 ```bash
 SPL Token Mint
-  Address: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
+  Address: AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
   Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
   Supply: 1000000000000
   Decimals: 9
-  Mint authority: 555G9UPbWGpDAcbpLbvhe793fLHVT72hBU9xWP2pJNxm
-  Freeze authority: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
+  Mint authority: A4SnwAxQnfuMn5DcZbipwawAfDz3aAosw81ujdSq543C
+  Freeze authority: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
 
 
 SPL Token Multisig
-  Address: 555G9UPbWGpDAcbpLbvhe793fLHVT72hBU9xWP2pJNxm
+  Address: A4SnwAxQnfuMn5DcZbipwawAfDz3aAosw81ujdSq543C
   Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
   M/N: 1/2
   Signers:
-    1: GLgULP9HDnQy5kQkeEdJJeLXTW1qK7NAbQRJ8xNniNFo
-    2: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
+    1: 5LZUPpzMudPAX6BNaDrzjPE28YuGbQArvJucM2f7JJMe
+    2: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
 ```
 
 </Fragment>
 </Tabs>
 
 Save the Phase 2 variables for cross-terminal access:
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Save Variables</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
 
 ```bash
 # Save all variables from Phases 1 and 2 to complete vars file
@@ -984,24 +1073,46 @@ export ETH_TOKEN_ADDRESS="$ETH_TOKEN_ADDRESS"
 export ETH_POOL_ADDRESS="$ETH_POOL_ADDRESS"
 export SOL_TOKEN_MINT="$SOL_TOKEN_MINT"
 export SOL_ADMIN_WALLET="$SOL_ADMIN_WALLET"
-export CCIP_POOL_PROGRAM="$CCIP_POOL_PROGRAM"
+export SOL_CCIP_POOL_PROGRAM="$SOL_CCIP_POOL_PROGRAM"
+export SOL_CCIP_ROUTER="$SOL_CCIP_ROUTER"
+export SOL_CCIP_FEE_QUOTER_PROGRAM="$SOL_CCIP_FEE_QUOTER_PROGRAM"
+export ETH_SEPOLIA_CHAIN_SELECTOR="$ETH_SEPOLIA_CHAIN_SELECTOR"
 export SOL_POOL_SIGNER_PDA="$SOL_POOL_SIGNER_PDA"
 export SOL_POOL_CONFIG_PDA="$SOL_POOL_CONFIG_PDA"
 export SOL_MULTISIG_ADDRESS="$SOL_MULTISIG_ADDRESS"
 EOF
 
-echo "All variables saved to ~/.ccip_complete_vars for cross-terminal access"
+echo "=== Phase 2 Complete - Solana Setup ==="
+echo "✅ SOL Token: $SOL_TOKEN_MINT"
+echo "✅ Pool Signer PDA: $SOL_POOL_SIGNER_PDA"
+echo "✅ Multisig Address: $SOL_MULTISIG_ADDRESS"
+echo "✅ Variables saved to ~/.ccip_complete_vars"
 ```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+=== Phase 2 Complete - Solana Setup ===
+✅ SOL Token: AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
+✅ Pool Signer PDA: 5LZUPpzMudPAX6BNaDrzjPE28YuGbQArvJucM2f7JJMe
+✅ Multisig Address: A4SnwAxQnfuMn5DcZbipwawAfDz3aAosw81ujdSq543C
+✅ Variables saved to ~/.ccip_complete_vars
+```
+
+</Fragment>
+</Tabs>
 
 ## Phase 3: Cross-Chain Configuration
 
-In this step, you will configure bidirectional connectivity between the token pools on both chains. Each chain uses different tools: **Solana** uses Starter Kit scripts to configure its pool to recognize Ethereum tokens and pools, while **Ethereum** uses Hardhat tasks to configure its pool to recognize Solana tokens and pools.
+In this step, you will configure bidirectional connectivity between the token pools on both chains. Each chain uses different tools: **Solana** uses [CCIP Solana BS58 Generator](https://github.com/smartcontractkit/ccip-solana-bs58-generator) commands to configure its pool to recognize Ethereum tokens and pools, while **Ethereum** uses Hardhat tasks to configure its pool to recognize Solana tokens and pools.
 
 ### Step 1: Configure Solana -> Ethereum
 
 #### Initialize Chain Remote Configuration
 
-In this step, you will use the `svm:pool:init-chain-remote-config` script to initialize the configuration for Ethereum Sepolia as a remote chain. This creates the basic chain configuration with token information but without pool addresses (those will be added in the next step).
+In this step, you will initialize the configuration for Ethereum Sepolia as a remote chain. This creates the basic chain configuration with token information but without pool addresses (those will be added in the next step).
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Initialize Config</Fragment>
@@ -1010,46 +1121,103 @@ In this step, you will use the `svm:pool:init-chain-remote-config` script to ini
 <Fragment slot="panel.1">
 ```bash
 # Initialize remote chain configuration for Ethereum Sepolia
-yarn svm:pool:init-chain-remote-config \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM \
-  --remote-chain ethereum-sepolia \
+pnpm bs58 --env devnet --execute burnmint-token-pool \
+  --instruction init-chain-remote-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_ADMIN_WALLET \
+  --remote-chain-selector $ETH_SEPOLIA_CHAIN_SELECTOR \
+  --pool-addresses '[]' \
   --token-address $ETH_TOKEN_ADDRESS \
   --decimals 9
 ```
-
-<Aside type="note" title="Expected Error Message">
-  You will see "Error: Chain config not found" in the output - this is **expected behavior** since we are creating the
-  configuration for the first time. The script will continue and successfully create the new configuration.
-</Aside>
 
 </Fragment>
 
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-22T10:36:13.643Z] Chain remote config initialized: 4DUicb3oeh5dpBYvZJsYc3kkHtjcUZUt1fkwhMVWHDra1p2J7mdcd7tsfrTEGP1wT7LFve7aQoD57VmHZQugT6jJ
-[2025-08-22T10:36:13.975Z]
-[2025-08-22T10:36:13.976Z] ✅ CHAIN CONFIG INITIALIZED SUCCESSFULLY
-[2025-08-22T10:36:13.976Z] ==========================================
-[2025-08-22T10:36:13.976Z] Transaction Signature: 4DUicb3oeh5dpBYvZJsYc3kkHtjcUZUt1fkwhMVWHDra1p2J7mdcd7tsfrTEGP1wT7LFve7aQoD57VmHZQugT6jJ
-[2025-08-22T10:36:13.976Z]
-[2025-08-22T10:36:13.976Z] 🔍 EXPLORER URLS
-[2025-08-22T10:36:13.976Z] ==========================================
-[2025-08-22T10:36:13.976Z] Transaction: https://explorer.solana.com/tx/4DUicb3oeh5dpBYvZJsYc3kkHtjcUZUt1fkwhMVWHDra1p2J7mdcd7tsfrTEGP1wT7LFve7aQoD57VmHZQugT6jJ?cluster=devnet
-[2025-08-22T10:36:13.976Z]
-[2025-08-22T10:36:13.976Z] 📋 NEXT STEPS
-[2025-08-22T10:36:13.976Z] ==========================================
-[2025-08-22T10:36:13.976Z] 1. View configuration details:
-[2025-08-22T10:36:13.976Z]    yarn svm:pool:get-info --token-mint 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS --burn-mint-pool-program 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-22T10:36:13.976Z]
-[2025-08-22T10:36:13.976Z] 2. Add pool addresses to enable cross-chain transfers:
-[2025-08-22T10:36:13.976Z]    yarn svm:pool:edit-chain-remote-config --token-mint 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS --burn-mint-pool-program 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB --remote-chain ethereum-sepolia --pool-addresses "0x..." --token-address "0x84426E21208D73E8D3760d9cbc4FaEFa279d3720" --decimals 9
-[2025-08-22T10:36:13.976Z]
-[2025-08-22T10:36:13.976Z] 🎉 Chain Configuration Initialization Complete!
-[2025-08-22T10:36:13.976Z] ✅ Remote chain ethereum-sepolia configuration created
-[2025-08-22T10:36:13.976Z] ✅ Token address and decimals configured
-[2025-08-22T10:36:13.976Z] ⚠️  Pool addresses must be added before transfers can occur
+🔄 Generating initChainRemoteConfig transaction...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
+   Mint: AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
+   Authority: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+   Remote Chain Selector: 16015286601757825753
+   Pool Addresses: 0 addresses (must be empty at init)
+   Token Address: 45cfb05d6278715716023ebeec733c081ce9f822
+   Decimals: 9
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-15 06:34:38.867 +0530]: Starting initChainRemoteConfig command
+    command: "burnmint-token-pool.init-chain-remote-config"
+    programId: "41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
+    mint: "AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7"
+    authority: "GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN"
+    remoteChainSelector: "16015286601757825753"
+    poolAddresses: "[]"
+    tokenAddress: "0x45cfb05d6278715716023ebeec733c081ce9f822"
+    decimals: "9"
+    globalOptions: {
+      "environment": "devnet",
+      "execute": true,
+      "resolvedRpcUrl": "https://api.devnet.solana.com",
+      "keypair": "/Users/syed-cll/.config/solana/id.json",
+      "_signerKeypair": {
+        "_keypair": {
+          "publicKey": {
+            "0": 230,
+            "1": 211,
+            "2": 30,
+            ...
+            "29": 179,
+            "30": 114,
+            "31": 73
+          },
+          "secretKey": {
+            "0": 191,
+            "1": 198,
+            "2": 244,
+            ...
+            "61": 179,
+            "62": 114,
+            "63": 73
+          }
+        }
+      }
+    }
+INFO [2026-06-15 06:34:39.236 +0530]: Transaction built successfully
+    instructionName: "initChainRemoteConfig"
+    transactionSize: "293 bytes"
+    base58Length: "399 characters"
+    hexLength: "586 characters"
+    accountCount: 4
+    signerCount: 1
+    computeUnits: 13402
+INFO [2026-06-15 06:34:39.237 +0530]: Completed buildTransaction (initChainRemoteConfig)
+    durationMs: 366
+INFO [2026-06-15 06:34:39.406 +0530]:
+INFO [2026-06-15 06:34:39.406 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-15 06:34:39.406 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 06:34:39.406 +0530]:    Instruction: initChainRemoteConfig
+INFO [2026-06-15 06:34:39.406 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-15 06:34:39.406 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-15 06:34:40.042 +0530]: Transaction confirmed successfully
+    signature: "5EWruYQEry3itWRUdSr57BprKnoPUqkBCfmMMNWBTNhTjTsRU2BX4y195aBCrmwHpJCxb6q2VB8WmnbEgkSwxhVq"
+    attempt: 1
+INFO [2026-06-15 06:34:40.042 +0530]:
+INFO [2026-06-15 06:34:40.042 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-15 06:34:40.042 +0530]:
+INFO [2026-06-15 06:34:40.042 +0530]: 📋 Execution Details:
+INFO [2026-06-15 06:34:40.042 +0530]:    Instruction: initChainRemoteConfig
+INFO [2026-06-15 06:34:40.042 +0530]:    Signature:   5EWruYQEry3itWRUdSr57BprKnoPUqkBCfmMMNWBTNhTjTsRU2BX4y195aBCrmwHpJCxb6q2VB8WmnbEgkSwxhVq
+INFO [2026-06-15 06:34:40.042 +0530]:    Explorer:    https://explorer.solana.com/tx/5EWruYQEry3itWRUdSr57BprKnoPUqkBCfmMMNWBTNhTjTsRU2BX4y195aBCrmwHpJCxb6q2VB8WmnbEgkSwxhVq?cluster=devnet
+INFO [2026-06-15 06:34:40.042 +0530]:
+INFO [2026-06-15 06:34:40.042 +0530]: initChainRemoteConfig command completed successfully
+    command: "burnmint-token-pool.init-chain-remote-config"
+    transactionSize: "293 bytes"
+    computeUnits: 13402
 ```
 
 </Fragment>
@@ -1057,7 +1225,7 @@ yarn svm:pool:init-chain-remote-config \
 
 #### Add Ethereum Pool Address
 
-In this step, you will use the `svm:pool:edit-chain-remote-config` script to update the previously created chain configuration with the Ethereum pool address. This completes the configuration by telling the Solana pool which Ethereum pool it should interact with for cross-chain transfers.
+In this step, you will update the previously created chain configuration with the Ethereum pool address.
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Add Pool Address</Fragment>
@@ -1067,11 +1235,13 @@ In this step, you will use the `svm:pool:edit-chain-remote-config` script to upd
 
 ```bash
 # Add Ethereum pool address to the configuration
-yarn svm:pool:edit-chain-remote-config \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM \
-  --remote-chain ethereum-sepolia \
-  --pool-addresses $ETH_POOL_ADDRESS \
+pnpm bs58 --env devnet --execute burnmint-token-pool \
+  --instruction edit-chain-remote-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_ADMIN_WALLET \
+  --remote-chain-selector $ETH_SEPOLIA_CHAIN_SELECTOR \
+  --pool-addresses "[\"$ETH_POOL_ADDRESS\"]" \
   --token-address $ETH_TOKEN_ADDRESS \
   --decimals 9
 ```
@@ -1081,30 +1251,87 @@ yarn svm:pool:edit-chain-remote-config \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-22T10:37:29.719Z] 🔧 EDITING CHAIN REMOTE CONFIG
-[2025-08-22T10:37:29.719Z] ==========================================
-[2025-08-22T10:37:29.719Z] Updating chain remote configuration...
-[2025-08-22T10:37:29.719Z] Editing chain remote config for chain 16015286601757825753 on mint: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:37:29.721Z] 📍 Pool Config PDA: DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE
-[2025-08-22T10:37:29.985Z] 📍 Chain Config PDA: 6NLyRKr3tr4f2QxfCbMRWvEyzSjPY67XiByWnTWFdSvf
-[2025-08-22T10:37:43.454Z] Chain remote config edited: 3sj7g59kxpktuBD7wWTi7GKoB7Ktj9zTFmCssUR1PFDju3N7Q3ikCQaHDJXYd3N5ntmep8gSXvaYNjbnGGDy7KwP
-[2025-08-22T10:37:43.779Z]
-[2025-08-22T10:37:43.779Z] ✅ CHAIN CONFIG EDITED SUCCESSFULLY
-[2025-08-22T10:37:43.779Z] ==========================================
-[2025-08-22T10:37:43.779Z] Transaction Signature: 3sj7g59kxpktuBD7wWTi7GKoB7Ktj9zTFmCssUR1PFDju3N7Q3ikCQaHDJXYd3N5ntmep8gSXvaYNjbnGGDy7KwP
-[2025-08-22T10:37:43.779Z]
-[2025-08-22T10:37:43.779Z] 🔍 EXPLORER URLS
-[2025-08-22T10:37:43.780Z] ==========================================
-[2025-08-22T10:37:43.780Z] Transaction: https://explorer.solana.com/tx/3sj7g59kxpktuBD7wWTi7GKoB7Ktj9zTFmCssUR1PFDju3N7Q3ikCQaHDJXYd3N5ntmep8gSXvaYNjbnGGDy7KwP?cluster=devnet
-[2025-08-22T10:37:43.780Z]
-[2025-08-22T10:37:43.780Z] 📋 NEXT STEPS
-[2025-08-22T10:37:43.780Z] ==========================================
-[2025-08-22T10:37:43.780Z] View updated configuration:
-[2025-08-22T10:37:43.780Z]   yarn svm:pool:get-info --token-mint 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS --burn-mint-pool-program 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-22T10:37:43.780Z]
-[2025-08-22T10:37:43.780Z] 🎉 Chain Configuration Update Complete!
-[2025-08-22T10:37:43.780Z] ✅ Remote chain ethereum-sepolia configuration updated
-[2025-08-22T10:37:43.780Z] ✅ Pool addresses: 1 configured
+🔄 Generating editChainRemoteConfig transaction...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
+   Mint: AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
+   Authority: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+   Remote Chain Selector: 16015286601757825753
+   Pool Addresses: 1 addresses
+   Token Address: 45cfb05d6278715716023ebeec733c081ce9f822
+   Decimals: 9
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-15 06:38:27.172 +0530]: Starting editChainRemoteConfig command
+    command: "burnmint-token-pool.edit-chain-remote-config"
+    programId: "41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB"
+    mint: "AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7"
+    authority: "GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN"
+    remoteChainSelector: "16015286601757825753"
+    poolAddresses: "[\"0x1df7ede88286c1ef95d024b311e12dc4b3106f1f\"]"
+    tokenAddress: "0x45cfb05d6278715716023ebeec733c081ce9f822"
+    decimals: "9"
+    globalOptions: {
+      "environment": "devnet",
+      "execute": true,
+      "resolvedRpcUrl": "https://api.devnet.solana.com",
+      "keypair": "/Users/syed-cll/.config/solana/id.json",
+      "_signerKeypair": {
+        "_keypair": {
+          "publicKey": {
+            "0": 230,
+            "1": 211,
+            "2": 30,
+            ...
+            "29": 179,
+            "30": 114,
+            "31": 73
+          },
+          "secretKey": {
+            "0": 191,
+            "1": 198,
+            "2": 244,
+            ...
+            "61": 179,
+            "62": 114,
+            "63": 73
+          }
+        }
+      }
+    }
+INFO [2026-06-15 06:38:27.594 +0530]: Transaction built successfully
+    instructionName: "editChainRemoteConfig"
+    transactionSize: "317 bytes"
+    base58Length: "432 characters"
+    hexLength: "634 characters"
+    accountCount: 4
+    signerCount: 1
+    computeUnits: 14533
+INFO [2026-06-15 06:38:27.594 +0530]: Completed buildTransaction (editChainRemoteConfig)
+    durationMs: 419
+INFO [2026-06-15 06:38:27.751 +0530]:
+INFO [2026-06-15 06:38:27.751 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-15 06:38:27.751 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 06:38:27.751 +0530]:    Instruction: editChainRemoteConfig
+INFO [2026-06-15 06:38:27.751 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-15 06:38:27.751 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-15 06:38:28.818 +0530]: Transaction confirmed successfully
+    signature: "4mBP7guEZsjgyMD4HgR4xWjkhkEdYsuUVoGTk58srjZjKZyiXPHENy3yC9LgmEA6FVVVBmKZLtbZXRSkxxJ4v18X"
+    attempt: 1
+INFO [2026-06-15 06:38:28.818 +0530]:
+INFO [2026-06-15 06:38:28.818 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-15 06:38:28.818 +0530]:
+INFO [2026-06-15 06:38:28.818 +0530]: 📋 Execution Details:
+INFO [2026-06-15 06:38:28.818 +0530]:    Instruction: editChainRemoteConfig
+INFO [2026-06-15 06:38:28.818 +0530]:    Signature:   4mBP7guEZsjgyMD4HgR4xWjkhkEdYsuUVoGTk58srjZjKZyiXPHENy3yC9LgmEA6FVVVBmKZLtbZXRSkxxJ4v18X
+INFO [2026-06-15 06:38:28.818 +0530]:    Explorer:    https://explorer.solana.com/tx/4mBP7guEZsjgyMD4HgR4xWjkhkEdYsuUVoGTk58srjZjKZyiXPHENy3yC9LgmEA6FVVVBmKZLtbZXRSkxxJ4v18X?cluster=devnet
+INFO [2026-06-15 06:38:28.818 +0530]:
+INFO [2026-06-15 06:38:28.818 +0530]: editChainRemoteConfig command completed successfully
+    command: "burnmint-token-pool.edit-chain-remote-config"
+    transactionSize: "317 bytes"
+    computeUnits: 14533
 ```
 
 </Fragment>
@@ -1112,7 +1339,7 @@ yarn svm:pool:edit-chain-remote-config \
 
 #### Verify Configuration
 
-In this step, you will use the `svm:pool:get-chain-config` script to verify that the Solana pool configuration for Ethereum Sepolia has been set up correctly with both the token address and pool address.
+In this step, you will verify that the Solana pool configuration for Ethereum Sepolia has been set up correctly.
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Verify Config</Fragment>
@@ -1122,10 +1349,11 @@ In this step, you will use the `svm:pool:get-chain-config` script to verify that
 
 ```bash
 # Verify the chain configuration is complete
-yarn svm:pool:get-chain-config \
-  --token-mint $SOL_TOKEN_MINT \
-  --burn-mint-pool-program $CCIP_POOL_PROGRAM \
-  --remote-chain ethereum-sepolia
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-chain-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --remote-chain-selector $ETH_SEPOLIA_CHAIN_SELECTOR
 ```
 
 </Fragment>
@@ -1133,48 +1361,48 @@ yarn svm:pool:get-chain-config \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-22T10:38:14.385Z] 🔍 CCIP Chain Configuration Reader (Read-Only)
-[2025-08-22T10:38:14.387Z] ==========================================
-[2025-08-22T10:38:14.387Z] Network: solana-devnet
-[2025-08-22T10:38:14.387Z] Token Mint: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:38:14.387Z] Burn-Mint Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
-[2025-08-22T10:38:14.387Z] Remote Chain: ethereum-sepolia
-[2025-08-22T10:38:14.387Z] Remote Chain Selector: 16015286601757825753
-[2025-08-22T10:38:14.416Z]
-[2025-08-22T10:38:14.416Z] 🔄 RETRIEVING CHAIN CONFIGURATION
-[2025-08-22T10:38:14.416Z] ==========================================
-[2025-08-22T10:38:14.416Z] Fetching chain configuration...
-[2025-08-22T10:38:14.417Z] 📍 Chain Config PDA: 6NLyRKr3tr4f2QxfCbMRWvEyzSjPY67XiByWnTWFdSvf
-[2025-08-22T10:38:15.131Z]
-[2025-08-22T10:38:15.131Z] 📋 CHAIN CONFIGURATION DETAILS
-[2025-08-22T10:38:15.131Z] ==========================================
-[2025-08-22T10:38:15.131Z] Account Address: 6NLyRKr3tr4f2QxfCbMRWvEyzSjPY67XiByWnTWFdSvf
-[2025-08-22T10:38:15.131Z]
-[2025-08-22T10:38:15.132Z] 🔗 REMOTE CHAIN INFORMATION
-[2025-08-22T10:38:15.132Z] ------------------------------------------
-[2025-08-22T10:38:15.132Z] Decimals: 9
-[2025-08-22T10:38:15.132Z] Token Address: 0x00000000000000000000000084426e21208d73e8d3760d9cbc4faefa279d3720
-[2025-08-22T10:38:15.132Z]
-[2025-08-22T10:38:15.132Z] 🏊 POOL ADDRESSES
-[2025-08-22T10:38:15.132Z] ------------------------------------------
-[2025-08-22T10:38:15.132Z] 1. 0x22d99df2246ed52063b0d2d0f24e03d7319b9299
-[2025-08-22T10:38:15.132Z]
-[2025-08-22T10:38:15.132Z] ⬇️  INBOUND RATE LIMIT
-[2025-08-22T10:38:15.132Z] ------------------------------------------
-[2025-08-22T10:38:15.132Z] Enabled: false
-[2025-08-22T10:38:15.132Z] Capacity: 0 (0 tokens)
-[2025-08-22T10:38:15.132Z] Rate: 0 (0 tokens/second)
-[2025-08-22T10:38:15.132Z] Current Bucket Value: 0 (0 tokens)
-[2025-08-22T10:38:15.132Z] Last Updated: 1970-01-01T00:00:00.000Z
-[2025-08-22T10:38:15.132Z]
-[2025-08-22T10:38:15.132Z] ⬆️  OUTBOUND RATE LIMIT
-[2025-08-22T10:38:15.132Z] ------------------------------------------
-[2025-08-22T10:38:15.132Z] Enabled: false
-[2025-08-22T10:38:15.132Z] Capacity: 0 (0 tokens)
-[2025-08-22T10:38:15.132Z] Rate: 0 (0 tokens/second)
-[2025-08-22T10:38:15.132Z] Current Bucket Value: 0 (0 tokens)
-[2025-08-22T10:38:15.132Z] Last Updated: 1970-01-01T00:00:00.000Z
-[2025-08-22T10:38:15.132Z]
+🔍 Reading chain configuration...
+   RPC URL: https://api.devnet.solana.com
+   Program ID: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
+   Mint: AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
+   Remote Chain Selector: 16015286601757825753
+   Chain Config PDA: DpoFzuYGtBmSPPrjmC19RqAMQY5MaUxxAGY3HH97sxcZ
+✅ Chain config account found
+
+📊 Chain Configuration for Remote Chain: 16015286601757825753
+
+Program Information:
+  Program Type:         Burnmint Token Pool
+  Program ID:           41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
+  Chain Config PDA:     DpoFzuYGtBmSPPrjmC19RqAMQY5MaUxxAGY3HH97sxcZ
+
+Local Token (Solana):
+  Mint Address:         AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
+  Decimals:             9
+  Note:                 Rate limits below use these decimals
+
+Remote Token (Destination Chain):
+  Token Address:        0x00000000000000000000000045cfb05d6278715716023ebeec733c081ce9f822 (32 bytes)
+  Token Decimals:       9
+  Pool Addresses:       1 address(es)
+    1. 0x1df7ede88286c1ef95d024b311e12dc4b3106f1f (20 bytes)
+
+Inbound Rate Limit: (in local token units)
+  Enabled:              false
+  Capacity:             N/A (disabled)
+  Rate:                 N/A (disabled)
+  Current Tokens:       N/A (disabled)
+  Last Updated:         N/A (disabled)
+
+Outbound Rate Limit: (in local token units)
+  Enabled:              false
+  Capacity:             N/A (disabled)
+  Rate:                 N/A (disabled)
+  Current Tokens:       N/A (disabled)
+  Last Updated:         N/A (disabled)
+
+INFO [2026-06-15 06:39:56.677 +0530]: getChainConfig command completed successfully
+    command: "burnmint-token-pool.get-chain-config"
 ```
 
 </Fragment>
@@ -1201,12 +1429,13 @@ Load all variables from previous phases:
 source ~/.ccip_complete_vars
 echo "Loaded variables:"
 echo "ETH_TOKEN_ADDRESS=$ETH_TOKEN_ADDRESS"
+echo "ETH_POOL_ADDRESS=$ETH_POOL_ADDRESS"
 echo "SOL_TOKEN_MINT=$SOL_TOKEN_MINT"
 echo "Pool Config PDA: $SOL_POOL_CONFIG_PDA"
 echo "Pool Signer PDA: $SOL_POOL_SIGNER_PDA"
 echo "Multisig Address: $SOL_MULTISIG_ADDRESS"
 echo "Admin Wallet: $SOL_ADMIN_WALLET"
-echo "Pool Program: $CCIP_POOL_PROGRAM"
+echo "Pool Program: $SOL_CCIP_POOL_PROGRAM"
 ```
 
 </Fragment>
@@ -1215,12 +1444,13 @@ echo "Pool Program: $CCIP_POOL_PROGRAM"
 
 ```bash
 Loaded variables:
-ETH_TOKEN_ADDRESS=0x84426E21208D73E8D3760d9cbc4FaEFa279d3720
-SOL_TOKEN_MINT=8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-Pool Config PDA: DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE
-Pool Signer PDA: GLgULP9HDnQy5kQkeEdJJeLXTW1qK7NAbQRJ8xNniNFo
-Multisig Address: 555G9UPbWGpDAcbpLbvhe793fLHVT72hBU9xWP2pJNxm
-Admin Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
+ETH_TOKEN_ADDRESS=0x45cfb05d6278715716023ebeec733c081ce9f822
+ETH_POOL_ADDRESS=0x1df7ede88286c1ef95d024b311e12dc4b3106f1f
+SOL_TOKEN_MINT=AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
+Pool Config PDA: Fuu3EwnQkV4WUrcLj1atwEq4xbfkpgvXF5tMRYPg3nCm
+Pool Signer PDA: 5LZUPpzMudPAX6BNaDrzjPE28YuGbQArvJucM2f7JJMe
+Multisig Address: A4SnwAxQnfuMn5DcZbipwawAfDz3aAosw81ujdSq543C
+Admin Wallet: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
 Pool Program: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB
 ```
 
@@ -1243,33 +1473,30 @@ npx hardhat applyChainUpdates \
   --remotechain solanaDevnet \
   --remotepooladdresses $SOL_POOL_CONFIG_PDA \
   --remotetokenaddress $SOL_TOKEN_MINT \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 </Fragment>
 
 <Fragment slot="panel.2">
 ```bash
-2025-08-22T10:45:49.006Z info: === Starting Chain Update Configuration ===
-2025-08-22T10:45:49.007Z info: 🔹 Local network: sepolia
-2025-08-22T10:45:49.007Z info: 🔹 Pool address: 0x22d99DF2246eD52063B0d2d0f24E03d7319b9299
-2025-08-22T10:45:49.007Z info: 🔹 Remote chain: solanaDevnet
-2025-08-22T10:45:49.007Z info: 🔹 Remote chain type detected: svm
-2025-08-22T10:45:49.008Z info: 🔹 Remote chain selector: 16423721717087811551
-2025-08-22T10:45:49.008Z info: 🔹 Parsed 1 remote pool addresses
-2025-08-22T10:45:49.032Z info: ✅ All addresses validated successfully
-2025-08-22T10:45:49.346Z info: 🔹 Using signer: 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-22T10:45:49.700Z info: ✅ Connected to pool contract
-2025-08-22T10:45:49.700Z info: 🔹 Remote pool address 1: DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE → 0xb7c5ec6b288ecaa92615f43fa0c26bc0126312a51c8b9c5e91bd2f531d70498f
-2025-08-22T10:45:49.701Z info: 🔹 Remote token address: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS → 0x7397eec252840cdb17409721e595fa494940289a0b1cf301577e31ca68a2d211
-2025-08-22T10:45:49.701Z info: === Rate Limiter Configuration ===
-2025-08-22T10:45:49.701Z info: 🔹 Outbound enabled: false
-2025-08-22T10:45:49.701Z info: 🔹 Inbound enabled: false
-2025-08-22T10:45:49.701Z info: === Executing Transaction ===
-2025-08-22T10:45:49.701Z info: 🔹 Sending applyChainUpdates transaction...
-2025-08-22T10:45:50.241Z info: 🔹 Transaction sent: 0x834104dc29fa9dd9e5a32f37fa7c1ea49409fc05144045b44006a3c7ff5a093a
-2025-08-22T10:45:50.241Z info: 🔹 Waiting for 3 confirmations...
-2025-08-22T10:46:24.834Z info: ✅ Chain update applied successfully!
+2026-06-15T01:14:32.717Z info: === Starting Chain Update Configuration ===
+2026-06-15T01:14:32.718Z info: 🔹 Local network: ethereumSepolia
+2026-06-15T01:14:32.718Z info: 🔹 Pool address: 0x1df7ede88286c1ef95d024b311e12dc4b3106f1f
+2026-06-15T01:14:32.718Z info: 🔹 Remote chain: solanaDevnet
+2026-06-15T01:14:32.718Z info: 🔹 Remote chain family: svm
+2026-06-15T01:14:32.718Z info: 🔹 Remote chain selector: 16423721717087811551
+2026-06-15T01:14:34.133Z info: ✅ All addresses validated successfully
+2026-06-15T01:14:34.572Z info: ✅ Using signer: 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-15T01:14:34.827Z info: ✅ Connected to TokenPool contract
+2026-06-15T01:14:34.828Z info:   Remote pool 1: Fuu3EwnQkV4WUrcLj1atwEq4xbfkpgvXF5tMRYPg3nCm → 0xdd90a8c837c128a246eb979efaa4a83325b4cfb673e9573b1a848c4f1871bf3e
+2026-06-15T01:14:34.828Z info: === Rate Limiter Configuration ===
+2026-06-15T01:14:34.828Z info: Outbound enabled: false
+2026-06-15T01:14:34.828Z info: Inbound enabled: false
+2026-06-15T01:14:34.829Z info: === Executing applyChainUpdates() ===
+2026-06-15T01:14:36.517Z info: 📤 TX sent: 0x2ae005781238feda7b6e0b6df0b3d63a0ecf3db001e4e52db03ac7423de31f58
+2026-06-15T01:14:36.517Z info: Waiting for 3 confirmations...
+2026-06-15T01:15:14.989Z info: ✅ Chain update applied successfully on ethereumSepolia (3 confirmations)!
 ```
 
 </Fragment>
@@ -1289,7 +1516,7 @@ Verify that the Ethereum pool is correctly configured to recognize the Solana ch
 # Verify Ethereum pool configuration
 npx hardhat getPoolConfig \
   --pooladdress $ETH_POOL_ADDRESS \
-  --network sepolia
+  --network ethereumSepolia
 ```
 
 </Fragment>
@@ -1297,26 +1524,32 @@ npx hardhat getPoolConfig \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-22T10:47:23.975Z info:
-Pool Basic Information:
-2025-08-22T10:47:23.975Z info:   Rate Limit Admin: 0x0000000000000000000000000000000000000000
-2025-08-22T10:47:23.975Z info:   Router Address: 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59
-2025-08-22T10:47:23.976Z info:   Token Address: 0x84426E21208D73E8D3760d9cbc4FaEFa279d3720
-2025-08-22T10:47:23.976Z info:   Allow List Enabled: false
-2025-08-22T10:47:23.976Z info: Fetching configuration for pool at address: 0x22d99DF2246eD52063B0d2d0f24E03d7319b9299
-2025-08-22T10:47:24.126Z info:
-Configuration for Remote Chain: solanaDevnet
-2025-08-22T10:47:24.126Z info:   Remote Pool Addresses:
-2025-08-22T10:47:24.126Z info:     1: DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE
-2025-08-22T10:47:24.127Z info:   Remote Token Address: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-2025-08-22T10:47:24.127Z info:   Outbound Rate Limiter:
-2025-08-22T10:47:24.127Z info:     Enabled: false
-2025-08-22T10:47:24.127Z info:     Capacity: 0
-2025-08-22T10:47:24.127Z info:     Rate: 0
-2025-08-22T10:47:24.127Z info:   Inbound Rate Limiter:
-2025-08-22T10:47:24.127Z info:     Enabled: false
-2025-08-22T10:47:24.127Z info:     Capacity: 0
-2025-08-22T10:47:24.127Z info:     Rate: 0
+2026-06-15T01:15:48.322Z info: 📊 Fetching pool configuration for 0x1df7ede88286c1ef95d024b311e12dc4b3106f1f on ethereumSepolia...
+2026-06-15T01:15:49.927Z info:
+Fetching pool configuration for: 0x1df7ede88286c1ef95d024b311e12dc4b3106f1f
+2026-06-15T01:15:50.182Z info:
+--- Pool Basic Information ---
+2026-06-15T01:15:50.182Z info: Rate Limit Admin: 0x0000000000000000000000000000000000000000
+2026-06-15T01:15:50.182Z info: Router Address:   0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59
+2026-06-15T01:15:50.182Z info: Token Address:    0x45cFB05d6278715716023EbeeC733C081Ce9F822
+2026-06-15T01:15:50.182Z info: Allow List Enabled: false
+2026-06-15T01:15:50.182Z info:
+Supported Remote Chains: 1
+2026-06-15T01:15:50.417Z info:
+--- Remote Chain: solanaDevnet ---
+2026-06-15T01:15:50.419Z info: Remote Pool Addresses:
+2026-06-15T01:15:50.420Z info:   1. Fuu3EwnQkV4WUrcLj1atwEq4xbfkpgvXF5tMRYPg3nCm
+2026-06-15T01:15:50.420Z info: Remote Token Address: AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
+2026-06-15T01:15:50.420Z info: Outbound Rate Limiter:
+2026-06-15T01:15:50.420Z info:   Enabled:  false
+2026-06-15T01:15:50.420Z info:   Capacity: 0
+2026-06-15T01:15:50.420Z info:   Rate:     0
+2026-06-15T01:15:50.420Z info: Inbound Rate Limiter:
+2026-06-15T01:15:50.420Z info:   Enabled:  false
+2026-06-15T01:15:50.420Z info:   Capacity: 0
+2026-06-15T01:15:50.420Z info:   Rate:     0
+2026-06-15T01:15:50.420Z info:
+✅ Pool configuration fetched successfully.
 ```
 
 </Fragment>
@@ -1349,14 +1582,11 @@ In this step, you will use the `setPool` Hardhat task to register the BurnMint t
 <Fragment slot="panel.1">
 
 ```bash
-
 # Register token pool with TokenAdminRegistry contract
-
 npx hardhat setPool \
  --tokenaddress $ETH_TOKEN_ADDRESS \
  --pooladdress $ETH_POOL_ADDRESS \
- --network sepolia
-
+ --network ethereumSepolia
 ```
 
 </Fragment>
@@ -1364,8 +1594,15 @@ npx hardhat setPool \
 <Fragment slot="panel.2">
 
 ```bash
-2025-08-22T10:48:38.108Z info: Setting pool for token 0x84426E21208D73E8D3760d9cbc4FaEFa279d3720 to 0x22d99DF2246eD52063B0d2d0f24E03d7319b9299 by 0x9d087fC03ae39b088326b67fA3C788236645b717
-2025-08-22T10:49:12.434Z info: Pool set for token 0x84426E21208D73E8D3760d9cbc4FaEFa279d3720 to 0x22d99DF2246eD52063B0d2d0f24E03d7319b9299
+2026-06-15T01:17:08.864Z info: 🔗 Setting pool for token 0x45cfb05d6278715716023ebeec733c081ce9f822 on ethereumSepolia...
+2026-06-15T01:17:11.131Z info: 🔹 Using signer: 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca
+2026-06-15T01:17:11.131Z info: Using TokenAdminRegistry: 0x95F29FEE11c5C55d26cCcf1DB6772DE953B37B82
+2026-06-15T01:17:11.376Z info: Checking token configuration for 0x45cfb05d6278715716023ebeec733c081ce9f822...
+2026-06-15T01:17:11.593Z info: Token 0x45cfb05d6278715716023ebeec733c081ce9f822 current admin: 0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA
+2026-06-15T01:17:11.594Z info: ✅ Current wallet 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca is the token administrator
+2026-06-15T01:17:11.594Z info: Setting pool 0x1df7ede88286c1ef95d024b311e12dc4b3106f1f for token 0x45cfb05d6278715716023ebeec733c081ce9f822...
+2026-06-15T01:17:13.162Z info: 📤 TX sent: 0xa53042f185709effbb9c81acdf030cf3fd10b1b1b6801bba775f3b5528788612. Waiting for 3 confirmations...
+2026-06-15T01:17:51.632Z info: ✅ Pool successfully set for token 0x45cfb05d6278715716023ebeec733c081ce9f822 → 0x1df7ede88286c1ef95d024b311e12dc4b3106f1f on ethereumSepolia (3 confirmations)
 ```
 
 </Fragment>
@@ -1373,16 +1610,16 @@ npx hardhat setPool \
 
 ### Step 2: Solana Devnet Pool Registration
 
-**Switch to Terminal 1 (Solana Starter Kit)**
+**Switch to Terminal 1** (CCIP Solana BS58 Generator)
 
 ```bash
 pwd
-# Should show: .../solana-starter-kit
+# Should show: .../ccip-solana-bs58-generator
 ```
 
 #### Create Address Lookup Table
 
-Create an Address Lookup Table (ALT) containing all required accounts for CCIP operations:
+Create an Address Lookup Table (ALT) containing all required CCIP accounts plus your multisig address:
 
 <Tabs client:visible>
 <Fragment slot="tab.1">Create ALT</Fragment>
@@ -1390,50 +1627,61 @@ Create an Address Lookup Table (ALT) containing all required accounts for CCIP o
 
 <Fragment slot="panel.1">
 ```bash
-# Create Address Lookup Table with all required accounts + your multisig address
-yarn svm:admin:create-alt \
-  --token-mint $SOL_TOKEN_MINT \
-  --pool-program $CCIP_POOL_PROGRAM \
-  --additional-addresses $SOL_MULTISIG_ADDRESS
+# Create ALT with 10 base CCIP addresses + multisig address
+pnpm bs58 --env devnet --execute router \
+  --instruction create-lookup-table \
+  --program-id $SOL_CCIP_ROUTER \
+  --fee-quoter-program-id $SOL_CCIP_FEE_QUOTER_PROGRAM \
+  --pool-program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_ADMIN_WALLET \
+  --additional-addresses "[\"$SOL_MULTISIG_ADDRESS\"]"
 ```
+
+<Aside type="note" title="EOA ALT Creation">
+
+Because your wallet signs immediately with `--execute`, the one-step `create-lookup-table` command avoids the blockhash expiration constraint that applies to multisig workflows.
+
+</Aside>
 
 </Fragment>
 
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-22T10:50:00.506Z] ✅ ALT CREATED SUCCESSFULLY
-[2025-08-22T10:50:00.506Z] ===================================================
-[2025-08-22T10:50:00.506Z] ALT Address: 4EZuCBu5f3jjLE8iVDkSxLwGqvEahuuYMim48GRj8ryP
-[2025-08-22T10:50:00.506Z] Transaction Signature: 3Y1tvRtEzcWjn7He2CJmrr2FWRRCb5ohU4LiqdRrzRUwwds8JTSCaa2wqgtRW44UscphQmvQFUwd4n8URPcj5Uaf
-[2025-08-22T10:50:00.506Z] Total Addresses Count: 11
-[2025-08-22T10:50:00.506Z] Base CCIP Addresses: 10
-[2025-08-22T10:50:00.506Z] Additional Custom Addresses: 1
-[2025-08-22T10:50:00.506Z]
-[2025-08-22T10:50:00.506Z] 📋 ALT CONTENTS
-[2025-08-22T10:50:00.506Z] ===================================================
-[2025-08-22T10:50:00.507Z] [0]: 4EZuCBu5f3jjLE8iVDkSxLwGqvEahuuYMim48GRj8ryP (Lookup table itself)
-[2025-08-22T10:50:00.507Z] [1]: 5qDd6VMfsemjo5shd4tGV9JvP3rzZuzSmJLNpBbkgoir (Token admin registry)
-[2025-08-22T10:50:00.507Z] [2]: 41FGToCmdaWa1dgZLKFAjvmx6e6AjVTX7SVRibvsMGVB (Pool program)
-[2025-08-22T10:50:00.507Z] [3]: DNNetX8iV1H7tuDioQ5AFxUhAX1gEqUdWDtCpgYvPmEE (Pool configuration)
-[2025-08-22T10:50:00.507Z] [4]: HaBXCZtWkJLAgagxeemKWoXmGYqP2fNQqtazuj6uJrxX (Pool token account)
-[2025-08-22T10:50:00.507Z] [5]: GLgULP9HDnQy5kQkeEdJJeLXTW1qK7NAbQRJ8xNniNFo (Pool signer)
-[2025-08-22T10:50:00.507Z] [6]: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA (Token program)
-[2025-08-22T10:50:00.507Z] [7]: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS (Token mint)
-[2025-08-22T10:50:00.507Z] [8]: EM98PFRiMG4ktNzXzmDKh6bHhiyJckWQYANVotpGAADC (Fee token config)
-[2025-08-22T10:50:00.507Z] [9]: H6ZviaabTYZqUPgiSoMDbeVthcNW9ULcAuUu3zRLFqDR (CCIP router pool signer)
-[2025-08-22T10:50:00.508Z] [10]: 555G9UPbWGpDAcbpLbvhe793fLHVT72hBU9xWP2pJNxm (Custom address 1)
-[2025-08-22T10:50:00.508Z]
-[2025-08-22T10:50:00.508Z] 🔍 EXPLORER URLS
-[2025-08-22T10:50:00.508Z] ===================================================
-[2025-08-22T10:50:00.508Z] Transaction: https://explorer.solana.com/tx/3Y1tvRtEzcWjn7He2CJmrr2FWRRCb5ohU4LiqdRrzRUwwds8JTSCaa2wqgtRW44UscphQmvQFUwd4n8URPcj5Uaf?cluster=devnet
-[2025-08-22T10:50:00.508Z]
-[2025-08-22T10:50:00.508Z] 🎉 ALT Creation Complete!
-[2025-08-22T10:50:00.508Z] ✅ Address Lookup Table: 4EZuCBu5f3jjLE8iVDkSxLwGqvEahuuYMim48GRj8ryP
-[2025-08-22T10:50:00.508Z] ✅ Contains 10 base CCIP addresses
-[2025-08-22T10:50:00.508Z] ✅ Plus 1 additional custom addresses
-[2025-08-22T10:50:00.508Z] ✅ Total addresses: 11
-[2025-08-22T10:50:00.508Z] ✅ Ready to be registered with setPool
+🔄 Generating create_lookup_table transaction...
+INFO [2026-06-15 06:48:38.306 +0530]: Detected SPL Token v1
+    mint: "AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+🔄 Building and simulating transaction...
+INFO [2026-06-15 06:48:38.589 +0530]: Transaction built successfully
+    instructionName: "router.create_lookup_table"
+    transactionSize: "557 bytes"
+    base58Length: "760 characters"
+    hexLength: "1114 characters"
+    accountCount: 4
+    signerCount: 2
+    computeUnits: 19419
+INFO [2026-06-15 06:48:38.589 +0530]: Completed buildTransaction (router.create_lookup_table)
+    durationMs: 190
+INFO [2026-06-15 06:48:38.772 +0530]:
+INFO [2026-06-15 06:48:38.772 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-15 06:48:38.773 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 06:48:38.773 +0530]:    Instruction: router.create_lookup_table
+INFO [2026-06-15 06:48:38.773 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-15 06:48:38.773 +0530]:
+📮 Derived Lookup Table Address: Ff9asmT33cvZ4y2Y82Dd7ig3M72w7usJ2iZmV7p6d2uR
+INFO [2026-06-15 06:48:39.728 +0530]: Transaction confirmed successfully
+    signature: "5JM3Yd6fK77Nc4EQioHsYHqgPCs2ap5rrzJNoyjp2b79xSpXfgxAdEDBohLfyGA8JQNrYnjuEuZj4u8y7ZNtkUAd"
+    attempt: 1
+INFO [2026-06-15 06:48:39.728 +0530]:
+INFO [2026-06-15 06:48:39.728 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-15 06:48:39.728 +0530]:
+INFO [2026-06-15 06:48:39.728 +0530]: 📋 Execution Details:
+INFO [2026-06-15 06:48:39.728 +0530]:    Instruction: router.create_lookup_table
+INFO [2026-06-15 06:48:39.728 +0530]:    Signature:   5JM3Yd6fK77Nc4EQioHsYHqgPCs2ap5rrzJNoyjp2b79xSpXfgxAdEDBohLfyGA8JQNrYnjuEuZj4u8y7ZNtkUAd
+INFO [2026-06-15 06:48:39.728 +0530]:    Explorer:    https://explorer.solana.com/tx/5JM3Yd6fK77Nc4EQioHsYHqgPCs2ap5rrzJNoyjp2b79xSpXfgxAdEDBohLfyGA8JQNrYnjuEuZj4u8y7ZNtkUAd?cluster=devnet
+INFO [2026-06-15 06:48:39.728 +0530]:
 ```
 
 </Fragment>
@@ -1462,7 +1710,7 @@ echo "ALT Address: $SOL_ALT_ADDRESS"
 <Fragment slot="panel.2">
 
 ```bash
-ALT Address: 4EZuCBu5f3jjLE8iVDkSxLwGqvEahuuYMim48GRj8ryP
+ALT Address: Ff9asmT33cvZ4y2Y82Dd7ig3M72w7usJ2iZmV7p6d2uR
 ```
 
 </Fragment>
@@ -1479,10 +1727,13 @@ Register your token pool with the CCIP Router using the Address Lookup Table:
 <Fragment slot="panel.1">
 ```bash
 # Register pool with CCIP Router using the ALT
-yarn svm:admin:set-pool \
-  --token-mint $SOL_TOKEN_MINT \
-  --lookup-table $SOL_ALT_ADDRESS \
-  --writable-indices 3,4,7
+pnpm bs58 --env devnet --execute router \
+  --instruction set-pool \
+  --program-id $SOL_CCIP_ROUTER \
+  --mint $SOL_TOKEN_MINT \
+  --authority $SOL_ADMIN_WALLET \
+  --pool-lookup-table $SOL_ALT_ADDRESS \
+  --writable-indexes "[3,4,7]"
 ```
 
 </Fragment>
@@ -1490,175 +1741,434 @@ yarn svm:admin:set-pool \
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-22T10:53:06.746Z] 🔍 LOOKUP TABLE VERIFICATION
-[2025-08-22T10:53:06.746Z] =============================================
-[2025-08-22T10:53:06.746Z] Verifying lookup table exists...
-[2025-08-22T10:53:06.987Z] Lookup table verified with 11 addresses
-[2025-08-22T10:53:06.987Z]
-[2025-08-22T10:53:06.987Z] 🏊 SETTING POOL
-[2025-08-22T10:53:06.987Z] =============================================
-[2025-08-22T10:53:06.987Z] Setting pool (registering ALT with token)...
-[2025-08-22T10:53:06.987Z] Setting pool for token 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS with lookup table 4EZuCBu5f3jjLE8iVDkSxLwGqvEahuuYMim48GRj8ryP
-[2025-08-22T10:53:20.651Z] Pool set successfully. Tx signature: 3UPoHJcUNdw2CWKNHzcTQBhGy5WoEtTFuSMZFjUnARZ2q1mXAkvpPWBf4tNnhwCjmDk7ZQa4bmaowq57vfmKyikj
-[2025-08-22T10:53:20.652Z]
-[2025-08-22T10:53:20.653Z] ✅ POOL SET SUCCESSFULLY
-[2025-08-22T10:53:20.653Z] =============================================
-[2025-08-22T10:53:20.653Z] Transaction Signature: 3UPoHJcUNdw2CWKNHzcTQBhGy5WoEtTFuSMZFjUnARZ2q1mXAkvpPWBf4tNnhwCjmDk7ZQa4bmaowq57vfmKyikj
-[2025-08-22T10:53:20.653Z]
-[2025-08-22T10:53:20.653Z] 🔍 EXPLORER URLS
-[2025-08-22T10:53:20.653Z] =============================================
-[2025-08-22T10:53:20.654Z] Transaction: https://explorer.solana.com/tx/3UPoHJcUNdw2CWKNHzcTQBhGy5WoEtTFuSMZFjUnARZ2q1mXAkvpPWBf4tNnhwCjmDk7ZQa4bmaowq57vfmKyikj?cluster=devnet
-[2025-08-22T10:53:20.654Z]
-[2025-08-22T10:53:20.654Z] 🔍 FINAL VERIFICATION
-[2025-08-22T10:53:20.654Z] =============================================
-[2025-08-22T10:53:20.654Z] Verifying pool registration...
-[2025-08-22T10:53:20.654Z] Fetching token admin registry for mint: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:53:20.934Z] ✅ Pool registration verified successfully!
-[2025-08-22T10:53:20.934Z] Registered lookup table: 4EZuCBu5f3jjLE8iVDkSxLwGqvEahuuYMim48GRj8ryP
-[2025-08-22T10:53:20.934Z] Writable indices: [3, 4, 7]
-[2025-08-22T10:53:20.935Z]
-[2025-08-22T10:53:20.935Z] 🎉 Pool Registration Complete!
-[2025-08-22T10:53:20.935Z] ✅ Token: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:53:20.935Z] ✅ ALT: 4EZuCBu5f3jjLE8iVDkSxLwGqvEahuuYMim48GRj8ryP
+🔄 Generating set_pool transaction...
+🔄 Building and simulating transaction...
+INFO [2026-06-15 06:50:12.996 +0530]: Transaction built successfully
+    instructionName: "router.set_pool"
+    transactionSize: "252 bytes"
+    base58Length: "343 characters"
+    hexLength: "504 characters"
+    accountCount: 5
+    signerCount: 1
+    computeUnits: 38867
+INFO [2026-06-15 06:50:12.996 +0530]: Completed buildTransaction (router.set_pool)
+    durationMs: 373
+INFO [2026-06-15 06:50:13.168 +0530]:
+INFO [2026-06-15 06:50:13.168 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-15 06:50:13.168 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 06:50:13.168 +0530]:    Instruction: router.set_pool
+INFO [2026-06-15 06:50:13.168 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-15 06:50:13.168 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-15 06:50:14.102 +0530]: Transaction confirmed successfully
+    signature: "okCJy5JwUePaxpAfvynevv3n8qWL5ZdeHhYtr3VrWHokYG89yc2u4vkdHu3q9yyUy7VeaZH87wqcgtk67TBW5cT"
+    attempt: 1
+INFO [2026-06-15 06:50:14.102 +0530]:
+INFO [2026-06-15 06:50:14.102 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-15 06:50:14.103 +0530]:
+INFO [2026-06-15 06:50:14.103 +0530]: 📋 Execution Details:
+INFO [2026-06-15 06:50:14.103 +0530]:    Instruction: router.set_pool
+INFO [2026-06-15 06:50:14.103 +0530]:    Signature:   okCJy5JwUePaxpAfvynevv3n8qWL5ZdeHhYtr3VrWHokYG89yc2u4vkdHu3q9yyUy7VeaZH87wqcgtk67TBW5cT
+INFO [2026-06-15 06:50:14.103 +0530]:    Explorer:    https://explorer.solana.com/tx/okCJy5JwUePaxpAfvynevv3n8qWL5ZdeHhYtr3VrWHokYG89yc2u4vkdHu3q9yyUy7VeaZH87wqcgtk67TBW5cT?cluster=devnet
+INFO [2026-06-15 06:50:14.103 +0530]:
 ```
 
 </Fragment>
 </Tabs>
 
-## Phase 5: Testing Cross-Chain Transfers
+Save the complete configuration including the ALT address:
 
-Test the complete cross-chain token transfer functionality in both directions.
+<Tabs client:visible>
+<Fragment slot="tab.1">Save Complete Configuration</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
 
-### Step 1: Transfer Solana → Ethereum
+<Fragment slot="panel.1">
 
-**Stay in Terminal 1 (Solana Starter Kit)**
+```bash
+cat >> ~/.ccip_complete_vars << EOF
+export SOL_ALT_ADDRESS="$SOL_ALT_ADDRESS"
+EOF
 
-Confirm you are in the correct directory:
+echo "=== Complete Configuration Saved ==="
+echo "✅ ALT Address: $SOL_ALT_ADDRESS"
+echo "✅ All variables saved to ~/.ccip_complete_vars"
+echo "✅ Ready for cross-chain testing"
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+=== Complete Configuration Saved ===
+✅ ALT Address: Ff9asmT33cvZ4y2Y82Dd7ig3M72w7usJ2iZmV7p6d2uR
+✅ All variables saved to ~/.ccip_complete_vars
+✅ Ready for cross-chain testing
+```
+
+</Fragment>
+</Tabs>
+
+## Phase 5: Pre-Transfer Setup
+
+Before validating your configuration, complete final setup steps.
+
+**Stay in Terminal 1** (CCIP Solana BS58 Generator)
 
 ```bash
 pwd
-# Should show: .../solana-starter-kit
+# Should show: .../ccip-solana-bs58-generator
 ```
 
-#### Prepare for Testing
+### Step 1: Delegate Token Authority
 
-Your Associated Token Account (ATA) was already created during token creation in Phase 1. Now verify your token balance and prepare for cross-chain transfers:
+Delegate token approval to the CCIP fee-billing signer PDA, which enables CCIP to transfer tokens on your behalf when sending cross-chain messages.
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Check Balance & Delegate</Fragment>
+<Fragment slot="tab.1">Derive Fee-Billing Signer</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Check your current token balance (should show 1000 from Phase 1)
+# Derive the CCIP fee-billing signer PDA
+export SOL_CCIP_FEE_BILLING_SIGNER=$(solana find-program-derived-address $SOL_CCIP_ROUTER string:fee_billing_signer | head -1)
+
+echo "SOL_CCIP_FEE_BILLING_SIGNER=$SOL_CCIP_FEE_BILLING_SIGNER"
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+SOL_CCIP_FEE_BILLING_SIGNER=2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
+```
+
+</Fragment>
+</Tabs>
+
+Approve the fee-billing signer to transfer tokens from your ATA:
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Delegate Authority</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+# --amount is u64 max (2^64 - 1): max delegation for CCIP fee billing
+pnpm bs58 --env devnet --execute spl-token \
+  --instruction approve \
+  --authority $SOL_ADMIN_WALLET \
+  --mint $SOL_TOKEN_MINT \
+  --delegate $SOL_CCIP_FEE_BILLING_SIGNER \
+  --amount 18446744073709551615
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+🔍 Detecting token program...
+INFO [2026-06-15 06:55:03.915 +0530]: Starting approve command
+    command: "spl-token.approve"
+    mint: "AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7"
+    delegate: "2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG"
+    authority: "GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN"
+    amount: "18446744073709551615"
+    globalOptions: {
+      "environment": "devnet",
+      "execute": true,
+      "resolvedRpcUrl": "https://api.devnet.solana.com",
+      "keypair": "/Users/syed-cll/.config/solana/id.json",
+      "_signerKeypair": {
+        "_keypair": {
+          "publicKey": {
+            "0": 230,
+            "1": 211,
+            "2": 30,
+            ...
+            "29": 179,
+            "30": 114,
+            "31": 73
+          },
+          "secretKey": {
+            "0": 191,
+            "1": 198,
+            "2": 244,
+            ...
+            "61": 179,
+            "62": 114,
+            "63": 73
+          }
+        }
+      }
+    }
+   ✅ Detected token program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+🔍 Auto-deriving Associated Token Account...
+   ✅ Derived ATA: 9Xv8WtoN9EpBfSjqWVoQfrf4qc5CMSvBmM5Hu9jApYhc
+🔄 Generating approve transaction...
+   RPC URL: https://api.devnet.solana.com
+   Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+   Mint: AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
+   Token Account: 9Xv8WtoN9EpBfSjqWVoQfrf4qc5CMSvBmM5Hu9jApYhc
+   Delegate: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
+   Authority (Token Account Owner): GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+   Amount: 18446744073709551615
+⚙️  Building transaction instruction...
+   ✅ Instruction built successfully
+🔄 Building and simulating transaction...
+INFO [2026-06-15 06:55:04.288 +0530]: Detected SPL Token v1
+    mint: "AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7"
+    programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+INFO [2026-06-15 06:55:04.446 +0530]: Transaction built successfully
+    instructionName: "approve"
+    transactionSize: "180 bytes"
+    base58Length: "245 characters"
+    hexLength: "360 characters"
+    accountCount: 3
+    signerCount: 1
+    computeUnits: 123
+INFO [2026-06-15 06:55:04.447 +0530]: Completed buildTransaction (approve)
+    durationMs: 157
+INFO [2026-06-15 06:55:04.604 +0530]:
+INFO [2026-06-15 06:55:04.604 +0530]: 🖊️  EXECUTE MODE — signing & sending on devnet
+INFO [2026-06-15 06:55:04.604 +0530]:    Signer:      GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+INFO [2026-06-15 06:55:04.604 +0530]:    Instruction: approve
+INFO [2026-06-15 06:55:04.604 +0530]:    RPC:         https://api.devnet.solana.com
+INFO [2026-06-15 06:55:04.605 +0530]:
+   ✅ Transaction simulation completed
+INFO [2026-06-15 06:55:05.412 +0530]: Transaction confirmed successfully
+    signature: "5hocYyLtzifa1M8DktwYJUbNR4fKU4wQVMWfTNMhBFCMfLh4cSkBb9bHsSf8FN6K7Zy6jEtg7PtPmrQ18zYZkug9"
+    attempt: 1
+INFO [2026-06-15 06:55:05.412 +0530]:
+INFO [2026-06-15 06:55:05.412 +0530]: 🎉 Transaction executed successfully!
+INFO [2026-06-15 06:55:05.412 +0530]:
+INFO [2026-06-15 06:55:05.412 +0530]: 📋 Execution Details:
+INFO [2026-06-15 06:55:05.412 +0530]:    Instruction: approve
+INFO [2026-06-15 06:55:05.412 +0530]:    Signature:   5hocYyLtzifa1M8DktwYJUbNR4fKU4wQVMWfTNMhBFCMfLh4cSkBb9bHsSf8FN6K7Zy6jEtg7PtPmrQ18zYZkug9
+INFO [2026-06-15 06:55:05.412 +0530]:    Explorer:    https://explorer.solana.com/tx/5hocYyLtzifa1M8DktwYJUbNR4fKU4wQVMWfTNMhBFCMfLh4cSkBb9bHsSf8FN6K7Zy6jEtg7PtPmrQ18zYZkug9?cluster=devnet
+INFO [2026-06-15 06:55:05.412 +0530]:
+INFO [2026-06-15 06:55:05.413 +0530]: approve command completed successfully
+    command: "spl-token.approve"
+    transactionSize: "180 bytes"
+    computeUnits: 123
+```
+
+</Fragment>
+</Tabs>
+
+### Step 2: Verify Delegation
+
+Check that your token account is delegated to the fee-billing signer:
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Find Token Account</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+# Find your Associated Token Account (ATA) address
+export SOL_TOKEN_ACCOUNT=$(spl-token accounts $SOL_TOKEN_MINT --owner $SOL_ADMIN_WALLET --addresses-only)
+
+echo "SOL_TOKEN_ACCOUNT=$SOL_TOKEN_ACCOUNT"
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+SOL_TOKEN_ACCOUNT=9Xv8WtoN9EpBfSjqWVoQfrf4qc5CMSvBmM5Hu9jApYhc
+```
+
+</Fragment>
+</Tabs>
+
+Display token account and delegation status:
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Check Delegation</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+spl-token display $SOL_TOKEN_ACCOUNT
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+SPL Token Account
+  Address: 9Xv8WtoN9EpBfSjqWVoQfrf4qc5CMSvBmM5Hu9jApYhc
+  Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+  Balance: 1000
+  Decimals: 9
+  Mint: AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
+  Owner: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+  State: Initialized
+  Delegation:
+    Delegate: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
+    Allowance: 18446744073.709551615
+  Close authority: (not set)
+```
+
+</Fragment>
+</Tabs>
+
+## Phase 6: Test Cross-Chain Transfers
+
+Validate your configuration, then execute bidirectional token transfers using the CCIP CLI.
+
+<Aside type="note" title="Cross-Chain Transfers with CCIP CLI">
+
+Use [`@chainlink/ccip-cli`](https://github.com/smartcontractkit/ccip-tools-ts) for bidirectional token transfers. Run Solana → EVM sends from Terminal 1 and EVM → Solana sends from Terminal 2. See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for full options.
+
+</Aside>
+
+### Step 1: Load Complete Configuration
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Load All Variables</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+source ~/.ccip_complete_vars
+
+echo "=== Configuration Validation ==="
+echo "✅ ETH Token: $ETH_TOKEN_ADDRESS"
+echo "✅ ETH Pool: $ETH_POOL_ADDRESS"
+echo "✅ SOL Token: $SOL_TOKEN_MINT"
+echo "✅ Pool Signer PDA: $SOL_POOL_SIGNER_PDA"
+echo "✅ Multisig Address: $SOL_MULTISIG_ADDRESS"
+echo "✅ ALT Address: $SOL_ALT_ADDRESS"
+echo "✅ Admin Wallet: $SOL_ADMIN_WALLET"
+```
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+=== Configuration Validation ===
+✅ ETH Token: 0x45cfb05d6278715716023ebeec733c081ce9f822
+✅ ETH Pool: 0x1df7ede88286c1ef95d024b311e12dc4b3106f1f
+✅ SOL Token: AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
+✅ Pool Signer PDA: 5LZUPpzMudPAX6BNaDrzjPE28YuGbQArvJucM2f7JJMe
+✅ Multisig Address: A4SnwAxQnfuMn5DcZbipwawAfDz3aAosw81ujdSq543C
+✅ ALT Address: Ff9asmT33cvZ4y2Y82Dd7ig3M72w7usJ2iZmV7p6d2uR
+✅ Admin Wallet: GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN
+```
+
+</Fragment>
+</Tabs>
+
+### Step 2: Verify Solana Pool and Chain Config
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Verification Commands</Fragment>
+<Fragment slot="tab.2">What to Confirm</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+# Verify pool state
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-state \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT
+
+# Verify Ethereum Sepolia remote chain config
+pnpm bs58 --env devnet burnmint-token-pool \
+  --instruction get-chain-config \
+  --program-id $SOL_CCIP_POOL_PROGRAM \
+  --mint $SOL_TOKEN_MINT \
+  --remote-chain-selector $ETH_SEPOLIA_CHAIN_SELECTOR
+
+# Verify mint authority is the multisig
+spl-token display $SOL_TOKEN_MINT
+
+# Verify token balance and delegation
 spl-token balance $SOL_TOKEN_MINT
-
-# Delegate tokens for CCIP transfers
-
-yarn svm:token:delegate --token-mint $SOL_TOKEN_MINT
-
-# Verify the delegation was successful
-
-yarn svm:token:check --token-mint $SOL_TOKEN_MINT
-
 ```
 
 </Fragment>
 
 <Fragment slot="panel.2">
 
-```bash
-1000
+Confirm the following:
 
-yarn run v1.22.22
-$ ts-node ./ccip-scripts/svm/token/delegate-token-authority.ts --token-mint 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:55:29.652Z] CCIP Token Authority Delegator
-[2025-08-22T10:55:29.654Z] =============================================
-[2025-08-22T10:55:29.681Z] Network: solana-devnet
-[2025-08-22T10:55:29.681Z] Router Program: Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
-[2025-08-22T10:55:29.681Z] Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-22T10:55:29.681Z]
-[2025-08-22T10:55:29.681Z] 💰 WALLET BALANCE
-[2025-08-22T10:55:29.681Z] =============================================
-[2025-08-22T10:55:30.472Z] SOL Balance: 65.633320271 SOL (65633320271 lamports)
-[2025-08-22T10:55:30.473Z]
-[2025-08-22T10:55:30.473Z] 🔐 PROCESSING TOKEN DELEGATIONS
-[2025-08-22T10:55:30.473Z] =============================================
-[2025-08-22T10:55:30.473Z] Custom token mints provided: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:55:30.473Z] Using 'fee-billing' delegation type for ccip_send compatibility
-[2025-08-22T10:55:30.473Z] Added custom token delegation for: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:55:30.473Z]
-[1/1] Processing delegation for mint: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:55:30.473Z] Getting mint account info for 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS to determine token program ID...
-[2025-08-22T10:55:30.777Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-22T10:55:30.780Z] Token Program ID: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-22T10:55:30.780Z] Delegation Type: fee-billing
-[2025-08-22T10:55:30.780Z] Delegate Address: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
-[2025-08-22T10:55:30.780Z] Amount to delegate: 18446744073709551615
-[2025-08-22T10:55:30.782Z] User Token Account: 4k3FoESSV3MHg1iKScE1Ccqeb3PfHiz71nX5PgkaL1kz
-[2025-08-22T10:55:31.037Z] Token account 4k3FoESSV3MHg1iKScE1Ccqeb3PfHiz71nX5PgkaL1kz exists.
-[2025-08-22T10:55:31.273Z] Sending transaction to delegate token authority...
-[2025-08-22T10:55:32.535Z] ✅ Token delegation successful!
-[2025-08-22T10:55:32.535Z] Transaction signature: oUspMZ2t4ndUVPN7r1KD5tBTiVkZcYuJhMWt377Xwmn5W97jbKrqb2w8tHipL2RQtKpCRoH6atkRETg4YZSbj9v
-[2025-08-22T10:55:32.535Z] Explorer URL: https://explorer.solana.com/tx/oUspMZ2t4ndUVPN7r1KD5tBTiVkZcYuJhMWt377Xwmn5W97jbKrqb2w8tHipL2RQtKpCRoH6atkRETg4YZSbj9v?cluster=devnet
-[2025-08-22T10:55:32.535Z]
-[2025-08-22T10:55:32.535Z] ✅ All delegations processed successfully
-✨  Done in 6.04s.
-yarn run v1.22.22
-$ ts-node ./ccip-scripts/svm/token/check-token-approval.ts --token-mint 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:55:35.519Z] CCIP Token Approval Checker
-[2025-08-22T10:55:35.521Z] =========================================
-[2025-08-22T10:55:35.548Z] Network: solana-devnet
-[2025-08-22T10:55:35.548Z] Router Program: Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C
-[2025-08-22T10:55:35.548Z] Wallet: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[2025-08-22T10:55:35.548Z]
-[2025-08-22T10:55:35.548Z] 💰 WALLET BALANCE
-[2025-08-22T10:55:35.548Z] =========================================
-[2025-08-22T10:55:35.898Z] SOL Balance: 65.633315271 SOL (65633315271 lamports)
-[2025-08-22T10:55:35.898Z]
-[2025-08-22T10:55:35.898Z] 🔍 PROCESSING TOKEN APPROVALS
-[2025-08-22T10:55:35.899Z] =========================================
-[2025-08-22T10:55:35.899Z] Custom token mints provided: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:55:35.899Z] Using 'fee-billing' delegation type for ccip_send compatibility
-[2025-08-22T10:55:35.899Z] Added custom token check for: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:55:35.899Z]
-[1/1] Processing token: Custom Token (8nEFofUq...)
-[2025-08-22T10:55:35.899Z] Mint: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-[2025-08-22T10:55:35.900Z] Getting mint account info for 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS to determine token program ID...
-[2025-08-22T10:55:35.996Z] Detected Standard Token Program: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-22T10:55:35.996Z] Token Program ID: TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
-[2025-08-22T10:55:35.998Z] Token Account: 4k3FoESSV3MHg1iKScE1Ccqeb3PfHiz71nX5PgkaL1kz
-[2025-08-22T10:55:35.999Z] Expected Delegate (fee-billing): 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
-[2025-08-22T10:55:36.093Z] Balance: 1000000000000
-[2025-08-22T10:55:36.093Z] Actual Delegate: 2AjuzTy6z2webxEUu7eZ1DkAyLagZaqH2dgzhbBYjJiG
-[2025-08-22T10:55:36.093Z] Delegated Amount: 18446744073709551615
-[2025-08-22T10:55:36.093Z] Matches Expected Delegate: ✓ Yes
-[2025-08-22T10:55:36.093Z]
-[2025-08-22T10:55:36.093Z] 📋 TOKEN APPROVAL SUMMARY
-[2025-08-22T10:55:36.093Z] =========================================
-[2025-08-22T10:55:36.093Z] Token | Description | Balance | Delegate | Delegated Amount | Status
-[2025-08-22T10:55:36.093Z] ------|-------------|---------|----------|-----------------|-------
-[2025-08-22T10:55:36.093Z] 8nEFofUq... | Custom Token (8nEFofUq...) | 1000000000000 | 2AjuzTy6... | 18446744073709551615 | ✓ Correct
-[2025-08-22T10:55:36.093Z]
-[2025-08-22T10:55:36.093Z] ✅ Token approval check completed successfully
-```
+- Pool owner matches `$SOL_ADMIN_WALLET`
+- Mint authority is the SPL token multisig (`$SOL_MULTISIG_ADDRESS`) with Pool Signer PDA as a signer
+- Remote chain config includes your `$ETH_POOL_ADDRESS` and `$ETH_TOKEN_ADDRESS`
+- Token delegation is set to the fee-billing signer
+- Your wallet holds tokens for transfer testing
 
 </Fragment>
 </Tabs>
 
-#### Execute Transfer
+### Step 3: Verify Ethereum Pool (Terminal 2)
+
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
+
+```bash
+npx hardhat getPoolConfig \
+  --pooladdress $ETH_POOL_ADDRESS \
+  --network ethereumSepolia
+```
+
+Confirm the Ethereum pool recognizes Solana Devnet with your `$SOL_POOL_CONFIG_PDA` and `$SOL_TOKEN_MINT`.
+
+### Configure CCIP CLI
+
+Export these RPC URLs once before your first transfer:
+
+```bash
+export SOLANA_DEVNET_RPC="https://api.devnet.solana.com"
+export ETHEREUM_SEPOLIA_RPC_URL="<YOUR_ETHEREUM_SEPOLIA_RPC_URL>"
+
+export ETH_CCIP_ROUTER="0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59"
+```
+
+Use the same `ETHEREUM_SEPOLIA_RPC_URL` from your env-enc setup in Terminal 2 (`npx env-enc view`). On `ccip-cli send`, the source chain RPC quotes fees and submits the transaction; for token-only transfers in this tutorial, that is the only RPC strictly required to send. Pass both RPCs on cross-chain commands anyway: the destination RPC is required for `ccip-cli show --wait` and for optional send features such as `--estimate-gas-limit` or `send --wait`.
+
+<Aside type="note" title="RPC and wallet configuration">
+  Repeat `--rpc` for multiple networks, or use `--rpcs` with comma-separated URLs. Alternatively, set `RPC_*` environment variables or a `.env` file — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration). Solana sends use `--wallet ~/.config/solana/id.json`. EVM sends: prefer `--wallet hardhat:<name>` from the Hardhat project directory ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)); alternatively export `PRIVATE_KEY` manually after `npx env-enc view` (Hardhat tasks load env-enc automatically, but `ccip-cli` does not). See [CCIP CLI wallet configuration](https://docs.chain.link/ccip/tools/cli/configuration#wallet-configuration).
+</Aside>
+
+### Transfer Solana → Ethereum
+
+**Terminal 1** (CCIP Solana BS58 Generator):
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Transfer Command</Fragment>
+<Fragment slot="tab.1">Send Command</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
 
 ```bash
-# Execute cross-chain transfer from Solana to Ethereum
-yarn svm:token-transfer --token-mint $SOL_TOKEN_MINT --token-amount 1000000 --receiver <REPLACE_WITH_YOUR_ETHEREUM_RECEIVER_ADDRESS>
+source ~/.ccip_complete_vars
 
+export ETH_RECEIVER_ADDRESS="<YOUR_ETHEREUM_RECEIVER_ADDRESS>"
+
+
+ccip-cli send \
+  -s solana-devnet \
+  -r $SOL_CCIP_ROUTER \
+  -d ethereum-testnet-sepolia \
+  --to $ETH_RECEIVER_ADDRESS \
+  -t $SOL_TOKEN_MINT=0.001 \
+  --wallet ~/.config/solana/id.json \
+  --rpc $SOLANA_DEVNET_RPC \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL
 ```
 
 </Fragment>
@@ -1666,151 +2176,287 @@ yarn svm:token-transfer --token-mint $SOL_TOKEN_MINT --token-amount 1000000 --re
 <Fragment slot="panel.2">
 
 ```bash
-[2025-08-22T10:58:33.715Z] CCIP message sent successfully: sb2kHXW3M4P56WNNH74LviWcPmeYXjNA4f6opmt8iPrYF1cu5FC9grLhyu2XTEwkABQUrTdaJoDWc5CHe2gQL2u
-[2025-08-22T10:58:33.716Z] Parsing CCIP message sent event for transaction: sb2kHXW3M4P56WNNH74LviWcPmeYXjNA4f6opmt8iPrYF1cu5FC9grLhyu2XTEwkABQUrTdaJoDWc5CHe2gQL2u
-[2025-08-22T10:58:33.825Z] Successfully extracted messageId: 0x9c486ce15650d0bbff3f9cd8ead0510aadd854f7247bf9b775918a1296408aaa
-[2025-08-22T10:58:33.826Z]
-[2025-08-22T10:58:33.826Z] ✅ TOKEN TRANSFER SENT SUCCESSFULLY
-[2025-08-22T10:58:33.826Z] =======================================
-[2025-08-22T10:58:33.826Z] Transaction Signature: sb2kHXW3M4P56WNNH74LviWcPmeYXjNA4f6opmt8iPrYF1cu5FC9grLhyu2XTEwkABQUrTdaJoDWc5CHe2gQL2u
-[2025-08-22T10:58:33.826Z] CCIP Message ID: 0x9c486ce15650d0bbff3f9cd8ead0510aadd854f7247bf9b775918a1296408aaa
-[2025-08-22T10:58:33.826Z]
-[2025-08-22T10:58:33.826Z] 🔍 EXPLORER URLS
-[2025-08-22T10:58:33.826Z] =======================================
-[2025-08-22T10:58:33.826Z] Solana Transaction: https://explorer.solana.com/tx/sb2kHXW3M4P56WNNH74LviWcPmeYXjNA4f6opmt8iPrYF1cu5FC9grLhyu2XTEwkABQUrTdaJoDWc5CHe2gQL2u?cluster=devnet
-[2025-08-22T10:58:33.826Z] CCIP Explorer: https://ccip.chain.link/msg/0x9c486ce15650d0bbff3f9cd8ead0510aadd854f7247bf9b775918a1296408aaa
-[2025-08-22T10:58:33.826Z]
-[2025-08-22T10:58:33.826Z] 🎉 Transfer Complete!
-[2025-08-22T10:58:33.826Z] ✅ Sent 1000000 tokens to 0x9d087fC03ae39b088326b67fA3C788236645b717
-[2025-08-22T10:58:33.826Z] ✅ Message ID: 0x9c486ce15650d0bbff3f9cd8ead0510aadd854f7247bf9b775918a1296408aaa
-[2025-08-22T10:58:33.826Z] ✅ Monitor progress on CCIP Explorer: https://ccip.chain.link/msg/0x9c486ce15650d0bbff3f9cd8ead0510aadd854f7247bf9b775918a1296408aaa
+Fee: 55271173n = 0.055271173 SOL
+🚀 Sending message to 0x8c244f0b2164e6a3bed74ab429b0ebd661bb14ca @ ethereum-testnet-sepolia , tx => 25n99NMQhYqP7ikkGW5Tkn6dAqfEaUYRTYh4JsVCNATrEpe39Bjnu6Cm6q1uKpAwZswQZBrc9gkpRtRS1D2MXjxV, messageId => 0xe4e131424902af9f4b72634372b088831cc91e50079251e8200e9106731f6a4c
+Using rate-limited fetch for public solana nodes, commands may be slow
+Lane:
+┌────────────────┬────────────────────────────────────────────────┬────────────────────────────┐
+│ (index)        │ source                                         │ dest                       │
+├────────────────┼────────────────────────────────────────────────┼────────────────────────────┤
+│ name           │ 'solana-devnet'                                │ 'ethereum-testnet-sepolia' │
+│ chainId        │ 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' │ 11155111                   │
+│ chainSelector  │ 16423721717087811551n                          │ 16015286601757825753n      │
+│ onRamp/version │ 'Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C' │ '1.6.0'                    │
+└────────────────┴────────────────────────────────────────────────┴────────────────────────────┘
+Request (source):
+┌──────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)                  │ Values                                                                                     │
+├──────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ messageId                │ '0xe4e131424902af9f4b72634372b088831cc91e50079251e8200e9106731f6a4c'                       │
+│ origin                   │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ sender                   │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ receiver                 │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ sequenceNumber           │ 3076                                                                                       │
+│ nonce                    │ '0 => allow out-of-order exec'                                                             │
+│ gasLimit                 │ 0n                                                                                         │
+│ transactionHash          │ '25n99NMQhYqP7ikkGW5Tkn6dAqfEaUYRTYh4JsVCNATrEpe39Bjnu6Cm6q1uKpAwZswQZBrc9gkpRtRS1D2MXjxV' │
+│ logIndex                 │ 34                                                                                         │
+│ blockNumber              │ 469500512                                                                                  │
+│ timestamp                │ '2026-06-15 01:31:03 (2s ago)'                                                             │
+│ finalized                │ '11s left'                                                                                 │
+│ fee                      │ '0.055271173 SOL'                                                                          │
+│ tokens                   │ '0.001 CCIP-AEM'                                                                           │
+│ data                     │ '0x'                                                                                       │
+│ feeValueJuels            │ 481763587000000000n                                                                        │
+│ allowOutOfOrderExecution │ true                                                                                       │
+└──────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
+CCIP Explorer: https://ccip.chain.link/msg/0xe4e131424902af9f4b72634372b088831cc91e50079251e8200e9106731f6a4c
 ```
 
 </Fragment>
-
 </Tabs>
 
-#### Monitor and Verify Transaction
-
-Upon successful execution, the system generates critical tracking identifiers for transaction monitoring and verification.
-
-**Transaction Identifiers:**
-
-- **Transaction Signature**: `sb2kHXW3M4P56WNNH74LviWcPmeYXjNA4f6opmt8iPrYF1cu5FC9grLhyu2XTEwkABQUrTdaJoDWc5CHe2gQL2u`
-- **CCIP Message ID**: `0x9c486ce15650d0bbff3f9cd8ead0510aadd854f7247bf9b775918a1296408aaa`
-
-**CCIP Explorer** (Primary monitoring interface):
-
-```
-https://ccip.chain.link/msg/0x9c486ce15650d0bbff3f9cd8ead0510aadd854f7247bf9b775918a1296408aaa
-```
-
-The CCIP Explorer provides comprehensive transaction visibility:
-
-- Source chain (Solana) transaction confirmation
-- CCIP message processing and routing
-- Destination chain (Ethereum) message delivery
-- Token minting completion on Ethereum
-
-**Solana Explorer** (Source chain verification):
-
-```
-https://explorer.solana.com/tx/sb2kHXW3M4P56WNNH74LviWcPmeYXjNA4f6opmt8iPrYF1cu5FC9grLhyu2XTEwkABQUrTdaJoDWc5CHe2gQL2u?cluster=devnet
-```
-
-### Step 2: Transfer Ethereum → Solana
-
-**In Terminal 1 (Solana Starter Kit)**
-
-#### Execute Transfer
+The `-t` flag uses human-readable amounts (0.001 tokens with 9 decimals = 1,000,000 smallest units).
 
 <Tabs client:visible>
-<Fragment slot="tab.1">Transfer Command</Fragment>
+<Fragment slot="tab.1">Monitor Transfer</Fragment>
 <Fragment slot="tab.2">Expected Output</Fragment>
 
 <Fragment slot="panel.1">
-```bash
-# Execute cross-chain transfer from Ethereum to Solana
-yarn evm:transfer --token $ETH_TOKEN_ADDRESS --amount 1000000000000000000 --token-receiver $SOL_ADMIN_WALLET
-```
 
-**Note**: You can replace the token receiver with another Solana address.
+```bash
+# Replace with the transaction hash or message ID from the send output
+ccip-cli show <TX_HASH_OR_MESSAGE_ID> --wait \
+  --rpc $SOLANA_DEVNET_RPC \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL
+```
 
 </Fragment>
 
 <Fragment slot="panel.2">
 
 ```bash
-==== Transfer Summary ====
-[token-transfer] [INFO] Source Chain: Ethereum Sepolia
-[token-transfer] [INFO] Destination Chain: Solana Devnet (16423721717087811551)
-[token-transfer] [INFO] Sender: 0x9d087fC03ae39b088326b67fA3C788236645b717
-[token-transfer] [INFO] Receiver: 11111111111111111111111111111111
-[token-transfer] [INFO] Token Receiver: EPUjBP3Xf76K1VKsDSc6GupBWE8uykNksCLJgXZn87CB
-[token-transfer] [INFO] Fee Token: 0x779877A7B0D9E8603169DdbD7836e478b4624789
-[token-transfer] [INFO]
-Token Transfers:
-[token-transfer] [INFO]   1. 1000000000000000000 raw units (0x84426E21208D73E8D3760d9cbc4FaEFa279d3720)
-[token-transfer] [INFO]
-Extra Args: Solana-specific, 228 bytes
-[token-transfer] [INFO]
-🚀 Executing Token Transfer
-[token-transfer] [INFO] =========================================
-[token-transfer] [INFO] Sending CCIP message...
-[ccip-messenger] [INFO] Estimated fee: 12806000814649244
-[ccip-messenger] [INFO] LINK already has sufficient allowance: 0.015367200977579092 (needed: 0.015367200977579092, surplus: 0.0)
-[ccip-messenger] [INFO] Using existing allowance for fee token
-[ccip-messenger] [INFO] Approving 1.0 BnMAEM for CCIP Router
-[ccip-messenger] [INFO] Approving 1.0 tokens for 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59
-[ccip-messenger] [INFO] BnMAEM approved for CCIP Router
-[ccip-messenger] [INFO] ✅ Verified on-chain allowance for BnMAEM: 1.0 (required: 1.0)
-[ccip-messenger] [INFO] Sending CCIP message...
-[ccip-messenger] [INFO] Sending CCIP message...
-[ccip-messenger] [INFO] Transaction sent: 0xb2d48398a4d57dde2aaf0551209abad448b092602ca5087e0d108eadd8a8c319
-[ccip-messenger] [INFO] Transaction sent: 0xb2d48398a4d57dde2aaf0551209abad448b092602ca5087e0d108eadd8a8c319
-[ccip-messenger] [INFO] Message ID: 0x567f4cdb2e1c52f6aef6354bd9acbeac6761aa4b1a5e74a356785c2e67197d88
-[token-transfer] [INFO]
-🎉 Transfer Results
-[token-transfer] [INFO] =========================================
-[token-transfer] [INFO]
-==== Transfer Results ====
-[token-transfer] [INFO] Transaction Hash: 0xb2d48398a4d57dde2aaf0551209abad448b092602ca5087e0d108eadd8a8c319
-[token-transfer] [INFO] Transaction URL: https://sepolia.etherscan.io/tx/0xb2d48398a4d57dde2aaf0551209abad448b092602ca5087e0d108eadd8a8c319
-[token-transfer] [INFO] Message ID: 0x567f4cdb2e1c52f6aef6354bd9acbeac6761aa4b1a5e74a356785c2e67197d88
-[token-transfer] [INFO] 👉 CCIP Explorer: https://ccip.chain.link/msg/0x567f4cdb2e1c52f6aef6354bd9acbeac6761aa4b1a5e74a356785c2e67197d88
+Using rate-limited fetch for public solana nodes, commands may be slow
+Lane:
+┌────────────────┬────────────────────────────────────────────────┬────────────────────────────┐
+│ (index)        │ source                                         │ dest                       │
+├────────────────┼────────────────────────────────────────────────┼────────────────────────────┤
+│ name           │ 'solana-devnet'                                │ 'ethereum-testnet-sepolia' │
+│ chainId        │ 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' │ 11155111                   │
+│ chainSelector  │ 16423721717087811551n                          │ 16015286601757825753n      │
+│ onRamp/version │ 'Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C' │ '1.6.2'                    │
+└────────────────┴────────────────────────────────────────────────┴────────────────────────────┘
+Request (source):
+┌────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)                            │ Values                                                                                     │
+├────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ messageId                          │ '0xe4e131424902af9f4b72634372b088831cc91e50079251e8200e9106731f6a4c'                       │
+│ origin                             │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ sender                             │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ receiver                           │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ sequenceNumber                     │ 3076                                                                                       │
+│ nonce                              │ '0 => allow out-of-order exec'                                                             │
+│ gasLimit                           │ 0n                                                                                         │
+│ transactionHash                    │ '25n99NMQhYqP7ikkGW5Tkn6dAqfEaUYRTYh4JsVCNATrEpe39Bjnu6Cm6q1uKpAwZswQZBrc9gkpRtRS1D2MXjxV' │
+│ logIndex                           │ 1                                                                                          │
+│ blockNumber                        │ 469500512                                                                                  │
+│ timestamp                          │ '2026-06-15 01:31:03 (47s ago)'                                                            │
+│ finalized                          │ true                                                                                       │
+│ fee                                │ '0.055271173 SOL'                                                                          │
+│ tokens                             │ '0.001 CCIP-AEM'                                                                           │
+│ fees.fixedFeesDetails.tokenAddress │ 'So11111111111111111111111111111111111111112'                                              │
+│ fees.fixedFeesDetails.totalAmount  │ 55271173n                                                                                  │
+│ finality                           │ 0n                                                                                         │
+│ finalityType                       │ 'FINALIZED'                                                                                │
+│ routerAddress                      │ 'Ccip842gzYHhvdDkSyi2YVCoAWPbYJoApMFzSxQroE9C'                                             │
+│ allowOutOfOrderExecution           │ true                                                                                       │
+│ status                             │ 'SOURCE_FINALIZED'                                                                         │
+│ readyForManualExecution            │ false                                                                                      │
+│ receiptTransactionHash             │ null                                                                                       │
+│ receiptTimestamp                   │ undefined                                                                                  │
+│ deliveryTime                       │ null                                                                                       │
+│ offRamp                            │ '0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0'                                               │
+└────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
+CCIP Explorer: https://ccip.chain.link/msg/0xe4e131424902af9f4b72634372b088831cc91e50079251e8200e9106731f6a4c
+[SENT] Waiting for source chain finalization...
+[SOURCE_FINALIZED] Source chain finalized
+[SOURCE_FINALIZED] Waiting for commit on destination chain...
+[COMMITTED] Commit report accepted on destination chain
+┌─────────────────┬──────────────────────────────────────────────────────────────────────┐
+│ (index)         │ Values                                                               │
+├─────────────────┼──────────────────────────────────────────────────────────────────────┤
+│ merkleRoot      │ '0x9e110e42e6882b066e5c3e7bd4b50a7273297462ab1135825a20fd54c3d69d6b' │
+│ min             │ 3076                                                                 │
+│ max             │ 3076                                                                 │
+│ origin          │ '0xc03BfDf1C576bc3720DcD45B6B4EF6A0aEf4dfe6'                         │
+│ contract        │ '0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0'                         │
+│ transactionHash │ '0x61b70445f7b1f90bd17d6e197364df7aed9c4f4d6873e81fda5e8e3784be8934' │
+│ blockNumber     │ 11062234                                                             │
+│ timestamp       │ '2026-06-15 01:31:48 (45s after request)'                            │
+└─────────────────┴──────────────────────────────────────────────────────────────────────┘
+[BLESSED] Waiting for execution on destination chain...
+[SUCCESS] Message executed on destination chain
+┌─────────────────┬──────────────────────────────────────────────────────────────────────┐
+│ (index)         │ Values                                                               │
+├─────────────────┼──────────────────────────────────────────────────────────────────────┤
+│ state           │ '✅ success'                                                         │
+│ gasUsed         │ 81076                                                                │
+│ origin          │ '0xF482Bd4AE751DEDA88bf48937A8CA38D8Da21522'                         │
+│ contract        │ '0x0820f975ce90EE5c508657F0C58b71D1fcc85cE0'                         │
+│ transactionHash │ '0x73e8d2d350aa63fab1f49d3fe80c61aa86dae3b8913d3be1d59cfe24b2deef37' │
+│ logIndex        │ 488                                                                  │
+│ blockNumber     │ 11062237                                                             │
+│ timestamp       │ '2026-06-15 01:32:24 (1m21s after request)'                          │
+└─────────────────┴──────────────────────────────────────────────────────────────────────┘
+```
+
+</Fragment>
+</Tabs>
+
+### Transfer Ethereum → Solana
+
+**Switch to Terminal 2** (Smart Contract Examples - Hardhat):
+
+`ccip-cli` does not load Hardhat env-enc automatically. Run these commands from the Hardhat project directory. Prefer [Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore) over exporting a private key in plain text.
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Hardhat keystore (Recommended)</Fragment>
+<Fragment slot="tab.2">PRIVATE_KEY (Alternative)</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+source ~/.ccip_complete_vars
+
+ccip-cli send \
+  -s ethereum-testnet-sepolia \
+  -r $ETH_CCIP_ROUTER \
+  -d solana-devnet \
+  --to $SOL_ADMIN_WALLET \
+  -t $ETH_TOKEN_ADDRESS=1.0 \
+  --wallet hardhat:<YOUR_KEYSTORE_ACCOUNT_NAME> \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
+```
+
+Use the keystore account name from your Hardhat project (see [Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)). This keeps the signing key encrypted instead of in shell history.
+
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+source ~/.ccip_complete_vars
+
+# ccip-cli does not read env-enc — view and export the same key used in Phase 1
+npx env-enc view
+export PRIVATE_KEY="<YOUR_PRIVATE_KEY_FROM_ENV_ENC>"
+
+ccip-cli send \
+  -s ethereum-testnet-sepolia \
+  -r $ETH_CCIP_ROUTER \
+  -d solana-devnet \
+  --to $SOL_ADMIN_WALLET \
+  -t $ETH_TOKEN_ADDRESS=1.0 \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
+```
+
+Do not commit or share the exported key. Prefer the Hardhat keystore tab for production-like workflows.
+
+</Fragment>
+</Tabs>
+
+For token-only transfers to Solana, `--to` is the destination wallet that receives minted tokens. CCIP fees are paid in native Sepolia ETH by default — ensure your wallet has sufficient ETH for gas and fees.
+
+<Aside type="note" title="Pay fees in LINK (optional)">
+  Add `--fee-token LINK` to pay CCIP fees in LINK instead of ETH (Sepolia LINK:
+  `0x779877A7B0D9E8603169DdbD7836e478b4624789`).
+</Aside>
+
+<Tabs client:visible>
+<Fragment slot="tab.1">Monitor Transfer</Fragment>
+<Fragment slot="tab.2">Expected Output</Fragment>
+
+<Fragment slot="panel.1">
+
+```bash
+ccip-cli show <TX_HASH_OR_MESSAGE_ID> --wait \
+  --rpc $ETHEREUM_SEPOLIA_RPC_URL \
+  --rpc $SOLANA_DEVNET_RPC
 ```
 
 </Fragment>
 
+<Fragment slot="panel.2">
+
+```bash
+Lane:
+┌────────────────┬──────────────────────────────────────────────┬────────────────────────────────────────────────┐
+│ (index)        │ source                                       │ dest                                           │
+├────────────────┼──────────────────────────────────────────────┼────────────────────────────────────────────────┤
+│ name           │ 'ethereum-testnet-sepolia'                   │ 'solana-devnet'                                │
+│ chainId        │ 11155111                                     │ 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG' │
+│ chainSelector  │ 16015286601757825753n                        │ 16423721717087811551n                          │
+│ onRamp/version │ '0x23a5084Fa78104F3DF11C63Ae59fcac4f6AD9DeE' │ '1.6.0'                                        │
+└────────────────┴──────────────────────────────────────────────┴────────────────────────────────────────────────┘
+Request (source):
+┌────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)                            │ Values                                                                                     │
+├────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ messageId                          │ '0xc64e289c9a0a9b3bff7f2bfe98996ef56dc138f7fdc500541e60b009ab7d98d3'                       │
+│ origin                             │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ sender                             │ '0x8C244f0B2164E6A3BED74ab429B0ebd661Bb14CA'                                               │
+│ receiver                           │ '11111111111111111111111111111111'                                                         │
+│ sequenceNumber                     │ 10199                                                                                      │
+│ nonce                              │ '0 => allow out-of-order exec'                                                             │
+│ computeUnits                       │ 0n                                                                                         │
+│ transactionHash                    │ '0xbf28e47f97c0320fef0fbc31ea01a2c6c10c00b538b868da7b1eafca37a1c622'                       │
+│ logIndex                           │ 891                                                                                        │
+│ blockNumber                        │ 11062259                                                                                   │
+│ timestamp                          │ '2026-06-15 01:36:48 (16m4s ago)'                                                          │
+│ finalized                          │ true                                                                                       │
+│ fee                                │ '0.000351018193797698 WETH'                                                                │
+│ tokens                             │ '1.0 BnMAEM'                                                                               │
+│ accounts                           │ undefined                                                                                  │
+│ fees.fixedFeesDetails.tokenAddress │ '0x097D90c9d3E0B50Ca60e1ae45F6A81010f9FB534'                                               │
+│ fees.fixedFeesDetails.totalAmount  │ 351018193797698n                                                                           │
+│ finality                           │ 0n                                                                                         │
+│ finalityType                       │ 'FINALIZED'                                                                                │
+│ routerAddress                      │ '0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59'                                               │
+│ accountIsWritableBitmap            │ 0n                                                                                         │
+│ allowOutOfOrderExecution           │ true                                                                                       │
+│ tokenReceiver                      │ 'GY3V5RAtSxoJf2dZGqAbzaSxDyXWb8RPMWQdv1mC5PXN'                                             │
+│ status                             │ 'SUCCESS'                                                                                  │
+│ readyForManualExecution            │ false                                                                                      │
+│ receiptTransactionHash             │ '2gtGHy8tqeyHgDGLm7AntoGC2V9yBfpQwTZKoaDozMDfCvWgNSJVEr3BiTn4z8W2fzHkPrbxzmxQG7ThWgExV2fR' │
+│ receiptTimestamp                   │ '2026-06-15 01:51:40'                                                                      │
+│ deliveryTime                       │ 892000n                                                                                    │
+│ offRamp                            │ 'offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm'                                              │
+└────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
+CCIP Explorer: https://ccip.chain.link/msg/0xc64e289c9a0a9b3bff7f2bfe98996ef56dc138f7fdc500541e60b009ab7d98d3
+[SENT] Waiting for source chain finalization...
+Using rate-limited fetch for public solana nodes, commands may be slow
+[SOURCE_FINALIZED] Source chain finalized
+[SOURCE_FINALIZED] Waiting for commit on destination chain...
+[SUCCESS] Message executed on destination chain
+┌─────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐
+│ (index)         │ Values                                                                                     │
+├─────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
+│ state           │ '✅ success'                                                                               │
+│ origin          │ 'DeJbuwyora8jj76hMbypp2v59MUa9vgPo9DPEnMDdJnC'                                             │
+│ contract        │ 'offqSMQWgQud6WJz694LRzkeN5kMYpCHTpXQr3Rkcjm'                                              │
+│ transactionHash │ '2gtGHy8tqeyHgDGLm7AntoGC2V9yBfpQwTZKoaDozMDfCvWgNSJVEr3BiTn4z8W2fzHkPrbxzmxQG7ThWgExV2fR' │
+│ logIndex        │ 23                                                                                         │
+│ blockNumber     │ 469503780                                                                                  │
+│ timestamp       │ '2026-06-15 01:51:40 (14m52s after request)'                                               │
+└─────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+</Fragment>
 </Tabs>
 
-#### Monitor and Verify Transaction
-
-Upon successful execution, the system generates distinct tracking identifiers for comprehensive monitoring across both blockchain networks.
-
-**Transaction Identifiers:**
-
-- **Ethereum Transaction Hash**: `0xb2d48398a4d57dde2aaf0551209abad448b092602ca5087e0d108eadd8a8c319`
-- **CCIP Message ID**: `0x567f4cdb2e1c52f6aef6354bd9acbeac6761aa4b1a5e74a356785c2e67197d88`
-
-**CCIP Explorer** (Primary monitoring interface):
-
-```
-https://ccip.chain.link/msg/0x567f4cdb2e1c52f6aef6354bd9acbeac6761aa4b1a5e74a356785c2e67197d88
-```
-
-The CCIP Explorer provides comprehensive transaction visibility:
-
-- Source chain (Ethereum) transaction confirmation
-- CCIP message processing and routing
-- Destination chain (Solana) message delivery
-- Token minting completion on Solana network
-
-**Ethereum Sepolia Explorer** (Source chain verification):
-
-```
-https://sepolia.etherscan.io/tx/0xb2d48398a4d57dde2aaf0551209abad448b092602ca5087e0d108eadd8a8c319
-```
+**Congratulations!** Your cross-chain token infrastructure with SPL token multisig governance is fully configured on both chains.
 
 ## Optional: Verify Mint Authority Control
 
@@ -1840,6 +2486,29 @@ solana config get
 
 </Aside>
 
+</Fragment>
+
+<Fragment slot="panel.2">
+
+```bash
+Minting 1 tokens
+  Token: AgHA2wyaRnjL5Jjnk1PirfXA2n3fF6w6t8RhRCG9pqp7
+  Recipient: 9Xv8WtoN9EpBfSjqWVoQfrf4qc5CMSvBmM5Hu9jApYhc
+
+Signature: 47EdSs3eUrbd6VB4W9iJzTMj81q9pyom38Nw4gyHpzqYDqMJQ6SqyKTs9csSvGp3BZvR5kVuxJnFTKX3DFGxpwyU
+```
+
+**Verify Transaction on Solana Explorer:**
+
+```
+https://explorer.solana.com/tx/4dYQyf8oTWojuVKNQdPNkdPLVwdJcGCbekW3sXP7ZdTd7UVksft9ekKLDWtkE4rgUvuTtFeTRNGWpgmF7HJNFJ3J?cluster=devnet
+```
+
+The successful transaction on Solana Explorer confirms that the multisig mint operation executed properly, proving that mint authority is retained and functional through the multisig structure.
+
+</Fragment>
+</Tabs>
+
 <Aside type="tip" title="Understanding This Demonstration">
 **What This Proves**: Successfully minting tokens through the multisig confirms that:
 - Mint authority transfer was successful
@@ -1859,28 +2528,5 @@ solana config get
 To learn more, see the [Production Multisig Tutorial](/ccip/tutorials/svm/cross-chain-tokens/production-multisig-tutorial).
 
 </Aside>
-
-</Fragment>
-
-<Fragment slot="panel.2">
-
-```bash
-Minting 1 tokens
-  Token: 8nEFofUqsXSxpvYzfw1TXZFVSM8L8UH1sLbQHdn4WNFS
-  Recipient: 4k3FoESSV3MHg1iKScE1Ccqeb3PfHiz71nX5PgkaL1kz
-
-Signature: 3y1kBhxJ1XG9qtDSfhtStV3AYJXTE2TvKJysg5JiJzsNrUmzRBWKby9sg67dsWf7Vr6hAYjAS5UTPSrCfuVohLtj
-```
-
-**Verify Transaction on Solana Explorer:**
-
-```
-https://explorer.solana.com/tx/4dYQyf8oTWojuVKNQdPNkdPLVwdJcGCbekW3sXP7ZdTd7UVksft9ekKLDWtkE4rgUvuTtFeTRNGWpgmF7HJNFJ3J?cluster=devnet
-```
-
-The successful transaction on Solana Explorer confirms that the multisig mint operation executed properly, proving that mint authority is retained and functional through the multisig structure.
-
-</Fragment>
-</Tabs>
 
 <CcipCommon callout="educationalDisclaimer" />

--- a/src/features/ccip/SvmCrossChainTokenPrerequisites.mdx
+++ b/src/features/ccip/SvmCrossChainTokenPrerequisites.mdx
@@ -2,76 +2,86 @@ import { Aside } from "@components"
 
 ## Prerequisites
 
-This tutorial requires setting up two different repositories in separate terminal windows. Follow the setup instructions for both environments before proceeding.
+This tutorial uses a **two-terminal workflow** across two repositories. Install the system tools below, clone both repos, then complete environment setup before starting Phase 1.
 
-### Development Environment Requirements
+### System Requirements
 
-**System Requirements:**
-
-- **Anchor and Solana CLI Tools**: Install following the [installation guide](https://www.anchor-lang.com/docs/installation). Requires Rust to be installed.
-- **Node.js v20 or higher**: Use the [nvm package](https://www.npmjs.com/package/nvm) to install and manage versions. Verify with `node -v`
-- **Yarn**: For dependency management
+- **Node.js v22 or higher**: Verify with `node -v` ([nvm](https://www.npmjs.com/package/nvm) recommended)
+- **pnpm**: Required for the BS58 generator (`npm install -g pnpm`)
+- **Solana CLI**: [Installation guide](https://docs.solana.com/cli/install-solana-cli-tools) (includes `spl-token`)
 - **Git**: For cloning repositories
+- **CCIP CLI**: For cross-chain transfer testing in the final phase
 
-### Terminal 1: Solana Starter Kit Setup
-
-**Clone and setup the Solana Starter Kit:**
+Install the [CCIP CLI](https://github.com/smartcontractkit/ccip-tools-ts) globally:
 
 ```bash
-git clone https://github.com/smartcontractkit/solana-starter-kit.git && cd solana-starter-kit
+npm install -g @chainlink/ccip-cli
+ccip-cli --help
 ```
 
-**Install dependencies:**
+See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for RPC and wallet configuration.
+
+### Tutorial Workflow
+
+| Terminal       | Repository                                                                                                                  | Purpose                              | Commands        |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | --------------- |
+| **Terminal 1** | [CCIP Solana BS58 Generator](https://github.com/smartcontractkit/ccip-solana-bs58-generator)                                | Solana setup and configuration       | `pnpm bs58`     |
+| **Terminal 2** | [Smart Contract Examples (Hardhat)](https://github.com/smartcontractkit/smart-contract-examples/tree/main/ccip/cct/hardhat) | EVM deploy and configuration         | `npx hardhat`   |
+| **Either**     | Global `@chainlink/ccip-cli`                                                                                                | Cross-chain transfer testing (final) | `ccip-cli send` |
+
+### Terminal 1: CCIP Solana BS58 Generator
+
+**Clone and install** (skip `git clone` if you already have the repo):
 
 ```bash
-yarn install
+git clone https://github.com/smartcontractkit/ccip-solana-bs58-generator.git
+cd ccip-solana-bs58-generator
+pnpm install
 ```
 
-**Configure your Solana environment:**
+**Configure Solana CLI for devnet:**
+
+First, check whether your environment is already set up:
 
 ```bash
-# Set Solana CLI to use devnet
+solana config get
+solana address
+solana balance
+```
+
+If the RPC URL is already `https://api.devnet.solana.com`, your keypair path is correct, and you have sufficient SOL, skip to [Terminal 2 setup](#terminal-2-smart-contract-examples-hardhat) below.
+
+Otherwise, run only the steps you need:
+
+```bash
+# Set devnet (skip if config get already shows devnet)
 solana config set --url https://api.devnet.solana.com
 
-# Set your keypair (create one if needed)
+# Point to your keypair (skip if config get already shows the path you want)
 solana config set --keypair ~/.config/solana/id.json
 
-# If you do not have a keypair, create one:
+# Create a keypair only if the file does not exist yet
 solana-keygen new --outfile ~/.config/solana/id.json
-```
 
-**Fund your Solana wallet:**
-
-```bash
-# Get your wallet address
-solana address
-
-# Request SOL from the devnet faucet
+# Fund your wallet if balance is low
 solana airdrop 2
-```
-
-**Verify your setup:**
-
-```bash
-# Check your SOL balance
 solana balance
-
-# Verify you are on devnet
-solana config get
 ```
 
-### Terminal 2: Smart Contract Examples Setup
+<Aside type="note" title="Direct Execution">
+  Append `--execute` to **mutating** `pnpm bs58` commands in Terminal 1 so your local wallet signs and sends
+  transactions. **Read-only** commands (`get-state`, `get-chain-config`, `derive-accounts`) omit `--execute`. See the
+  [CCIP Solana BS58 Generator
+  README](https://github.com/smartcontractkit/ccip-solana-bs58-generator/blob/main/README.md) for command syntax.
+</Aside>
 
-**Clone the repository and navigate to the Hardhat project:**
+### Terminal 2: Smart Contract Examples (Hardhat)
+
+**Clone, install, and compile** (skip `git clone` if you already have the repo):
 
 ```bash
 git clone https://github.com/smartcontractkit/smart-contract-examples.git
 cd smart-contract-examples/ccip/cct/hardhat
-```
-
-**Install and compile dependencies:**
-
-```bash
 npm install
 npm run compile
 ```
@@ -79,24 +89,54 @@ npm run compile
 **Set up encrypted environment variables:**
 
 ```bash
-# Set encryption password
+# Required at the start of each session
 npx env-enc set-pw
 
-# Configure environment variables
+# Verify existing variables (skip npx env-enc set if all required vars are already configured)
+npx env-enc view
+
+# Add or update variables only if missing
 npx env-enc set
 ```
 
-**Required environment variables for Ethereum Sepolia:**
+**Required variables for Ethereum Sepolia:**
 
 - `ETHEREUM_SEPOLIA_RPC_URL`: RPC endpoint from [Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/)
 - `PRIVATE_KEY`: Your testnet wallet private key ([MetaMask export guide](https://support.metamask.io/managing-my-wallet/secret-recovery-phrase-and-private-keys/how-to-export-an-accounts-private-key/))
 - `ETHERSCAN_API_KEY`: API key from [Etherscan](https://docs.etherscan.io/getting-started/viewing-api-usage-statistics)
 
-**Fund your wallet:**
+**Fund your EVM wallet:**
 
-- Acquire LINK and ETH on Ethereum Sepolia using [Chainlink faucets](https://faucets.chain.link/)
+- Acquire **ETH** on Ethereum Sepolia for transaction gas and CCIP fees ([Chainlink faucet](https://faucets.chain.link/) or [Google Cloud Faucet](https://cloud.google.com/application/web3/faucet/ethereum/sepolia))
+- **LINK** is optional — use `--fee-token LINK` on EVM → Solana sends if you prefer paying CCIP fees in LINK
+
+### Cross-Chain Transfers (CCIP CLI)
+
+The final tutorial phase uses globally installed `ccip-cli` (not the BS58 generator):
+
+- **Solana → EVM**: Run from Terminal 1 with `--wallet ~/.config/solana/id.json`
+- **EVM → Solana**: Run from Terminal 2 (Hardhat directory). Prefer `--wallet hardhat:<name>` ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)) so the signing key stays encrypted. Hardhat tasks load env-enc automatically; `ccip-cli` does not. As an alternative, view the same key with `npx env-enc view` and export `PRIVATE_KEY` manually for the send command.
+
+**RPC endpoints** (required for source and destination chains). You can provide them any of these ways — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration):
+
+- **Command line:** pass `--rpc` on each command (repeat for multiple networks), or `--rpcs` with comma-separated URLs
+- **Environment variables:** export `RPC_*` variables (e.g., `RPC_SEPOLIA`, `RPC_SOLANA_DEVNET`) or the tutorial's `SOLANA_DEVNET_RPC` and `ETHEREUM_SEPOLIA_RPC_URL` exports
+- **File:** create a `.env` file in the directory where you run `ccip-cli` (default `--rpcs-file`, one URL per line)
+
+See the tutorial's **Configure CCIP CLI** section for the recommended `--rpc` examples.
+
+### Environment Variables
+
+Variables use prefixes to prevent confusion across repositories and tools:
+
+| Prefix       | Usage                   | Examples                                                                  |
+| ------------ | ----------------------- | ------------------------------------------------------------------------- |
+| `ETH_*`      | Ethereum addresses      | `ETH_TOKEN_ADDRESS`, `ETH_POOL_ADDRESS`                                   |
+| `SOL_*`      | Solana addresses        | `SOL_TOKEN_MINT`, `SOL_POOL_ADDRESS`, `SOL_WALLET_ADDRESS`                |
+| `SOL_CCIP_*` | Solana CCIP program IDs | `SOL_CCIP_POOL_PROGRAM`, `SOL_CCIP_ROUTER`, `SOL_CCIP_FEE_QUOTER_PROGRAM` |
 
 <Aside type="note" title="Two-Terminal Workflow">
-  Keep both terminal windows open throughout the tutorial. You will switch between the Solana Starter Kit (Terminal 1)
-  and Hardhat project (Terminal 2) as you progress through the phases.
+  Keep both terminal windows open throughout the tutorial. Switch between the CCIP Solana BS58 Generator (Terminal 1)
+  and the Hardhat project (Terminal 2) as each phase indicates. Cross-chain transfer commands use `ccip-cli` from the
+  terminal that matches the source chain.
 </Aside>

--- a/src/features/ccip/SvmCrossChainTokenProductionPrerequisites.mdx
+++ b/src/features/ccip/SvmCrossChainTokenProductionPrerequisites.mdx
@@ -2,30 +2,34 @@ import { Aside } from "@components"
 
 ## Prerequisites
 
+This tutorial uses a **two-terminal workflow** with **Squads multisig governance** on Solana. Install the system tools below, create your Squad on devnet, clone both repositories, then complete environment setup before starting Phase 1.
+
 ### System Requirements
 
-Install these tools before starting:
-
-**Package Managers:**
-
-- **Node.js v20+**: Required for all repositories
-- **pnpm**: Required for base58 Generator (`npm install -g pnpm`)
-- **yarn**: Required for Solana Starter Kit (`npm install -g yarn`)
-
-**Solana Development:**
-
-- **Solana CLI**: [Installation guide](https://docs.solana.com/cli/install-solana-cli-tools)
+- **Node.js v22 or higher**: Required for all tools. Verify with `node -v`
+- **pnpm**: Required for the BS58 generator (`npm install -g pnpm`)
+- **npm**: Required for the Hardhat project (bundled with Node.js)
+- **Solana CLI**: [Installation guide](https://docs.solana.com/cli/install-solana-cli-tools) (includes `spl-token`)
+- **Git**: For cloning repositories
+- **CCIP CLI**: For cross-chain transfer testing in the final phase
 
 **Wallets:**
 
-- **Solana wallet**: [Phantom](https://phantom.app/) or [Backpack](https://backpack.app/) for Devnet operations
-- **Ethereum wallet**: [MetaMask](https://metamask.io/) for Sepolia testnet operations
+- **Solana**: [Phantom](https://phantom.app/) or [Backpack](https://backpack.app/) for Devnet and Squads operations
+- **Ethereum**: [MetaMask](https://metamask.io/) for Sepolia testnet operations
+
+Install the [CCIP CLI](https://github.com/smartcontractkit/ccip-tools-ts) globally:
+
+```bash
+npm install -g @chainlink/ccip-cli
+ccip-cli --help
+```
+
+See the [CCIP CLI documentation](https://docs.chain.link/ccip/tools/cli/) for RPC and wallet configuration.
 
 ### Repository Setup
 
-Clone and install dependencies for all three repositories:
-
-**Terminal 1: base58 Generator**
+**Terminal 1: CCIP Solana BS58 Generator** (skip `git clone` if you already have the repo)
 
 ```bash
 git clone https://github.com/smartcontractkit/ccip-solana-bs58-generator.git
@@ -33,7 +37,7 @@ cd ccip-solana-bs58-generator
 pnpm install
 ```
 
-**Terminal 2: EVM Hardhat**
+**Terminal 2: Smart Contract Examples (Hardhat)** (skip `git clone` if you already have the repo)
 
 ```bash
 git clone https://github.com/smartcontractkit/smart-contract-examples.git
@@ -42,76 +46,77 @@ npm install
 npm run compile
 ```
 
-**Terminal 3: Solana Starter Kit**
-
-```bash
-git clone https://github.com/smartcontractkit/solana-starter-kit.git
-cd solana-starter-kit
-yarn install
-```
-
-**Create and configure the .env file:**
-
-```bash
-# Create .env file in the project root
-cat > .env << 'EOF'
-EVM_PRIVATE_KEY=your_private_key_here
-EVM_RPC_URL=your_rpc_url_here
-EOF
-```
-
-Replace the placeholder values with:
-
-- `EVM_PRIVATE_KEY`: Your Ethereum wallet private key (for Sepolia testnet operations)
-- `EVM_RPC_URL`: Your Ethereum RPC URL (from [Alchemy](https://www.alchemy.com/), [Infura](https://www.infura.io/), or another provider)
-
 ### Environment Configuration
 
-**Solana Configuration:**
+#### Solana (Terminal 1)
+
+First, check whether your environment is already set up:
 
 ```bash
-# Set Solana CLI to devnet
-solana config set --url https://api.devnet.solana.com
-
-# Create keypair (ONLY IF NEEDED)
-solana-keygen new --outfile ~/.config/solana/id.json
-
-# Check Config
 solana config get
-
-# Fund wallet
-solana airdrop 3
+solana address
+solana balance
 ```
 
-**Ethereum Sepolia Configuration:**
+If the RPC URL is already `https://api.devnet.solana.com`, your keypair path is correct, and you have sufficient SOL, skip to [Ethereum Sepolia setup](#ethereum-sepolia-terminal-2) below.
+
+Otherwise, run only the steps you need:
 
 ```bash
-# In Terminal 2 (Hardhat directory)
+# Set devnet (skip if config get already shows devnet)
+solana config set --url https://api.devnet.solana.com
+
+# Point to your keypair (skip if config get already shows the path you want)
+solana config set --keypair ~/.config/solana/id.json
+
+# Create a keypair only if the file does not exist yet
+solana-keygen new --outfile ~/.config/solana/id.json
+
+# Fund your wallet if balance is low
+solana airdrop 3
+solana balance
+```
+
+#### Ethereum Sepolia (Terminal 2)
+
+```bash
+# Required at the start of each session
 npx env-enc set-pw
+
+# Verify existing variables (skip npx env-enc set if all required vars are already configured)
+npx env-enc view
+
+# Add or update variables only if missing
 npx env-enc set
 ```
 
-Required environment variables:
+Required variables:
 
 - `ETHEREUM_SEPOLIA_RPC_URL`: RPC endpoint ([Alchemy](https://www.alchemy.com/) or [Infura](https://www.infura.io/))
 - `PRIVATE_KEY`: Testnet wallet private key
 - `ETHERSCAN_API_KEY`: API key from [Etherscan](https://etherscan.io/apis)
 
-**Testnet Tokens:**
+**Testnet tokens:**
 
-- **Solana Devnet**: Use `solana airdrop 3` for SOL
-- **Ethereum Sepolia**: Use [Chainlink faucets](https://faucets.chain.link/) for LINK and ETH
+- **Solana Devnet**: `solana airdrop 3` for SOL
+- **Ethereum Sepolia**: ETH for gas and CCIP fees ([Chainlink faucet](https://faucets.chain.link/) or [Google Cloud Faucet](https://cloud.google.com/application/web3/faucet/ethereum/sepolia)). LINK is optional for `--fee-token LINK` on EVM sends.
+
+<Aside type="note" title="When to Use --execute">
+  **Governance steps** generate base58-encoded transactions in Terminal 1 **without** `--execute`. Import the output
+  into Squads and sign there. **Pre-transfer steps** (token delegation, pool ATA creation) use your local Solana wallet
+  with `--execute` on `pnpm bs58` commands. **Read-only** commands (`get-state`, `get-chain-config`) omit `--execute`.
+  See the [CCIP Solana BS58 Generator
+  README](https://github.com/smartcontractkit/ccip-solana-bs58-generator/blob/main/README.md).
+</Aside>
 
 ### Squads Multisig Setup
 
 <Aside type="caution" title="Required: Create Squads Multisig">
-  **Before starting this tutorial**, you must create a Squads multisig on Solana Devnet. This will serve as your
-  governance mechanism for all CCIP administrative operations.
+  **Before starting this tutorial**, create a Squads multisig on Solana Devnet. It serves as your governance mechanism
+  for CCIP administrative operations.
 </Aside>
 
-**Step 1: Prepare Signers**
-
-Create multiple wallet addresses for your multisig signers:
+**Step 1: Prepare signers**
 
 ```bash
 # Create additional signers using Solana CLI
@@ -128,22 +133,18 @@ solana transfer <SIGNER2_ADDRESS> 0.1 --allow-unfunded-recipient
 solana transfer <SIGNER3_ADDRESS> 0.1 --allow-unfunded-recipient
 ```
 
-Alternatively, create signers in Phantom wallet and fund them:
+Alternatively, create signers in Phantom and fund them:
 
 ```bash
-# Transfer SOL to Phantom-created addresses
 solana transfer <PHANTOM_SIGNER_ADDRESS> 0.5 --allow-unfunded-recipient
 ```
 
-**Step 2: Create Your Squad**
+**Step 2: Create your Squad**
 
 1. Visit [devnet.squads.so](https://devnet.squads.so)
-1. Connect your Solana wallet (e.g., Phantom/Backpack)
-1. Click "Create New Squad"
-1. Configure your multisig:
-   - **Squad Name**: Choose a descriptive name (e.g., "CCIP Token Governance")
-   - **Members**: Add wallet addresses of all signers
-   - **Threshold**: Set approval threshold (recommended: 2/3 or 3/5)
+1. Connect your Solana wallet (Phantom or Backpack)
+1. Click **Create New Squad**
+1. Configure members and threshold (recommended: 2/3 or 3/5)
 
 <Aside type="note" title="Threshold Best Practices">
 
@@ -152,97 +153,87 @@ solana transfer <PHANTOM_SIGNER_ADDRESS> 0.5 --allow-unfunded-recipient
 
 </Aside>
 
-**Step 3: Record Critical Addresses**
+**Step 3: Record the vault address**
 
-After Squad creation, navigate to Settings tab and record these addresses.
+After Squad creation, open the Settings tab and copy the **vault address** (not the multisig address).
 
-**In Terminal 1 (base58 Generator), export the vault address:**
+**In Terminal 1:**
 
 ```bash
 # CRITICAL: Use the VAULT address, NOT the multisig address
 export SOL_SQUAD_VAULT_MULTISIG="YOUR_VAULT_ADDRESS_HERE"
-```
-
-Verify the export:
-
-```bash
 echo "Squads Vault Address: $SOL_SQUAD_VAULT_MULTISIG"
 ```
 
 <Aside type="caution" title="Vault vs Multisig Address">
-  **IMPORTANT**: Only use the **Vault address** for setting authorities and receiving funds. The **Multisig address** is
-  used only for CLI detection - sending assets to it causes **irreversible loss**.
+  Use the **vault address** for authorities and receiving funds. The **multisig address** is for CLI detection only —
+  sending assets to it causes **irreversible loss**.
 </Aside>
 
-**Step 4: Test Your Squad**
-
-Perform a small test transaction to verify setup:
+**Step 4: Test your Squad**
 
 1. Send a small amount of SOL to your Squad vault
 1. Create a test transaction in Squads UI (e.g., SOL transfer to your wallet)
-1. Confirm all signers can approve transactions
-1. Execute the transaction
+1. Confirm signers can approve and execute
 
-For detailed setup guidance, see the [Squads Documentation](https://docs.squads.so/).
+See [Squads Documentation](https://docs.squads.so/) for detailed setup guidance.
 
 ### Token Creation Option
 
 <Aside type="note" title="Existing Token Requirements">
-  **Important**: You can only skip token creation if you have an existing SPL token where the **mint authority is already controlled by your Squad vault**.
+  You can skip token creation only if you have an existing SPL token where **mint authority is already controlled by your
+  Squad vault**.
 
 **Two scenarios:**
 
-1. **Mint authority = Squad vault**: Skip to Step 3 (pool initialization) and export your existing mint address
-1. **Mint authority ≠ Squad vault**: You must first transfer mint authority to your Squad vault, OR create a fresh token in Step 2
+1. **Mint authority = Squad vault**: Skip to pool initialization and export your existing mint address
+1. **Mint authority ≠ Squad vault**: Transfer mint authority to your Squad vault first, or create a fresh token in the tutorial
 
-**For fresh start**: Proceed with Step 2 to create a new token with Squad vault as mint authority from the beginning.
+**For a fresh start**: Proceed with token creation so the Squad vault is mint authority from the beginning.
 
 </Aside>
 
 ## Tutorial Approach
 
-This tutorial implements production-grade cross-chain tokens using a three-terminal workflow across specialized repositories:
+| Terminal       | Repository                                                                                                                  | Purpose                                    | Commands        |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | --------------- |
+| **Terminal 1** | [CCIP Solana BS58 Generator](https://github.com/smartcontractkit/ccip-solana-bs58-generator)                                | Governance txs and pre-transfer setup      | `pnpm bs58`     |
+| **Terminal 2** | [Smart Contract Examples (Hardhat)](https://github.com/smartcontractkit/smart-contract-examples/tree/main/ccip/cct/hardhat) | Deploy and configure EVM components        | `npx hardhat`   |
+| **Either**     | Global `@chainlink/ccip-cli`                                                                                                | Cross-chain transfer testing (final phase) | `ccip-cli send` |
 
-| Terminal       | Repository                                                                                                                  | Purpose                          | Commands      |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ------------- |
-| **Terminal 1** | [CCIP Solana base58 Generator](https://github.com/smartcontractkit/ccip-solana-bs58-generator)                              | Generate governance transactions | `pnpm bs58`   |
-| **Terminal 2** | [Smart Contract Examples (Hardhat)](https://github.com/smartcontractkit/smart-contract-examples/tree/main/ccip/cct/hardhat) | Deploy EVM components            | `npx hardhat` |
-| **Terminal 3** | [Solana Starter Kit](https://github.com/smartcontractkit/solana-starter-kit)                                                | Test cross-chain transfers       | `yarn`        |
-
-**Note**: Each repository contains comprehensive READMEs with detailed technical explanations and troubleshooting guides.
+The [CCIP Solana BS58 Generator README](https://github.com/smartcontractkit/ccip-solana-bs58-generator/blob/main/README.md) contains command syntax, simulation behavior, and troubleshooting.
 
 ### Key Implementation Notes
 
-- **Terminal 1** generates base58-encoded transactions for Squads multisig governance
-- **Terminal 2** uses EOA for tutorial simplicity; production deployments should use multisig wallets (e.g., Safe)
-- **Terminal 3** validates end-to-end cross-chain functionality
+- **Terminal 1** generates base58 transactions for Squads governance (no `--execute`). Pre-transfer delegation steps use `--execute` with your local wallet.
+- **Terminal 2** uses an EOA for tutorial simplicity; production EVM deployments should use multisig wallets (e.g., Safe).
+- **Cross-chain transfers** use [`@chainlink/ccip-cli`](https://github.com/smartcontractkit/ccip-tools-ts): Terminal 1 for Solana → EVM, Terminal 2 for EVM → Solana. For EVM sends, prefer `--wallet hardhat:<name>` ([Hardhat keystore](https://hardhat.org/docs/plugins/hardhat-keystore)) from the Hardhat directory; alternatively export `PRIVATE_KEY` manually after `npx env-enc view` (Hardhat tasks load env-enc automatically, but `ccip-cli` does not). Provide RPCs via `--rpc`/`--rpcs`, `RPC_*` environment variables, or a `.env` file — see [CCIP CLI configuration](https://docs.chain.link/ccip/tools/cli/configuration).
 
 ### base58 Transaction Execution Workflow
 
-**Transaction Generation and Validation:**
+**Transaction generation:**
 
-1. **CLI Simulation**: Each base58 transaction is automatically simulated during generation
-1. **Error Handling**: If simulation fails, error logs appear in terminal - do not upload failed transactions to Squads
-1. **Success Indicator**: Successful simulation shows transaction preview and base58 output
+1. **CLI simulation**: Each base58 transaction is simulated during generation
+1. **Error handling**: If simulation fails, do not upload the transaction to Squads
+1. **Success**: Terminal shows a transaction preview and base58 output
 
-**Squads Multisig Execution Process:**
+**Squads execution:**
 
-1. **Propose**: A signer imports the base58 transaction into Squads UI → "Add instruction" → "Import base58 encoded tx" → **Initiate Transaction**
-1. **Approve**: Required threshold (M) of signers review and approve the transaction
-1. **Simulate** (Recommended): Before execution, signers can simulate through Squads interface to preview onchain effects
-1. **Execute**: After threshold approval, any signer can execute the transaction
+1. **Propose**: Import base58 output in Squads UI → **Developers** (left sidebar) → **TX Builder** → **Import base58 encoded tx** → **Initiate Transaction**
+1. **Approve**: Required threshold of signers approves
+1. **Simulate** (recommended): Preview onchain effects in Squads before execution
+1. **Execute**: Any approved signer executes after threshold is met
 
 <Aside type="note" title="Security Best Practice">
-  Always simulate before execution using Squads' built-in simulation feature. This shows exactly what will happen
-  onchain and is critical for validating complex governance operations before commitment.
+  Always simulate in Squads before execution. This validates complex governance operations before commitment.
 </Aside>
 
 ### Environment Variables
 
 Variables use prefixes to prevent confusion across repositories:
 
-| Prefix   | Usage              | Examples                                   |
-| -------- | ------------------ | ------------------------------------------ |
-| `ETH_*`  | Ethereum addresses | `ETH_TOKEN_ADDRESS`, `ETH_POOL_ADDRESS`    |
-| `SOL_*`  | Solana addresses   | `SOL_TOKEN_MINT`, `SOL_POOL_ADDRESS`       |
-| `CCIP_*` | Protocol constants | `CCIP_POOL_PROGRAM`, `CCIP_ROUTER_PROGRAM` |
+| Prefix       | Usage                   | Examples                                                                  |
+| ------------ | ----------------------- | ------------------------------------------------------------------------- |
+| `ETH_*`      | Ethereum addresses      | `ETH_TOKEN_ADDRESS`, `ETH_POOL_ADDRESS`                                   |
+| `SOL_*`      | Solana addresses        | `SOL_TOKEN_MINT`, `SOL_POOL_ADDRESS`                                      |
+| `SOL_CCIP_*` | Solana CCIP program IDs | `SOL_CCIP_POOL_PROGRAM`, `SOL_CCIP_ROUTER`, `SOL_CCIP_FEE_QUOTER_PROGRAM` |


### PR DESCRIPTION
## Summary

- Migrate all four Solana CCT tutorials from `solana-starter-kit` to `ccip-solana-bs58-generator` + Hardhat + `ccip-cli`
- Update shared prerequisites for the two-terminal workflow and Squads setup
- Refresh expected outputs from June 2026 E2E runs on Sepolia and Solana Devnet