### PR TITLE
Add Get Support page to Data Streams docs

### DIFF
--- a/src/config/sidebar.ts
+++ b/src/config/sidebar.ts
@@ -1089,6 +1089,10 @@ export const SIDEBAR: Partial<Record<Sections, SectionEntry[]>> = {
           url: "data-streams/sign-up",
         },
         {
+          title: "Get Support",
+          url: "data-streams/get-support",
+        },
+        {
           title: "Developer Responsibilities",
           url: "data-streams/developer-responsibilities",
         },

--- a/src/content/data-streams/get-support.mdx
+++ b/src/content/data-streams/get-support.mdx
@@ -1,0 +1,24 @@
+---
+section: dataStreams
+title: "Get Support"
+isIndex: false
+metadata:
+  title: "Get Support for Chainlink Data Streams"
+  description: "Learn how to create a support ticket for Chainlink Data Streams through the self-service portal at app.chain.link."
+whatsnext:
+  { "Sign up for Data Streams": "/data-streams/sign-up", "Learn about Data Streams billing": "/data-streams/billing" }
+---
+
+If you need help with Chainlink Data Streams, you can submit a support ticket through the self-service portal at [app.chain.link](https://app.chain.link).
+
+## Create a support ticket
+
+1. Sign in to [app.chain.link](https://app.chain.link).
+2. Navigate to **Streams** &rarr; **Billing** at [app.chain.link/streams/billing](https://app.chain.link/streams/billing).
+3. Click **Get Support**.
+
+The portal automatically includes your Data Streams user ID with the ticket.
+
+## If your credentials were issued outside the portal
+
+If you are using Data Streams credentials that were issued outside the self-service portal, your streams user ID will not be attached automatically. Include your streams user ID — represented as a UUID — in your support request.

--- a/src/content/data-streams/llms-full.txt
+++ b/src/content/data-streams/llms-full.txt
@@ -867,6 +867,25 @@ Source: https://docs.chain.link/data-streams/exchange-rate-streams
 
 ---
 
+# Get Support
+Source: https://docs.chain.link/data-streams/get-support
+
+If you need help with Chainlink Data Streams, you can submit a support ticket through the self-service portal at [app.chain.link](https://app.chain.link).
+
+## Create a support ticket
+
+1. Sign in to [app.chain.link](https://app.chain.link).
+2. Navigate to **Streams** → **Billing** at [app.chain.link/streams/billing](https://app.chain.link/streams/billing).
+3. Click **Get Support**.
+
+The portal automatically includes your Data Streams user ID with the ticket.
+
+## If your credentials were issued outside the portal
+
+If you are using Data Streams credentials that were issued outside the self-service portal, your streams user ID will not be attached automatically. Include your streams user ID — represented as a UUID — in your support request.
+
+---
+
 # Chainlink Data Streams
 Source: https://docs.chain.link/data-streams
 


### PR DESCRIPTION
## Summary

- Adds a new **Get Support** page at `/data-streams/get-support` directing users to submit a support ticket via [app.chain.link/streams/billing](https://app.chain.link/streams/billing)
- Adds the **Get Support** nav item to the Data Streams sidebar, positioned after Sign Up for Data Streams
- Notes that the portal automatically attaches the user's streams user ID to the ticket
- Covers the case where credentials were issued outside the portal (user must include their UUID-format streams user ID manually)

## Test plan

- [ ] Verify `/data-streams/get-support` renders correctly
- [ ] Verify nav item appears after Sign Up for Data Streams in the Data Streams sidebar
- [ ] Check links resolve (app.chain.link, app.chain.link/streams/billing)