### PR TITLE
CRE: CLI 1.19 -> 1.21

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -2280,6 +2280,34 @@
     },
     {
       "category": "release",
+      "date": "2026-06-18",
+      "description": "CRE CLI version 1.21.0 is now available. Using `--unsigned` or `--changeset` with `--secrets-auth=browser` or a private registry now produces a clear upfront error instead of a confusing failure mid-operation.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.20.0...v1.21.0)",
+      "title": "CRE CLI v1.21.0 — MSIG Mode Guard",
+      "topic": "CRE"
+    },
+    {
+      "category": "release",
+      "date": "2026-06-12",
+      "description": "CRE CLI version 1.20.0 is now available. Simulation resource limits now match production — including higher execution concurrency, doubled gas limits, and larger payload caps for HTTP action and ConfidentialHTTP.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.19.0...v1.20.0)",
+      "title": "CRE CLI v1.20.0 — Simulation Limits Match Production",
+      "topic": "CRE"
+    },
+    {
+      "category": "release",
+      "date": "2026-06-11",
+      "description": "Go SDK version 1.12.0 adds Solana mainnet chain selectors and workflow bindings, enabling production workflows that target Solana mainnet.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.11.0...v1.12.0)",
+      "title": "Go SDK v1.12.0 — Solana Mainnet",
+      "topic": "CRE"
+    },
+    {
+      "category": "release",
+      "date": "2026-06-11",
+      "description": "CRE CLI version 1.19.0 is now available. A new `--listen` flag for `cre workflow simulate` keeps the simulator alive and reruns it for each incoming HTTP POST or EVM log trigger event, making it easier to iterate on trigger-driven workflows. Browser OAuth secrets auth is now enabled in production (with a fix for flows that broke when the default `CRE_ETH_PRIVATE_KEY` placeholder was set). Workflow output for deploy, activate, and pause now shows the resolved DON Family. The CLI also auto-resolves RPC endpoints for the capability registry chain and prompts for consent during secrets operations.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.18.0...v1.19.0)",
+      "title": "CRE CLI v1.19.0 — `--listen` for Simulate, Browser Secrets in Production",
+      "topic": "CRE"
+    },
+    {
+      "category": "release",
       "date": "2026-06-04",
       "description": "CRE CLI version 1.18.0 is now available. This release includes internal reliability improvements across context propagation, secret handling, and registry type management.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.17.0...v1.18.0)",
       "title": "CRE CLI v1.18.0 — Internal Improvements",
@@ -3485,9 +3513,30 @@
     },
     {
       "category": "release",
+      "date": "2026-05-21",
+      "description": "Go SDK version 1.11.0 adds `private-testnet-rhyolite` EVM capabilities for the Rhyolite private testnet.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.10.0...v1.11.0)",
+      "title": "Go SDK v1.11.0 — Rhyolite Testnet Support",
+      "topic": "CRE"
+    },
+    {
+      "category": "release",
+      "date": "2026-05-20",
+      "description": "Go SDK version 1.10.0 adds ADI mainnet (`adi-mainnet`) EVM capabilities, enabling workflows that target ADI mainnet.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.9.0...v1.10.0)",
+      "title": "Go SDK v1.10.0 — ADI Mainnet Support",
+      "topic": "CRE"
+    },
+    {
+      "category": "release",
       "date": "2026-05-14",
       "description": "CRE CLI version 1.15.0 is now available. This release upgrades `cre workflow supported-chains` to show tenant-specific chains and their mock forwarder addresses (requires `cre login` or `CRE_API_KEY`), adds ADI testnet and Celo Sepolia support, and introduces a global `--allow-unknown-chains` flag to skip chain validation for experimental networks during simulation and deploy. `cre workflow hash` now auto-derives the workflow owner based on your target registry — on-chain uses `CRE_ETH_PRIVATE_KEY` or `workflow-owner-address`, off-chain uses the owner from your login session. The release also includes private registry bug fixes.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.14.0...v1.15.0)",
       "title": "CRE CLI v1.15.0 — Tenant-Scoped Chains and Chain Expansion",
+      "topic": "CRE"
+    },
+    {
+      "category": "release",
+      "date": "2026-05-13",
+      "description": "Go SDK version 1.9.0 adds ADI testnet (`adi-testnet`) and Celo Sepolia (`celo-sepolia`) EVM capabilities, enabling simulation and deployment to these networks.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.8.0...v1.9.0)",
+      "title": "Go SDK v1.9.0 — ADI Testnet and Celo Sepolia Support",
       "topic": "CRE"
     },
     {

--- a/src/config/versions/index.ts
+++ b/src/config/versions/index.ts
@@ -77,8 +77,11 @@ export const VERSIONS = {
   },
   // CRE CLI Versions — update LATEST here for each new release
   "cre-cli": {
-    LATEST: "v1.18.0",
+    LATEST: "v1.21.0",
     ALL: [
+      "v1.21.0",
+      "v1.20.0",
+      "v1.19.0",
       "v1.18.0",
       "v1.17.0",
       "v1.16.0",
@@ -92,6 +95,9 @@ export const VERSIONS = {
       "v1.8.0",
     ] as const,
     RELEASE_DATES: {
+      "v1.21.0": "2026-06-18T00:00:00Z",
+      "v1.20.0": "2026-06-12T00:00:00Z",
+      "v1.19.0": "2026-06-11T00:00:00Z",
       "v1.18.0": "2026-06-04T00:00:00Z",
       "v1.17.0": "2026-05-28T00:00:00Z",
       "v1.16.0": "2026-05-22T00:00:00Z",

--- a/src/content/cre/guides/operations/simulating-workflows.mdx
+++ b/src/content/cre/guides/operations/simulating-workflows.mdx
@@ -5,7 +5,7 @@ title: "Simulating Workflows"
 metadata:
   description: "Simulate your workflows: learn to simulate CRE workflows with real API and testnet calls before deploying them."
   datePublished: "2025-11-04"
-  lastModified: "2025-11-04"
+  lastModified: "2026-06-11"
 ---
 
 import { Aside, CopyText } from "@components"
@@ -111,6 +111,19 @@ cre workflow simulate my-workflow --non-interactive --trigger-index 0 --target s
   multiple handlers (e.g., one for an HTTP trigger and one for an EVM log trigger), use `0` for the first, `1` for the
   second, etc., based on their order in your code.
 </Aside>
+
+## Listen mode
+
+The `--listen` flag keeps the simulator alive and re-runs it for each incoming trigger event, instead of compiling and executing once then exiting.
+
+- **HTTP triggers**: starts a local HTTP server on port `2000`. Each POST request triggers a fresh simulation run.
+- **EVM log triggers**: watches the configured chain and re-runs on each matching log event.
+
+```bash
+cre workflow simulate my-workflow --listen --target staging-settings
+```
+
+This is useful during active development — make a code change, resave, send another event, and see the result immediately without restarting the CLI. See [Testing HTTP Triggers in Simulation](/cre/guides/workflow/using-triggers/http-trigger/testing-in-simulation) for a detailed walkthrough with HTTP triggers.
 
 ## The `--broadcast` flag
 

--- a/src/content/cre/guides/workflow/using-evm-client/forwarder-directory-go.mdx
+++ b/src/content/cre/guides/workflow/using-evm-client/forwarder-directory-go.mdx
@@ -7,13 +7,19 @@ pageId: "evm-forwarder-directory"
 metadata:
   description: "Find forwarder contract addresses for CRE workflows on supported EVM networks."
   datePublished: "2025-11-04"
-  lastModified: "2026-05-22"
+  lastModified: "2026-06-24"
 ---
 
 import { Aside, CopyText } from "@components"
 
 <Aside type="note" title="Looking for supported networks?">
   For a complete list of supported networks and version requirements, see [Supported Networks](/cre/supported-networks).
+</Aside>
+
+<Aside type="tip" title="Tenant-scoped chain list">
+  Chain availability and mock forwarder addresses depend on your CRE tenant. Run [`cre workflow
+  supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) after `cre login` to see the chains and
+  mock forwarder addresses enabled for your organization. Use `--output json` for scripting.
 </Aside>
 
 This page lists forwarder contract addresses for CRE workflows, organized by network.
@@ -49,66 +55,67 @@ If you configure forwarder validation in your consumer contract, **remember to u
 
 These `MockKeystoneForwarder` addresses are used when running `cre workflow simulate` with the `--broadcast` flag. Use these addresses **only** during local development and testing.
 
+The tables below reflect chains commonly enabled for simulation. Your tenant may have a different set — run [`cre workflow supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) for the authoritative list and mock forwarder addresses for your organization.
+
 ### Simulation Mainnets
 
-| Network                                                                                                                                                             | Chain Name                                            | Mock Forwarder Address                                             |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------ |
-| <a href="https://explorer.adifoundation.ai/address/0x6Aa382fb8762E1232936478DD9DbC04F637028f1" target="_blank" rel="noopener noreferrer">ADI Mainnet</a>            | <CopyText text="adi-mainnet" code/>                   | <CopyText text="0x6Aa382fb8762E1232936478DD9DbC04F637028f1" code/> |
-| <a href="https://arbiscan.io/address/0xd770499057619c9a76205fd4168161cf94abc532" target="_blank" rel="noopener noreferrer">Arbitrum One</a>                         | <CopyText text="ethereum-mainnet-arbitrum-1" code/>   | <CopyText text="0xd770499057619c9a76205fd4168161cf94abc532" code/> |
-| <a href="https://snowscan.xyz/address/0xdc21e279934ff6721cadfdd112dafb3261f09a2c" target="_blank" rel="noopener noreferrer">Avalanche</a>                           | <CopyText text="avalanche-mainnet" code/>             | <CopyText text="0xdc21e279934ff6721cadfdd112dafb3261f09a2c" code/> |
-| <a href="https://basescan.org/address/0x5e342a8438b4f5d39e72875fcee6f76b39cce548" target="_blank" rel="noopener noreferrer">Base</a>                                | <CopyText text="ethereum-mainnet-base-1" code/>       | <CopyText text="0x5e342a8438b4f5d39e72875fcee6f76b39cce548" code/> |
-| <a href="https://bscscan.com/address/0x6f3239bbb26e98961e1115aba83f8a282e5508c8" target="_blank" rel="noopener noreferrer">BNB Chain</a>                            | <CopyText text="binance_smart_chain-mainnet" code/>   | <CopyText text="0x6f3239bbb26e98961e1115aba83f8a282e5508c8" code/> |
-| <a href="https://explorer.celo.org/mainnet/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Celo</a>                   | <CopyText text="celo-mainnet" code/>                  | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://etherscan.io/address/0xa3d1ad4ac559a6575a114998affb2fb2ec97a7d9" target="_blank" rel="noopener noreferrer">Ethereum Mainnet</a>                    | <CopyText text="ethereum-mainnet" code/>              | <CopyText text="0xa3d1ad4ac559a6575a114998affb2fb2ec97a7d9" code/> |
-| <a href="https://gnosisscan.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Gnosis Chain</a>                       | <CopyText text="gnosis-chain-mainnet" code/>          | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://app.hyperliquid.xyz/explorer/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Hyperliquid Mainnet</a> | <CopyText text="hyperliquid-mainnet" code/>           | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://explorer.inkonchain.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Ink</a>                      | <CopyText text="ethereum-mainnet-ink-1" code/>        | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://explorer.jovay.io/address/0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" target="_blank" rel="noopener noreferrer">Jovay Mainnet</a>                  | <CopyText text="jovay-mainnet" code/>                 | <CopyText text="0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" code/> |
-| <a href="https://lineascan.build/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Linea</a>                            | <CopyText text="ethereum-mainnet-linea-1" code/>      | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://mantlescan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Mantle</a>                            | <CopyText text="ethereum-mainnet-mantle-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://megaeth.blockscout.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">MegaETH</a>                   | <CopyText text="megaeth-mainnet" code/>               | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://optimistic.etherscan.io/address/0x9119a1501550ed94a3f2794038ed9258337afa18" target="_blank" rel="noopener noreferrer">OP Mainnet</a>               | <CopyText text="ethereum-mainnet-optimism-1" code/>   | <CopyText text="0x9119a1501550ed94a3f2794038ed9258337afa18" code/> |
-| <a href="https://pharosscan.xyz/address/0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" target="_blank" rel="noopener noreferrer">Pharos Mainnet</a>                    | <CopyText text="pharos-mainnet" code/>                | <CopyText text="0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" code/> |
-| <a href="https://plasmascan.to/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Plasma</a>                             | <CopyText text="plasma-mainnet" code/>                | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://polygonscan.com/address/0xf458d621885e29a5003ea9bbba5280d54e19b1ce" target="_blank" rel="noopener noreferrer">Polygon</a>                          | <CopyText text="polygon-mainnet" code/>               | <CopyText text="0xf458d621885e29a5003ea9bbba5280d54e19b1ce" code/> |
-| <a href="https://scrollscan.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Scroll</a>                            | <CopyText text="ethereum-mainnet-scroll-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sonicscan.org/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Sonic</a>                              | <CopyText text="sonic-mainnet" code/>                 | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://worldscan.org/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">World Chain</a>                        | <CopyText text="ethereum-mainnet-worldchain-1" code/> | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://www.oklink.com/xlayer/address/0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" target="_blank" rel="noopener noreferrer">XLayer Mainnet</a>             | <CopyText text="ethereum-mainnet-xlayer-1" code/>     | <CopyText text="0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" code/> |
-| <a href="https://explorer.zksync.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">ZKSync Era</a>                    | <CopyText text="ethereum-mainnet-zksync-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
+| Network             | Chain Name                                            | Mock Forwarder Address                                             |
+| ------------------- | ----------------------------------------------------- | ------------------------------------------------------------------ |
+| Arbitrum One        | <CopyText text="ethereum-mainnet-arbitrum-1" code/>   | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
+| Avalanche           | <CopyText text="avalanche-mainnet" code/>             | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Base                | <CopyText text="ethereum-mainnet-base-1" code/>       | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
+| BNB Chain           | <CopyText text="binance_smart_chain-mainnet" code/>   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Celo                | <CopyText text="celo-mainnet" code/>                  | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| Ethereum Mainnet    | <CopyText text="ethereum-mainnet" code/>              | <CopyText text="0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" code/> |
+| Gnosis Chain        | <CopyText text="gnosis_chain-mainnet" code/>          | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| Hyperliquid Mainnet | <CopyText text="hyperliquid-mainnet" code/>           | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| Ink                 | <CopyText text="ethereum-mainnet-ink-1" code/>        | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| Jovay Mainnet       | <CopyText text="jovay-mainnet" code/>                 | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Linea               | <CopyText text="ethereum-mainnet-linea-1" code/>      | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| Mantle              | <CopyText text="ethereum-mainnet-mantle-1" code/>     | <CopyText text="0xB9F79d863261869B234c481D1f9A7af84AeAd192" code/> |
+| MegaETH             | <CopyText text="megaeth-mainnet" code/>               | <CopyText text="0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" code/> |
+| OP Mainnet          | <CopyText text="ethereum-mainnet-optimism-1" code/>   | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
+| Pharos Mainnet      | <CopyText text="pharos-mainnet" code/>                | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Plasma              | <CopyText text="plasma-mainnet" code/>                | <CopyText text="0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" code/> |
+| Polygon             | <CopyText text="polygon-mainnet" code/>               | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Scroll              | <CopyText text="ethereum-mainnet-scroll-1" code/>     | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| Sonic               | <CopyText text="sonic-mainnet" code/>                 | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| World Chain         | <CopyText text="ethereum-mainnet-worldchain-1" code/> | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| XLayer Mainnet      | <CopyText text="ethereum-mainnet-xlayer-1" code/>     | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| ZKSync Era          | <CopyText text="ethereum-mainnet-zksync-1" code/>     | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 
 ### Simulation Testnets
 
-| Network                                                                                                                                                            | Chain Name                                                    | Mock Forwarder Address                                             |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- | ------------------------------------------------------------------ |
-| <a href="https://explorer.testnet.adifoundation.ai/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">ADI Testnet</a>   | <CopyText text="adi-testnet" code/>                           | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
-| <a href="https://explorer.curtis.apechain.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Apechain Curtis</a>    | <CopyText text="apechain-testnet-curtis" code/>               | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://testnet.arcscan.app/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Arc Testnet</a>                 | <CopyText text="arc-testnet" code/>                           | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.arbiscan.io/address/0xd41263567ddfead91504199b8c6c87371e83ca5d" target="_blank" rel="noopener noreferrer">Arbitrum Sepolia</a>            | <CopyText text="ethereum-testnet-sepolia-arbitrum-1" code/>   | <CopyText text="0xd41263567ddfead91504199b8c6c87371e83ca5d" code/> |
-| <a href="https://testnet.snowscan.xyz/address/0x2e7371a5d032489e4f60216d8d898a4c10805963" target="_blank" rel="noopener noreferrer">Avalanche Fuji</a>             | <CopyText text="avalanche-testnet-fuji" code/>                | <CopyText text="0x2e7371a5d032489e4f60216d8d898a4c10805963" code/> |
-| <a href="https://sepolia.basescan.org/address/0x82300bd7c3958625581cc2f77bc6464dcecdf3e5" target="_blank" rel="noopener noreferrer">Base Sepolia</a>               | <CopyText text="ethereum-testnet-sepolia-base-1" code/>       | <CopyText text="0x82300bd7c3958625581cc2f77bc6464dcecdf3e5" code/> |
-| <a href="https://testnet.bscscan.com/address/0xa238e42cb8782808dbb2f37e19859244ec4779b0" target="_blank" rel="noopener noreferrer">BNB Chain Testnet</a>           | <CopyText text="binance_smart_chain-testnet" code/>           | <CopyText text="0xa238e42cb8782808dbb2f37e19859244ec4779b0" code/> |
-| <a href="https://celo-sepolia.blockscout.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Celo Sepolia</a>        | <CopyText text="celo-sepolia" code/>                          | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://explorer.cronos.org/testnet/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Cronos Testnet</a>      | <CopyText text="cronos-testnet" code/>                        | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.etherscan.io/address/0x15fC6ae953E024d975e77382eEeC56A9101f9F88" target="_blank" rel="noopener noreferrer">Ethereum Sepolia</a>           | <CopyText text="ethereum-testnet-sepolia" code/>              | <CopyText text="0x15fC6ae953E024d975e77382eEeC56A9101f9F88" code/> |
-| <a href="https://gnosis-chiado.blockscout.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Gnosis Chiado</a>      | <CopyText text="gnosis-chain-testnet-chiado" code/>           | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://explore-testnet.hyperpc.app/address/0xB27fA1c28288c50542527F64BCda22C9FbAc24CB" target="_blank" rel="noopener noreferrer">Hyperliquid Testnet</a> | <CopyText text="hyperliquid-testnet" code/>                   | <CopyText text="0xB27fA1c28288c50542527F64BCda22C9FbAc24CB" code/> |
-| <a href="https://explorer-sepolia.inkonchain.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Ink Sepolia</a>     | <CopyText text="ink-testnet-sepolia" code/>                   | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia-explorer.jovay.io/l2/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Jovay Testnet</a>      | <CopyText text="jovay-testnet" code/>                         | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.lineascan.build/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Linea Sepolia</a>           | <CopyText text="ethereum-testnet-sepolia-linea-1" code/>      | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.mantlescan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Mantle Sepolia</a>           | <CopyText text="ethereum-testnet-sepolia-mantle-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://megaexplorer.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">MegaETH Testnet 2</a>              | <CopyText text="megaeth-testnet-2" code/>                     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia-optimism.etherscan.io/address/0xa2888380dff3704a8ab6d1cd1a8f69c15fea5ee3" target="_blank" rel="noopener noreferrer">OP Sepolia</a>        | <CopyText text="ethereum-testnet-sepolia-optimism-1" code/>   | <CopyText text="0xa2888380dff3704a8ab6d1cd1a8f69c15fea5ee3" code/> |
-| <a href="https://atlantic.pharosscan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Pharos Atlantic Testnet</a> | <CopyText text="pharos-atlantic-testnet" code/>               | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://testnet.plasmascan.to/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Plasma Testnet</a>            | <CopyText text="plasma-testnet" code/>                        | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://amoy.polygonscan.com/address/0x3675a5eb2286a3f87e8278fc66edf458a2e3bb74" target="_blank" rel="noopener noreferrer">Polygon Amoy</a>               | <CopyText text="polygon-testnet-amoy" code/>                  | <CopyText text="0x3675a5eb2286a3f87e8278fc66edf458a2e3bb74" code/> |
-| <a href="https://sepolia-blockscout.scroll.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Scroll Sepolia</a>     | <CopyText text="ethereum-testnet-sepolia-scroll-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://explorer.testnet.soniclabs.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Sonic Testnet</a>    | <CopyText text="sonic-testnet" code/>                         | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://spb.explorer.tac.build/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">TAC Testnet</a>              | <CopyText text="tac-testnet" code/>                           | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.uniscan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Unichain Sepolia</a>            | <CopyText text="ethereum-testnet-sepolia-unichain-1" code/>   | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.worldscan.org/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">World Chain Sepolia</a>       | <CopyText text="ethereum-testnet-sepolia-worldchain-1" code/> | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://www.oklink.com/xlayer-test/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">XLayer Testnet</a>       | <CopyText text="xlayer-testnet" code/>                        | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.explorer.zksync.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">ZKSync Era Sepolia</a>   | <CopyText text="ethereum-testnet-sepolia-zksync-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
+| Network                 | Chain Name                                                    | Mock Forwarder Address                                             |
+| ----------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------ |
+| ADI Testnet             | <CopyText text="adi-testnet" code/>                           | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Apechain Curtis         | <CopyText text="apechain-testnet-curtis" code/>               | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Arc Testnet             | <CopyText text="arc-testnet" code/>                           | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Arbitrum Sepolia        | <CopyText text="ethereum-testnet-sepolia-arbitrum-1" code/>   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Avalanche Fuji          | <CopyText text="avalanche-testnet-fuji" code/>                | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Base Sepolia            | <CopyText text="ethereum-testnet-sepolia-base-1" code/>       | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
+| BNB Chain Testnet       | <CopyText text="binance_smart_chain-testnet" code/>           | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Celo Sepolia            | <CopyText text="celo-sepolia" code/>                          | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| Cronos Testnet          | <CopyText text="cronos-testnet" code/>                        | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| Ethereum Sepolia        | <CopyText text="ethereum-testnet-sepolia" code/>              | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
+| Gnosis Chiado           | <CopyText text="gnosis_chain-testnet-chiado" code/>           | <CopyText text="0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" code/> |
+| Hyperliquid Testnet     | <CopyText text="hyperliquid-testnet" code/>                   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Ink Sepolia             | <CopyText text="ink-testnet-sepolia" code/>                   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Jovay Testnet           | <CopyText text="jovay-testnet" code/>                         | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Linea Sepolia           | <CopyText text="ethereum-testnet-sepolia-linea-1" code/>      | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Mantle Sepolia          | <CopyText text="ethereum-testnet-sepolia-mantle-1" code/>     | <CopyText text="0xB9F79d863261869B234c481D1f9A7af84AeAd192" code/> |
+| MegaETH Testnet 2       | <CopyText text="megaeth-testnet-2" code/>                     | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| OP Sepolia              | <CopyText text="ethereum-testnet-sepolia-optimism-1" code/>   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Pharos Atlantic Testnet | <CopyText text="pharos-atlantic-testnet" code/>               | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Plasma Testnet          | <CopyText text="plasma-testnet" code/>                        | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Polygon Amoy            | <CopyText text="polygon-testnet-amoy" code/>                  | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Scroll Sepolia          | <CopyText text="ethereum-testnet-sepolia-scroll-1" code/>     | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| Sonic Testnet           | <CopyText text="sonic-testnet" code/>                         | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| TAC Testnet             | <CopyText text="tac-testnet" code/>                           | <CopyText text="0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" code/> |
+| Unichain Sepolia        | <CopyText text="ethereum-testnet-sepolia-unichain-1" code/>   | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| World Chain Sepolia     | <CopyText text="ethereum-testnet-sepolia-worldchain-1" code/> | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| XLayer Testnet          | <CopyText text="xlayer-testnet" code/>                        | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| ZKSync Era Sepolia      | <CopyText text="ethereum-testnet-sepolia-zksync-1" code/>     | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 
 ## Production Forwarders
 
@@ -125,7 +132,7 @@ These `KeystoneForwarder` addresses are used by deployed workflows. Use these ad
 | <a href="https://bscscan.com/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">BNB Chain</a>                            | <CopyText text="binance_smart_chain-mainnet" code/>   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 | <a href="https://explorer.celo.org/mainnet/address/0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" target="_blank" rel="noopener noreferrer">Celo</a>                   | <CopyText text="celo-mainnet" code/>                  | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
 | <a href="https://etherscan.io/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" target="_blank" rel="noopener noreferrer">Ethereum Mainnet</a>                    | <CopyText text="ethereum-mainnet" code/>              | <CopyText text="0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" code/> |
-| <a href="https://gnosisscan.io/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Gnosis Chain</a>                       | <CopyText text="gnosis-chain-mainnet" code/>          | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| <a href="https://gnosisscan.io/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Gnosis Chain</a>                       | <CopyText text="gnosis_chain-mainnet" code/>          | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | <a href="https://app.hyperliquid.xyz/explorer/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Hyperliquid Mainnet</a> | <CopyText text="hyperliquid-mainnet" code/>           | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | <a href="https://explorer.inkonchain.com/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Ink</a>                      | <CopyText text="ethereum-mainnet-ink-1" code/>        | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | <a href="https://explorer.jovay.io/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Jovay Mainnet</a>                  | <CopyText text="jovay-mainnet" code/>                 | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
@@ -156,7 +163,7 @@ These `KeystoneForwarder` addresses are used by deployed workflows. Use these ad
 | <a href="https://celo-sepolia.blockscout.com/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Celo Sepolia</a>        | <CopyText text="celo-sepolia" code/>                          | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | <a href="https://explorer.cronos.org/testnet/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Cronos Testnet</a>      | <CopyText text="cronos-testnet" code/>                        | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | <a href="https://sepolia.etherscan.io/address/0xF8344CFd5c43616a4366C34E3EEE75af79a74482" target="_blank" rel="noopener noreferrer">Ethereum Sepolia</a>           | <CopyText text="ethereum-testnet-sepolia" code/>              | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
-| <a href="https://gnosis-chiado.blockscout.com/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" target="_blank" rel="noopener noreferrer">Gnosis Chiado</a>      | <CopyText text="gnosis-chain-testnet-chiado" code/>           | <CopyText text="0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" code/> |
+| <a href="https://gnosis-chiado.blockscout.com/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" target="_blank" rel="noopener noreferrer">Gnosis Chiado</a>      | <CopyText text="gnosis_chain-testnet-chiado" code/>           | <CopyText text="0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" code/> |
 | <a href="https://explore-testnet.hyperpc.app/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Hyperliquid Testnet</a> | <CopyText text="hyperliquid-testnet" code/>                   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 | <a href="https://explorer-sepolia.inkonchain.com/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Ink Sepolia</a>     | <CopyText text="ink-testnet-sepolia" code/>                   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 | <a href="https://sepolia-explorer.jovay.io/l2/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Jovay Testnet</a>      | <CopyText text="jovay-testnet" code/>                         | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |

--- a/src/content/cre/guides/workflow/using-evm-client/forwarder-directory-ts.mdx
+++ b/src/content/cre/guides/workflow/using-evm-client/forwarder-directory-ts.mdx
@@ -7,13 +7,19 @@ pageId: "evm-forwarder-directory"
 metadata:
   description: "Find forwarder contract addresses for CRE workflows on supported EVM networks."
   datePublished: "2025-11-04"
-  lastModified: "2026-05-22"
+  lastModified: "2026-06-24"
 ---
 
 import { Aside, CopyText } from "@components"
 
 <Aside type="note" title="Looking for supported networks?">
   For a complete list of supported networks and version requirements, see [Supported Networks](/cre/supported-networks).
+</Aside>
+
+<Aside type="tip" title="Tenant-scoped chain list">
+  Chain availability and mock forwarder addresses depend on your CRE tenant. Run [`cre workflow
+  supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) after `cre login` to see the chains and
+  mock forwarder addresses enabled for your organization. Use `--output json` for scripting.
 </Aside>
 
 This page lists forwarder contract addresses for CRE workflows, organized by network.
@@ -49,66 +55,67 @@ If you configure forwarder validation in your consumer contract, **remember to u
 
 These `MockKeystoneForwarder` addresses are used when running `cre workflow simulate` with the `--broadcast` flag. Use these addresses **only** during local development and testing.
 
+The tables below reflect chains commonly enabled for simulation. Your tenant may have a different set — run [`cre workflow supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) for the authoritative list and mock forwarder addresses for your organization.
+
 ### Simulation Mainnets
 
-| Network                                                                                                                                                             | Chain Name                                            | Mock Forwarder Address                                             |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------ |
-| <a href="https://explorer.adifoundation.ai/address/0x6Aa382fb8762E1232936478DD9DbC04F637028f1" target="_blank" rel="noopener noreferrer">ADI Mainnet</a>            | <CopyText text="adi-mainnet" code/>                   | <CopyText text="0x6Aa382fb8762E1232936478DD9DbC04F637028f1" code/> |
-| <a href="https://arbiscan.io/address/0xd770499057619c9a76205fd4168161cf94abc532" target="_blank" rel="noopener noreferrer">Arbitrum One</a>                         | <CopyText text="ethereum-mainnet-arbitrum-1" code/>   | <CopyText text="0xd770499057619c9a76205fd4168161cf94abc532" code/> |
-| <a href="https://snowscan.xyz/address/0xdc21e279934ff6721cadfdd112dafb3261f09a2c" target="_blank" rel="noopener noreferrer">Avalanche</a>                           | <CopyText text="avalanche-mainnet" code/>             | <CopyText text="0xdc21e279934ff6721cadfdd112dafb3261f09a2c" code/> |
-| <a href="https://basescan.org/address/0x5e342a8438b4f5d39e72875fcee6f76b39cce548" target="_blank" rel="noopener noreferrer">Base</a>                                | <CopyText text="ethereum-mainnet-base-1" code/>       | <CopyText text="0x5e342a8438b4f5d39e72875fcee6f76b39cce548" code/> |
-| <a href="https://bscscan.com/address/0x6f3239bbb26e98961e1115aba83f8a282e5508c8" target="_blank" rel="noopener noreferrer">BNB Smart Chain</a>                      | <CopyText text="binance_smart_chain-mainnet" code/>   | <CopyText text="0x6f3239bbb26e98961e1115aba83f8a282e5508c8" code/> |
-| <a href="https://explorer.celo.org/mainnet/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Celo</a>                   | <CopyText text="celo-mainnet" code/>                  | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://etherscan.io/address/0xa3d1ad4ac559a6575a114998affb2fb2ec97a7d9" target="_blank" rel="noopener noreferrer">Ethereum Mainnet</a>                    | <CopyText text="ethereum-mainnet" code/>              | <CopyText text="0xa3d1ad4ac559a6575a114998affb2fb2ec97a7d9" code/> |
-| <a href="https://gnosisscan.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Gnosis Chain</a>                       | <CopyText text="gnosis-chain-mainnet" code/>          | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://app.hyperliquid.xyz/explorer/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Hyperliquid Mainnet</a> | <CopyText text="hyperliquid-mainnet" code/>           | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://explorer.inkonchain.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Ink</a>                      | <CopyText text="ethereum-mainnet-ink-1" code/>        | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://explorer.jovay.io/address/0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" target="_blank" rel="noopener noreferrer">Jovay Mainnet</a>                  | <CopyText text="jovay-mainnet" code/>                 | <CopyText text="0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" code/> |
-| <a href="https://lineascan.build/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Linea</a>                            | <CopyText text="ethereum-mainnet-linea-1" code/>      | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://mantlescan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Mantle</a>                            | <CopyText text="ethereum-mainnet-mantle-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://megaeth.blockscout.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">MegaETH</a>                   | <CopyText text="megaeth-mainnet" code/>               | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://optimistic.etherscan.io/address/0x9119a1501550ed94a3f2794038ed9258337afa18" target="_blank" rel="noopener noreferrer">OP Mainnet</a>               | <CopyText text="ethereum-mainnet-optimism-1" code/>   | <CopyText text="0x9119a1501550ed94a3f2794038ed9258337afa18" code/> |
-| <a href="https://pharosscan.xyz/address/0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" target="_blank" rel="noopener noreferrer">Pharos Mainnet</a>                    | <CopyText text="pharos-mainnet" code/>                | <CopyText text="0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" code/> |
-| <a href="https://plasmascan.to/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Plasma</a>                             | <CopyText text="plasma-mainnet" code/>                | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://polygonscan.com/address/0xf458d621885e29a5003ea9bbba5280d54e19b1ce" target="_blank" rel="noopener noreferrer">Polygon</a>                          | <CopyText text="polygon-mainnet" code/>               | <CopyText text="0xf458d621885e29a5003ea9bbba5280d54e19b1ce" code/> |
-| <a href="https://scrollscan.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Scroll</a>                            | <CopyText text="ethereum-mainnet-scroll-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sonicscan.org/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Sonic</a>                              | <CopyText text="sonic-mainnet" code/>                 | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://worldscan.org/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">World Chain</a>                        | <CopyText text="ethereum-mainnet-worldchain-1" code/> | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://www.oklink.com/xlayer/address/0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" target="_blank" rel="noopener noreferrer">XLayer Mainnet</a>             | <CopyText text="ethereum-mainnet-xlayer-1" code/>     | <CopyText text="0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" code/> |
-| <a href="https://explorer.zksync.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">ZKSync Era</a>                    | <CopyText text="ethereum-mainnet-zksync-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
+| Network             | Chain Name                                            | Mock Forwarder Address                                             |
+| ------------------- | ----------------------------------------------------- | ------------------------------------------------------------------ |
+| Arbitrum One        | <CopyText text="ethereum-mainnet-arbitrum-1" code/>   | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
+| Avalanche           | <CopyText text="avalanche-mainnet" code/>             | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Base                | <CopyText text="ethereum-mainnet-base-1" code/>       | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
+| BNB Smart Chain     | <CopyText text="binance_smart_chain-mainnet" code/>   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Celo                | <CopyText text="celo-mainnet" code/>                  | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| Ethereum Mainnet    | <CopyText text="ethereum-mainnet" code/>              | <CopyText text="0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" code/> |
+| Gnosis Chain        | <CopyText text="gnosis_chain-mainnet" code/>          | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| Hyperliquid Mainnet | <CopyText text="hyperliquid-mainnet" code/>           | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| Ink                 | <CopyText text="ethereum-mainnet-ink-1" code/>        | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| Jovay Mainnet       | <CopyText text="jovay-mainnet" code/>                 | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Linea               | <CopyText text="ethereum-mainnet-linea-1" code/>      | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| Mantle              | <CopyText text="ethereum-mainnet-mantle-1" code/>     | <CopyText text="0xB9F79d863261869B234c481D1f9A7af84AeAd192" code/> |
+| MegaETH             | <CopyText text="megaeth-mainnet" code/>               | <CopyText text="0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" code/> |
+| OP Mainnet          | <CopyText text="ethereum-mainnet-optimism-1" code/>   | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
+| Pharos Mainnet      | <CopyText text="pharos-mainnet" code/>                | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Plasma              | <CopyText text="plasma-mainnet" code/>                | <CopyText text="0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" code/> |
+| Polygon             | <CopyText text="polygon-mainnet" code/>               | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Scroll              | <CopyText text="ethereum-mainnet-scroll-1" code/>     | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| Sonic               | <CopyText text="sonic-mainnet" code/>                 | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| World Chain         | <CopyText text="ethereum-mainnet-worldchain-1" code/> | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| XLayer Mainnet      | <CopyText text="ethereum-mainnet-xlayer-1" code/>     | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| ZKSync Era          | <CopyText text="ethereum-mainnet-zksync-1" code/>     | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 
 ### Simulation Testnets
 
-| Network                                                                                                                                                            | Chain Name                                                    | Mock Forwarder Address                                             |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- | ------------------------------------------------------------------ |
-| <a href="https://explorer.testnet.adifoundation.ai/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">ADI Testnet</a>   | <CopyText text="adi-testnet" code/>                           | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
-| <a href="https://explorer.curtis.apechain.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Apechain Curtis</a>    | <CopyText text="apechain-testnet-curtis" code/>               | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://testnet.arcscan.app/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Arc Testnet</a>                 | <CopyText text="arc-testnet" code/>                           | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.arbiscan.io/address/0xd41263567ddfead91504199b8c6c87371e83ca5d" target="_blank" rel="noopener noreferrer">Arbitrum Sepolia</a>            | <CopyText text="ethereum-testnet-sepolia-arbitrum-1" code/>   | <CopyText text="0xd41263567ddfead91504199b8c6c87371e83ca5d" code/> |
-| <a href="https://testnet.snowscan.xyz/address/0x2e7371a5d032489e4f60216d8d898a4c10805963" target="_blank" rel="noopener noreferrer">Avalanche Fuji</a>             | <CopyText text="avalanche-testnet-fuji" code/>                | <CopyText text="0x2e7371a5d032489e4f60216d8d898a4c10805963" code/> |
-| <a href="https://sepolia.basescan.org/address/0x82300bd7c3958625581cc2f77bc6464dcecdf3e5" target="_blank" rel="noopener noreferrer">Base Sepolia</a>               | <CopyText text="ethereum-testnet-sepolia-base-1" code/>       | <CopyText text="0x82300bd7c3958625581cc2f77bc6464dcecdf3e5" code/> |
-| <a href="https://testnet.bscscan.com/address/0xa238e42cb8782808dbb2f37e19859244ec4779b0" target="_blank" rel="noopener noreferrer">BSC Testnet</a>                 | <CopyText text="binance_smart_chain-testnet" code/>           | <CopyText text="0xa238e42cb8782808dbb2f37e19859244ec4779b0" code/> |
-| <a href="https://celo-sepolia.blockscout.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Celo Sepolia</a>        | <CopyText text="celo-sepolia" code/>                          | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://explorer.cronos.org/testnet/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Cronos Testnet</a>      | <CopyText text="cronos-testnet" code/>                        | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.etherscan.io/address/0x15fC6ae953E024d975e77382eEeC56A9101f9F88" target="_blank" rel="noopener noreferrer">Ethereum Sepolia</a>           | <CopyText text="ethereum-testnet-sepolia" code/>              | <CopyText text="0x15fC6ae953E024d975e77382eEeC56A9101f9F88" code/> |
-| <a href="https://gnosis-chiado.blockscout.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Gnosis Chiado</a>      | <CopyText text="gnosis-chain-testnet-chiado" code/>           | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://explore-testnet.hyperpc.app/address/0xB27fA1c28288c50542527F64BCda22C9FbAc24CB" target="_blank" rel="noopener noreferrer">Hyperliquid Testnet</a> | <CopyText text="hyperliquid-testnet" code/>                   | <CopyText text="0xB27fA1c28288c50542527F64BCda22C9FbAc24CB" code/> |
-| <a href="https://explorer-sepolia.inkonchain.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Ink Sepolia</a>     | <CopyText text="ink-testnet-sepolia" code/>                   | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia-explorer.jovay.io/l2/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Jovay Testnet</a>      | <CopyText text="jovay-testnet" code/>                         | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.lineascan.build/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Linea Sepolia</a>           | <CopyText text="ethereum-testnet-sepolia-linea-1" code/>      | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.mantlescan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Mantle Sepolia</a>           | <CopyText text="ethereum-testnet-sepolia-mantle-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://megaexplorer.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">MegaETH Testnet 2</a>              | <CopyText text="megaeth-testnet-2" code/>                     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia-optimism.etherscan.io/address/0xa2888380dff3704a8ab6d1cd1a8f69c15fea5ee3" target="_blank" rel="noopener noreferrer">OP Sepolia</a>        | <CopyText text="ethereum-testnet-sepolia-optimism-1" code/>   | <CopyText text="0xa2888380dff3704a8ab6d1cd1a8f69c15fea5ee3" code/> |
-| <a href="https://atlantic.pharosscan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Pharos Atlantic Testnet</a> | <CopyText text="pharos-atlantic-testnet" code/>               | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://testnet.plasmascan.to/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Plasma Testnet</a>            | <CopyText text="plasma-testnet" code/>                        | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://amoy.polygonscan.com/address/0x3675a5eb2286a3f87e8278fc66edf458a2e3bb74" target="_blank" rel="noopener noreferrer">Polygon Amoy</a>               | <CopyText text="polygon-testnet-amoy" code/>                  | <CopyText text="0x3675a5eb2286a3f87e8278fc66edf458a2e3bb74" code/> |
-| <a href="https://sepolia-blockscout.scroll.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Scroll Sepolia</a>     | <CopyText text="ethereum-testnet-sepolia-scroll-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://explorer.testnet.soniclabs.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Sonic Testnet</a>    | <CopyText text="sonic-testnet" code/>                         | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://spb.explorer.tac.build/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">TAC Testnet</a>              | <CopyText text="tac-testnet" code/>                           | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.uniscan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Unichain Sepolia</a>            | <CopyText text="ethereum-testnet-sepolia-unichain-1" code/>   | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.worldscan.org/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">World Chain Sepolia</a>       | <CopyText text="ethereum-testnet-sepolia-worldchain-1" code/> | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://www.oklink.com/xlayer-test/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">XLayer Testnet</a>       | <CopyText text="xlayer-testnet" code/>                        | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
-| <a href="https://sepolia.explorer.zksync.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">ZKSync Era Sepolia</a>   | <CopyText text="ethereum-testnet-sepolia-zksync-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
+| Network                 | Chain Name                                                    | Mock Forwarder Address                                             |
+| ----------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------ |
+| ADI Testnet             | <CopyText text="adi-testnet" code/>                           | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Apechain Curtis         | <CopyText text="apechain-testnet-curtis" code/>               | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Arc Testnet             | <CopyText text="arc-testnet" code/>                           | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Arbitrum Sepolia        | <CopyText text="ethereum-testnet-sepolia-arbitrum-1" code/>   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Avalanche Fuji          | <CopyText text="avalanche-testnet-fuji" code/>                | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Base Sepolia            | <CopyText text="ethereum-testnet-sepolia-base-1" code/>       | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
+| BSC Testnet             | <CopyText text="binance_smart_chain-testnet" code/>           | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Celo Sepolia            | <CopyText text="celo-sepolia" code/>                          | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| Cronos Testnet          | <CopyText text="cronos-testnet" code/>                        | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| Ethereum Sepolia        | <CopyText text="ethereum-testnet-sepolia" code/>              | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
+| Gnosis Chiado           | <CopyText text="gnosis_chain-testnet-chiado" code/>           | <CopyText text="0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" code/> |
+| Hyperliquid Testnet     | <CopyText text="hyperliquid-testnet" code/>                   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Ink Sepolia             | <CopyText text="ink-testnet-sepolia" code/>                   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Jovay Testnet           | <CopyText text="jovay-testnet" code/>                         | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Linea Sepolia           | <CopyText text="ethereum-testnet-sepolia-linea-1" code/>      | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Mantle Sepolia          | <CopyText text="ethereum-testnet-sepolia-mantle-1" code/>     | <CopyText text="0xB9F79d863261869B234c481D1f9A7af84AeAd192" code/> |
+| MegaETH Testnet 2       | <CopyText text="megaeth-testnet-2" code/>                     | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| OP Sepolia              | <CopyText text="ethereum-testnet-sepolia-optimism-1" code/>   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Pharos Atlantic Testnet | <CopyText text="pharos-atlantic-testnet" code/>               | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Plasma Testnet          | <CopyText text="plasma-testnet" code/>                        | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Polygon Amoy            | <CopyText text="polygon-testnet-amoy" code/>                  | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| Scroll Sepolia          | <CopyText text="ethereum-testnet-sepolia-scroll-1" code/>     | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| Sonic Testnet           | <CopyText text="sonic-testnet" code/>                         | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| TAC Testnet             | <CopyText text="tac-testnet" code/>                           | <CopyText text="0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" code/> |
+| Unichain Sepolia        | <CopyText text="ethereum-testnet-sepolia-unichain-1" code/>   | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
+| World Chain Sepolia     | <CopyText text="ethereum-testnet-sepolia-worldchain-1" code/> | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
+| XLayer Testnet          | <CopyText text="xlayer-testnet" code/>                        | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| ZKSync Era Sepolia      | <CopyText text="ethereum-testnet-sepolia-zksync-1" code/>     | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 
 ## Production Forwarders
 
@@ -125,7 +132,7 @@ These `KeystoneForwarder` addresses are used by deployed workflows. Use these ad
 | <a href="https://bscscan.com/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">BNB Smart Chain</a>                      | <CopyText text="binance_smart_chain-mainnet" code/>   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 | <a href="https://explorer.celo.org/mainnet/address/0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" target="_blank" rel="noopener noreferrer">Celo</a>                   | <CopyText text="celo-mainnet" code/>                  | <CopyText text="0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" code/> |
 | <a href="https://etherscan.io/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" target="_blank" rel="noopener noreferrer">Ethereum Mainnet</a>                    | <CopyText text="ethereum-mainnet" code/>              | <CopyText text="0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" code/> |
-| <a href="https://gnosisscan.io/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Gnosis Chain</a>                       | <CopyText text="gnosis-chain-mainnet" code/>          | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
+| <a href="https://gnosisscan.io/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Gnosis Chain</a>                       | <CopyText text="gnosis_chain-mainnet" code/>          | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | <a href="https://app.hyperliquid.xyz/explorer/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Hyperliquid Mainnet</a> | <CopyText text="hyperliquid-mainnet" code/>           | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | <a href="https://explorer.inkonchain.com/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Ink</a>                      | <CopyText text="ethereum-mainnet-ink-1" code/>        | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | <a href="https://explorer.jovay.io/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Jovay Mainnet</a>                  | <CopyText text="jovay-mainnet" code/>                 | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
@@ -156,7 +163,7 @@ These `KeystoneForwarder` addresses are used by deployed workflows. Use these ad
 | <a href="https://celo-sepolia.blockscout.com/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Celo Sepolia</a>        | <CopyText text="celo-sepolia" code/>                          | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | <a href="https://explorer.cronos.org/testnet/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Cronos Testnet</a>      | <CopyText text="cronos-testnet" code/>                        | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | <a href="https://sepolia.etherscan.io/address/0xF8344CFd5c43616a4366C34E3EEE75af79a74482" target="_blank" rel="noopener noreferrer">Ethereum Sepolia</a>           | <CopyText text="ethereum-testnet-sepolia" code/>              | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
-| <a href="https://gnosis-chiado.blockscout.com/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" target="_blank" rel="noopener noreferrer">Gnosis Chiado</a>      | <CopyText text="gnosis-chain-testnet-chiado" code/>           | <CopyText text="0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" code/> |
+| <a href="https://gnosis-chiado.blockscout.com/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" target="_blank" rel="noopener noreferrer">Gnosis Chiado</a>      | <CopyText text="gnosis_chain-testnet-chiado" code/>           | <CopyText text="0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" code/> |
 | <a href="https://explore-testnet.hyperpc.app/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Hyperliquid Testnet</a> | <CopyText text="hyperliquid-testnet" code/>                   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 | <a href="https://explorer-sepolia.inkonchain.com/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Ink Sepolia</a>     | <CopyText text="ink-testnet-sepolia" code/>                   | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 | <a href="https://sepolia-explorer.jovay.io/l2/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Jovay Testnet</a>      | <CopyText text="jovay-testnet" code/>                         | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |

--- a/src/content/cre/guides/workflow/using-triggers/http-trigger/testing-in-simulation.mdx
+++ b/src/content/cre/guides/workflow/using-triggers/http-trigger/testing-in-simulation.mdx
@@ -5,7 +5,7 @@ date: Last Modified
 metadata:
   description: "Test HTTP triggers locally with the CRE simulator: provide JSON payloads interactively or via command-line flags for rapid development."
   datePublished: "2025-11-10"
-  lastModified: "2025-11-10"
+  lastModified: "2026-06-11"
 ---
 
 import { Aside, CodeHighlightBlockMulti } from "@components"
@@ -44,6 +44,24 @@ cre workflow simulate my-http-workflow --target staging-settings
 ```
 
 The simulator will detect your HTTP trigger and prompt you to select it from available triggers.
+
+## Listen mode
+
+Use `--listen` to keep the simulator alive between runs. Instead of simulating once and exiting, the CLI starts a local HTTP server on port `2000` and re-runs the simulator every time it receives a POST request — no need to restart between tests.
+
+```bash
+cre workflow simulate my-http-workflow --listen --target staging-settings
+```
+
+Once running, send payloads with any HTTP client:
+
+```bash
+curl -X POST http://localhost:2000 \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"123","action":"purchase","amount":100}'
+```
+
+Each POST triggers a fresh simulation run. Press `Ctrl+C` to stop.
 
 ## Providing input data
 

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -514,9 +514,59 @@ To help us assist you faster, please include:
 
 # Release Notes
 Source: https://docs.chain.link/cre/release-notes
-Last Updated: 2026-06-04
+Last Updated: 2026-06-18
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.21.0 - June 18, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.21.0" target="_blank">CRE CLI version 1.21.0</a> is now available.**
+
+- **MSIG mode guard**: Using `--unsigned` or `--changeset` with `--secrets-auth=browser` or a private registry now produces a clear upfront error instead of a confusing failure mid-operation.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.20.0...v1.21.0)
+
+## CLI v1.20.0 - June 12, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.20.0" target="_blank">CRE CLI version 1.20.0</a> is now available.**
+
+- **Simulation limits aligned with production**: The local simulator's resource limits now match production. Notable increases: execution concurrency (10 → 50), EVM transaction gas limit (5M → 10M), chain write report size (5 KB → 50 KB), HTTP action payload sizes (10 KB request / 100 KB response → 120 KB / 250 KB), and ConfidentialHTTP payload sizes (10 KB / 100 KB → 125 KB / 500 KB). Workflows that previously hit local-only caps should now simulate more faithfully.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.19.0...v1.20.0)
+
+## CLI v1.19.0 - June 11, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.19.0" target="_blank">CRE CLI version 1.19.0</a> is now available.**
+
+- **`--listen` flag for `cre workflow simulate`**: A new `--listen` flag keeps the simulator alive and re-runs it for each incoming event — HTTP POST requests on port 2000 or matching EVM log trigger events. Use it when iterating on trigger-driven workflows without restarting the simulator between runs. Also added `--evm-receipt-timeout` (default `1m`) to control how long the simulator waits for an EVM transaction receipt.
+- **Browser OAuth secrets auth in production**: Browser-based OAuth authentication for secrets is now fully enabled in production environments. A related fix prevents secrets flows from failing when the default `CRE_ETH_PRIVATE_KEY` placeholder is set in your environment.
+- **DON Family shown in workflow output**: The `DON Family` field is now displayed in the details section after `cre workflow deploy`, `activate`, and `pause`. The underlying resolution now uses your tenant's platform default instead of the embedded config, so the displayed value reflects what the platform actually uses.
+- **Capability registry RPC auto-resolution**: The CLI now resolves RPC endpoints for the capability registry chain automatically and prompts for consent when needed, removing the need to configure these connections manually in your secrets workflows.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.18.0...v1.19.0)
+
+## Go SDK v1.12.0 - June 11, 2026
+
+**Go SDK version 1.12.0** adds Solana mainnet support.
+
+- **Solana mainnet**: Solana mainnet chain selectors and workflow bindings are now included in the SDK, enabling production workflows that target Solana mainnet.
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.11.0...v1.12.0)
 
 ## CLI v1.18.0 - June 4, 2026
 
@@ -558,6 +608,22 @@ This page provides detailed release notes for CRE. It includes information on ne
 
 [See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.15.0...v1.16.0)
 
+## Go SDK v1.11.0 - May 21, 2026
+
+**Go SDK version 1.11.0** adds private Rhyolite testnet support.
+
+- **`private-testnet-rhyolite` support**: EVM capabilities for the Rhyolite private testnet are now included. Use the `private-testnet-rhyolite` chain name when building workflows that target this network.
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.10.0...v1.11.0)
+
+## Go SDK v1.10.0 - May 20, 2026
+
+**Go SDK version 1.10.0** adds ADI mainnet support.
+
+- **ADI mainnet**: EVM capabilities for ADI mainnet (`adi-mainnet`) are now included, supporting workflows deployed to ADI mainnet.
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.9.0...v1.10.0)
+
 ## CLI v1.15.0 - May 14, 2026
 
 **<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.15.0" target="_blank">CRE CLI version 1.15.0</a> is now available.**
@@ -588,6 +654,14 @@ This page provides detailed release notes for CRE. It includes information on ne
 - **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
 
 [See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.13.0...v1.14.0)
+
+## Go SDK v1.9.0 - May 13, 2026
+
+**Go SDK version 1.9.0** adds ADI testnet and Celo Sepolia support.
+
+- **ADI testnet and Celo Sepolia**: EVM capabilities for ADI testnet (`adi-testnet`) and Celo Sepolia (`celo-sepolia`) are now included, enabling simulation and deployment to these networks.
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.8.0...v1.9.0)
 
 ## CLI v1.13.0 - April 30, 2026
 
@@ -1535,7 +1609,7 @@ This section provides detailed guides for each available trigger type:
 
 # Testing HTTP Triggers in Simulation
 Source: https://docs.chain.link/cre/guides/workflow/using-triggers/http-trigger/testing-in-simulation
-Last Updated: 2025-11-10
+Last Updated: 2026-06-11
 
 During development, you can test your HTTP trigger workflows locally using the `cre workflow simulate` command. The simulator allows you to provide test payloads without setting up authorization keys or JWT authentication.
 
@@ -1569,6 +1643,24 @@ cre workflow simulate my-http-workflow --target staging-settings
 ```
 
 The simulator will detect your HTTP trigger and prompt you to select it from available triggers.
+
+## Listen mode
+
+Use `--listen` to keep the simulator alive between runs. Instead of simulating once and exiting, the CLI starts a local HTTP server on port `2000` and re-runs the simulator every time it receives a POST request — no need to restart between tests.
+
+```bash
+cre workflow simulate my-http-workflow --listen --target staging-settings
+```
+
+Once running, send payloads with any HTTP client:
+
+```bash
+curl -X POST http://localhost:2000 \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"123","action":"purchase","amount":100}'
+```
+
+Each POST triggers a fresh simulation run. Press `Ctrl+C` to stop.
 
 ## Providing input data
 
@@ -5519,7 +5611,7 @@ Yes. Once you call `runtime.Rand()` and get a `*rand.Rand` object, you can reuse
 
 # Simulating Workflows
 Source: https://docs.chain.link/cre/guides/operations/simulating-workflows
-Last Updated: 2025-11-04
+Last Updated: 2026-06-11
 
 Workflow simulation is a local execution environment that **compiles your workflow to <a href="https://webassembly.org" target="blank" ref="noopener noreferrer">WebAssembly (WASM)</a>** and runs it on **your machine**. It allows you to test and debug your workflow logic before deploying it. The simulator makes real calls to public testnets and live HTTP endpoints, giving you high confidence that your code will work as expected when deployed.
 
@@ -5622,6 +5714,19 @@ cre workflow simulate my-workflow --non-interactive --trigger-index 0 --target s
   multiple handlers (e.g., one for an HTTP trigger and one for an EVM log trigger), use `0` for the first, `1` for the
   second, etc., based on their order in your code.
 </Aside>
+
+## Listen mode
+
+The `--listen` flag keeps the simulator alive and re-runs it for each incoming trigger event, instead of compiling and executing once then exiting.
+
+- **HTTP triggers**: starts a local HTTP server on port `2000`. Each POST request triggers a fresh simulation run.
+- **EVM log triggers**: watches the configured chain and re-runs on each matching log event.
+
+```bash
+cre workflow simulate my-workflow --listen --target staging-settings
+```
+
+This is useful during active development — make a code change, resave, send another event, and see the result immediately without restarting the CLI. See [Testing HTTP Triggers in Simulation](/cre/guides/workflow/using-triggers/http-trigger/testing-in-simulation) for a detailed walkthrough with HTTP triggers.
 
 ## The `--broadcast` flag
 
@@ -8816,7 +8921,7 @@ When you run this command, the CLI will:
 
 # Workflow Commands
 Source: https://docs.chain.link/cre/reference/cli/workflow
-Last Updated: 2026-05-14
+Last Updated: 2026-06-11
 
 The `cre workflow` commands manage workflows throughout their entire lifecycle, from local testing to deployment and ongoing management.
 
@@ -8889,17 +8994,19 @@ cre workflow simulate <workflow-name-or-path> [flags]
 
 **Flags:**
 
-| Flag                      | Description                                                                                                                                                                                                                                                                      |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--broadcast`             | Broadcast onchain write transactions (default: `false`). Without this flag, a dry run is performed                                                                                                                                                                               |
-| `-g, --engine-logs`       | Enable non-fatal engine logging                                                                                                                                                                                                                                                  |
-| `--non-interactive`       | Run without prompts; requires `--trigger-index` (see the line below) and inputs for the selected trigger type                                                                                                                                                                    |
-| `--trigger-index <int>`   | Selects which handler to run (0-based position). If your workflow has multiple handlers, `0` is the first, `1` is the second, etc. Required with `--non-interactive`                                                                                                             |
-| `--http-payload <string>` | HTTP trigger payload as JSON string or path to a JSON file. File paths are resolved relative to the directory where you ran the command. For HTTP triggers only                                                                                                                  |
-| `--evm-tx-hash <string>`  | Transaction hash (`0x...`) containing the event that triggered your workflow. For EVM log triggers only                                                                                                                                                                          |
-| `--evm-event-index <int>` | Which log/event within the transaction to use (0-based position). If the transaction emitted multiple events, `0` is the first, `1` is the second, etc. For EVM log triggers only                                                                                                |
-| `--limits <string>`       | Production limits to enforce during simulation: `default` (embedded prod limits), a path to a limits JSON file (e.g. from `cre workflow limits export`), or `none` to disable. See [Testing Production Limits](/cre/guides/operations/understanding-limits) (default: `default`) |
-| `--skip-type-checks`      | Skip TypeScript type checking during compilation. Speeds up iteration in development; not recommended for production builds                                                                                                                                                      |
+| Flag                               | Description                                                                                                                                                                                                                                                                                                      |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--broadcast`                      | Broadcast onchain write transactions (default: `false`). Without this flag, a dry run is performed                                                                                                                                                                                                               |
+| `-g, --engine-logs`                | Enable non-fatal engine logging                                                                                                                                                                                                                                                                                  |
+| `--listen`                         | Keep the simulator alive and re-run it for each incoming trigger event. For HTTP triggers, listens for POST requests on port `2000`. For EVM log triggers, watches the chain and re-runs on each matching event. Useful when iterating on trigger-driven workflows without restarting the simulator between runs |
+| `--non-interactive`                | Run without prompts; requires `--trigger-index` (see the line below) and inputs for the selected trigger type                                                                                                                                                                                                    |
+| `--trigger-index <int>`            | Selects which handler to run (0-based position). If your workflow has multiple handlers, `0` is the first, `1` is the second, etc. Required with `--non-interactive`                                                                                                                                             |
+| `--http-payload <string>`          | HTTP trigger payload as JSON string or path to a JSON file. File paths are resolved relative to the directory where you ran the command. For HTTP triggers only                                                                                                                                                  |
+| `--evm-tx-hash <string>`           | Transaction hash (`0x...`) containing the event that triggered your workflow. For EVM log triggers only                                                                                                                                                                                                          |
+| `--evm-event-index <int>`          | Which log/event within the transaction to use (0-based position). If the transaction emitted multiple events, `0` is the first, `1` is the second, etc. For EVM log triggers only                                                                                                                                |
+| `--evm-receipt-timeout <duration>` | How long to wait for an EVM transaction receipt before timing out (e.g. `30s`, `2m`). For EVM log triggers only (default: `1m`)                                                                                                                                                                                  |
+| `--limits <string>`                | Production limits to enforce during simulation: `default` (embedded prod limits), a path to a limits JSON file (e.g. from `cre workflow limits export`), or `none` to disable. See [Testing Production Limits](/cre/guides/operations/understanding-limits) (default: `default`)                                 |
+| `--skip-type-checks`               | Skip TypeScript type checking during compilation. Speeds up iteration in development; not recommended for production builds                                                                                                                                                                                      |
 
 **Examples:**
 
@@ -8928,6 +9035,18 @@ cre workflow simulate <workflow-name-or-path> [flags]
   # If your EVM log trigger handler is the second handler in your workflow, use --trigger-index 1
   # --evm-event-index 0 means you want the first event from that transaction
   cre workflow simulate my-workflow --non-interactive --trigger-index 1 --evm-tx-hash 0x420721d7d00130a03c5b525b2dbfd42550906ddb3075e8377f9bb5d1a5992f8e --evm-event-index 0 --target staging-settings
+  ```
+
+- Listen mode — re-run on every HTTP trigger POST (port 2000)
+
+  ```bash
+  cre workflow simulate ./my-workflow --listen --target local-simulation
+  ```
+
+- Listen mode — re-run on every matching EVM log event
+
+  ```bash
+  cre workflow simulate ./my-workflow --listen --trigger-index 1 --target staging-settings
   ```
 
 
@@ -13389,10 +13508,16 @@ For the full list of types and methods available on the Confidential HTTP client
 
 # Forwarder Directory
 Source: https://docs.chain.link/cre/guides/workflow/using-evm-client/forwarder-directory-go
-Last Updated: 2026-05-22
+Last Updated: 2026-06-24
 
 <Aside type="note" title="Looking for supported networks?">
   For a complete list of supported networks and version requirements, see [Supported Networks](/cre/supported-networks).
+</Aside>
+
+<Aside type="tip" title="Tenant-scoped chain list">
+  Chain availability and mock forwarder addresses depend on your CRE tenant. Run [`cre workflow
+    supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) after `cre login` to see the chains and
+  mock forwarder addresses enabled for your organization. Use `--output json` for scripting.
 </Aside>
 
 This page lists forwarder contract addresses for CRE workflows, organized by network.
@@ -13428,66 +13553,67 @@ If you configure forwarder validation in your consumer contract, **remember to u
 
 These `MockKeystoneForwarder` addresses are used when running `cre workflow simulate` with the `--broadcast` flag. Use these addresses **only** during local development and testing.
 
+The tables below reflect chains commonly enabled for simulation. Your tenant may have a different set — run [`cre workflow supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) for the authoritative list and mock forwarder addresses for your organization.
+
 ### Simulation Mainnets
 
-| Network                                                                                                                                                             | Chain Name                    | Mock Forwarder Address                     |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------ |
-| <a href="https://explorer.adifoundation.ai/address/0x6Aa382fb8762E1232936478DD9DbC04F637028f1" target="_blank" rel="noopener noreferrer">ADI Mainnet</a>            | adi-mainnet                   | 0x6Aa382fb8762E1232936478DD9DbC04F637028f1 |
-| <a href="https://arbiscan.io/address/0xd770499057619c9a76205fd4168161cf94abc532" target="_blank" rel="noopener noreferrer">Arbitrum One</a>                         | ethereum-mainnet-arbitrum-1   | 0xd770499057619c9a76205fd4168161cf94abc532 |
-| <a href="https://snowscan.xyz/address/0xdc21e279934ff6721cadfdd112dafb3261f09a2c" target="_blank" rel="noopener noreferrer">Avalanche</a>                           | avalanche-mainnet             | 0xdc21e279934ff6721cadfdd112dafb3261f09a2c |
-| <a href="https://basescan.org/address/0x5e342a8438b4f5d39e72875fcee6f76b39cce548" target="_blank" rel="noopener noreferrer">Base</a>                                | ethereum-mainnet-base-1       | 0x5e342a8438b4f5d39e72875fcee6f76b39cce548 |
-| <a href="https://bscscan.com/address/0x6f3239bbb26e98961e1115aba83f8a282e5508c8" target="_blank" rel="noopener noreferrer">BNB Chain</a>                            | binance_smart_chain-mainnet | 0x6f3239bbb26e98961e1115aba83f8a282e5508c8 |
-| <a href="https://explorer.celo.org/mainnet/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Celo</a>                   | celo-mainnet                  | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://etherscan.io/address/0xa3d1ad4ac559a6575a114998affb2fb2ec97a7d9" target="_blank" rel="noopener noreferrer">Ethereum Mainnet</a>                    | ethereum-mainnet              | 0xa3d1ad4ac559a6575a114998affb2fb2ec97a7d9 |
-| <a href="https://gnosisscan.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Gnosis Chain</a>                       | gnosis-chain-mainnet          | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://app.hyperliquid.xyz/explorer/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Hyperliquid Mainnet</a> | hyperliquid-mainnet           | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://explorer.inkonchain.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Ink</a>                      | ethereum-mainnet-ink-1        | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://explorer.jovay.io/address/0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" target="_blank" rel="noopener noreferrer">Jovay Mainnet</a>                  | jovay-mainnet                 | 0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4 |
-| <a href="https://lineascan.build/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Linea</a>                            | ethereum-mainnet-linea-1      | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://mantlescan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Mantle</a>                            | ethereum-mainnet-mantle-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://megaeth.blockscout.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">MegaETH</a>                   | megaeth-mainnet               | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://optimistic.etherscan.io/address/0x9119a1501550ed94a3f2794038ed9258337afa18" target="_blank" rel="noopener noreferrer">OP Mainnet</a>               | ethereum-mainnet-optimism-1   | 0x9119a1501550ed94a3f2794038ed9258337afa18 |
-| <a href="https://pharosscan.xyz/address/0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" target="_blank" rel="noopener noreferrer">Pharos Mainnet</a>                    | pharos-mainnet                | 0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4 |
-| <a href="https://plasmascan.to/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Plasma</a>                             | plasma-mainnet                | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://polygonscan.com/address/0xf458d621885e29a5003ea9bbba5280d54e19b1ce" target="_blank" rel="noopener noreferrer">Polygon</a>                          | polygon-mainnet               | 0xf458d621885e29a5003ea9bbba5280d54e19b1ce |
-| <a href="https://scrollscan.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Scroll</a>                            | ethereum-mainnet-scroll-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sonicscan.org/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Sonic</a>                              | sonic-mainnet                 | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://worldscan.org/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">World Chain</a>                        | ethereum-mainnet-worldchain-1 | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://www.oklink.com/xlayer/address/0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" target="_blank" rel="noopener noreferrer">XLayer Mainnet</a>             | ethereum-mainnet-xlayer-1     | 0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4 |
-| <a href="https://explorer.zksync.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">ZKSync Era</a>                    | ethereum-mainnet-zksync-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
+| Network             | Chain Name                    | Mock Forwarder Address                     |
+| ------------------- | ----------------------------- | ------------------------------------------ |
+| Arbitrum One        | ethereum-mainnet-arbitrum-1   | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
+| Avalanche           | avalanche-mainnet             | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Base                | ethereum-mainnet-base-1       | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
+| BNB Chain           | binance_smart_chain-mainnet | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Celo                | celo-mainnet                  | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| Ethereum Mainnet    | ethereum-mainnet              | 0x0b93082D9b3C7C97fAcd250082899BAcf3af3885 |
+| Gnosis Chain        | gnosis_chain-mainnet         | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| Hyperliquid Mainnet | hyperliquid-mainnet           | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| Ink                 | ethereum-mainnet-ink-1        | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| Jovay Mainnet       | jovay-mainnet                 | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Linea               | ethereum-mainnet-linea-1      | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| Mantle              | ethereum-mainnet-mantle-1     | 0xB9F79d863261869B234c481D1f9A7af84AeAd192 |
+| MegaETH             | megaeth-mainnet               | 0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c |
+| OP Mainnet          | ethereum-mainnet-optimism-1   | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
+| Pharos Mainnet      | pharos-mainnet                | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Plasma              | plasma-mainnet                | 0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c |
+| Polygon             | polygon-mainnet               | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Scroll              | ethereum-mainnet-scroll-1     | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| Sonic               | sonic-mainnet                 | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| World Chain         | ethereum-mainnet-worldchain-1 | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| XLayer Mainnet      | ethereum-mainnet-xlayer-1     | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| ZKSync Era          | ethereum-mainnet-zksync-1     | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 
 ### Simulation Testnets
 
-| Network                                                                                                                                                            | Chain Name                            | Mock Forwarder Address                     |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- | ------------------------------------------ |
-| <a href="https://explorer.testnet.adifoundation.ai/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">ADI Testnet</a>   | adi-testnet                           | 0x9eF6468C5f37b976E57d52054c693269479A784d |
-| <a href="https://explorer.curtis.apechain.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Apechain Curtis</a>    | apechain-testnet-curtis               | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://testnet.arcscan.app/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Arc Testnet</a>                 | arc-testnet                           | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.arbiscan.io/address/0xd41263567ddfead91504199b8c6c87371e83ca5d" target="_blank" rel="noopener noreferrer">Arbitrum Sepolia</a>            | ethereum-testnet-sepolia-arbitrum-1   | 0xd41263567ddfead91504199b8c6c87371e83ca5d |
-| <a href="https://testnet.snowscan.xyz/address/0x2e7371a5d032489e4f60216d8d898a4c10805963" target="_blank" rel="noopener noreferrer">Avalanche Fuji</a>             | avalanche-testnet-fuji                | 0x2e7371a5d032489e4f60216d8d898a4c10805963 |
-| <a href="https://sepolia.basescan.org/address/0x82300bd7c3958625581cc2f77bc6464dcecdf3e5" target="_blank" rel="noopener noreferrer">Base Sepolia</a>               | ethereum-testnet-sepolia-base-1       | 0x82300bd7c3958625581cc2f77bc6464dcecdf3e5 |
-| <a href="https://testnet.bscscan.com/address/0xa238e42cb8782808dbb2f37e19859244ec4779b0" target="_blank" rel="noopener noreferrer">BNB Chain Testnet</a>           | binance_smart_chain-testnet         | 0xa238e42cb8782808dbb2f37e19859244ec4779b0 |
-| <a href="https://celo-sepolia.blockscout.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Celo Sepolia</a>        | celo-sepolia                          | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://explorer.cronos.org/testnet/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Cronos Testnet</a>      | cronos-testnet                        | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.etherscan.io/address/0x15fC6ae953E024d975e77382eEeC56A9101f9F88" target="_blank" rel="noopener noreferrer">Ethereum Sepolia</a>           | ethereum-testnet-sepolia              | 0x15fC6ae953E024d975e77382eEeC56A9101f9F88 |
-| <a href="https://gnosis-chiado.blockscout.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Gnosis Chiado</a>      | gnosis-chain-testnet-chiado           | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://explore-testnet.hyperpc.app/address/0xB27fA1c28288c50542527F64BCda22C9FbAc24CB" target="_blank" rel="noopener noreferrer">Hyperliquid Testnet</a> | hyperliquid-testnet                   | 0xB27fA1c28288c50542527F64BCda22C9FbAc24CB |
-| <a href="https://explorer-sepolia.inkonchain.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Ink Sepolia</a>     | ink-testnet-sepolia                   | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia-explorer.jovay.io/l2/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Jovay Testnet</a>      | jovay-testnet                         | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.lineascan.build/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Linea Sepolia</a>           | ethereum-testnet-sepolia-linea-1      | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.mantlescan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Mantle Sepolia</a>           | ethereum-testnet-sepolia-mantle-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://megaexplorer.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">MegaETH Testnet 2</a>              | megaeth-testnet-2                     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia-optimism.etherscan.io/address/0xa2888380dff3704a8ab6d1cd1a8f69c15fea5ee3" target="_blank" rel="noopener noreferrer">OP Sepolia</a>        | ethereum-testnet-sepolia-optimism-1   | 0xa2888380dff3704a8ab6d1cd1a8f69c15fea5ee3 |
-| <a href="https://atlantic.pharosscan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Pharos Atlantic Testnet</a> | pharos-atlantic-testnet               | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://testnet.plasmascan.to/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Plasma Testnet</a>            | plasma-testnet                        | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://amoy.polygonscan.com/address/0x3675a5eb2286a3f87e8278fc66edf458a2e3bb74" target="_blank" rel="noopener noreferrer">Polygon Amoy</a>               | polygon-testnet-amoy                  | 0x3675a5eb2286a3f87e8278fc66edf458a2e3bb74 |
-| <a href="https://sepolia-blockscout.scroll.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Scroll Sepolia</a>     | ethereum-testnet-sepolia-scroll-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://explorer.testnet.soniclabs.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Sonic Testnet</a>    | sonic-testnet                         | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://spb.explorer.tac.build/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">TAC Testnet</a>              | tac-testnet                           | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.uniscan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Unichain Sepolia</a>            | ethereum-testnet-sepolia-unichain-1   | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.worldscan.org/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">World Chain Sepolia</a>       | ethereum-testnet-sepolia-worldchain-1 | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://www.oklink.com/xlayer-test/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">XLayer Testnet</a>       | xlayer-testnet                        | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.explorer.zksync.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">ZKSync Era Sepolia</a>   | ethereum-testnet-sepolia-zksync-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
+| Network                 | Chain Name                            | Mock Forwarder Address                     |
+| ----------------------- | ------------------------------------- | ------------------------------------------ |
+| ADI Testnet             | adi-testnet                           | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Apechain Curtis         | apechain-testnet-curtis               | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Arc Testnet             | arc-testnet                           | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Arbitrum Sepolia        | ethereum-testnet-sepolia-arbitrum-1   | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Avalanche Fuji          | avalanche-testnet-fuji                | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Base Sepolia            | ethereum-testnet-sepolia-base-1       | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
+| BNB Chain Testnet       | binance_smart_chain-testnet         | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Celo Sepolia            | celo-sepolia                          | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| Cronos Testnet          | cronos-testnet                        | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| Ethereum Sepolia        | ethereum-testnet-sepolia              | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
+| Gnosis Chiado           | gnosis_chain-testnet-chiado          | 0x0b93082D9b3C7C97fAcd250082899BAcf3af3885 |
+| Hyperliquid Testnet     | hyperliquid-testnet                   | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Ink Sepolia             | ink-testnet-sepolia                   | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Jovay Testnet           | jovay-testnet                         | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Linea Sepolia           | ethereum-testnet-sepolia-linea-1      | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Mantle Sepolia          | ethereum-testnet-sepolia-mantle-1     | 0xB9F79d863261869B234c481D1f9A7af84AeAd192 |
+| MegaETH Testnet 2       | megaeth-testnet-2                     | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| OP Sepolia              | ethereum-testnet-sepolia-optimism-1   | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Pharos Atlantic Testnet | pharos-atlantic-testnet               | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Plasma Testnet          | plasma-testnet                        | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Polygon Amoy            | polygon-testnet-amoy                  | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Scroll Sepolia          | ethereum-testnet-sepolia-scroll-1     | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| Sonic Testnet           | sonic-testnet                         | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| TAC Testnet             | tac-testnet                           | 0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c |
+| Unichain Sepolia        | ethereum-testnet-sepolia-unichain-1   | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| World Chain Sepolia     | ethereum-testnet-sepolia-worldchain-1 | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| XLayer Testnet          | xlayer-testnet                        | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| ZKSync Era Sepolia      | ethereum-testnet-sepolia-zksync-1     | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 
 ## Production Forwarders
 
@@ -13504,7 +13630,7 @@ These `KeystoneForwarder` addresses are used by deployed workflows. Use these ad
 | <a href="https://bscscan.com/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">BNB Chain</a>                            | binance_smart_chain-mainnet | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 | <a href="https://explorer.celo.org/mainnet/address/0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" target="_blank" rel="noopener noreferrer">Celo</a>                   | celo-mainnet                  | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
 | <a href="https://etherscan.io/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" target="_blank" rel="noopener noreferrer">Ethereum Mainnet</a>                    | ethereum-mainnet              | 0x0b93082D9b3C7C97fAcd250082899BAcf3af3885 |
-| <a href="https://gnosisscan.io/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Gnosis Chain</a>                       | gnosis-chain-mainnet          | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| <a href="https://gnosisscan.io/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Gnosis Chain</a>                       | gnosis_chain-mainnet         | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | <a href="https://app.hyperliquid.xyz/explorer/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Hyperliquid Mainnet</a> | hyperliquid-mainnet           | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | <a href="https://explorer.inkonchain.com/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Ink</a>                      | ethereum-mainnet-ink-1        | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | <a href="https://explorer.jovay.io/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Jovay Mainnet</a>                  | jovay-mainnet                 | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
@@ -13535,7 +13661,7 @@ These `KeystoneForwarder` addresses are used by deployed workflows. Use these ad
 | <a href="https://celo-sepolia.blockscout.com/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Celo Sepolia</a>        | celo-sepolia                          | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | <a href="https://explorer.cronos.org/testnet/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Cronos Testnet</a>      | cronos-testnet                        | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | <a href="https://sepolia.etherscan.io/address/0xF8344CFd5c43616a4366C34E3EEE75af79a74482" target="_blank" rel="noopener noreferrer">Ethereum Sepolia</a>           | ethereum-testnet-sepolia              | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
-| <a href="https://gnosis-chiado.blockscout.com/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" target="_blank" rel="noopener noreferrer">Gnosis Chiado</a>      | gnosis-chain-testnet-chiado           | 0x0b93082D9b3C7C97fAcd250082899BAcf3af3885 |
+| <a href="https://gnosis-chiado.blockscout.com/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" target="_blank" rel="noopener noreferrer">Gnosis Chiado</a>      | gnosis_chain-testnet-chiado          | 0x0b93082D9b3C7C97fAcd250082899BAcf3af3885 |
 | <a href="https://explore-testnet.hyperpc.app/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Hyperliquid Testnet</a> | hyperliquid-testnet                   | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 | <a href="https://explorer-sepolia.inkonchain.com/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Ink Sepolia</a>     | ink-testnet-sepolia                   | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 | <a href="https://sepolia-explorer.jovay.io/l2/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Jovay Testnet</a>      | jovay-testnet                         | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
@@ -20483,9 +20609,16 @@ This section provides a reference for the built-in trigger capabilities of the C
 
 # Supported Networks
 Source: https://docs.chain.link/cre/supported-networks-go
-Last Updated: 2026-05-22
+Last Updated: 2026-06-24
 
-This page lists all EVM-compatible networks supported by CRE workflows, along with the minimum CLI and SDK versions required for each network.
+This page lists EVM-compatible networks supported by CRE workflows, along with the minimum CLI and SDK versions required for each network.
+
+<Aside type="tip" title="Check chains enabled for your tenant">
+  The tables below show minimum version requirements for each network. To see which chains and mock forwarder addresses
+  are enabled for **your** organization, run [`cre workflow
+    supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) after `cre login` (or with `CRE_API_KEY`
+  set). Use `--output json` for machine-readable output.
+</Aside>
 
 ## Version Requirements
 
@@ -20558,6 +20691,8 @@ Network support depends on your CLI and SDK versions. The tables below show the 
 ## Forwarder Addresses
 
 For forwarder contract addresses and chain names, see the [Forwarder Directory](/cre/guides/workflow/using-evm-client/forwarder-directory). Forwarder addresses are used when building consumer contracts that receive workflow reports onchain. Learn more about [Onchain Write](/cre/guides/workflow/using-evm-client/onchain-write/overview).
+
+Run [`cre workflow supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) anytime to list the chains and mock forwarder addresses currently enabled for your tenant.
 
 ---
 

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -7583,7 +7583,7 @@ CRE uses a simple role-based access control system with two roles:
 
 # Linking Wallet Keys
 Source: https://docs.chain.link/cre/organization/linking-keys
-Last Updated: 2025-11-04
+Last Updated: 2026-06-24
 
 Before you can deploy workflows to the public onchain registry (`deployment-registry: "onchain:ethereum-mainnet"`), you must link a public key address to your CRE organization. This process registers your wallet address onchain in the Workflow Registry contract—the smart contract on Ethereum Mainnet that stores and manages public CRE workflows—associating it with your organization and allowing you to deploy and manage workflows through the onchain registry.
 
@@ -7603,7 +7603,7 @@ Key linking is the process of connecting a blockchain wallet address to your CRE
 **Important constraints:**
 
 - **One organization per address**: Each wallet address can only be linked to one CRE organization at a time. If you need to use the same address with a different organization, you must first [unlink it](#unlinking-a-key) from the current organization.
-- **Maximum 2 keys per organization**: Each organization can link a maximum of 2 web3 keys. If you need to link a third key, you must first [unlink](#unlinking-a-key) one of the existing keys.
+- **Per-organization key limit**: The number of web3 keys your organization can link is subject to your plan quota. See [Service Quotas](/cre/service-quotas#registry-quotas) for the current limit. To request an increase, [contact us](/cre/support-feedback).
 
 However, an organization can have multiple wallet addresses linked to it, allowing team members to use their own addresses or enabling separation between development, staging, and production environments.
 
@@ -7760,7 +7760,7 @@ Linked Owners:
 
 ## Linking multiple addresses
 
-Your organization can link **up to 2 wallet addresses**. Each individual address can only be linked to one organization at a time.
+Your organization can link more than one wallet address, subject to your plan's key limit. See [Service Quotas](/cre/service-quotas#registry-quotas) for the current limit, or [contact us](/cre/support-feedback) to request an increase. Each individual address can only be linked to one organization at a time.
 
 This is useful for:
 

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -7124,7 +7124,7 @@ CRE uses a simple role-based access control system with two roles:
 
 # Linking Wallet Keys
 Source: https://docs.chain.link/cre/organization/linking-keys
-Last Updated: 2025-11-04
+Last Updated: 2026-06-24
 
 Before you can deploy workflows to the public onchain registry (`deployment-registry: "onchain:ethereum-mainnet"`), you must link a public key address to your CRE organization. This process registers your wallet address onchain in the Workflow Registry contract—the smart contract on Ethereum Mainnet that stores and manages public CRE workflows—associating it with your organization and allowing you to deploy and manage workflows through the onchain registry.
 
@@ -7144,7 +7144,7 @@ Key linking is the process of connecting a blockchain wallet address to your CRE
 **Important constraints:**
 
 - **One organization per address**: Each wallet address can only be linked to one CRE organization at a time. If you need to use the same address with a different organization, you must first [unlink it](#unlinking-a-key) from the current organization.
-- **Maximum 2 keys per organization**: Each organization can link a maximum of 2 web3 keys. If you need to link a third key, you must first [unlink](#unlinking-a-key) one of the existing keys.
+- **Per-organization key limit**: The number of web3 keys your organization can link is subject to your plan quota. See [Service Quotas](/cre/service-quotas#registry-quotas) for the current limit. To request an increase, [contact us](/cre/support-feedback).
 
 However, an organization can have multiple wallet addresses linked to it, allowing team members to use their own addresses or enabling separation between development, staging, and production environments.
 
@@ -7301,7 +7301,7 @@ Linked Owners:
 
 ## Linking multiple addresses
 
-Your organization can link **up to 2 wallet addresses**. Each individual address can only be linked to one organization at a time.
+Your organization can link more than one wallet address, subject to your plan's key limit. See [Service Quotas](/cre/service-quotas#registry-quotas) for the current limit, or [contact us](/cre/support-feedback) to request an increase. Each individual address can only be linked to one organization at a time.
 
 This is useful for:
 

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -514,9 +514,59 @@ To help us assist you faster, please include:
 
 # Release Notes
 Source: https://docs.chain.link/cre/release-notes
-Last Updated: 2026-06-04
+Last Updated: 2026-06-18
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.21.0 - June 18, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.21.0" target="_blank">CRE CLI version 1.21.0</a> is now available.**
+
+- **MSIG mode guard**: Using `--unsigned` or `--changeset` with `--secrets-auth=browser` or a private registry now produces a clear upfront error instead of a confusing failure mid-operation.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.20.0...v1.21.0)
+
+## CLI v1.20.0 - June 12, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.20.0" target="_blank">CRE CLI version 1.20.0</a> is now available.**
+
+- **Simulation limits aligned with production**: The local simulator's resource limits now match production. Notable increases: execution concurrency (10 → 50), EVM transaction gas limit (5M → 10M), chain write report size (5 KB → 50 KB), HTTP action payload sizes (10 KB request / 100 KB response → 120 KB / 250 KB), and ConfidentialHTTP payload sizes (10 KB / 100 KB → 125 KB / 500 KB). Workflows that previously hit local-only caps should now simulate more faithfully.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.19.0...v1.20.0)
+
+## CLI v1.19.0 - June 11, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.19.0" target="_blank">CRE CLI version 1.19.0</a> is now available.**
+
+- **`--listen` flag for `cre workflow simulate`**: A new `--listen` flag keeps the simulator alive and re-runs it for each incoming event — HTTP POST requests on port 2000 or matching EVM log trigger events. Use it when iterating on trigger-driven workflows without restarting the simulator between runs. Also added `--evm-receipt-timeout` (default `1m`) to control how long the simulator waits for an EVM transaction receipt.
+- **Browser OAuth secrets auth in production**: Browser-based OAuth authentication for secrets is now fully enabled in production environments. A related fix prevents secrets flows from failing when the default `CRE_ETH_PRIVATE_KEY` placeholder is set in your environment.
+- **DON Family shown in workflow output**: The `DON Family` field is now displayed in the details section after `cre workflow deploy`, `activate`, and `pause`. The underlying resolution now uses your tenant's platform default instead of the embedded config, so the displayed value reflects what the platform actually uses.
+- **Capability registry RPC auto-resolution**: The CLI now resolves RPC endpoints for the capability registry chain automatically and prompts for consent when needed, removing the need to configure these connections manually in your secrets workflows.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.18.0...v1.19.0)
+
+## Go SDK v1.12.0 - June 11, 2026
+
+**Go SDK version 1.12.0** adds Solana mainnet support.
+
+- **Solana mainnet**: Solana mainnet chain selectors and workflow bindings are now included in the SDK, enabling production workflows that target Solana mainnet.
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.11.0...v1.12.0)
 
 ## CLI v1.18.0 - June 4, 2026
 
@@ -558,6 +608,22 @@ This page provides detailed release notes for CRE. It includes information on ne
 
 [See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.15.0...v1.16.0)
 
+## Go SDK v1.11.0 - May 21, 2026
+
+**Go SDK version 1.11.0** adds private Rhyolite testnet support.
+
+- **`private-testnet-rhyolite` support**: EVM capabilities for the Rhyolite private testnet are now included. Use the `private-testnet-rhyolite` chain name when building workflows that target this network.
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.10.0...v1.11.0)
+
+## Go SDK v1.10.0 - May 20, 2026
+
+**Go SDK version 1.10.0** adds ADI mainnet support.
+
+- **ADI mainnet**: EVM capabilities for ADI mainnet (`adi-mainnet`) are now included, supporting workflows deployed to ADI mainnet.
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.9.0...v1.10.0)
+
 ## CLI v1.15.0 - May 14, 2026
 
 **<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.15.0" target="_blank">CRE CLI version 1.15.0</a> is now available.**
@@ -588,6 +654,14 @@ This page provides detailed release notes for CRE. It includes information on ne
 - **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
 
 [See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.13.0...v1.14.0)
+
+## Go SDK v1.9.0 - May 13, 2026
+
+**Go SDK version 1.9.0** adds ADI testnet and Celo Sepolia support.
+
+- **ADI testnet and Celo Sepolia**: EVM capabilities for ADI testnet (`adi-testnet`) and Celo Sepolia (`celo-sepolia`) are now included, enabling simulation and deployment to these networks.
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.8.0...v1.9.0)
 
 ## CLI v1.13.0 - April 30, 2026
 
@@ -1535,7 +1609,7 @@ This section provides detailed guides for each available trigger type:
 
 # Testing HTTP Triggers in Simulation
 Source: https://docs.chain.link/cre/guides/workflow/using-triggers/http-trigger/testing-in-simulation
-Last Updated: 2025-11-10
+Last Updated: 2026-06-11
 
 During development, you can test your HTTP trigger workflows locally using the `cre workflow simulate` command. The simulator allows you to provide test payloads without setting up authorization keys or JWT authentication.
 
@@ -1569,6 +1643,24 @@ cre workflow simulate my-http-workflow --target staging-settings
 ```
 
 The simulator will detect your HTTP trigger and prompt you to select it from available triggers.
+
+## Listen mode
+
+Use `--listen` to keep the simulator alive between runs. Instead of simulating once and exiting, the CLI starts a local HTTP server on port `2000` and re-runs the simulator every time it receives a POST request — no need to restart between tests.
+
+```bash
+cre workflow simulate my-http-workflow --listen --target staging-settings
+```
+
+Once running, send payloads with any HTTP client:
+
+```bash
+curl -X POST http://localhost:2000 \
+  -H "Content-Type: application/json" \
+  -d '{"userId":"123","action":"purchase","amount":100}'
+```
+
+Each POST triggers a fresh simulation run. Press `Ctrl+C` to stop.
 
 ## Providing input data
 
@@ -4607,7 +4699,7 @@ By following this pattern, you can manage your secrets securely without ever exp
 
 # Simulating Workflows
 Source: https://docs.chain.link/cre/guides/operations/simulating-workflows
-Last Updated: 2025-11-04
+Last Updated: 2026-06-11
 
 Workflow simulation is a local execution environment that **compiles your workflow to <a href="https://webassembly.org" target="blank" ref="noopener noreferrer">WebAssembly (WASM)</a>** and runs it on **your machine**. It allows you to test and debug your workflow logic before deploying it. The simulator makes real calls to public testnets and live HTTP endpoints, giving you high confidence that your code will work as expected when deployed.
 
@@ -4710,6 +4802,19 @@ cre workflow simulate my-workflow --non-interactive --trigger-index 0 --target s
   multiple handlers (e.g., one for an HTTP trigger and one for an EVM log trigger), use `0` for the first, `1` for the
   second, etc., based on their order in your code.
 </Aside>
+
+## Listen mode
+
+The `--listen` flag keeps the simulator alive and re-runs it for each incoming trigger event, instead of compiling and executing once then exiting.
+
+- **HTTP triggers**: starts a local HTTP server on port `2000`. Each POST request triggers a fresh simulation run.
+- **EVM log triggers**: watches the configured chain and re-runs on each matching log event.
+
+```bash
+cre workflow simulate my-workflow --listen --target staging-settings
+```
+
+This is useful during active development — make a code change, resave, send another event, and see the result immediately without restarting the CLI. See [Testing HTTP Triggers in Simulation](/cre/guides/workflow/using-triggers/http-trigger/testing-in-simulation) for a detailed walkthrough with HTTP triggers.
 
 ## The `--broadcast` flag
 
@@ -8418,7 +8523,7 @@ When you run this command, the CLI will:
 
 # Workflow Commands
 Source: https://docs.chain.link/cre/reference/cli/workflow
-Last Updated: 2026-05-14
+Last Updated: 2026-06-11
 
 The `cre workflow` commands manage workflows throughout their entire lifecycle, from local testing to deployment and ongoing management.
 
@@ -8491,17 +8596,19 @@ cre workflow simulate <workflow-name-or-path> [flags]
 
 **Flags:**
 
-| Flag                      | Description                                                                                                                                                                                                                                                                      |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--broadcast`             | Broadcast onchain write transactions (default: `false`). Without this flag, a dry run is performed                                                                                                                                                                               |
-| `-g, --engine-logs`       | Enable non-fatal engine logging                                                                                                                                                                                                                                                  |
-| `--non-interactive`       | Run without prompts; requires `--trigger-index` (see the line below) and inputs for the selected trigger type                                                                                                                                                                    |
-| `--trigger-index <int>`   | Selects which handler to run (0-based position). If your workflow has multiple handlers, `0` is the first, `1` is the second, etc. Required with `--non-interactive`                                                                                                             |
-| `--http-payload <string>` | HTTP trigger payload as JSON string or path to a JSON file. File paths are resolved relative to the directory where you ran the command. For HTTP triggers only                                                                                                                  |
-| `--evm-tx-hash <string>`  | Transaction hash (`0x...`) containing the event that triggered your workflow. For EVM log triggers only                                                                                                                                                                          |
-| `--evm-event-index <int>` | Which log/event within the transaction to use (0-based position). If the transaction emitted multiple events, `0` is the first, `1` is the second, etc. For EVM log triggers only                                                                                                |
-| `--limits <string>`       | Production limits to enforce during simulation: `default` (embedded prod limits), a path to a limits JSON file (e.g. from `cre workflow limits export`), or `none` to disable. See [Testing Production Limits](/cre/guides/operations/understanding-limits) (default: `default`) |
-| `--skip-type-checks`      | Skip TypeScript type checking during compilation. Speeds up iteration in development; not recommended for production builds                                                                                                                                                      |
+| Flag                               | Description                                                                                                                                                                                                                                                                                                      |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--broadcast`                      | Broadcast onchain write transactions (default: `false`). Without this flag, a dry run is performed                                                                                                                                                                                                               |
+| `-g, --engine-logs`                | Enable non-fatal engine logging                                                                                                                                                                                                                                                                                  |
+| `--listen`                         | Keep the simulator alive and re-run it for each incoming trigger event. For HTTP triggers, listens for POST requests on port `2000`. For EVM log triggers, watches the chain and re-runs on each matching event. Useful when iterating on trigger-driven workflows without restarting the simulator between runs |
+| `--non-interactive`                | Run without prompts; requires `--trigger-index` (see the line below) and inputs for the selected trigger type                                                                                                                                                                                                    |
+| `--trigger-index <int>`            | Selects which handler to run (0-based position). If your workflow has multiple handlers, `0` is the first, `1` is the second, etc. Required with `--non-interactive`                                                                                                                                             |
+| `--http-payload <string>`          | HTTP trigger payload as JSON string or path to a JSON file. File paths are resolved relative to the directory where you ran the command. For HTTP triggers only                                                                                                                                                  |
+| `--evm-tx-hash <string>`           | Transaction hash (`0x...`) containing the event that triggered your workflow. For EVM log triggers only                                                                                                                                                                                                          |
+| `--evm-event-index <int>`          | Which log/event within the transaction to use (0-based position). If the transaction emitted multiple events, `0` is the first, `1` is the second, etc. For EVM log triggers only                                                                                                                                |
+| `--evm-receipt-timeout <duration>` | How long to wait for an EVM transaction receipt before timing out (e.g. `30s`, `2m`). For EVM log triggers only (default: `1m`)                                                                                                                                                                                  |
+| `--limits <string>`                | Production limits to enforce during simulation: `default` (embedded prod limits), a path to a limits JSON file (e.g. from `cre workflow limits export`), or `none` to disable. See [Testing Production Limits](/cre/guides/operations/understanding-limits) (default: `default`)                                 |
+| `--skip-type-checks`               | Skip TypeScript type checking during compilation. Speeds up iteration in development; not recommended for production builds                                                                                                                                                                                      |
 
 **Examples:**
 
@@ -8530,6 +8637,18 @@ cre workflow simulate <workflow-name-or-path> [flags]
   # If your EVM log trigger handler is the second handler in your workflow, use --trigger-index 1
   # --evm-event-index 0 means you want the first event from that transaction
   cre workflow simulate my-workflow --non-interactive --trigger-index 1 --evm-tx-hash 0x420721d7d00130a03c5b525b2dbfd42550906ddb3075e8377f9bb5d1a5992f8e --evm-event-index 0 --target staging-settings
+  ```
+
+- Listen mode — re-run on every HTTP trigger POST (port 2000)
+
+  ```bash
+  cre workflow simulate ./my-workflow --listen --target local-simulation
+  ```
+
+- Listen mode — re-run on every matching EVM log event
+
+  ```bash
+  cre workflow simulate ./my-workflow --listen --trigger-index 1 --target staging-settings
   ```
 
 
@@ -13175,10 +13294,16 @@ For the full list of types and methods available on the Confidential HTTP client
 
 # Forwarder Directory
 Source: https://docs.chain.link/cre/guides/workflow/using-evm-client/forwarder-directory-ts
-Last Updated: 2026-05-22
+Last Updated: 2026-06-24
 
 <Aside type="note" title="Looking for supported networks?">
   For a complete list of supported networks and version requirements, see [Supported Networks](/cre/supported-networks).
+</Aside>
+
+<Aside type="tip" title="Tenant-scoped chain list">
+  Chain availability and mock forwarder addresses depend on your CRE tenant. Run [`cre workflow
+    supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) after `cre login` to see the chains and
+  mock forwarder addresses enabled for your organization. Use `--output json` for scripting.
 </Aside>
 
 This page lists forwarder contract addresses for CRE workflows, organized by network.
@@ -13214,66 +13339,67 @@ If you configure forwarder validation in your consumer contract, **remember to u
 
 These `MockKeystoneForwarder` addresses are used when running `cre workflow simulate` with the `--broadcast` flag. Use these addresses **only** during local development and testing.
 
+The tables below reflect chains commonly enabled for simulation. Your tenant may have a different set — run [`cre workflow supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) for the authoritative list and mock forwarder addresses for your organization.
+
 ### Simulation Mainnets
 
-| Network                                                                                                                                                             | Chain Name                    | Mock Forwarder Address                     |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------ |
-| <a href="https://explorer.adifoundation.ai/address/0x6Aa382fb8762E1232936478DD9DbC04F637028f1" target="_blank" rel="noopener noreferrer">ADI Mainnet</a>            | adi-mainnet                   | 0x6Aa382fb8762E1232936478DD9DbC04F637028f1 |
-| <a href="https://arbiscan.io/address/0xd770499057619c9a76205fd4168161cf94abc532" target="_blank" rel="noopener noreferrer">Arbitrum One</a>                         | ethereum-mainnet-arbitrum-1   | 0xd770499057619c9a76205fd4168161cf94abc532 |
-| <a href="https://snowscan.xyz/address/0xdc21e279934ff6721cadfdd112dafb3261f09a2c" target="_blank" rel="noopener noreferrer">Avalanche</a>                           | avalanche-mainnet             | 0xdc21e279934ff6721cadfdd112dafb3261f09a2c |
-| <a href="https://basescan.org/address/0x5e342a8438b4f5d39e72875fcee6f76b39cce548" target="_blank" rel="noopener noreferrer">Base</a>                                | ethereum-mainnet-base-1       | 0x5e342a8438b4f5d39e72875fcee6f76b39cce548 |
-| <a href="https://bscscan.com/address/0x6f3239bbb26e98961e1115aba83f8a282e5508c8" target="_blank" rel="noopener noreferrer">BNB Smart Chain</a>                      | binance_smart_chain-mainnet | 0x6f3239bbb26e98961e1115aba83f8a282e5508c8 |
-| <a href="https://explorer.celo.org/mainnet/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Celo</a>                   | celo-mainnet                  | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://etherscan.io/address/0xa3d1ad4ac559a6575a114998affb2fb2ec97a7d9" target="_blank" rel="noopener noreferrer">Ethereum Mainnet</a>                    | ethereum-mainnet              | 0xa3d1ad4ac559a6575a114998affb2fb2ec97a7d9 |
-| <a href="https://gnosisscan.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Gnosis Chain</a>                       | gnosis-chain-mainnet          | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://app.hyperliquid.xyz/explorer/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Hyperliquid Mainnet</a> | hyperliquid-mainnet           | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://explorer.inkonchain.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Ink</a>                      | ethereum-mainnet-ink-1        | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://explorer.jovay.io/address/0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" target="_blank" rel="noopener noreferrer">Jovay Mainnet</a>                  | jovay-mainnet                 | 0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4 |
-| <a href="https://lineascan.build/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Linea</a>                            | ethereum-mainnet-linea-1      | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://mantlescan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Mantle</a>                            | ethereum-mainnet-mantle-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://megaeth.blockscout.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">MegaETH</a>                   | megaeth-mainnet               | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://optimistic.etherscan.io/address/0x9119a1501550ed94a3f2794038ed9258337afa18" target="_blank" rel="noopener noreferrer">OP Mainnet</a>               | ethereum-mainnet-optimism-1   | 0x9119a1501550ed94a3f2794038ed9258337afa18 |
-| <a href="https://pharosscan.xyz/address/0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" target="_blank" rel="noopener noreferrer">Pharos Mainnet</a>                    | pharos-mainnet                | 0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4 |
-| <a href="https://plasmascan.to/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Plasma</a>                             | plasma-mainnet                | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://polygonscan.com/address/0xf458d621885e29a5003ea9bbba5280d54e19b1ce" target="_blank" rel="noopener noreferrer">Polygon</a>                          | polygon-mainnet               | 0xf458d621885e29a5003ea9bbba5280d54e19b1ce |
-| <a href="https://scrollscan.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Scroll</a>                            | ethereum-mainnet-scroll-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sonicscan.org/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Sonic</a>                              | sonic-mainnet                 | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://worldscan.org/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">World Chain</a>                        | ethereum-mainnet-worldchain-1 | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://www.oklink.com/xlayer/address/0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" target="_blank" rel="noopener noreferrer">XLayer Mainnet</a>             | ethereum-mainnet-xlayer-1     | 0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4 |
-| <a href="https://explorer.zksync.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">ZKSync Era</a>                    | ethereum-mainnet-zksync-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
+| Network             | Chain Name                    | Mock Forwarder Address                     |
+| ------------------- | ----------------------------- | ------------------------------------------ |
+| Arbitrum One        | ethereum-mainnet-arbitrum-1   | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
+| Avalanche           | avalanche-mainnet             | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Base                | ethereum-mainnet-base-1       | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
+| BNB Smart Chain     | binance_smart_chain-mainnet | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Celo                | celo-mainnet                  | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| Ethereum Mainnet    | ethereum-mainnet              | 0x0b93082D9b3C7C97fAcd250082899BAcf3af3885 |
+| Gnosis Chain        | gnosis_chain-mainnet         | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| Hyperliquid Mainnet | hyperliquid-mainnet           | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| Ink                 | ethereum-mainnet-ink-1        | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| Jovay Mainnet       | jovay-mainnet                 | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Linea               | ethereum-mainnet-linea-1      | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| Mantle              | ethereum-mainnet-mantle-1     | 0xB9F79d863261869B234c481D1f9A7af84AeAd192 |
+| MegaETH             | megaeth-mainnet               | 0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c |
+| OP Mainnet          | ethereum-mainnet-optimism-1   | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
+| Pharos Mainnet      | pharos-mainnet                | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Plasma              | plasma-mainnet                | 0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c |
+| Polygon             | polygon-mainnet               | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Scroll              | ethereum-mainnet-scroll-1     | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| Sonic               | sonic-mainnet                 | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| World Chain         | ethereum-mainnet-worldchain-1 | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| XLayer Mainnet      | ethereum-mainnet-xlayer-1     | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| ZKSync Era          | ethereum-mainnet-zksync-1     | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 
 ### Simulation Testnets
 
-| Network                                                                                                                                                            | Chain Name                            | Mock Forwarder Address                     |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- | ------------------------------------------ |
-| <a href="https://explorer.testnet.adifoundation.ai/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">ADI Testnet</a>   | adi-testnet                           | 0x9eF6468C5f37b976E57d52054c693269479A784d |
-| <a href="https://explorer.curtis.apechain.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Apechain Curtis</a>    | apechain-testnet-curtis               | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://testnet.arcscan.app/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Arc Testnet</a>                 | arc-testnet                           | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.arbiscan.io/address/0xd41263567ddfead91504199b8c6c87371e83ca5d" target="_blank" rel="noopener noreferrer">Arbitrum Sepolia</a>            | ethereum-testnet-sepolia-arbitrum-1   | 0xd41263567ddfead91504199b8c6c87371e83ca5d |
-| <a href="https://testnet.snowscan.xyz/address/0x2e7371a5d032489e4f60216d8d898a4c10805963" target="_blank" rel="noopener noreferrer">Avalanche Fuji</a>             | avalanche-testnet-fuji                | 0x2e7371a5d032489e4f60216d8d898a4c10805963 |
-| <a href="https://sepolia.basescan.org/address/0x82300bd7c3958625581cc2f77bc6464dcecdf3e5" target="_blank" rel="noopener noreferrer">Base Sepolia</a>               | ethereum-testnet-sepolia-base-1       | 0x82300bd7c3958625581cc2f77bc6464dcecdf3e5 |
-| <a href="https://testnet.bscscan.com/address/0xa238e42cb8782808dbb2f37e19859244ec4779b0" target="_blank" rel="noopener noreferrer">BSC Testnet</a>                 | binance_smart_chain-testnet         | 0xa238e42cb8782808dbb2f37e19859244ec4779b0 |
-| <a href="https://celo-sepolia.blockscout.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Celo Sepolia</a>        | celo-sepolia                          | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://explorer.cronos.org/testnet/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Cronos Testnet</a>      | cronos-testnet                        | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.etherscan.io/address/0x15fC6ae953E024d975e77382eEeC56A9101f9F88" target="_blank" rel="noopener noreferrer">Ethereum Sepolia</a>           | ethereum-testnet-sepolia              | 0x15fC6ae953E024d975e77382eEeC56A9101f9F88 |
-| <a href="https://gnosis-chiado.blockscout.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Gnosis Chiado</a>      | gnosis-chain-testnet-chiado           | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://explore-testnet.hyperpc.app/address/0xB27fA1c28288c50542527F64BCda22C9FbAc24CB" target="_blank" rel="noopener noreferrer">Hyperliquid Testnet</a> | hyperliquid-testnet                   | 0xB27fA1c28288c50542527F64BCda22C9FbAc24CB |
-| <a href="https://explorer-sepolia.inkonchain.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Ink Sepolia</a>     | ink-testnet-sepolia                   | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia-explorer.jovay.io/l2/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Jovay Testnet</a>      | jovay-testnet                         | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.lineascan.build/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Linea Sepolia</a>           | ethereum-testnet-sepolia-linea-1      | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.mantlescan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Mantle Sepolia</a>           | ethereum-testnet-sepolia-mantle-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://megaexplorer.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">MegaETH Testnet 2</a>              | megaeth-testnet-2                     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia-optimism.etherscan.io/address/0xa2888380dff3704a8ab6d1cd1a8f69c15fea5ee3" target="_blank" rel="noopener noreferrer">OP Sepolia</a>        | ethereum-testnet-sepolia-optimism-1   | 0xa2888380dff3704a8ab6d1cd1a8f69c15fea5ee3 |
-| <a href="https://atlantic.pharosscan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Pharos Atlantic Testnet</a> | pharos-atlantic-testnet               | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://testnet.plasmascan.to/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Plasma Testnet</a>            | plasma-testnet                        | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://amoy.polygonscan.com/address/0x3675a5eb2286a3f87e8278fc66edf458a2e3bb74" target="_blank" rel="noopener noreferrer">Polygon Amoy</a>               | polygon-testnet-amoy                  | 0x3675a5eb2286a3f87e8278fc66edf458a2e3bb74 |
-| <a href="https://sepolia-blockscout.scroll.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Scroll Sepolia</a>     | ethereum-testnet-sepolia-scroll-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://explorer.testnet.soniclabs.com/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Sonic Testnet</a>    | sonic-testnet                         | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://spb.explorer.tac.build/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">TAC Testnet</a>              | tac-testnet                           | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.uniscan.xyz/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">Unichain Sepolia</a>            | ethereum-testnet-sepolia-unichain-1   | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.worldscan.org/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">World Chain Sepolia</a>       | ethereum-testnet-sepolia-worldchain-1 | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://www.oklink.com/xlayer-test/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">XLayer Testnet</a>       | xlayer-testnet                        | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
-| <a href="https://sepolia.explorer.zksync.io/address/0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" target="_blank" rel="noopener noreferrer">ZKSync Era Sepolia</a>   | ethereum-testnet-sepolia-zksync-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
+| Network                 | Chain Name                            | Mock Forwarder Address                     |
+| ----------------------- | ------------------------------------- | ------------------------------------------ |
+| ADI Testnet             | adi-testnet                           | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Apechain Curtis         | apechain-testnet-curtis               | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Arc Testnet             | arc-testnet                           | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Arbitrum Sepolia        | ethereum-testnet-sepolia-arbitrum-1   | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Avalanche Fuji          | avalanche-testnet-fuji                | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Base Sepolia            | ethereum-testnet-sepolia-base-1       | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
+| BSC Testnet             | binance_smart_chain-testnet         | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Celo Sepolia            | celo-sepolia                          | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| Cronos Testnet          | cronos-testnet                        | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| Ethereum Sepolia        | ethereum-testnet-sepolia              | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
+| Gnosis Chiado           | gnosis_chain-testnet-chiado          | 0x0b93082D9b3C7C97fAcd250082899BAcf3af3885 |
+| Hyperliquid Testnet     | hyperliquid-testnet                   | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Ink Sepolia             | ink-testnet-sepolia                   | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Jovay Testnet           | jovay-testnet                         | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Linea Sepolia           | ethereum-testnet-sepolia-linea-1      | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Mantle Sepolia          | ethereum-testnet-sepolia-mantle-1     | 0xB9F79d863261869B234c481D1f9A7af84AeAd192 |
+| MegaETH Testnet 2       | megaeth-testnet-2                     | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| OP Sepolia              | ethereum-testnet-sepolia-optimism-1   | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Pharos Atlantic Testnet | pharos-atlantic-testnet               | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Plasma Testnet          | plasma-testnet                        | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Polygon Amoy            | polygon-testnet-amoy                  | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| Scroll Sepolia          | ethereum-testnet-sepolia-scroll-1     | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| Sonic Testnet           | sonic-testnet                         | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| TAC Testnet             | tac-testnet                           | 0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c |
+| Unichain Sepolia        | ethereum-testnet-sepolia-unichain-1   | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
+| World Chain Sepolia     | ethereum-testnet-sepolia-worldchain-1 | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
+| XLayer Testnet          | xlayer-testnet                        | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| ZKSync Era Sepolia      | ethereum-testnet-sepolia-zksync-1     | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 
 ## Production Forwarders
 
@@ -13290,7 +13416,7 @@ These `KeystoneForwarder` addresses are used by deployed workflows. Use these ad
 | <a href="https://bscscan.com/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">BNB Smart Chain</a>                      | binance_smart_chain-mainnet | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 | <a href="https://explorer.celo.org/mainnet/address/0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1" target="_blank" rel="noopener noreferrer">Celo</a>                   | celo-mainnet                  | 0x98B8335d29Aca40840Ed8426dA1A0aAa8677d8D1 |
 | <a href="https://etherscan.io/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" target="_blank" rel="noopener noreferrer">Ethereum Mainnet</a>                    | ethereum-mainnet              | 0x0b93082D9b3C7C97fAcd250082899BAcf3af3885 |
-| <a href="https://gnosisscan.io/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Gnosis Chain</a>                       | gnosis-chain-mainnet          | 0x9eF6468C5f37b976E57d52054c693269479A784d |
+| <a href="https://gnosisscan.io/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Gnosis Chain</a>                       | gnosis_chain-mainnet         | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | <a href="https://app.hyperliquid.xyz/explorer/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Hyperliquid Mainnet</a> | hyperliquid-mainnet           | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | <a href="https://explorer.inkonchain.com/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Ink</a>                      | ethereum-mainnet-ink-1        | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | <a href="https://explorer.jovay.io/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Jovay Mainnet</a>                  | jovay-mainnet                 | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
@@ -13321,7 +13447,7 @@ These `KeystoneForwarder` addresses are used by deployed workflows. Use these ad
 | <a href="https://celo-sepolia.blockscout.com/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Celo Sepolia</a>        | celo-sepolia                          | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | <a href="https://explorer.cronos.org/testnet/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Cronos Testnet</a>      | cronos-testnet                        | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | <a href="https://sepolia.etherscan.io/address/0xF8344CFd5c43616a4366C34E3EEE75af79a74482" target="_blank" rel="noopener noreferrer">Ethereum Sepolia</a>           | ethereum-testnet-sepolia              | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
-| <a href="https://gnosis-chiado.blockscout.com/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" target="_blank" rel="noopener noreferrer">Gnosis Chiado</a>      | gnosis-chain-testnet-chiado           | 0x0b93082D9b3C7C97fAcd250082899BAcf3af3885 |
+| <a href="https://gnosis-chiado.blockscout.com/address/0x0b93082D9b3C7C97fAcd250082899BAcf3af3885" target="_blank" rel="noopener noreferrer">Gnosis Chiado</a>      | gnosis_chain-testnet-chiado          | 0x0b93082D9b3C7C97fAcd250082899BAcf3af3885 |
 | <a href="https://explore-testnet.hyperpc.app/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Hyperliquid Testnet</a> | hyperliquid-testnet                   | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 | <a href="https://explorer-sepolia.inkonchain.com/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Ink Sepolia</a>     | ink-testnet-sepolia                   | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 | <a href="https://sepolia-explorer.jovay.io/l2/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Jovay Testnet</a>      | jovay-testnet                         | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
@@ -21910,9 +22036,16 @@ This section provides a reference for the built-in trigger capabilities of the C
 
 # Supported Networks
 Source: https://docs.chain.link/cre/supported-networks-ts
-Last Updated: 2026-05-22
+Last Updated: 2026-06-24
 
-This page lists all EVM-compatible networks supported by CRE workflows, along with the minimum CLI and SDK versions required for each network.
+This page lists EVM-compatible networks supported by CRE workflows, along with the minimum CLI and SDK versions required for each network.
+
+<Aside type="tip" title="Check chains enabled for your tenant">
+  The tables below show minimum version requirements for each network. To see which chains and mock forwarder addresses
+  are enabled for **your** organization, run [`cre workflow
+    supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) after `cre login` (or with `CRE_API_KEY`
+  set). Use `--output json` for machine-readable output.
+</Aside>
 
 ## Version Requirements
 
@@ -21985,6 +22118,8 @@ Network support depends on your CLI and SDK versions. The tables below show the 
 ## Forwarder Addresses
 
 For forwarder contract addresses and chain names, see the [Forwarder Directory](/cre/guides/workflow/using-evm-client/forwarder-directory). Forwarder addresses are used when building consumer contracts that receive workflow reports onchain. Learn more about [Onchain Write](/cre/guides/workflow/using-evm-client/onchain-write/overview).
+
+Run [`cre workflow supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) anytime to list the chains and mock forwarder addresses currently enabled for your tenant.
 
 ---
 

--- a/src/content/cre/organization/linking-keys.mdx
+++ b/src/content/cre/organization/linking-keys.mdx
@@ -5,7 +5,7 @@ title: "Linking Wallet Keys"
 metadata:
   description: "Link your wallet to CRE: connect your address for public onchain registry workflows, set up multi-sig wallets, and manage your organization's keys."
   datePublished: "2025-11-04"
-  lastModified: "2025-11-04"
+  lastModified: "2026-06-24"
 ---
 
 import { Aside, CopyText } from "@components"
@@ -28,7 +28,7 @@ Key linking is the process of connecting a blockchain wallet address to your CRE
 **Important constraints:**
 
 - **One organization per address**: Each wallet address can only be linked to one CRE organization at a time. If you need to use the same address with a different organization, you must first [unlink it](#unlinking-a-key) from the current organization.
-- **Maximum 2 keys per organization**: Each organization can link a maximum of 2 web3 keys. If you need to link a third key, you must first [unlink](#unlinking-a-key) one of the existing keys.
+- **Per-organization key limit**: The number of web3 keys your organization can link is subject to your plan quota. See [Service Quotas](/cre/service-quotas#registry-quotas) for the current limit. To request an increase, [contact us](/cre/support-feedback).
 
 However, an organization can have multiple wallet addresses linked to it, allowing team members to use their own addresses or enabling separation between development, staging, and production environments.
 
@@ -183,7 +183,7 @@ Linked Owners:
 
 ## Linking multiple addresses
 
-Your organization can link **up to 2 wallet addresses**. Each individual address can only be linked to one organization at a time.
+Your organization can link more than one wallet address, subject to your plan's key limit. See [Service Quotas](/cre/service-quotas#registry-quotas) for the current limit, or [contact us](/cre/support-feedback) to request an increase. Each individual address can only be linked to one organization at a time.
 
 This is useful for:
 

--- a/src/content/cre/reference/cli/workflow.mdx
+++ b/src/content/cre/reference/cli/workflow.mdx
@@ -5,7 +5,7 @@ title: "Workflow Commands"
 metadata:
   description: "Manage workflows with CLI: complete command reference for simulating, deploying, activating, pausing, and deleting workflows."
   datePublished: "2025-11-04"
-  lastModified: "2026-05-14"
+  lastModified: "2026-06-11"
 ---
 
 import { Aside } from "@components"
@@ -81,17 +81,19 @@ cre workflow simulate <workflow-name-or-path> [flags]
 
 **Flags:**
 
-| <div style={{ width: "200px" }}>Flag</div> | Description                                                                                                                                                                                                                                                                      |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--broadcast`                              | Broadcast onchain write transactions (default: `false`). Without this flag, a dry run is performed                                                                                                                                                                               |
-| `-g, --engine-logs`                        | Enable non-fatal engine logging                                                                                                                                                                                                                                                  |
-| `--non-interactive`                        | Run without prompts; requires `--trigger-index` (see the line below) and inputs for the selected trigger type                                                                                                                                                                    |
-| `--trigger-index <int>`                    | Selects which handler to run (0-based position). If your workflow has multiple handlers, `0` is the first, `1` is the second, etc. Required with `--non-interactive`                                                                                                             |
-| `--http-payload <string>`                  | HTTP trigger payload as JSON string or path to a JSON file. File paths are resolved relative to the directory where you ran the command. For HTTP triggers only                                                                                                                  |
-| `--evm-tx-hash <string>`                   | Transaction hash (`0x...`) containing the event that triggered your workflow. For EVM log triggers only                                                                                                                                                                          |
-| `--evm-event-index <int>`                  | Which log/event within the transaction to use (0-based position). If the transaction emitted multiple events, `0` is the first, `1` is the second, etc. For EVM log triggers only                                                                                                |
-| `--limits <string>`                        | Production limits to enforce during simulation: `default` (embedded prod limits), a path to a limits JSON file (e.g. from `cre workflow limits export`), or `none` to disable. See [Testing Production Limits](/cre/guides/operations/understanding-limits) (default: `default`) |
-| `--skip-type-checks`                       | Skip TypeScript type checking during compilation. Speeds up iteration in development; not recommended for production builds                                                                                                                                                      |
+| <div style={{ width: "200px" }}>Flag</div> | Description                                                                                                                                                                                                                                                                                                      |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--broadcast`                              | Broadcast onchain write transactions (default: `false`). Without this flag, a dry run is performed                                                                                                                                                                                                               |
+| `-g, --engine-logs`                        | Enable non-fatal engine logging                                                                                                                                                                                                                                                                                  |
+| `--listen`                                 | Keep the simulator alive and re-run it for each incoming trigger event. For HTTP triggers, listens for POST requests on port `2000`. For EVM log triggers, watches the chain and re-runs on each matching event. Useful when iterating on trigger-driven workflows without restarting the simulator between runs |
+| `--non-interactive`                        | Run without prompts; requires `--trigger-index` (see the line below) and inputs for the selected trigger type                                                                                                                                                                                                    |
+| `--trigger-index <int>`                    | Selects which handler to run (0-based position). If your workflow has multiple handlers, `0` is the first, `1` is the second, etc. Required with `--non-interactive`                                                                                                                                             |
+| `--http-payload <string>`                  | HTTP trigger payload as JSON string or path to a JSON file. File paths are resolved relative to the directory where you ran the command. For HTTP triggers only                                                                                                                                                  |
+| `--evm-tx-hash <string>`                   | Transaction hash (`0x...`) containing the event that triggered your workflow. For EVM log triggers only                                                                                                                                                                                                          |
+| `--evm-event-index <int>`                  | Which log/event within the transaction to use (0-based position). If the transaction emitted multiple events, `0` is the first, `1` is the second, etc. For EVM log triggers only                                                                                                                                |
+| `--evm-receipt-timeout <duration>`         | How long to wait for an EVM transaction receipt before timing out (e.g. `30s`, `2m`). For EVM log triggers only (default: `1m`)                                                                                                                                                                                  |
+| `--limits <string>`                        | Production limits to enforce during simulation: `default` (embedded prod limits), a path to a limits JSON file (e.g. from `cre workflow limits export`), or `none` to disable. See [Testing Production Limits](/cre/guides/operations/understanding-limits) (default: `default`)                                 |
+| `--skip-type-checks`                       | Skip TypeScript type checking during compilation. Speeds up iteration in development; not recommended for production builds                                                                                                                                                                                      |
 
 **Examples:**
 
@@ -120,6 +122,18 @@ cre workflow simulate <workflow-name-or-path> [flags]
   # If your EVM log trigger handler is the second handler in your workflow, use --trigger-index 1
   # --evm-event-index 0 means you want the first event from that transaction
   cre workflow simulate my-workflow --non-interactive --trigger-index 1 --evm-tx-hash 0x420721d7d00130a03c5b525b2dbfd42550906ddb3075e8377f9bb5d1a5992f8e --evm-event-index 0 --target staging-settings
+  ```
+
+- Listen mode — re-run on every HTTP trigger POST (port 2000)
+
+  ```bash
+  cre workflow simulate ./my-workflow --listen --target local-simulation
+  ```
+
+- Listen mode — re-run on every matching EVM log event
+
+  ```bash
+  cre workflow simulate ./my-workflow --listen --trigger-index 1 --target staging-settings
   ```
 
 {/* prettier-ignore */}

--- a/src/content/cre/release-notes.mdx
+++ b/src/content/cre/release-notes.mdx
@@ -5,12 +5,62 @@ date: Last Modified
 metadata:
   description: "Discover what's new in CRE: latest features, changes, and improvements in each release of the Chainlink Runtime Environment."
   datePublished: "2025-11-04"
-  lastModified: "2026-06-04"
+  lastModified: "2026-06-18"
 ---
 
 import { Aside } from "@components"
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.21.0 - June 18, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.21.0" target="_blank">CRE CLI version 1.21.0</a> is now available.**
+
+- **MSIG mode guard**: Using `--unsigned` or `--changeset` with `--secrets-auth=browser` or a private registry now produces a clear upfront error instead of a confusing failure mid-operation.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.20.0...v1.21.0)
+
+## CLI v1.20.0 - June 12, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.20.0" target="_blank">CRE CLI version 1.20.0</a> is now available.**
+
+- **Simulation limits aligned with production**: The local simulator's resource limits now match production. Notable increases: execution concurrency (10 → 50), EVM transaction gas limit (5M → 10M), chain write report size (5 KB → 50 KB), HTTP action payload sizes (10 KB request / 100 KB response → 120 KB / 250 KB), and ConfidentialHTTP payload sizes (10 KB / 100 KB → 125 KB / 500 KB). Workflows that previously hit local-only caps should now simulate more faithfully.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.19.0...v1.20.0)
+
+## CLI v1.19.0 - June 11, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.19.0" target="_blank">CRE CLI version 1.19.0</a> is now available.**
+
+- **`--listen` flag for `cre workflow simulate`**: A new `--listen` flag keeps the simulator alive and re-runs it for each incoming event — HTTP POST requests on port 2000 or matching EVM log trigger events. Use it when iterating on trigger-driven workflows without restarting the simulator between runs. Also added `--evm-receipt-timeout` (default `1m`) to control how long the simulator waits for an EVM transaction receipt.
+- **Browser OAuth secrets auth in production**: Browser-based OAuth authentication for secrets is now fully enabled in production environments. A related fix prevents secrets flows from failing when the default `CRE_ETH_PRIVATE_KEY` placeholder is set in your environment.
+- **DON Family shown in workflow output**: The `DON Family` field is now displayed in the details section after `cre workflow deploy`, `activate`, and `pause`. The underlying resolution now uses your tenant's platform default instead of the embedded config, so the displayed value reflects what the platform actually uses.
+- **Capability registry RPC auto-resolution**: The CLI now resolves RPC endpoints for the capability registry chain automatically and prompts for consent when needed, removing the need to configure these connections manually in your secrets workflows.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.18.0...v1.19.0)
+
+## Go SDK v1.12.0 - June 11, 2026
+
+**Go SDK version 1.12.0** adds Solana mainnet support.
+
+- **Solana mainnet**: Solana mainnet chain selectors and workflow bindings are now included in the SDK, enabling production workflows that target Solana mainnet.
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.11.0...v1.12.0)
 
 ## CLI v1.18.0 - June 4, 2026
 
@@ -52,6 +102,22 @@ This page provides detailed release notes for CRE. It includes information on ne
 
 [See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.15.0...v1.16.0)
 
+## Go SDK v1.11.0 - May 21, 2026
+
+**Go SDK version 1.11.0** adds private Rhyolite testnet support.
+
+- **`private-testnet-rhyolite` support**: EVM capabilities for the Rhyolite private testnet are now included. Use the `private-testnet-rhyolite` chain name when building workflows that target this network.
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.10.0...v1.11.0)
+
+## Go SDK v1.10.0 - May 20, 2026
+
+**Go SDK version 1.10.0** adds ADI mainnet support.
+
+- **ADI mainnet**: EVM capabilities for ADI mainnet (`adi-mainnet`) are now included, supporting workflows deployed to ADI mainnet.
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.9.0...v1.10.0)
+
 ## CLI v1.15.0 - May 14, 2026
 
 **<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.15.0" target="_blank">CRE CLI version 1.15.0</a> is now available.**
@@ -82,6 +148,14 @@ This page provides detailed release notes for CRE. It includes information on ne
 - **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
 
 [See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.13.0...v1.14.0)
+
+## Go SDK v1.9.0 - May 13, 2026
+
+**Go SDK version 1.9.0** adds ADI testnet and Celo Sepolia support.
+
+- **ADI testnet and Celo Sepolia**: EVM capabilities for ADI testnet (`adi-testnet`) and Celo Sepolia (`celo-sepolia`) are now included, enabling simulation and deployment to these networks.
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-sdk-go/compare/v1.8.0...v1.9.0)
 
 ## CLI v1.13.0 - April 30, 2026
 

--- a/src/content/cre/supported-networks-go.mdx
+++ b/src/content/cre/supported-networks-go.mdx
@@ -7,10 +7,19 @@ pageId: "supported-networks"
 metadata:
   description: "View all EVM networks supported by CRE workflows, including required CLI and SDK versions for each network."
   datePublished: "2026-02-03"
-  lastModified: "2026-05-22"
+  lastModified: "2026-06-24"
 ---
 
-This page lists all EVM-compatible networks supported by CRE workflows, along with the minimum CLI and SDK versions required for each network.
+import { Aside } from "@components"
+
+This page lists EVM-compatible networks supported by CRE workflows, along with the minimum CLI and SDK versions required for each network.
+
+<Aside type="tip" title="Check chains enabled for your tenant">
+  The tables below show minimum version requirements for each network. To see which chains and mock forwarder addresses
+  are enabled for **your** organization, run [`cre workflow
+  supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) after `cre login` (or with `CRE_API_KEY`
+  set). Use `--output json` for machine-readable output.
+</Aside>
 
 ## Version Requirements
 
@@ -83,3 +92,5 @@ Network support depends on your CLI and SDK versions. The tables below show the 
 ## Forwarder Addresses
 
 For forwarder contract addresses and chain names, see the [Forwarder Directory](/cre/guides/workflow/using-evm-client/forwarder-directory). Forwarder addresses are used when building consumer contracts that receive workflow reports onchain. Learn more about [Onchain Write](/cre/guides/workflow/using-evm-client/onchain-write/overview).
+
+Run [`cre workflow supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) anytime to list the chains and mock forwarder addresses currently enabled for your tenant.

--- a/src/content/cre/supported-networks-ts.mdx
+++ b/src/content/cre/supported-networks-ts.mdx
@@ -7,10 +7,19 @@ pageId: "supported-networks"
 metadata:
   description: "View all EVM networks supported by CRE workflows, including required CLI and SDK versions for each network."
   datePublished: "2026-02-03"
-  lastModified: "2026-05-22"
+  lastModified: "2026-06-24"
 ---
 
-This page lists all EVM-compatible networks supported by CRE workflows, along with the minimum CLI and SDK versions required for each network.
+import { Aside } from "@components"
+
+This page lists EVM-compatible networks supported by CRE workflows, along with the minimum CLI and SDK versions required for each network.
+
+<Aside type="tip" title="Check chains enabled for your tenant">
+  The tables below show minimum version requirements for each network. To see which chains and mock forwarder addresses
+  are enabled for **your** organization, run [`cre workflow
+  supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) after `cre login` (or with `CRE_API_KEY`
+  set). Use `--output json` for machine-readable output.
+</Aside>
 
 ## Version Requirements
 
@@ -83,3 +92,5 @@ Network support depends on your CLI and SDK versions. The tables below show the 
 ## Forwarder Addresses
 
 For forwarder contract addresses and chain names, see the [Forwarder Directory](/cre/guides/workflow/using-evm-client/forwarder-directory). Forwarder addresses are used when building consumer contracts that receive workflow reports onchain. Learn more about [Onchain Write](/cre/guides/workflow/using-evm-client/onchain-write/overview).
+
+Run [`cre workflow supported-chains`](/cre/reference/cli/workflow#cre-workflow-supported-chains) anytime to list the chains and mock forwarder addresses currently enabled for your tenant.


### PR DESCRIPTION
This pull request updates CRE documentation and configuration to reflect the latest CLI and SDK releases, introduces new features in the workflow simulation guide, and clarifies forwarder directory usage. The most important changes are as follows:

**Release and Version Updates**
* Added changelog entries for recent CRE CLI and Go SDK releases, including CLI versions v1.19.0, v1.20.0, v1.21.0, and Go SDK versions v1.9.0, v1.10.0, v1.11.0, and v1.12.0, with descriptions of new features and improvements. [[1]](diffhunk://#diff-5323f35752748a8eb45ef9c8e62cda3a9d5b83c420d2feb0e307e66676bb2558R2281-R2308) [[2]](diffhunk://#diff-5323f35752748a8eb45ef9c8e62cda3a9d5b83c420d2feb0e307e66676bb2558R3514-R3541)
* Updated the `cre-cli` version config: set `LATEST` to v1.21.0, added v1.19.0–v1.21.0 to the version list, and registered their release dates. [[1]](diffhunk://#diff-11892e6b40841ca0f483f57267775d1ae2ccf579daa451f843c66de7f1558b3aL80-R84) [[2]](diffhunk://#diff-11892e6b40841ca0f483f57267775d1ae2ccf579daa451f843c66de7f1558b3aR98-R100)

**Documentation Improvements**
* Documented the new `--listen` flag for `cre workflow simulate`, explaining how it enables persistent simulation for HTTP/EVM triggers and improves development workflow.
* Updated the workflow simulation guide's metadata to reflect the latest modification date.

**Forwarder Directory Enhancements**
* Clarified that supported chains and mock forwarder addresses are tenant-scoped, and added instructions for using `cre workflow supported-chains` to view them. Updated the forwarder directory guide's metadata. [[1]](diffhunk://#diff-4c35ef91b04013f57724894b21618880b50abe5cb5ec2a2d50f2c397051bfe93R19-R24) [[2]](diffhunk://#diff-4c35ef91b04013f57724894b21618880b50abe5cb5ec2a2d50f2c397051bfe93L10-R10)