### PR TITLE
Data Feeds + Streams: Robinhood Integration

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -419,6 +419,22 @@
     },
     {
       "category": "integration",
+      "date": "2026-07-01",
+      "description": "Chainlink Data Streams is available for Robinhood Chain Mainnet. The verifier proxy addresses and stream IDs are available on the [Stream Addresses](https://docs.chain.link/data-streams/supported-networks?streamsNetwork=robinhood) page.",
+      "relatedNetworks": ["robinhood"],
+      "title": "Data Streams Expands to Robinhood Chain Mainnet",
+      "topic": "Data Streams"
+    },
+    {
+      "category": "integration",
+      "date": "2026-07-01",
+      "description": "Chainlink Data Feeds is available on Robinhood Chain Mainnet. View the available price feed information on the [Price Feed Addresses](https://docs.chain.link/data-feeds/price-feeds/addresses?network=robinhood&page=1) page.",
+      "relatedNetworks": ["robinhood"],
+      "title": "Data Feeds Expands to Robinhood Chain Mainnet",
+      "topic": "Data Feeds"
+    },
+    {
+      "category": "integration",
       "date": "2026-06-30",
       "description": "A new version of CCIP is being progressively deployed across the following lanes. No disruption to existing integrations or protocol downtime is anticipated during the upgrade process. For more information, please reach out to your Chainlink Labs point of contact or visit the [Chainlink CCIP Contact form](https://chain.link/ccip-contact).",
       "relatedNetworks": ["arbitrum", "bnb-chain", "mantle"],

--- a/src/config/sidebar.ts
+++ b/src/config/sidebar.ts
@@ -807,7 +807,10 @@ export const SIDEBAR: Partial<Record<Sections, SectionEntry[]>> = {
                 {
                   title: "Provider Catalog",
                   url: "data-feeds/tokenized-equity-feeds/providers",
-                  children: [{ title: "Ondo Finance", url: "data-feeds/tokenized-equity-feeds/ondo" }],
+                  children: [
+                    { title: "Ondo Finance", url: "data-feeds/tokenized-equity-feeds/ondo" },
+                    { title: "Robinhood", url: "data-feeds/tokenized-equity-feeds/robinhood" },
+                  ],
                 },
               ],
             },

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -17796,8 +17796,12 @@ Directly replaces the on-chain entry path of `_sendRequest()`. Instead of your c
 ```ts
 const evmClient = new cre.evm.EVMClient(CHAIN_SELECTOR)
 const trigger = evmClient.logTrigger({
-  addresses: [/* base64-encoded contract address */],
-  topics: [/* base64-encoded event signature hash */],
+  addresses: [
+    /* base64-encoded contract address */
+  ],
+  topics: [
+    /* base64-encoded event signature hash */
+  ],
 })
 ```
 
@@ -20723,11 +20727,7 @@ const workflow = (runtime: Runtime<Config>) => {
 
   // Call the high-level sendRequest with your custom function
   const price = httpClient
-    .sendRequest(
-      runtime,
-      fetchPrice,
-      consensusMedianAggregation<number>()
-    )(runtime.config.apiUrl)
+    .sendRequest(runtime, fetchPrice, consensusMedianAggregation<number>())(runtime.config.apiUrl)
     .result()
 
   runtime.log(`Aggregated price: ${price}`)
@@ -21249,11 +21249,7 @@ const createResource = (sendRequester: HTTPSendRequester, payload: { name: strin
 // In your workflow
 const httpClient = new HTTPClient()
 const resource = httpClient
-  .sendRequest(
-    runtime,
-    createResource,
-    consensusIdenticalAggregation<{ id: string }>()
-  )({ name: "My Resource" })
+  .sendRequest(runtime, createResource, consensusIdenticalAggregation<{ id: string }>())({ name: "My Resource" })
   .result()
 ```
 

--- a/src/content/cre/reference/clf-migration-ts.mdx
+++ b/src/content/cre/reference/clf-migration-ts.mdx
@@ -94,8 +94,12 @@ Directly replaces the on-chain entry path of `_sendRequest()`. Instead of your c
 ```ts
 const evmClient = new cre.evm.EVMClient(CHAIN_SELECTOR)
 const trigger = evmClient.logTrigger({
-  addresses: [/* base64-encoded contract address */],
-  topics: [/* base64-encoded event signature hash */],
+  addresses: [
+    /* base64-encoded contract address */
+  ],
+  topics: [
+    /* base64-encoded event signature hash */
+  ],
 })
 ```
 

--- a/src/content/cre/reference/sdk/http-client-ts.mdx
+++ b/src/content/cre/reference/sdk/http-client-ts.mdx
@@ -76,11 +76,7 @@ const workflow = (runtime: Runtime<Config>) => {
 
   // Call the high-level sendRequest with your custom function
   const price = httpClient
-    .sendRequest(
-      runtime,
-      fetchPrice,
-      consensusMedianAggregation<number>()
-    )(runtime.config.apiUrl)
+    .sendRequest(runtime, fetchPrice, consensusMedianAggregation<number>())(runtime.config.apiUrl)
     .result()
 
   runtime.log(`Aggregated price: ${price}`)
@@ -602,11 +598,7 @@ const createResource = (sendRequester: HTTPSendRequester, payload: { name: strin
 // In your workflow
 const httpClient = new HTTPClient()
 const resource = httpClient
-  .sendRequest(
-    runtime,
-    createResource,
-    consensusIdenticalAggregation<{ id: string }>()
-  )({ name: "My Resource" })
+  .sendRequest(runtime, createResource, consensusIdenticalAggregation<{ id: string }>())({ name: "My Resource" })
   .result()
 ```
 

--- a/src/content/data-feeds/llms-full.txt
+++ b/src/content/data-feeds/llms-full.txt
@@ -7091,13 +7091,149 @@ Tokenized equity feeds have issuer-specific implementations that affect pricing 
 
 ## Available providers
 
-| Provider     | Feed Type          | Price Calculation                                      | Corporate Action Handling            | Documentation                                           | Issuer Contact                        |
-| :----------- | :----------------- | :----------------------------------------------------- | :----------------------------------- | :------------------------------------------------------ | :------------------------------------ |
-| Ondo Finance | Total Return Value | Underlying Equity Market Price × Multiplier (`sValue`) | Pause-based with manual confirmation | [View details](/data-feeds/tokenized-equity-feeds/ondo) | [Contact page](https://ondo.finance/) |
+| Provider     | Feed Type          | Price Calculation                                      | Corporate Action Handling            | Documentation                                                | Issuer Contact                         |
+| :----------- | :----------------- | :----------------------------------------------------- | :----------------------------------- | :----------------------------------------------------------- | :------------------------------------- |
+| Ondo Finance | Total Return Value | Underlying Equity Market Price × Multiplier (`sValue`) | Pause-based with manual confirmation | [View details](/data-feeds/tokenized-equity-feeds/ondo)      | [Contact page](https://ondo.finance/)  |
+| Robinhood    | Multiplier-scaled  | Underlying Equity Market Price × `uiMultiplier`        | Oracle pause on token contract       | [View details](/data-feeds/tokenized-equity-feeds/robinhood) | [Contact page](https://robinhood.com/) |
 
 ## Provider-specific considerations
 
 Each provider may implement tokenized equity feeds differently based on their token design and corporate action handling requirements. Review the provider-specific documentation and contact Chainlink Labs at [chainlink_data_feeds@smartcontract.com](mailto:chainlink_data_feeds@smartcontract.com) before integrating their tokenized equity feeds into your protocol.
+
+---
+
+# Robinhood Tokenized Equities
+Source: https://docs.chain.link/data-feeds/tokenized-equity-feeds/robinhood
+
+<TokenizedEquityFeeds section="tokenizedEquityNote" />
+
+Chainlink provides tokenized equity feeds for Robinhood tokenized stocks. Each Robinhood tokenized stock is represented by its own ERC-20 token contract, deployed on Robinhood Chain (one contract per ticker). The corresponding Chainlink feed reports the Total Return Value of the token by combining the underlying equity's market price with a multiplier read directly from the Robinhood token contract, rather than the raw equity price.
+
+These feeds use the standard Chainlink V3 aggregator interface (`latestRoundData()`), so any consumer reads the published price through the proxy in the same way as a crypto price feed. They are push-based oracles intended for compliance reference pricing, protocol integration, and similar use cases.
+
+## Available Robinhood tokenized equity feeds
+
+The following table shows the available Robinhood tokenized equity feeds.
+
+## Total Return Value calculation
+
+Robinhood tokenized equity feeds calculate the token price using the following formula:
+
+```
+Token Price = Underlying Equity Market Price × Multiplier
+```
+
+Where:
+
+- **Underlying Equity Market Price**: Sourced from Chainlink's 24/5 equity price feeds, which aggregate data across regular, pre-market, post-market, and overnight trading sessions.
+- **Multiplier**: Read from the Robinhood token contract via the `uiMultiplier()` function. The multiplier accounts for dividend reinvestments and corporate action adjustments (see [Corporate action handling](#corporate-action-handling-and-oracle-pause) below).
+
+This approach ensures the token price reflects the total return of the underlying equity, including dividend reinvestments and corporate action adjustments, rather than just the current market price per share.
+
+## How the multiplier works
+
+The multiplier accounts for events that change the relationship between token quantity and underlying equity value:
+
+| Event Type                   | Multiplier Behavior             | Example                       |
+| :--------------------------- | :------------------------------ | :---------------------------- |
+| Dividend reinvestment        | Small increase                  | `uiMultiplier`: 1.000 → 1.008 |
+| Stock split (10:1 example)   | Large increase                  | `uiMultiplier`: 1.0 → 10.0    |
+| Reverse split (1:10 example) | Large decrease                  | `uiMultiplier`: 10.0 → 1.0    |
+| Spin-offs                    | Adjustment to reflect new value | Varies by event               |
+
+Robinhood updates the multiplier on the token contract through two paths:
+
+- **Immediate update**: `updateMultiplier(uint256)` sets a new `uiMultiplier` effective immediately.
+- **Scheduled update**: `updateMultiplier(uint256, uint256 effectiveAt)` stages the next multiplier. The staged value is exposed through `newUIMultiplier()` and the activation time through `effectiveAt()`. The new value becomes the active `uiMultiplier` once the `effectiveAt` timestamp is reached.
+
+The `UIMultiplierUpdated` event (`oldMultiplier`, `newMultiplier`, `effectiveAtTimestamp`) is emitted whenever the multiplier changes or a new value is staged.
+
+Robinhood's on-chain token contract enforces two update paths:
+
+- **Small updates** (no price discontinuity): Applied immediately via automated processes. These handle routine dividend reinvestments.
+- **Large updates** (price discontinuity): Requires a scheduled pause window and manual confirmation before unpause. These handle major corporate actions like stock splits.
+
+## Corporate action handling and oracle pause
+
+Corporate actions are coordinated by Robinhood as the asset issuer. Chainlink does not provide corporate-action calendar data or automated pause triggers; pause timing and multiplier updates are coordinated by Robinhood.
+
+The Robinhood token contract exposes a dedicated oracle pause flag, `oraclePaused()`, that the feed honors:
+
+**Normal mode** (`oraclePaused() == false`): The feed returns the current underlying equity market price multiplied by the current `uiMultiplier`.
+
+**Paused mode** (`oraclePaused() == true`): The feed stops publishing new prices and holds the last known good value. This prevents an inconsistent token price from being published while a corporate action is in progress and the underlying price and multiplier are temporarily out of sync.
+
+During a corporate action, the issuer-driven workflow keeps the token price continuous:
+
+1. Robinhood pauses the oracle (`pauseOracle()`), freezing the feed at the last known good value.
+2. The new multiplier is staged via `updateMultiplier(newMultiplier, effectiveAt)` (or applied at the scheduled time).
+3. After the corporate action takes effect and Robinhood confirms that both the underlying market price and the multiplier reflect the new values correctly, the oracle is unpaused (`unpauseOracle()`).
+4. The feed resumes publishing using the updated multiplier.
+
+For example, during a 10:1 stock split:
+
+| Stage         | Stock Price | `uiMultiplier` | Token Price   |
+| :------------ | :---------- | :------------- | :------------ |
+| Before split  | $200        | 1.0            | $200          |
+| During pause  | Frozen      | Pending: 10.0  | $200 (frozen) |
+| After unpause | $20         | 10.0           | $200          |
+
+The token price remains continuous at $200 throughout the event, even though the underlying equity market price dropped from $200 to $20.
+
+## Example scenarios
+
+**Normal operation**
+
+```
+- Stock price: $200 → $201
+- uiMultiplier: 1.000 (unchanged)
+- Token price: $201
+```
+
+**Dividend reinvestment** (small multiplier drift)
+
+```
+- Stock price: $200
+- uiMultiplier: 1.000 → 1.008
+- Token price: $201.60
+```
+
+**Stock split** (10:1, scheduled corporate action)
+
+```
+1. Robinhood pauses the oracle and stages newUIMultiplier = 10 with an effectiveAt timestamp
+2. The feed freezes at the current token price while oraclePaused() is true
+3. Market reopens with the underlying stock price at $20 (post-split)
+4. Robinhood confirms alignment and calls unpauseOracle()
+5. uiMultiplier becomes 10.0, token price = $20 × 10 = $200 (continuous)
+```
+
+**Split with timing mismatch** (stock price updates before the multiplier)
+
+```
+- Oracle paused with newUIMultiplier = 10 staged
+- Underlying stock price = $20, uiMultiplier still 1.0 (not yet effective)
+- Result: Feed remains frozen at the pre-pause price until Robinhood unpauses the oracle
+```
+
+This fail-safe behavior prevents incorrect token prices from being published when the underlying stock price and the multiplier are temporarily out of sync.
+
+## Off-hours and session behavior
+
+Robinhood tokenized equity feeds are configured as 24/5 tokenized equity feeds (regular, pre-market, post-market, and overnight sessions), where underlying liquidity and session data quality support it. Integrators should be aware of standard tokenized equity behavior:
+
+- **Off-hours / closed sessions**: When underlying equity markets are closed (weekends, holidays, thin overnight windows), the feed may hold the last published price even though the contract remains callable via `latestRoundData()`. These feeds do not have heartbeats during off-hours.
+- **Staleness checks**: Integrators should read `updatedAt` and implement staleness bounds appropriate to their use case.
+
+See [Tokenized Equity Feeds](/data-feeds/tokenized-equity-feeds) for the shared behavioral model across providers.
+
+## Smart Value Recapture (SVR)
+
+Primary mint and redeem for Robinhood tokenized equities can be permissioned, but once the tokens are onchain, anyone can hold them and anyone can liquidate positions that use the feed.
+
+Robinhood feeds have SVR enabled even when the primary market is not public to all participants. The liquidator set includes teams that can also access primary mint and redeem when they need to. Permissioned mint and redeem concerns the primary market; tokens can still circulate onchain and positions that use the feed can still be liquidated outside that path.
+
+For Oracle Extractable Value (OEV) and how SVR relates to standard feeds, use [SVR Feeds](/data-feeds/svr-feeds)—especially [Understanding MEV and OEV](/data-feeds/svr-feeds#understanding-mev-and-oev). To read answers from contracts, follow [Using Data Feeds](/data-feeds/using-data-feeds) and point at the proxy address for your feed.
 
 ---
 

--- a/src/content/data-feeds/tokenized-equity-feeds/providers.mdx
+++ b/src/content/data-feeds/tokenized-equity-feeds/providers.mdx
@@ -9,6 +9,7 @@ metadata:
 whatsnext:
   {
     "Learn about Ondo Finance feeds": "/data-feeds/tokenized-equity-feeds/ondo",
+    "Learn about Robinhood feeds": "/data-feeds/tokenized-equity-feeds/robinhood",
     "Find Price Feed Addresses": "/data-feeds/price-feeds/addresses",
     "Learn about developer responsibilities": "/data-feeds/developer-responsibilities",
   }
@@ -22,9 +23,10 @@ Tokenized equity feeds have issuer-specific implementations that affect pricing 
 
 ## Available providers
 
-| Provider     | Feed Type          | Price Calculation                                      | Corporate Action Handling            | Documentation                                           | Issuer Contact                        |
-| :----------- | :----------------- | :----------------------------------------------------- | :----------------------------------- | :------------------------------------------------------ | :------------------------------------ |
-| Ondo Finance | Total Return Value | Underlying Equity Market Price × Multiplier (`sValue`) | Pause-based with manual confirmation | [View details](/data-feeds/tokenized-equity-feeds/ondo) | [Contact page](https://ondo.finance/) |
+| Provider     | Feed Type          | Price Calculation                                      | Corporate Action Handling            | Documentation                                                | Issuer Contact                         |
+| :----------- | :----------------- | :----------------------------------------------------- | :----------------------------------- | :----------------------------------------------------------- | :------------------------------------- |
+| Ondo Finance | Total Return Value | Underlying Equity Market Price × Multiplier (`sValue`) | Pause-based with manual confirmation | [View details](/data-feeds/tokenized-equity-feeds/ondo)      | [Contact page](https://ondo.finance/)  |
+| Robinhood    | Multiplier-scaled  | Underlying Equity Market Price × `uiMultiplier`        | Oracle pause on token contract       | [View details](/data-feeds/tokenized-equity-feeds/robinhood) | [Contact page](https://robinhood.com/) |
 
 ## Provider-specific considerations
 

--- a/src/content/data-feeds/tokenized-equity-feeds/robinhood.mdx
+++ b/src/content/data-feeds/tokenized-equity-feeds/robinhood.mdx
@@ -1,0 +1,162 @@
+---
+section: dataFeeds
+date: "Last Modified"
+title: "Robinhood Tokenized Equities"
+metadata:
+  title: "Robinhood Tokenized Equity Feeds | Chainlink Data Feeds"
+  description: "Learn about Chainlink tokenized equity feeds for Robinhood tokenized stocks, including Total Return Value calculation, multiplier handling, and corporate action management."
+  keywords:
+    [
+      "Robinhood",
+      "Tokenized Equities",
+      "Total Return Value",
+      "uiMultiplier",
+      "Corporate Actions",
+      "Oracle Pause",
+      "SVR",
+      "Smart Value Recapture",
+    ]
+whatsnext:
+  {
+    "Smart Value Recapture (SVR) Feeds": "/data-feeds/svr-feeds",
+    "View Provider Catalog": "/data-feeds/tokenized-equity-feeds/providers",
+    "Learn about tokenized equity feeds": "/data-feeds/tokenized-equity-feeds",
+    "Find Price Feed Addresses": "/data-feeds/price-feeds/addresses",
+  }
+---
+
+import { Aside } from "@components"
+import TokenizedEquityFeeds from "@features/tokenized-equity-feeds/common/TokenizedEquityFeeds.astro"
+import { FeedList } from "@features/feeds"
+
+<TokenizedEquityFeeds section="tokenizedEquityNote" />
+
+Chainlink provides tokenized equity feeds for Robinhood tokenized stocks. Each Robinhood tokenized stock is represented by its own ERC-20 token contract, deployed on Robinhood Chain (one contract per ticker). The corresponding Chainlink feed reports the Total Return Value of the token by combining the underlying equity's market price with a multiplier read directly from the Robinhood token contract, rather than the raw equity price.
+
+These feeds use the standard Chainlink V3 aggregator interface (`latestRoundData()`), so any consumer reads the published price through the proxy in the same way as a crypto price feed. They are push-based oracles intended for compliance reference pricing, protocol integration, and similar use cases.
+
+## Available Robinhood tokenized equity feeds
+
+The following table shows the available Robinhood tokenized equity feeds.
+
+<FeedList client:idle initialNetwork="robinhood" dataFeedType="tokenizedEquity" tokenizedEquityProvider="robinhood" />
+
+## Total Return Value calculation
+
+Robinhood tokenized equity feeds calculate the token price using the following formula:
+
+```
+Token Price = Underlying Equity Market Price × Multiplier
+```
+
+Where:
+
+- **Underlying Equity Market Price**: Sourced from Chainlink's 24/5 equity price feeds, which aggregate data across regular, pre-market, post-market, and overnight trading sessions.
+- **Multiplier**: Read from the Robinhood token contract via the `uiMultiplier()` function. The multiplier accounts for dividend reinvestments and corporate action adjustments (see [Corporate action handling](#corporate-action-handling-and-oracle-pause) below).
+
+This approach ensures the token price reflects the total return of the underlying equity, including dividend reinvestments and corporate action adjustments, rather than just the current market price per share.
+
+## How the multiplier works
+
+The multiplier accounts for events that change the relationship between token quantity and underlying equity value:
+
+| Event Type                   | Multiplier Behavior             | Example                       |
+| :--------------------------- | :------------------------------ | :---------------------------- |
+| Dividend reinvestment        | Small increase                  | `uiMultiplier`: 1.000 → 1.008 |
+| Stock split (10:1 example)   | Large increase                  | `uiMultiplier`: 1.0 → 10.0    |
+| Reverse split (1:10 example) | Large decrease                  | `uiMultiplier`: 10.0 → 1.0    |
+| Spin-offs                    | Adjustment to reflect new value | Varies by event               |
+
+Robinhood updates the multiplier on the token contract through two paths:
+
+- **Immediate update**: `updateMultiplier(uint256)` sets a new `uiMultiplier` effective immediately.
+- **Scheduled update**: `updateMultiplier(uint256, uint256 effectiveAt)` stages the next multiplier. The staged value is exposed through `newUIMultiplier()` and the activation time through `effectiveAt()`. The new value becomes the active `uiMultiplier` once the `effectiveAt` timestamp is reached.
+
+The `UIMultiplierUpdated` event (`oldMultiplier`, `newMultiplier`, `effectiveAtTimestamp`) is emitted whenever the multiplier changes or a new value is staged.
+
+Robinhood's on-chain token contract enforces two update paths:
+
+- **Small updates** (no price discontinuity): Applied immediately via automated processes. These handle routine dividend reinvestments.
+- **Large updates** (price discontinuity): Requires a scheduled pause window and manual confirmation before unpause. These handle major corporate actions like stock splits.
+
+## Corporate action handling and oracle pause
+
+Corporate actions are coordinated by Robinhood as the asset issuer. Chainlink does not provide corporate-action calendar data or automated pause triggers; pause timing and multiplier updates are coordinated by Robinhood.
+
+The Robinhood token contract exposes a dedicated oracle pause flag, `oraclePaused()`, that the feed honors:
+
+**Normal mode** (`oraclePaused() == false`): The feed returns the current underlying equity market price multiplied by the current `uiMultiplier`.
+
+**Paused mode** (`oraclePaused() == true`): The feed stops publishing new prices and holds the last known good value. This prevents an inconsistent token price from being published while a corporate action is in progress and the underlying price and multiplier are temporarily out of sync.
+
+During a corporate action, the issuer-driven workflow keeps the token price continuous:
+
+1. Robinhood pauses the oracle (`pauseOracle()`), freezing the feed at the last known good value.
+1. The new multiplier is staged via `updateMultiplier(newMultiplier, effectiveAt)` (or applied at the scheduled time).
+1. After the corporate action takes effect and Robinhood confirms that both the underlying market price and the multiplier reflect the new values correctly, the oracle is unpaused (`unpauseOracle()`).
+1. The feed resumes publishing using the updated multiplier.
+
+For example, during a 10:1 stock split:
+
+| Stage         | Stock Price | `uiMultiplier` | Token Price   |
+| :------------ | :---------- | :------------- | :------------ |
+| Before split  | $200        | 1.0            | $200          |
+| During pause  | Frozen      | Pending: 10.0  | $200 (frozen) |
+| After unpause | $20         | 10.0           | $200          |
+
+The token price remains continuous at $200 throughout the event, even though the underlying equity market price dropped from $200 to $20.
+
+## Example scenarios
+
+**Normal operation**
+
+```
+- Stock price: $200 → $201
+- uiMultiplier: 1.000 (unchanged)
+- Token price: $201
+```
+
+**Dividend reinvestment** (small multiplier drift)
+
+```
+- Stock price: $200
+- uiMultiplier: 1.000 → 1.008
+- Token price: $201.60
+```
+
+**Stock split** (10:1, scheduled corporate action)
+
+```
+1. Robinhood pauses the oracle and stages newUIMultiplier = 10 with an effectiveAt timestamp
+2. The feed freezes at the current token price while oraclePaused() is true
+3. Market reopens with the underlying stock price at $20 (post-split)
+4. Robinhood confirms alignment and calls unpauseOracle()
+5. uiMultiplier becomes 10.0, token price = $20 × 10 = $200 (continuous)
+```
+
+**Split with timing mismatch** (stock price updates before the multiplier)
+
+```
+- Oracle paused with newUIMultiplier = 10 staged
+- Underlying stock price = $20, uiMultiplier still 1.0 (not yet effective)
+- Result: Feed remains frozen at the pre-pause price until Robinhood unpauses the oracle
+```
+
+This fail-safe behavior prevents incorrect token prices from being published when the underlying stock price and the multiplier are temporarily out of sync.
+
+## Off-hours and session behavior
+
+Robinhood tokenized equity feeds are configured as 24/5 tokenized equity feeds (regular, pre-market, post-market, and overnight sessions), where underlying liquidity and session data quality support it. Integrators should be aware of standard tokenized equity behavior:
+
+- **Off-hours / closed sessions**: When underlying equity markets are closed (weekends, holidays, thin overnight windows), the feed may hold the last published price even though the contract remains callable via `latestRoundData()`. These feeds do not have heartbeats during off-hours.
+- **Staleness checks**: Integrators should read `updatedAt` and implement staleness bounds appropriate to their use case.
+
+See [Tokenized Equity Feeds](/data-feeds/tokenized-equity-feeds) for the shared behavioral model across providers.
+
+## Smart Value Recapture (SVR)
+
+Primary mint and redeem for Robinhood tokenized equities can be permissioned, but once the tokens are onchain, anyone can hold them and anyone can liquidate positions that use the feed.
+
+Robinhood feeds have SVR enabled even when the primary market is not public to all participants. The liquidator set includes teams that can also access primary mint and redeem when they need to. Permissioned mint and redeem concerns the primary market; tokens can still circulate onchain and positions that use the feed can still be liquidated outside that path.
+
+For Oracle Extractable Value (OEV) and how SVR relates to standard feeds, use [SVR Feeds](/data-feeds/svr-feeds)—especially [Understanding MEV and OEV](/data-feeds/svr-feeds#understanding-mev-and-oev). To read answers from contracts, follow [Using Data Feeds](/data-feeds/using-data-feeds) and point at the proxy address for your feed.

--- a/src/content/data-streams/llms-full.txt
+++ b/src/content/data-streams/llms-full.txt
@@ -5190,7 +5190,9 @@ Pass your logger to the SDK and choose a verbosity level. For deep WS diagnostic
 import { createClient, LogLevel } from "@chainlink/data-streams-sdk"
 
 // Silent mode (default) - Zero overhead
-const client = createClient({/* ... config without logging */})
+const client = createClient({
+  /* ... config without logging */
+})
 
 // Basic console logging
 const client = createClient({

--- a/src/content/data-streams/reference/data-streams-api/ts-sdk.mdx
+++ b/src/content/data-streams/reference/data-streams-api/ts-sdk.mdx
@@ -362,7 +362,9 @@ Pass your logger to the SDK and choose a verbosity level. For deep WS diagnostic
 import { createClient, LogLevel } from "@chainlink/data-streams-sdk"
 
 // Silent mode (default) - Zero overhead
-const client = createClient({/* ... config without logging */})
+const client = createClient({
+  /* ... config without logging */
+})
 
 // Basic console logging
 const client = createClient({

--- a/src/features/data/api/index.ts
+++ b/src/features/data/api/index.ts
@@ -66,13 +66,15 @@ export const getFeedsMetadata = (url: string): Promise<ChainMetadata[]> => {
 export const getChainMetadata = async (chain: Chain): Promise<ChainMetadata | any> => {
   const requests = chain.networks.map((network) =>
     network?.rddUrl
-      ? getFeedsMetadata(network?.rddUrl).then((metadata) => ({
-          ...network,
-          metadata: metadata.filter(
-            (meta) => meta.docs?.hidden !== true && (meta.proxyAddress || meta.transmissionsAccount || meta.feedId)
-          ),
-        }))
-      : undefined
+      ? getFeedsMetadata(network?.rddUrl)
+          .then((metadata) => ({
+            ...network,
+            metadata: metadata.filter(
+              (meta) => meta.docs?.hidden !== true && (meta.proxyAddress || meta.transmissionsAccount || meta.feedId)
+            ),
+          }))
+          .catch(() => ({ ...network, metadata: [] }))
+      : { ...network, metadata: [] }
   )
   const networks = await Promise.all(requests)
 

--- a/src/features/data/chains.ts
+++ b/src/features/data/chains.ts
@@ -599,6 +599,25 @@ export const CHAINS: Chain[] = [
     ],
   },
   {
+    page: "robinhood",
+    label: "Robinhood Chain",
+    title: "Robinhood Chain Data Feeds",
+    img: "/assets/chains/robinhood-chain.svg",
+    networkStatusUrl: "https://docs.robinhood.com/chain/",
+    tags: ["default", "tokenizedEquity"],
+    supportedFeatures: ["feeds"],
+    networks: [
+      {
+        name: "Robinhood Chain Mainnet",
+        explorerUrl: "https://explorer.chain.robinhood.com/address/%s",
+        networkType: "mainnet",
+        rddUrl: "https://reference-data-directory.vercel.app/feeds-robinhood-mainnet.json",
+        queryString: "robinhood-mainnet",
+        tags: ["tokenizedEquity"],
+      },
+    ],
+  },
+  {
     page: "ronin",
     label: "Ronin",
     title: "Ronin Data Feeds",

--- a/src/features/feeds/data/StreamsNetworksData.ts
+++ b/src/features/feeds/data/StreamsNetworksData.ts
@@ -572,6 +572,11 @@ export const StreamsNetworksData: NetworkData[] = [
   {
     network: "Robinhood Chain",
     logoUrl: "/assets/chains/robinhood-chain.svg",
+    mainnet: {
+      label: "Robinhood Chain Mainnet",
+      verifierProxy: "0xcE73c8ad08CBDEaCa6078BF0627C8fe0a9a536E7",
+      explorerUrl: "https://explorer.chain.robinhood.com/address/%s",
+    },
     testnet: {
       label: "Robinhood Chain Testnet",
       verifierProxy: "0x72790f9eB82db492a7DDb6d2af22A270Dcc3Db64",

--- a/src/features/feeds/utils/feedVisibility.ts
+++ b/src/features/feeds/utils/feedVisibility.ts
@@ -133,8 +133,9 @@ export function isFeedVisible(
   } else if (isRates) {
     isVisible = feed.docs?.productType === "Rates" || feed.docs?.productSubType === "Realized Volatility"
   } else if (isTokenizedEquity) {
+    const assetClass = feed.docs?.assetClass
     isVisible =
-      feed.docs?.assetClass === "Equity" &&
+      (assetClass === "Equity" || assetClass === "Equities") &&
       feed.contractType !== "verifier" &&
       feed.docs?.productTypeCode === "primaryTokenizedPrice"
   } else {
@@ -183,6 +184,20 @@ export function isFeedVisible(
       const assetName = (feed.assetName || "").toLowerCase()
       const isOndoFeed = assetName.includes("ondo") && feed.docs?.productTypeCode === "primaryTokenizedPrice"
       if (!isOndoFeed) return false
+    }
+
+    if (provider === "robinhood") {
+      if (feed.docs?.productTypeCode !== "primaryTokenizedPrice") return false
+
+      const assetName = (feed.assetName || "").toLowerCase()
+      const baseAsset = (feed.docs?.baseAsset || "").toUpperCase()
+      const isRobinhoodFeed =
+        feed.docs?.blockchainName === "Robinhood" ||
+        baseAsset.startsWith("RH") ||
+        assetName.includes("robinhood") ||
+        (feed.name || "").toLowerCase().startsWith("robinhood ")
+
+      if (!isRobinhoodFeed) return false
     }
   }
 

--- a/src/pages/[...path].md.ts
+++ b/src/pages/[...path].md.ts
@@ -80,7 +80,9 @@ async function resolveSpecialCanonicalMarkdownPath(cleanPath: string): Promise<S
 }
 
 type CreResolution =
-  { kind: "none" } | { kind: "resolved"; path: string } | { kind: "selector"; goPath: string; tsPath: string }
+  | { kind: "none" }
+  | { kind: "resolved"; path: string }
+  | { kind: "selector"; goPath: string; tsPath: string }
 
 async function resolveCreCanonicalMarkdownPath(cleanPath: string): Promise<CreResolution> {
   if (!cleanPath.startsWith("cre/")) {

--- a/src/scripts/chains-metadata.ts
+++ b/src/scripts/chains-metadata.ts
@@ -87,7 +87,8 @@ function normalizeChainName(name: string): string {
 }
 
 type ChainMatchResult =
-  { matched: true; reason: "name" | "nativeCurrency" } | { matched: false; existingName: string | undefined }
+  | { matched: true; reason: "name" | "nativeCurrency" }
+  | { matched: false; existingName: string | undefined }
 
 /**
  * When chainid.network flags a chain as reusedChainId, determines whether the incoming

--- a/src/scripts/data/detect-new-data.ts
+++ b/src/scripts/data/detect-new-data.ts
@@ -51,6 +51,7 @@ const NETWORK_ENDPOINTS: Record<string, string> = {
   plasma: "https://reference-data-directory.vercel.app/feeds-plasma-mainnet.json",
   hyperevm: "https://reference-data-directory.vercel.app/feeds-hyperliquid-mainnet.json",
   megaeth: "https://reference-data-directory.vercel.app/feeds-megaeth-mainnet.json",
+  robinhood: "https://reference-data-directory.vercel.app/feeds-robinhood-mainnet.json",
 }
 
 const STREAM_DEPRECATION_ENDPOINTS: Array<{ network: string; networkType: "mainnet" | "testnet"; url: string }> = [


### PR DESCRIPTION
This pull request adds support and documentation for Robinhood as a new provider of Chainlink tokenized equity feeds. It introduces Robinhood-specific details to the data feeds documentation, updates the changelog to reflect the expansion of Chainlink services to Robinhood Chain Mainnet, and ensures Robinhood is included in all relevant navigation and reference materials.

**Robinhood Tokenized Equity Feeds Integration:**

* Added Robinhood as a provider in the tokenized equity feeds documentation, including a detailed section describing how Robinhood tokenized equity feeds work, how prices are calculated using the `uiMultiplier`, corporate action handling, and fail-safe behaviors. [[1]](diffhunk://#diff-f3c5f7403a3f7af339d5c2831e47af654f1db0d11036b121065cb7129ebfe92eL7095-R7239) [[2]](diffhunk://#diff-758b7ec3075b215bfde57354fbe714c670aea4d060b9381cc7565995facaeda0L26-R29)
* Updated provider tables and navigation to include Robinhood, ensuring users can find Robinhood-specific documentation and contact information in both the main provider catalog and the sidebar. [[1]](diffhunk://#diff-758b7ec3075b215bfde57354fbe714c670aea4d060b9381cc7565995facaeda0L26-R29) [[2]](diffhunk://#diff-758b7ec3075b215bfde57354fbe714c670aea4d060b9381cc7565995facaeda0R12) [[3]](diffhunk://#diff-d6089daa2dd1e8916f282347f13c40b762a0617e7524ae687640f7a1d685a8b2L810-R813)

**Changelog Updates:**

* Added changelog entries announcing the availability of Chainlink Data Streams and Data Feeds on Robinhood Chain Mainnet, with links to relevant documentation pages.

**Documentation Consistency and Examples:**

* Updated TypeScript code examples in multiple files to use a more consistent, readable formatting style for function calls and argument lists. [[1]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L17799-R17804) [[2]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L20726-R20730) [[3]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L21252-R21252) [[4]](diffhunk://#diff-f8c6fd9773e15b6d7056c9f891b2900c430b16de35aecae2505d83f6d22c1357L97-R102) [[5]](diffhunk://#diff-1b05482d15a5401cb53e083bb0dda0a0a5115952ed96dc5505039beba8e69ff9L79-R79) [[6]](diffhunk://#diff-1b05482d15a5401cb53e083bb0dda0a0a5115952ed96dc5505039beba8e69ff9L605-R601)

These changes ensure that Robinhood tokenized equities are fully documented and discoverable as part of Chainlink's data feed offerings, and that users have access to clear, consistent integration examples and references.