### PR TITLE
Update CCIP decommissioned chain page

### DIFF
--- a/src/components/CCIP/Chain/DecommissionedChain.astro
+++ b/src/components/CCIP/Chain/DecommissionedChain.astro
@@ -1,10 +1,16 @@
 ---
 import CcipDirectoryLayout from "~/layouts/CcipDirectoryLayout.astro"
 import { getEntry, render } from "astro:content"
-import { Environment, DecommissionedNetwork, getAllDecommissionedNetworks } from "~/config/data/ccip"
-import Breadcrumb from "~/components/CCIP/Breadcrumb/Breadcrumb"
-import Aside from "~/components/Aside.astro"
-import CopyValue from "~/components/CCIP/CopyValue/CopyValue"
+import {
+  Environment,
+  DecommissionedNetwork,
+  getAllDecommissionedNetworks,
+  getAllNetworks,
+  getDecommissionedNetworkWithDetails,
+  getSearchLanes,
+  Network,
+} from "~/config/data/ccip"
+import ChainHero from "~/components/CCIP/ChainHero/ChainHero"
 import { generateDecommissionedChainStructuredData } from "~/utils/ccipStructuredData"
 import StructuredData from "~/components/StructuredData.astro"
 
@@ -21,22 +27,52 @@ if (!entry) {
 
 const { headings } = await render(entry)
 
-// CCIP Explorer URL
-const ccipExplorerUrl = `https://ccip.chain.link/`
-
-// Get all networks for potential search context
-const allDecommissionedNetworks = getAllDecommissionedNetworks({ filter: environment })
-
-// Generate dynamic metadata for this decommissioned chain
-const environmentText = environment === Environment.Mainnet ? "Mainnet" : "Testnet"
-const chainMetadata = {
-  title: `${network.name} CCIP Network (Decommissioned) - ${environmentText}`,
-  description: `Decommissioned CCIP network for ${network.name} on ${environmentText}. This chain is no longer active but historical transaction data remains accessible via CCIP Explorer.`,
-  image: network.logo,
-  excerpt: `${network.name} decommissioned CCIP network ${environmentText.toLowerCase()} historical data chain selector ${network.chainSelector} blockchain interoperability`,
+const networkDetails = getDecommissionedNetworkWithDetails({ chain: network.chain, filter: environment })
+const heroNetwork: Network = networkDetails ?? {
+  name: network.name,
+  chain: network.chain,
+  chainSelector: network.chainSelector,
+  logo: network.logo,
+  explorer: network.explorer,
+  chainType: network.chainType,
+  key: network.chain,
+  totalLanes: 0,
+  totalTokens: 0,
+  routerExplorerUrl: "",
+  armProxy: {
+    address: "",
+    version: "",
+  },
 }
 
-// Generate structured data for this decommissioned chain
+const activeNetworks = getAllNetworks({ filter: environment })
+const decommissionedNetworks = getAllDecommissionedNetworks({ filter: environment })
+const searchChains = [
+  ...activeNetworks.map(({ name, totalLanes, totalTokens, logo, chain }) => ({
+    name,
+    totalLanes,
+    totalTokens,
+    logo,
+    chain,
+  })),
+  ...decommissionedNetworks.map(({ name, logo, chain }) => ({
+    name,
+    totalLanes: 0,
+    totalTokens: 0,
+    logo,
+    chain,
+  })),
+]
+const searchLanes = getSearchLanes({ environment })
+
+const environmentText = environment === Environment.Mainnet ? "Mainnet" : "Testnet"
+const chainMetadata = {
+  title: `${network.name} CCIP Network (Inactive) - ${environmentText}`,
+  description: `Inactive CCIP network for ${network.name} on ${environmentText}. This chain is no longer active but historical transaction data remains accessible via CCIP Explorer.`,
+  image: network.logo,
+  excerpt: `${network.name} inactive CCIP network ${environmentText.toLowerCase()} historical data chain selector ${network.chainSelector} blockchain interoperability`,
+}
+
 const currentURL = new URL(Astro.request.url).href
 const decommissionedChainStructuredData = generateDecommissionedChainStructuredData(network, environment, currentURL)
 ---
@@ -55,72 +91,18 @@ const decommissionedChainStructuredData = generateDecommissionedChainStructuredD
   environment={environment}
 >
   <StructuredData data={decommissionedChainStructuredData} />
-  <!-- Hero Section - Consistent with ChainHero pattern -->
-  <section class="ccip-decom-hero">
-    <div class="ccip-decom-hero__content">
-      <div class="ccip-decom-hero__top">
-        <Breadcrumb
-          items={[
-            {
-              name: "CCIP Directory",
-              url: `/ccip/directory/${environment}`,
-            },
-            {
-              name: network.name,
-              url: `/ccip/directory/${environment}/chain/${network.chain}`,
-            },
-          ]}
-          client:load
-        />
-      </div>
-
-      <!-- Decommissioned Banner -->
-      <Aside type="caution" title="Decommissioned Chain">
-        <p>
-          This chain has been decommissioned from the CCIP network. No new transactions can be initiated, but historical
-          transactions remain accessible in the CCIP Explorer.
-        </p>
-      </Aside>
-
-      <div class="ccip-decom-hero__heading">
-        <img src={network.logo} alt={network.name} class="ccip-decom-hero__logo" />
-        <div class="ccip-decom-hero__title">
-          <h1>{network.name}</h1>
-          <span class="ccip-decom-hero__status">Decommissioned</span>
-        </div>
-      </div>
-
-      <div class="ccip-decom-hero__details">
-        <div class="ccip-decom-hero__details__item">
-          <div class="ccip-decom-hero__details__label">Chain selector</div>
-          <div class="ccip-decom-hero__details__value">
-            <CopyValue value={network.chainSelector} client:load />
-          </div>
-        </div>
-
-        <div class="ccip-decom-hero__details__item">
-          <div class="ccip-decom-hero__details__label">Status</div>
-          <div class="ccip-decom-hero__details__value">
-            <span class="ccip-decom-hero__status-badge">Decommissioned</span>
-          </div>
-        </div>
-
-        <div class="ccip-decom-hero__details__item">
-          <div class="ccip-decom-hero__details__label">Historical data</div>
-          <div class="ccip-decom-hero__details__value">
-            <a href={ccipExplorerUrl} target="_blank" rel="noopener noreferrer" class="ccip-decom-hero__explorer-link">
-              View in CCIP Explorer →
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- Content Section -->
+  <ChainHero
+    chains={searchChains}
+    tokens={[]}
+    network={heroNetwork}
+    environment={environment}
+    lanes={searchLanes}
+    isDecommissioned={true}
+    client:load
+  />
   <section class="layout">
     <div class="decom-content">
-      <h2>About Decommissioned Chains</h2>
+      <h2>About Inactive Chains</h2>
       <div class="decom-info-grid">
         <div class="decom-info-item">
           <h3>🚫 No New Transactions</h3>
@@ -146,108 +128,6 @@ const decommissionedChainStructuredData = generateDecommissionedChainStructuredD
 </CcipDirectoryLayout>
 
 <style scoped="false">
-  /* Hero Section - Consistent with ChainHero */
-  .ccip-decom-hero {
-    background-color: var(--gray-100);
-    border-bottom: 1px solid var(--gray-200);
-    min-height: 280px;
-  }
-
-  .ccip-decom-hero__content {
-    --gutter: var(--space-6x);
-    --doc-padding: var(--space-6x);
-    gap: var(--gutter);
-    padding: var(--space-6x);
-    margin: 0 auto;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .ccip-decom-hero__top {
-    display: flex;
-    justify-content: flex-start;
-  }
-
-  /* Heading Section */
-  .ccip-decom-hero__heading {
-    color: var(--gray-900);
-    display: flex;
-    align-items: center;
-    gap: var(--space-6x);
-    padding: var(--space-4x) 0;
-  }
-
-  .ccip-decom-hero__logo {
-    width: 80px;
-    height: 80px;
-  }
-
-  .ccip-decom-hero__title h1 {
-    margin: 0;
-    font-size: 28px;
-    font-weight: 500;
-    line-height: 1.2;
-  }
-
-  .ccip-decom-hero__status {
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--color-warning-text);
-    background: var(--color-warning-background);
-    padding: var(--space-1x) var(--space-2x);
-    border-radius: var(--border-radius);
-    margin-top: var(--space-2x);
-    display: inline-block;
-  }
-
-  /* Details Grid */
-  .ccip-decom-hero__details {
-    display: grid;
-    gap: var(--space-6x);
-    grid-template-columns: 1fr;
-  }
-
-  .ccip-decom-hero__details__label {
-    font-family: "Inter";
-    font-style: normal;
-    font-weight: 600;
-    font-size: 14px;
-    line-height: 22px;
-    padding-bottom: var(--space-2x);
-    color: var(--gray-500);
-  }
-
-  .ccip-decom-hero__details__value {
-    font-family: "Inter";
-    font-style: normal;
-    font-weight: 400;
-    font-size: 16px;
-    line-height: 24px;
-    font-feature-settings: "liga" off;
-    color: var(--gray-900);
-  }
-
-  .ccip-decom-hero__status-badge {
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--color-warning-text);
-    background: var(--color-warning-background);
-    padding: var(--space-1x) var(--space-2x);
-    border-radius: var(--border-radius);
-  }
-
-  .ccip-decom-hero__explorer-link {
-    color: var(--color-accent);
-    text-decoration: none;
-    font-weight: 500;
-    transition: color 0.2s ease;
-  }
-
-  .ccip-decom-hero__explorer-link:hover {
-    color: var(--color-accent-dark);
-  }
-
-  /* Content Layout */
   .layout {
     --gutter: var(--space-10x);
     --doc-padding: var(--space-4x);
@@ -261,6 +141,7 @@ const decommissionedChainStructuredData = generateDecommissionedChainStructuredD
   .decom-content {
     max-width: 800px;
     margin: 0 auto;
+    width: 100%;
   }
 
   .decom-content h2 {
@@ -318,7 +199,6 @@ const decommissionedChainStructuredData = generateDecommissionedChainStructuredD
     color: var(--gray-900);
   }
 
-  /* Responsive Design */
   @media (min-width: 40em) {
     .decom-info-grid {
       grid-template-columns: 1fr 1fr;
@@ -326,11 +206,8 @@ const decommissionedChainStructuredData = generateDecommissionedChainStructuredD
   }
 
   @media (min-width: 50em) {
-    .ccip-decom-hero__content {
-      max-width: 1500px;
-    }
-
     .layout {
+      max-width: 1500px;
       padding: 0 var(--space-6x);
     }
 
@@ -340,19 +217,12 @@ const decommissionedChainStructuredData = generateDecommissionedChainStructuredD
   }
 
   @media (min-width: 992px) {
-    .ccip-decom-hero__content {
-      --gutter: var(--space-10x);
-      padding: var(--space-10x) var(--space-8x);
-    }
-
-    .ccip-decom-hero__details {
-      grid-template-columns: 1fr 1fr 1fr;
-      column-gap: var(--space-4x);
-      row-gap: var(--space-12x);
-    }
-
     .layout {
       padding: var(--space-10x) var(--space-8x);
+    }
+
+    .decom-content {
+      max-width: none;
     }
   }
 </style>

--- a/src/components/CCIP/ChainHero/ChainHero.css
+++ b/src/components/CCIP/ChainHero/ChainHero.css
@@ -211,3 +211,65 @@
     width: 100%;
   }
 }
+
+.ccip-chain-hero__title-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2x);
+}
+
+.ccip-chain-hero__decom-subtitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-warning-text);
+}
+
+.ccip-chain-hero__decom-banner {
+  display: flex;
+  gap: var(--space-4x);
+  padding: var(--space-4x);
+  background-color: var(--color-background-warning);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--border-radius-10);
+  color: var(--color-text-info);
+}
+
+.ccip-chain-hero__decom-banner__icon {
+  flex-shrink: 0;
+  width: 1.5em;
+  height: 1.5em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+}
+
+.ccip-chain-hero__decom-banner__title {
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--theme-text);
+  margin: 0 0 var(--space-1x) 0;
+}
+
+.ccip-chain-hero__decom-banner__content p:last-child {
+  margin: 0;
+  color: var(--theme-text-light);
+  line-height: 1.5;
+  font-size: 14px;
+}
+
+.ccip-chain-hero__decom-status-badge {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-warning-text);
+}
+
+.ccip-chain-hero__decom-explorer-link {
+  color: var(--color-accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.ccip-chain-hero__decom-explorer-link:hover {
+  color: var(--color-accent-dark);
+}

--- a/src/components/CCIP/ChainHero/ChainHero.tsx
+++ b/src/components/CCIP/ChainHero/ChainHero.tsx
@@ -54,11 +54,16 @@ interface ChainHeroProps {
     symbol: string
   }
   environment: Environment
+  isDecommissioned?: boolean
 }
 
-function ChainHero({ chains, tokens, network, token, environment, lanes }: ChainHeroProps) {
+const CCIP_EXPLORER_URL = "https://ccip.chain.link/"
+
+function ChainHero({ chains, tokens, network, token, environment, lanes, isDecommissioned = false }: ChainHeroProps) {
   // Get chain-specific tooltip configuration
-  const chainTooltipConfig = network?.chain ? getChainTooltip(network.chain) : null
+  const chainTooltipConfig = network?.chain && !isDecommissioned ? getChainTooltip(network.chain) : null
+  const hasFullNetworkDetails = Boolean(network?.router?.address)
+  const showNetworkConfiguration = !isDecommissioned || hasFullNetworkDetails
 
   const feeTokensWithAddress =
     network?.feeTokens?.map((feeToken) => {
@@ -117,6 +122,21 @@ function ChainHero({ chains, tokens, network, token, environment, lanes }: Chain
           </div>
         </div>
 
+        {isDecommissioned && (
+          <aside className="ccip-chain-hero__decom-banner" aria-label="Inactive Chain">
+            <div className="ccip-chain-hero__decom-banner__icon" aria-hidden="true">
+              !
+            </div>
+            <div className="ccip-chain-hero__decom-banner__content">
+              <p className="ccip-chain-hero__decom-banner__title">Inactive Chain</p>
+              <p>
+                This chain is inactive on the CCIP network. No new transactions can be initiated, but historical
+                transactions remain accessible in the CCIP Explorer.
+              </p>
+            </div>
+          </aside>
+        )}
+
         <div className="ccip-chain-hero__heading">
           <img
             src={network?.logo || token?.logo}
@@ -127,200 +147,240 @@ function ChainHero({ chains, tokens, network, token, environment, lanes }: Chain
               currentTarget.src = fallbackTokenIconUrl
             }}
           />
-          <h1
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "8px",
-              position: "relative",
-              overflow: "visible",
-            }}
-          >
-            {network?.name || token?.id}
-            <span className="ccip-chain-hero__token-logo__symbol">
-              {token?.id === "USDC" ? "USD Coin" : token?.name}
-            </span>
+          <div className="ccip-chain-hero__title-group">
+            <h1
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+                position: "relative",
+                overflow: "visible",
+              }}
+            >
+              {network?.name || token?.id}
+              <span className="ccip-chain-hero__token-logo__symbol">
+                {token?.id === "USDC" ? "USD Coin" : token?.name}
+              </span>
 
-            {chainTooltipConfig && (
-              <Tooltip
-                tip={chainTooltipConfig.content}
-                hoverable={chainTooltipConfig.hoverable}
-                hideDelay={chainTooltipConfig.hideDelay}
-              />
-            )}
-          </h1>
+              {chainTooltipConfig && (
+                <Tooltip
+                  tip={chainTooltipConfig.content}
+                  hoverable={chainTooltipConfig.hoverable}
+                  hideDelay={chainTooltipConfig.hideDelay}
+                />
+              )}
+            </h1>
+            {isDecommissioned && network && <span className="ccip-chain-hero__decom-subtitle">Inactive</span>}
+          </div>
         </div>
         {network && (
           <div className="ccip-chain-hero__details">
-            <div className="ccip-chain-hero__details__item">
-              <div className="ccip-chain-hero__details__label">Router</div>
-              <div className="ccip-chain-hero__details__value" data-clipboard-type="router">
-                <Address
-                  endLength={4}
-                  contractUrl={
-                    network.router?.address
-                      ? getExplorerAddressUrl(network.explorer, network.chainType)(network.router.address)
-                      : ""
-                  }
-                  address={network.router?.address}
-                />
-              </div>
-            </div>
-            <div className="ccip-chain-hero__details__item">
-              <div className="ccip-chain-hero__details__label" data-clipboard-type="chain-selector">
-                Chain selector
-                <Tooltip
-                  label=""
-                  tip="CCIP Blockchain identifier."
-                  labelStyle={{
-                    marginRight: "8px",
-                  }}
-                  style={{
-                    display: "inline-block",
-                    verticalAlign: "middle",
-                    marginBottom: "2px",
-                  }}
-                />
-              </div>
-              <div className="ccip-chain-hero__details__value">
-                {network.chainSelector ? <CopyValue value={network.chainSelector} /> : "n/a"}{" "}
-              </div>
-            </div>
-            <div className="ccip-chain-hero__details__item">
-              <div className="ccip-chain-hero__details__label">
-                RMN
-                <Tooltip
-                  label=""
-                  tip="The RMN contract is used to curse."
-                  labelStyle={{
-                    marginRight: "8px",
-                  }}
-                  style={{
-                    display: "inline-block",
-                    verticalAlign: "middle",
-                    marginBottom: "2px",
-                  }}
-                />
-              </div>
-              <div className="ccip-chain-hero__details__value" data-clipboard-type="rmn">
-                {network.armProxy ? (
-                  <Address
-                    endLength={4}
-                    contractUrl={getExplorerAddressUrl(network.explorer, network.chainType)(network.armProxy.address)}
-                    address={network.armProxy.address}
-                  />
-                ) : (
-                  "n/a"
+            {showNetworkConfiguration && (
+              <>
+                <div className="ccip-chain-hero__details__item">
+                  <div className="ccip-chain-hero__details__label">Router</div>
+                  <div className="ccip-chain-hero__details__value" data-clipboard-type="router">
+                    <Address
+                      endLength={4}
+                      contractUrl={
+                        network.router?.address
+                          ? getExplorerAddressUrl(network.explorer, network.chainType)(network.router.address)
+                          : ""
+                      }
+                      address={network.router?.address}
+                    />
+                  </div>
+                </div>
+                <div className="ccip-chain-hero__details__item">
+                  <div className="ccip-chain-hero__details__label" data-clipboard-type="chain-selector">
+                    Chain selector
+                    <Tooltip
+                      label=""
+                      tip="CCIP Blockchain identifier."
+                      labelStyle={{
+                        marginRight: "8px",
+                      }}
+                      style={{
+                        display: "inline-block",
+                        verticalAlign: "middle",
+                        marginBottom: "2px",
+                      }}
+                    />
+                  </div>
+                  <div className="ccip-chain-hero__details__value">
+                    {network.chainSelector ? <CopyValue value={network.chainSelector} /> : "n/a"}{" "}
+                  </div>
+                </div>
+                <div className="ccip-chain-hero__details__item">
+                  <div className="ccip-chain-hero__details__label">
+                    RMN
+                    <Tooltip
+                      label=""
+                      tip="The RMN contract is used to curse."
+                      labelStyle={{
+                        marginRight: "8px",
+                      }}
+                      style={{
+                        display: "inline-block",
+                        verticalAlign: "middle",
+                        marginBottom: "2px",
+                      }}
+                    />
+                  </div>
+                  <div className="ccip-chain-hero__details__value" data-clipboard-type="rmn">
+                    {network.armProxy ? (
+                      <Address
+                        endLength={4}
+                        contractUrl={getExplorerAddressUrl(
+                          network.explorer,
+                          network.chainType
+                        )(network.armProxy.address)}
+                        address={network.armProxy.address}
+                      />
+                    ) : (
+                      "n/a"
+                    )}
+                  </div>
+                </div>
+
+                {/* Conditional rendering based on chain type */}
+                {network.chainType === "evm" && (
+                  <>
+                    <div className="ccip-chain-hero__details__item">
+                      <div className="ccip-chain-hero__details__label">
+                        Token admin registry
+                        <Tooltip
+                          label=""
+                          tip="The TokenAdminRegistry contract is responsible for managing the configuration of token pools for all cross chain tokens."
+                          labelStyle={{
+                            marginRight: "8px",
+                          }}
+                          style={{
+                            display: "inline-block",
+                            verticalAlign: "middle",
+                            marginBottom: "2px",
+                          }}
+                        />
+                      </div>
+                      <div className="ccip-chain-hero__details__value" data-clipboard-type="token-registry">
+                        {network.tokenAdminRegistry ? (
+                          <Address
+                            endLength={4}
+                            contractUrl={getExplorerAddressUrl(
+                              network.explorer,
+                              network.chainType
+                            )(network.tokenAdminRegistry)}
+                            address={network.tokenAdminRegistry}
+                          />
+                        ) : (
+                          "n/a"
+                        )}
+                      </div>
+                    </div>
+                    <div className="ccip-chain-hero__details__item">
+                      <div className="ccip-chain-hero__details__label">
+                        Registry module owner
+                        <Tooltip
+                          label=""
+                          tip="The RegistryModuleOwnerCustom contract is responsible for registering the administrator of a token in the TokenAdminRegistry."
+                          labelStyle={{
+                            marginRight: "8px",
+                          }}
+                          style={{
+                            display: "inline-block",
+                            verticalAlign: "middle",
+                            marginBottom: "2px",
+                          }}
+                        />
+                      </div>
+                      <div className="ccip-chain-hero__details__value" data-clipboard-type="registry">
+                        {network.registryModule ? (
+                          <Address
+                            endLength={4}
+                            contractUrl={getExplorerAddressUrl(
+                              network.explorer,
+                              network.chainType
+                            )(network.registryModule)}
+                            address={network.registryModule}
+                          />
+                        ) : (
+                          "n/a"
+                        )}
+                      </div>
+                    </div>
+                  </>
                 )}
-              </div>
-            </div>
 
-            {/* Conditional rendering based on chain type */}
-            {network.chainType === "evm" && (
-              <>
-                <div className="ccip-chain-hero__details__item">
-                  <div className="ccip-chain-hero__details__label">
-                    Token admin registry
-                    <Tooltip
-                      label=""
-                      tip="The TokenAdminRegistry contract is responsible for managing the configuration of token pools for all cross chain tokens."
-                      labelStyle={{
-                        marginRight: "8px",
-                      }}
-                      style={{
-                        display: "inline-block",
-                        verticalAlign: "middle",
-                        marginBottom: "2px",
-                      }}
-                    />
-                  </div>
-                  <div className="ccip-chain-hero__details__value" data-clipboard-type="token-registry">
-                    {network.tokenAdminRegistry ? (
-                      <Address
-                        endLength={4}
-                        contractUrl={getExplorerAddressUrl(
-                          network.explorer,
-                          network.chainType
-                        )(network.tokenAdminRegistry)}
-                        address={network.tokenAdminRegistry}
-                      />
-                    ) : (
-                      "n/a"
-                    )}
-                  </div>
-                </div>
-                <div className="ccip-chain-hero__details__item">
-                  <div className="ccip-chain-hero__details__label">
-                    Registry module owner
-                    <Tooltip
-                      label=""
-                      tip="The RegistryModuleOwnerCustom contract is responsible for registering the administrator of a token in the TokenAdminRegistry."
-                      labelStyle={{
-                        marginRight: "8px",
-                      }}
-                      style={{
-                        display: "inline-block",
-                        verticalAlign: "middle",
-                        marginBottom: "2px",
-                      }}
-                    />
-                  </div>
-                  <div className="ccip-chain-hero__details__value" data-clipboard-type="registry">
-                    {network.registryModule ? (
-                      <Address
-                        endLength={4}
-                        contractUrl={getExplorerAddressUrl(network.explorer, network.chainType)(network.registryModule)}
-                        address={network.registryModule}
-                      />
-                    ) : (
-                      "n/a"
-                    )}
-                  </div>
-                </div>
-              </>
-            )}
+                {network.chainType === "aptos" && (
+                  <>
+                    <div className="ccip-chain-hero__details__item">
+                      <div className="ccip-chain-hero__details__label">
+                        Token admin registry
+                        <Tooltip
+                          label=""
+                          tip="The TokenAdminRegistry module is responsible for managing the configuration of token pools for all cross chain tokens."
+                          labelStyle={{
+                            marginRight: "8px",
+                          }}
+                          style={{
+                            display: "inline-block",
+                            verticalAlign: "middle",
+                            marginBottom: "2px",
+                          }}
+                        />
+                      </div>
+                      <div className="ccip-chain-hero__details__value" data-clipboard-type="token-registry">
+                        {network.tokenAdminRegistry ? (
+                          <Address
+                            endLength={4}
+                            contractUrl={getExplorerAddressUrl(
+                              network.explorer,
+                              network.chainType
+                            )(network.tokenAdminRegistry)}
+                            address={network.tokenAdminRegistry}
+                          />
+                        ) : (
+                          "n/a"
+                        )}
+                      </div>
+                    </div>
 
-            {network.chainType === "aptos" && (
-              <>
-                <div className="ccip-chain-hero__details__item">
-                  <div className="ccip-chain-hero__details__label">
-                    Token admin registry
-                    <Tooltip
-                      label=""
-                      tip="The TokenAdminRegistry module is responsible for managing the configuration of token pools for all cross chain tokens."
-                      labelStyle={{
-                        marginRight: "8px",
-                      }}
-                      style={{
-                        display: "inline-block",
-                        verticalAlign: "middle",
-                        marginBottom: "2px",
-                      }}
-                    />
-                  </div>
-                  <div className="ccip-chain-hero__details__value" data-clipboard-type="token-registry">
-                    {network.tokenAdminRegistry ? (
-                      <Address
-                        endLength={4}
-                        contractUrl={getExplorerAddressUrl(
-                          network.explorer,
-                          network.chainType
-                        )(network.tokenAdminRegistry)}
-                        address={network.tokenAdminRegistry}
-                      />
-                    ) : (
-                      "n/a"
+                    {network.mcms && (
+                      <div className="ccip-chain-hero__details__item">
+                        <div className="ccip-chain-hero__details__label">
+                          MCMS
+                          <Tooltip
+                            label=""
+                            tip="The MCMS address must be added as a dependency in your Move.toml file when building modules that interact with CCIP on Aptos chains."
+                            labelStyle={{
+                              marginRight: "8px",
+                            }}
+                            style={{
+                              display: "inline-block",
+                              verticalAlign: "middle",
+                              marginBottom: "2px",
+                            }}
+                          />
+                        </div>
+                        <div className="ccip-chain-hero__details__value" data-clipboard-type="mcms">
+                          <Address
+                            endLength={4}
+                            contractUrl={getExplorerAddressUrl(network.explorer, network.chainType)(network.mcms)}
+                            address={network.mcms}
+                          />
+                        </div>
+                      </div>
                     )}
-                  </div>
-                </div>
+                  </>
+                )}
 
-                {network.mcms && (
+                {network.chainType === "solana" && (
                   <div className="ccip-chain-hero__details__item">
                     <div className="ccip-chain-hero__details__label">
-                      MCMS
+                      Fee Quoter Program
                       <Tooltip
                         label=""
-                        tip="The MCMS address must be added as a dependency in your Move.toml file when building modules that interact with CCIP on Aptos chains."
+                        tip="The Fee Quoter Program provides fee calculations for CCIP transactions on Solana."
                         labelStyle={{
                           marginRight: "8px",
                         }}
@@ -331,194 +391,221 @@ function ChainHero({ chains, tokens, network, token, environment, lanes }: Chain
                         }}
                       />
                     </div>
-                    <div className="ccip-chain-hero__details__value" data-clipboard-type="mcms">
-                      <Address
-                        endLength={4}
-                        contractUrl={getExplorerAddressUrl(network.explorer, network.chainType)(network.mcms)}
-                        address={network.mcms}
-                      />
+                    <div className="ccip-chain-hero__details__value" data-clipboard-type="fee-quoter">
+                      {network.feeQuoter ? (
+                        <Address
+                          endLength={4}
+                          contractUrl={getExplorerAddressUrl(network.explorer, network.chainType)(network.feeQuoter)}
+                          address={network.feeQuoter}
+                        />
+                      ) : (
+                        "n/a"
+                      )}
                     </div>
                   </div>
                 )}
-              </>
-            )}
 
-            {network.chainType === "solana" && (
-              <div className="ccip-chain-hero__details__item">
-                <div className="ccip-chain-hero__details__label">
-                  Fee Quoter Program
-                  <Tooltip
-                    label=""
-                    tip="The Fee Quoter Program provides fee calculations for CCIP transactions on Solana."
-                    labelStyle={{
-                      marginRight: "8px",
-                    }}
-                    style={{
-                      display: "inline-block",
-                      verticalAlign: "middle",
-                      marginBottom: "2px",
-                    }}
-                  />
-                </div>
-                <div className="ccip-chain-hero__details__value" data-clipboard-type="fee-quoter">
-                  {network.feeQuoter ? (
-                    <Address
-                      endLength={4}
-                      contractUrl={getExplorerAddressUrl(network.explorer, network.chainType)(network.feeQuoter)}
-                      address={network.feeQuoter}
-                    />
-                  ) : (
-                    "n/a"
-                  )}
-                </div>
-              </div>
-            )}
-
-            {network.chainType === "solana" && network.poolPrograms && (
-              <div className="ccip-chain-hero__details__item">
-                <div className="ccip-chain-hero__details__label">
-                  Self-service pool programs
-                  <PoolProgramTooltip />
-                </div>
-                <div className="ccip-chain-hero__details__value ccip-chain-hero__pool-programs-container">
-                  {network.poolPrograms.BurnMintTokenPool && (
-                    <div className="ccip-chain-hero__pool-program-entry">
-                      <span className="ccip-chain-hero__pool-program-type">BurnMint:</span>
-                      <Address
-                        endLength={4}
-                        contractUrl={getExplorerAddressUrl(network.explorer)(network.poolPrograms.BurnMintTokenPool)}
-                        address={network.poolPrograms.BurnMintTokenPool}
-                      />
+                {network.chainType === "solana" && network.poolPrograms && (
+                  <div className="ccip-chain-hero__details__item">
+                    <div className="ccip-chain-hero__details__label">
+                      Self-service pool programs
+                      <PoolProgramTooltip />
                     </div>
-                  )}
-                  {network.poolPrograms.LockReleaseTokenPool && (
-                    <div className="ccip-chain-hero__pool-program-entry">
-                      <span className="ccip-chain-hero__pool-program-type">LockRelease:</span>
-                      <Address
-                        endLength={4}
-                        contractUrl={getExplorerAddressUrl(network.explorer)(network.poolPrograms.LockReleaseTokenPool)}
-                        address={network.poolPrograms.LockReleaseTokenPool}
-                      />
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-
-            {network.ccipHome && (
-              <div className="ccip-chain-hero__details__item">
-                <div className="ccip-chain-hero__details__label">
-                  CCIP home
-                  <Tooltip
-                    label=""
-                    tip="The CCIPHome Contract is used for v1.6 config"
-                    labelStyle={{
-                      marginRight: "8px",
-                    }}
-                    style={{
-                      display: "inline-block",
-                      verticalAlign: "middle",
-                      marginBottom: "2px",
-                    }}
-                  />
-                </div>
-                <div className="ccip-chain-hero__details__value" data-clipboard-type="ccip-home">
-                  <Address
-                    endLength={4}
-                    contractUrl={getExplorerAddressUrl(network.explorer, network.chainType)(network.ccipHome)}
-                    address={network.ccipHome}
-                  />
-                </div>
-              </div>
-            )}
-
-            {network.tokenPoolFactory && (
-              <div className="ccip-chain-hero__details__item">
-                <div className="ccip-chain-hero__details__label">
-                  Token pool factory
-                  <Tooltip
-                    label=""
-                    tip="The TokenPoolFactory contract can be used for deploying CrossChainTokens and TokenPools for cross-chain token transfers."
-                    labelStyle={{
-                      marginRight: "8px",
-                    }}
-                    style={{
-                      display: "inline-block",
-                      verticalAlign: "middle",
-                      marginBottom: "2px",
-                    }}
-                  />
-                </div>
-                <div className="ccip-chain-hero__details__value" data-clipboard-type="token-pool-factory">
-                  <Address
-                    endLength={4}
-                    contractUrl={getExplorerAddressUrl(network.explorer, network.chainType)(network.tokenPoolFactory)}
-                    address={network.tokenPoolFactory}
-                  />
-                </div>
-              </div>
-            )}
-
-            {/* Start of new Fee Tokens Group */}
-            {network &&
-              ((feeTokensWithAddress && feeTokensWithAddress.length > 0) ||
-                (!nativeTokenHasAddress() && nativeCurrency)) && (
-                <div className="ccip-chain-hero__details__item ccip-chain-hero__fee-tokens-group-item">
-                  <div className="ccip-chain-hero__details__label">Fee tokens</div>
-                  <div className="ccip-chain-hero__details__value" data-clipboard-type="fee-tokens-group">
-                    <div className="ccip-chain-hero__feeTokens__list">
-                      {" "}
-                      {/* This new div will hold all token items */}
-                      {feeTokensWithAddress &&
-                        feeTokensWithAddress.map(({ token, address, logo, contractUrl }, index) => (
-                          <div key={`fee-token-${index}`} className="ccip-chain-hero__feeTokens__item">
-                            <object
-                              data={logo}
-                              type="image/png"
-                              width="20px"
-                              height="20px"
-                              className="ccip-chain-hero__feeTokens__item__logo"
-                            >
-                              <img
-                                src={fallbackTokenIconUrl}
-                                alt={`${token.name} token logo`}
-                                width="20px"
-                                height="20px"
-                              />
-                            </object>
-                            <div>{token.name}</div>
-                            <Address
-                              endLength={4}
-                              contractUrl={token.name === "TON" ? undefined : contractUrl}
-                              address={address}
-                            />
-                          </div>
-                        ))}
-                      {!nativeTokenHasAddress() && nativeCurrency && (
-                        <div className="ccip-chain-hero__feeTokens__item">
-                          <object
-                            data={`${getTokenIconUrl(nativeCurrency.symbol)}`}
-                            type="image/png"
-                            width="20px"
-                            height="20px"
-                            className="ccip-chain-hero__feeTokens__item__logo"
-                          >
-                            <img
-                              src={fallbackTokenIconUrl}
-                              alt={`${nativeCurrency.symbol} token logo`}
-                              width="20px"
-                              height="20px"
-                            />
-                          </object>
-                          <div>{nativeCurrency.symbol}</div>
-                          <span className="ccip-chain-hero__feeTokens__native-gas-token">(native gas token)</span>
+                    <div className="ccip-chain-hero__details__value ccip-chain-hero__pool-programs-container">
+                      {network.poolPrograms.BurnMintTokenPool && (
+                        <div className="ccip-chain-hero__pool-program-entry">
+                          <span className="ccip-chain-hero__pool-program-type">BurnMint:</span>
+                          <Address
+                            endLength={4}
+                            contractUrl={getExplorerAddressUrl(network.explorer)(
+                              network.poolPrograms.BurnMintTokenPool
+                            )}
+                            address={network.poolPrograms.BurnMintTokenPool}
+                          />
+                        </div>
+                      )}
+                      {network.poolPrograms.LockReleaseTokenPool && (
+                        <div className="ccip-chain-hero__pool-program-entry">
+                          <span className="ccip-chain-hero__pool-program-type">LockRelease:</span>
+                          <Address
+                            endLength={4}
+                            contractUrl={getExplorerAddressUrl(network.explorer)(
+                              network.poolPrograms.LockReleaseTokenPool
+                            )}
+                            address={network.poolPrograms.LockReleaseTokenPool}
+                          />
                         </div>
                       )}
                     </div>
                   </div>
+                )}
+
+                {network.ccipHome && (
+                  <div className="ccip-chain-hero__details__item">
+                    <div className="ccip-chain-hero__details__label">
+                      CCIP home
+                      <Tooltip
+                        label=""
+                        tip="The CCIPHome Contract is used for v1.6 config"
+                        labelStyle={{
+                          marginRight: "8px",
+                        }}
+                        style={{
+                          display: "inline-block",
+                          verticalAlign: "middle",
+                          marginBottom: "2px",
+                        }}
+                      />
+                    </div>
+                    <div className="ccip-chain-hero__details__value" data-clipboard-type="ccip-home">
+                      <Address
+                        endLength={4}
+                        contractUrl={getExplorerAddressUrl(network.explorer, network.chainType)(network.ccipHome)}
+                        address={network.ccipHome}
+                      />
+                    </div>
+                  </div>
+                )}
+
+                {network.tokenPoolFactory && (
+                  <div className="ccip-chain-hero__details__item">
+                    <div className="ccip-chain-hero__details__label">
+                      Token pool factory
+                      <Tooltip
+                        label=""
+                        tip="The TokenPoolFactory contract can be used for deploying CrossChainTokens and TokenPools for cross-chain token transfers."
+                        labelStyle={{
+                          marginRight: "8px",
+                        }}
+                        style={{
+                          display: "inline-block",
+                          verticalAlign: "middle",
+                          marginBottom: "2px",
+                        }}
+                      />
+                    </div>
+                    <div className="ccip-chain-hero__details__value" data-clipboard-type="token-pool-factory">
+                      <Address
+                        endLength={4}
+                        contractUrl={getExplorerAddressUrl(
+                          network.explorer,
+                          network.chainType
+                        )(network.tokenPoolFactory)}
+                        address={network.tokenPoolFactory}
+                      />
+                    </div>
+                  </div>
+                )}
+
+                {/* Start of new Fee Tokens Group */}
+                {network &&
+                  ((feeTokensWithAddress && feeTokensWithAddress.length > 0) ||
+                    (!nativeTokenHasAddress() && nativeCurrency)) && (
+                    <div className="ccip-chain-hero__details__item ccip-chain-hero__fee-tokens-group-item">
+                      <div className="ccip-chain-hero__details__label">Fee tokens</div>
+                      <div className="ccip-chain-hero__details__value" data-clipboard-type="fee-tokens-group">
+                        <div className="ccip-chain-hero__feeTokens__list">
+                          {" "}
+                          {/* This new div will hold all token items */}
+                          {feeTokensWithAddress &&
+                            feeTokensWithAddress.map(({ token, address, logo, contractUrl }, index) => (
+                              <div key={`fee-token-${index}`} className="ccip-chain-hero__feeTokens__item">
+                                <object
+                                  data={logo}
+                                  type="image/png"
+                                  width="20px"
+                                  height="20px"
+                                  className="ccip-chain-hero__feeTokens__item__logo"
+                                >
+                                  <img
+                                    src={fallbackTokenIconUrl}
+                                    alt={`${token.name} token logo`}
+                                    width="20px"
+                                    height="20px"
+                                  />
+                                </object>
+                                <div>{token.name}</div>
+                                <Address
+                                  endLength={4}
+                                  contractUrl={token.name === "TON" ? undefined : contractUrl}
+                                  address={address}
+                                />
+                              </div>
+                            ))}
+                          {!nativeTokenHasAddress() && nativeCurrency && (
+                            <div className="ccip-chain-hero__feeTokens__item">
+                              <object
+                                data={`${getTokenIconUrl(nativeCurrency.symbol)}`}
+                                type="image/png"
+                                width="20px"
+                                height="20px"
+                                className="ccip-chain-hero__feeTokens__item__logo"
+                              >
+                                <img
+                                  src={fallbackTokenIconUrl}
+                                  alt={`${nativeCurrency.symbol} token logo`}
+                                  width="20px"
+                                  height="20px"
+                                />
+                              </object>
+                              <div>{nativeCurrency.symbol}</div>
+                              <span className="ccip-chain-hero__feeTokens__native-gas-token">(native gas token)</span>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                {/* End of new Fee Tokens Group */}
+              </>
+            )}
+
+            {!showNetworkConfiguration && isDecommissioned && (
+              <div className="ccip-chain-hero__details__item">
+                <div className="ccip-chain-hero__details__label" data-clipboard-type="chain-selector">
+                  Chain selector
+                  <Tooltip
+                    label=""
+                    tip="CCIP Blockchain identifier."
+                    labelStyle={{
+                      marginRight: "8px",
+                    }}
+                    style={{
+                      display: "inline-block",
+                      verticalAlign: "middle",
+                      marginBottom: "2px",
+                    }}
+                  />
                 </div>
-              )}
-            {/* End of new Fee Tokens Group */}
+                <div className="ccip-chain-hero__details__value">
+                  {network.chainSelector ? <CopyValue value={network.chainSelector} /> : "n/a"}
+                </div>
+              </div>
+            )}
+
+            {isDecommissioned && (
+              <>
+                <div className="ccip-chain-hero__details__item">
+                  <div className="ccip-chain-hero__details__label">Status</div>
+                  <div className="ccip-chain-hero__details__value">
+                    <span className="ccip-chain-hero__decom-status-badge">Inactive</span>
+                  </div>
+                </div>
+                <div className="ccip-chain-hero__details__item">
+                  <div className="ccip-chain-hero__details__label">Historical data</div>
+                  <div className="ccip-chain-hero__details__value">
+                    <a
+                      href={CCIP_EXPLORER_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ccip-chain-hero__decom-explorer-link"
+                    >
+                      View in CCIP Explorer →
+                    </a>
+                  </div>
+                </div>
+              </>
+            )}
           </div>
         )}
       </div>

--- a/src/config/data/ccip/data.ts
+++ b/src/config/data/ccip/data.ts
@@ -456,6 +456,8 @@ export const getLnMParams = ({ supportedChain, version }: { supportedChain: Supp
 }
 
 export const getTokensOfChain = ({ chain, filter }: { chain: string; filter: Environment }): string[] => {
+  if (getDecommissionedChainKeys({ filter }).has(chain)) return []
+
   // Create a mapping object to avoid the switch statement
   const tokensDataMap: { [key in Environment]?: TokensConfig } = {
     [Environment.Mainnet]: tokensMainnetv120 as TokensConfig,
@@ -481,6 +483,76 @@ export const getTokensOfChain = ({ chain, filter }: { chain: string; filter: Env
   })
 }
 
+const getDecommissionedChainKeys = ({ filter }: { filter: Environment }): Set<string> => {
+  const { decomReferenceData } = loadDecommissionedData({
+    environment: filter,
+    version: Version.V1_2_0,
+  })
+  return new Set(Object.keys(decomReferenceData))
+}
+
+const buildNetworkForChain = ({ chain, filter }: { chain: string; filter: Environment }): Network | undefined => {
+  const chainsReferenceData =
+    Environment.Mainnet === filter
+      ? (chainsMainnetv120 as unknown as ChainsConfig)
+      : (chainsTestnetv120 as unknown as ChainsConfig)
+  const chainConfig = chainsReferenceData[chain]
+  if (!chainConfig) return undefined
+
+  const supportedChain = directoryToSupportedChain(chain)
+  const title = getTitle(supportedChain)
+  if (!title) throw Error(`Title not found for ${supportedChain}`)
+
+  const lanes = Environment.Mainnet === filter ? lanesMainnetv120 : lanesTestnetv120
+  const logo = getChainIcon(supportedChain)
+  if (!logo) throw Error(`Logo not found for ${supportedChain}`)
+  const token = getTokensOfChain({ chain, filter })
+  const explorer = getExplorer(supportedChain)
+  const router = chainConfig.router
+  if (!explorer) throw Error(`Explorer not found for ${supportedChain}`)
+
+  const { chainType } = getChainTypeAndFamily(supportedChain)
+
+  const routerExplorerUrl = getExplorerAddressUrl(explorer, chainType)(router.address)
+  const nativeToken = getNativeCurrency(supportedChain)
+  if (!nativeToken) throw Error(`Native token not found for ${supportedChain}`)
+
+  const decommissionedChainKeys = getDecommissionedChainKeys({ filter })
+
+  return {
+    name: title,
+    logo,
+    totalLanes: lanes[chain]
+      ? Object.keys(lanes[chain]).filter((destination) => !decommissionedChainKeys.has(destination)).length
+      : 0,
+    totalTokens: token.length,
+    chain,
+    key: chain,
+    explorer,
+    chainType,
+    tokenAdminRegistry: chainConfig.tokenAdminRegistry?.address,
+    tokenPoolFactory: chainConfig.tokenPoolFactory?.address,
+    ccipHome: chainConfig.ccipHome?.address,
+    registryModule: chainConfig.registryModule?.address,
+    router,
+    routerExplorerUrl,
+    chainSelector: chainConfig.chainSelector,
+    nativeToken: {
+      name: nativeToken.name,
+      symbol: nativeToken.symbol,
+      logo: getTokenIconUrl(nativeToken.symbol),
+    },
+    feeTokens: chainConfig.feeTokens?.map((tokenName: string) => ({
+      name: tokenName,
+      logo: getTokenIconUrl(tokenName),
+    })),
+    armProxy: chainConfig.armProxy,
+    feeQuoter: chainType === "solana" ? chainConfig.feeQuoter : undefined,
+    mcms: chainType === "aptos" ? chainConfig.mcms?.address : undefined,
+    poolPrograms: chainType === "solana" ? chainConfig.poolPrograms : undefined,
+  }
+}
+
 export const getAllNetworks = ({ filter }: { filter: Environment }): Network[] => {
   const chains = getAllChains({
     mainnetVersion: Version.V1_2_0,
@@ -488,59 +560,14 @@ export const getAllNetworks = ({ filter }: { filter: Environment }): Network[] =
     environment: filter,
   })
 
+  const decommissionedChainKeys = getDecommissionedChainKeys({ filter })
   const allChains: Network[] = []
 
   for (const chain of chains) {
-    const supportedChain = directoryToSupportedChain(chain)
-    const title = getTitle(supportedChain)
-    if (!title) throw Error(`Title not found for ${supportedChain}`)
+    if (decommissionedChainKeys.has(chain)) continue
 
-    const lanes = Environment.Mainnet === filter ? lanesMainnetv120 : lanesTestnetv120
-    const chains = Environment.Mainnet === filter ? chainsMainnetv120 : chainsTestnetv120
-    const logo = getChainIcon(supportedChain)
-    if (!logo) throw Error(`Logo not found for ${supportedChain}`)
-    const token = getTokensOfChain({ chain, filter })
-    const explorer = getExplorer(supportedChain)
-    const router = chains[chain].router
-    if (!explorer) throw Error(`Explorer not found for ${supportedChain}`)
-
-    // Determine chain type based on chain name
-    const { chainType } = getChainTypeAndFamily(supportedChain)
-
-    const routerExplorerUrl = getExplorerAddressUrl(explorer, chainType)(router.address)
-    const nativeToken = getNativeCurrency(supportedChain)
-    if (!nativeToken) throw Error(`Native token not found for ${supportedChain}`)
-
-    allChains.push({
-      name: title,
-      logo,
-      totalLanes: lanes[chain] ? Object.keys(lanes[chain]).length : 0,
-      totalTokens: token.length,
-      chain,
-      key: chain,
-      explorer,
-      chainType,
-      tokenAdminRegistry: chains[chain]?.tokenAdminRegistry?.address,
-      tokenPoolFactory: chains[chain]?.tokenPoolFactory?.address,
-      ccipHome: chains[chain]?.ccipHome?.address,
-      registryModule: chains[chain]?.registryModule?.address,
-      router,
-      routerExplorerUrl,
-      chainSelector: chains[chain].chainSelector,
-      nativeToken: {
-        name: nativeToken.name,
-        symbol: nativeToken.symbol,
-        logo: getTokenIconUrl(nativeToken.symbol),
-      },
-      feeTokens: chains[chain].feeTokens?.map((tokenName: string) => ({
-        name: tokenName,
-        logo: getTokenIconUrl(tokenName),
-      })),
-      armProxy: chains[chain].armProxy,
-      feeQuoter: chainType === "solana" ? chains[chain]?.feeQuoter : undefined,
-      mcms: chainType === "aptos" ? chains[chain]?.mcms?.address : undefined,
-      poolPrograms: chainType === "solana" ? chains[chain]?.poolPrograms : undefined,
-    })
+    const network = buildNetworkForChain({ chain, filter })
+    if (network) allChains.push(network)
   }
 
   return allChains.sort((a, b) => a.name.localeCompare(b.name))
@@ -579,6 +606,8 @@ export const getNetwork = ({ chain, filter }: { chain: string; filter: Environme
 }
 
 export const getChainsOfToken = ({ token, filter }: { token: string; filter: Environment }): string[] => {
+  const decommissionedChainKeys = getDecommissionedChainKeys({ filter })
+
   // Get the tokens data based on the filter
   const tokensData = (() => {
     switch (filter) {
@@ -593,6 +622,7 @@ export const getChainsOfToken = ({ token, filter }: { token: string; filter: Env
 
   // Get all valid chains for the given token
   return Object.entries(tokensData[token])
+    .filter(([chain]) => !decommissionedChainKeys.has(chain))
     .filter(([, tokenData]) => tokenData.poolType !== "feeTokenOnly")
     .filter(([chain]) => {
       const lanes = getAllTokenLanes({ token, environment: filter })
@@ -610,12 +640,16 @@ export const getAllNetworkLanes = async ({
   environment: Environment
   version: Version
 }) => {
+  const decommissionedChainKeys = getDecommissionedChainKeys({ filter: environment })
+  if (decommissionedChainKeys.has(chain)) return []
+
   const { lanesReferenceData } = loadReferenceData({
     environment,
     version,
   })
 
   const allLanes = lanesReferenceData[chain]
+  if (!allLanes) return []
 
   const lanesData: {
     name: string
@@ -630,22 +664,24 @@ export const getAllNetworkLanes = async ({
       address: string
       version: string
     }
-  }[] = Object.keys(allLanes).map((lane) => {
-    const laneData = allLanes[lane]
+  }[] = Object.keys(allLanes)
+    .filter((lane) => !decommissionedChainKeys.has(lane))
+    .map((lane) => {
+      const laneData = allLanes[lane]
 
-    const directory = directoryToSupportedChain(lane || "")
-    const title = getTitle(directory)
-    const networkLogo = getChainIcon(directory)
+      const directory = directoryToSupportedChain(lane || "")
+      const title = getTitle(directory)
+      const networkLogo = getChainIcon(directory)
 
-    return {
-      name: title || "",
-      logo: networkLogo || "",
-      onRamp: laneData.onRamp,
-      offRamp: laneData.offRamp,
-      key: lane,
-      directory,
-    }
-  })
+      return {
+        name: title || "",
+        logo: networkLogo || "",
+        onRamp: laneData.onRamp,
+        offRamp: laneData.offRamp,
+        key: lane,
+        directory,
+      }
+    })
 
   return lanesData.sort((a, b) => a.name.localeCompare(b.name))
 }
@@ -664,6 +700,8 @@ export function getAllTokenLanes({
     version,
   })
 
+  const decommissionedChainKeys = getDecommissionedChainKeys({ filter: environment })
+
   // Define the resulting object
   const allDestinationLanes: {
     [sourceChain: string]: {
@@ -673,8 +711,12 @@ export function getAllTokenLanes({
 
   // Iterate over the source chains
   for (const sourceChain in lanesReferenceData) {
+    if (decommissionedChainKeys.has(sourceChain)) continue
+
     const sourceData = lanesReferenceData[sourceChain]
     for (const destinationChain in sourceData) {
+      if (decommissionedChainKeys.has(destinationChain)) continue
+
       const destinationData = sourceData[destinationChain]
 
       // Check if the token is supported
@@ -711,6 +753,7 @@ export function getLane({
 
 export function getSearchLanes({ environment }: { environment: Environment }) {
   const lanes = environment === Environment.Mainnet ? lanesMainnetv120 : lanesTestnetv120
+  const decommissionedChainKeys = getDecommissionedChainKeys({ filter: environment })
   const allLanes: {
     sourceNetwork: {
       name: string
@@ -729,12 +772,16 @@ export function getSearchLanes({ environment }: { environment: Environment }) {
   }[] = []
 
   for (const sourceChain in lanes) {
+    if (decommissionedChainKeys.has(sourceChain)) continue
+
     const sourceSupportedChain = directoryToSupportedChain(sourceChain)
     const sourceChainTitle = getTitle(sourceSupportedChain)
     const sourceChainLogo = getChainIcon(sourceSupportedChain)
     const { chainType: sourceChainType } = getChainTypeAndFamily(sourceSupportedChain)
 
     for (const destinationChain in lanes[sourceChain]) {
+      if (decommissionedChainKeys.has(destinationChain)) continue
+
       const destinationSupportedChain = directoryToSupportedChain(destinationChain)
       const destinationChainTitle = getTitle(destinationSupportedChain)
       const destinationChainLogo = getChainIcon(destinationSupportedChain)
@@ -822,4 +869,21 @@ export const getAllDecommissionedNetworks = ({ filter }: { filter: Environment }
 export const getDecommissionedNetwork = ({ chain, filter }: { chain: string; filter: Environment }) => {
   const decommissionedChains = getAllDecommissionedNetworks({ filter })
   return decommissionedChains.find((network) => network.chain === chain)
+}
+
+export const getDecommissionedNetworkWithDetails = ({
+  chain,
+  filter,
+}: {
+  chain: string
+  filter: Environment
+}): Network | undefined => {
+  const { decomReferenceData } = loadDecommissionedData({
+    environment: filter,
+    version: Version.V1_2_0,
+  })
+
+  if (!(chain in decomReferenceData)) return undefined
+
+  return buildNetworkForChain({ chain, filter })
 }

--- a/src/config/data/ccip/v1_2_0/mainnet/decom.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/decom.json
@@ -22,5 +22,8 @@
   },
   "mind-mainnet": {
     "chainSelector": "11690709103138290329"
+  },
+  "bitcoin-mainnet-botanix": {
+    "chainSelector": "4560701533377838164"
   }
 }

--- a/src/config/data/ccip/v1_2_0/mainnet/decom.json
+++ b/src/config/data/ccip/v1_2_0/mainnet/decom.json
@@ -25,5 +25,8 @@
   },
   "bitcoin-mainnet-botanix": {
     "chainSelector": "4560701533377838164"
+  },
+  "corn-mainnet": {
+    "chainSelector": "9043146809313071210"
   }
 }

--- a/src/config/data/ccip/v1_2_0/testnet/decom.json
+++ b/src/config/data/ccip/v1_2_0/testnet/decom.json
@@ -58,5 +58,8 @@
   },
   "ronin-testnet-saigon": {
     "chainSelector": "13116810400804392105"
+  },
+  "ethereum-testnet-sepolia-corn-1": {
+    "chainSelector": "1467427327723633929"
   }
 }

--- a/src/utils/ccipStructuredData.ts
+++ b/src/utils/ccipStructuredData.ts
@@ -252,8 +252,8 @@ export function generateDecommissionedChainStructuredData(
   structuredData.push({
     "@context": "https://schema.org",
     "@type": "Service",
-    name: `${network.name} CCIP Network (Decommissioned)`,
-    description: `Decommissioned cross-chain interoperability service for ${network.name} blockchain on ${environmentText}. Historical data remains accessible.`,
+    name: `${network.name} CCIP Network (Inactive)`,
+    description: `Inactive cross-chain interoperability service for ${network.name} blockchain on ${environmentText}. Historical data remains accessible.`,
     url: canonicalURL,
     serviceType: "Blockchain Interoperability Protocol",
     provider: CHAINLINK_ORGANIZATION,
@@ -313,7 +313,7 @@ export function generateDecommissionedChainStructuredData(
       {
         "@type": "ListItem",
         position: 5,
-        name: `${network.name} (Decommissioned)`,
+        name: `${network.name} (Inactive)`,
         item: canonicalURL,
       },
     ],


### PR DESCRIPTION
Revamps decommissioned chain pages to show the hero (through fee tokens) with Status and Historical data, hides lanes/tokens, and excludes decommissioned chains from active directory listings and lane search.