### PR TITLE
Data Feeds: Robinhood link fix

### DIFF
--- a/src/features/data/chains.ts
+++ b/src/features/data/chains.ts
@@ -609,7 +609,7 @@ export const CHAINS: Chain[] = [
     networks: [
       {
         name: "Robinhood Chain Mainnet",
-        explorerUrl: "https://explorer.chain.robinhood.com/address/%s",
+        explorerUrl: "https://robinhoodchain.blockscout.com/address/%s",
         networkType: "mainnet",
         rddUrl: "https://reference-data-directory.vercel.app/feeds-robinhood-mainnet.json",
         queryString: "robinhood-mainnet",


### PR DESCRIPTION
This pull request makes a minor update to the Robinhood Chain Mainnet configuration. The block explorer URL in the `CHAINS` array has been updated to point to the correct Blockscout instance.

- Updated the `explorerUrl` for Robinhood Chain Mainnet to use `https://robinhoodchain.blockscout.com/address/%s` in `chains.ts`