### PR TITLE
Fix: handle per-network fetch errors gracefully in getserversidechainmetadata

### DIFF
--- a/src/features/data/api/backend.ts
+++ b/src/features/data/api/backend.ts
@@ -14,12 +14,17 @@ export const getServerSideChainMetadata = async (
         ? EleventyFetch(nw?.rddUrl, {
             duration: skipCache ? "0s" : "1d",
             type: "json",
-          }).then((metadata) => ({
-            ...nw,
-            metadata: metadata.filter(
-              (meta) => meta.docs?.hidden !== true && (meta.proxyAddress || meta.transmissionsAccount || meta.feedId)
-            ),
-          }))
+          })
+            .then((metadata) => ({
+              ...nw,
+              metadata: metadata.filter(
+                (meta) => meta.docs?.hidden !== true && (meta.proxyAddress || meta.transmissionsAccount || meta.feedId)
+              ),
+            }))
+            .catch((error) => {
+              console.warn(`[getServerSideChainMetadata] Failed to fetch ${nw.rddUrl}: ${error?.message ?? error}`)
+              return { ...nw, metadata: [] }
+            })
         : undefined
     )
     const networks = await Promise.all(requests)


### PR DESCRIPTION
This pull request improves the robustness of the `getServerSideChainMetadata` function by adding error handling for failed metadata fetches. Now, if a fetch fails, the error is logged and an empty metadata array is returned for that network, preventing the function from crashing.

**Error handling improvements:**

* [`src/features/data/api/backend.ts`](diffhunk://#diff-9818e17d6899487eaca4dc788b0c570827f21ed5fe79ed1b80f1207ca9b79200L17-R27): Added a `.catch` block to log fetch errors and return an empty `metadata` array if fetching from `nw.rddUrl` fails.