### PR TITLE
Support Context7 ownership verification for docs LLM text files

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -60,8 +60,8 @@ export default defineConfig({
       customPages: [
         "https://docs.chain.link/llms.txt",
         "https://docs.chain.link/ace/llms-full.txt",
-        "https://docs.chain.link/cre/llms-full-go.txt",
-        "https://docs.chain.link/cre/llms-full-ts.txt",
+        "https://docs.chain.link/cre/go/llms-full.txt",
+        "https://docs.chain.link/cre/ts/llms-full.txt",
         "https://docs.chain.link/vrf/llms-full.txt",
         "https://docs.chain.link/ccip/llms-full.txt",
         "https://docs.chain.link/data-feeds/llms-full.txt",

--- a/public/ccip/context7.json
+++ b/public/ccip/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/llmstxt/chain_link_ccip_llms-full_txt",
+  "public_key": "pk_nsBvFzEpWNJq5XpYfKBFc"
+}

--- a/public/context7.json
+++ b/public/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/llmstxt/chain_link_llms_txt",
+  "public_key": "pk_nsBvFzEpWNJq5XpYfKBFc"
+}

--- a/public/cre/llms.txt
+++ b/public/cre/llms.txt
@@ -4,7 +4,7 @@
 
 Prefer specific `.md` pages. Match Go or TypeScript examples to the user's language or existing codebase.
 
-Use `llms-full-go.txt` or `llms-full-ts.txt` only when broad CRE context is required.
+Use `go/llms-full.txt` or `ts/llms-full.txt` only when broad CRE context is required.
 
 ## Overview
 
@@ -72,5 +72,5 @@ Use `llms-full-go.txt` or `llms-full-ts.txt` only when broad CRE context is requ
 
 ## Full Context
 
-- [CRE Full (Go)](https://docs.chain.link/cre/llms-full-go.txt)
-- [CRE Full (TypeScript)](https://docs.chain.link/cre/llms-full-ts.txt)
+- [CRE Full (Go)](https://docs.chain.link/cre/go/llms-full.txt)
+- [CRE Full (TypeScript)](https://docs.chain.link/cre/ts/llms-full.txt)

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -215,7 +215,7 @@ If `.md` is unavailable or incomplete, use the HTML page as the source of truth.
 
 Use `llms-full.txt` only when broad product-level context is required or when the relevant page cannot be identified from the curated index.
 
-- [CRE Full](https://docs.chain.link/cre/llms-full-ts.txt)
+- [CRE Full](https://docs.chain.link/cre/ts/llms-full.txt)
 - [CRE Connect Full](https://docs.chain.link/crec/llms-full.txt)
 - [CCIP Full](https://docs.chain.link/ccip/llms-full.txt)
 - [Data Feeds Full](https://docs.chain.link/data-feeds/llms-full.txt)

--- a/src/components/RightSidebar/LlmsLink.tsx
+++ b/src/components/RightSidebar/LlmsLink.tsx
@@ -39,7 +39,7 @@ export function LlmsLink({ section, supportedLanguages, currentPageLanguage }: L
     // Language-specific section (like CRE)
     const langToUse =
       effectiveLanguage && supportedLanguages.includes(effectiveLanguage) ? effectiveLanguage : supportedLanguages[0]
-    llmsHref = `/${section}/llms-full-${langToUse}.txt`
+    llmsHref = `/${section}/${langToUse}/llms-full.txt`
 
     // For CRE: just show language, no product name
     if (section === "cre") {

--- a/src/content/cre/getting-started/build-with-ai-go.mdx
+++ b/src/content/cre/getting-started/build-with-ai-go.mdx
@@ -89,7 +89,7 @@ When diagnosing errors, the skill identifies the capability involved, fetches th
 
 If you prefer to work directly in an AI assistant, you can load the full CRE Go documentation into the context window and prompt from there. This is useful for broad exploration, but loads the entire SDK reference upfront — the skill approach above keeps your context window focused on your current task.
 
-**Context file**: <CopyText text="https://docs.chain.link/cre/llms-full-go.txt" code />
+**Context file**: <CopyText text="https://docs.chain.link/cre/go/llms-full.txt" code />
 
 Alternatively, you can click the "Copy Page" button in the top right corner of any Chainlink docs page to load the full page content into the context window of your preferred AI assistant. Loading a single page — for example, just the triggers reference or the EVM client page — rather than the entire SDK consumes fewer tokens (lower cost per request for pay-per-token APIs), keeps you within the limits of smaller context windows, and gives the model more relevant signal to attend to, which tends to produce more accurate output.
 
@@ -99,7 +99,7 @@ Copy the starter prompt below, replace the placeholder at the end with your use 
 I'm building a Chainlink CRE workflow using the Go SDK.
 
 Here is the full CRE Go documentation:
-https://docs.chain.link/cre/llms-full-go.txt
+https://docs.chain.link/cre/go/llms-full.txt
 
 Please fetch and read that file. After you've read it, please:
 - Help me build a CRE workflow based on what I describe

--- a/src/content/cre/getting-started/build-with-ai-ts.mdx
+++ b/src/content/cre/getting-started/build-with-ai-ts.mdx
@@ -89,7 +89,7 @@ When diagnosing errors, the skill identifies the capability involved, fetches th
 
 If you prefer to work directly in an AI assistant, you can load the full CRE TypeScript documentation into the context window and prompt from there. This is useful for broad exploration, but loads the entire SDK reference upfront — the skill approach above keeps your context window focused on your current task.
 
-**Context file**: <CopyText text="https://docs.chain.link/cre/llms-full-ts.txt" code />
+**Context file**: <CopyText text="https://docs.chain.link/cre/ts/llms-full.txt" code />
 
 Alternatively, you can click the "Copy Page" button in the top right corner of any Chainlink docs page to load the full page content into the context window of your preferred AI assistant. Loading a single page — for example, just the triggers reference or the EVM client page — rather than the entire SDK consumes fewer tokens (lower cost per request for pay-per-token APIs), keeps you within the limits of smaller context windows, and gives the model more relevant signal to attend to, which tends to produce more accurate output.
 
@@ -99,7 +99,7 @@ Copy the starter prompt below, replace the placeholder at the end with your use 
 I'm building a Chainlink CRE workflow using the TypeScript SDK.
 
 Here is the full CRE TypeScript documentation:
-https://docs.chain.link/cre/llms-full-ts.txt
+https://docs.chain.link/cre/ts/llms-full.txt
 
 Please fetch and read that file. After you've read it, please:
 - Help me build a CRE workflow based on what I describe

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -10660,7 +10660,7 @@ When diagnosing errors, the skill identifies the capability involved, fetches th
 
 If you prefer to work directly in an AI assistant, you can load the full CRE Go documentation into the context window and prompt from there. This is useful for broad exploration, but loads the entire SDK reference upfront — the skill approach above keeps your context window focused on your current task.
 
-**Context file**: https\://docs.chain.link/cre/llms-full-go.txt
+**Context file**: https\://docs.chain.link/cre/go/llms-full.txt
 
 Alternatively, you can click the "Copy Page" button in the top right corner of any Chainlink docs page to load the full page content into the context window of your preferred AI assistant. Loading a single page — for example, just the triggers reference or the EVM client page — rather than the entire SDK consumes fewer tokens (lower cost per request for pay-per-token APIs), keeps you within the limits of smaller context windows, and gives the model more relevant signal to attend to, which tends to produce more accurate output.
 
@@ -10670,7 +10670,7 @@ Copy the starter prompt below, replace the placeholder at the end with your use 
 I'm building a Chainlink CRE workflow using the Go SDK.
 
 Here is the full CRE Go documentation:
-https://docs.chain.link/cre/llms-full-go.txt
+https://docs.chain.link/cre/go/llms-full.txt
 
 Please fetch and read that file. After you've read it, please:
 - Help me build a CRE workflow based on what I describe

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -10542,7 +10542,7 @@ When diagnosing errors, the skill identifies the capability involved, fetches th
 
 If you prefer to work directly in an AI assistant, you can load the full CRE TypeScript documentation into the context window and prompt from there. This is useful for broad exploration, but loads the entire SDK reference upfront — the skill approach above keeps your context window focused on your current task.
 
-**Context file**: https\://docs.chain.link/cre/llms-full-ts.txt
+**Context file**: https\://docs.chain.link/cre/ts/llms-full.txt
 
 Alternatively, you can click the "Copy Page" button in the top right corner of any Chainlink docs page to load the full page content into the context window of your preferred AI assistant. Loading a single page — for example, just the triggers reference or the EVM client page — rather than the entire SDK consumes fewer tokens (lower cost per request for pay-per-token APIs), keeps you within the limits of smaller context windows, and gives the model more relevant signal to attend to, which tends to produce more accurate output.
 
@@ -10552,7 +10552,7 @@ Copy the starter prompt below, replace the placeholder at the end with your use 
 I'm building a Chainlink CRE workflow using the TypeScript SDK.
 
 Here is the full CRE TypeScript documentation:
-https://docs.chain.link/cre/llms-full-ts.txt
+https://docs.chain.link/cre/ts/llms-full.txt
 
 Please fetch and read that file. After you've read it, please:
 - Help me build a CRE workflow based on what I describe

--- a/src/content/cre/llms.txt
+++ b/src/content/cre/llms.txt
@@ -4,7 +4,7 @@
 
 Prefer specific `.md` pages. Match Go or TypeScript examples to the user's language or existing codebase.
 
-Use `llms-full-go.txt` or `llms-full-ts.txt` only when broad CRE context is required.
+Use `go/llms-full.txt` or `ts/llms-full.txt` only when broad CRE context is required.
 
 ## Overview
 
@@ -72,5 +72,5 @@ Use `llms-full-go.txt` or `llms-full-ts.txt` only when broad CRE context is requ
 
 ## Full Context
 
-- [CRE Full (Go)](https://docs.chain.link/cre/llms-full-go.txt)
-- [CRE Full (TypeScript)](https://docs.chain.link/cre/llms-full-ts.txt)
+- [CRE Full (Go)](https://docs.chain.link/cre/go/llms-full.txt)
+- [CRE Full (TypeScript)](https://docs.chain.link/cre/ts/llms-full.txt)

--- a/src/pages/[section]/[lang]/llms-full.txt.ts
+++ b/src/pages/[section]/[lang]/llms-full.txt.ts
@@ -1,0 +1,51 @@
+import fs from "fs/promises"
+import path from "path"
+import type { APIRoute } from "astro"
+import { SUPPORTED_LLM_SECTIONS, LLM_SECTIONS_CONFIG } from "../../../config/llms.js"
+
+export const GET: APIRoute = async ({ params }) => {
+  const { section, lang } = params
+
+  if (!section || !(SUPPORTED_LLM_SECTIONS as readonly string[]).includes(section)) {
+    return new Response("Section not found or not supported.", { status: 404 })
+  }
+
+  const cfg = LLM_SECTIONS_CONFIG[section as keyof typeof LLM_SECTIONS_CONFIG]
+  const supportedLanguages = cfg?.languages || []
+
+  if (!lang || !supportedLanguages.includes(lang)) {
+    return new Response("Language not supported for this section.", { status: 404 })
+  }
+
+  const filePath = path.resolve(`src/content/${section}/llms-full-${lang}.txt`)
+
+  try {
+    const fileContents = await fs.readFile(filePath, "utf-8")
+    return new Response(fileContents, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800",
+      },
+    })
+  } catch (error) {
+    return new Response("File not found.", { status: 404 })
+  }
+}
+
+export function getStaticPaths() {
+  const paths: Array<{ params: { section: string; lang: string } }> = []
+
+  for (const section of SUPPORTED_LLM_SECTIONS) {
+    const cfg = LLM_SECTIONS_CONFIG[section as keyof typeof LLM_SECTIONS_CONFIG]
+    const languages = cfg?.languages || []
+
+    for (const lang of languages) {
+      paths.push({
+        params: { section, lang },
+      })
+    }
+  }
+
+  return paths
+}


### PR DESCRIPTION

## Closing issues

closes #3927

## Description

<!-- Please provide enough information so that others can review your pull request: -->

This PR adds Context7 ownership metadata for Chainlink docs LLM text files and updates CRE language-specific full-context URLs to use Context7-compatible paths.

Context7 ownership metadata is now exposed for the top-level docs LLM file and the CCIP full-context LLM file. CRE full-context bundles are also now served through language-scoped URLs:

- `https://docs.chain.link/cre/go/llms-full.txt`
- `https://docs.chain.link/cre/ts/llms-full.txt`

The underlying generated CRE source files remain `src/content/cre/llms-full-go.txt` and `src/content/cre/llms-full-ts.txt`; the new route maps the cleaner public URLs to those existing files.

## Changes

<!--Explain the **details** for making this change. What existing problem does the pull request solve? -->

- Added `public/context7.json` for the top-level docs LLM index.
- Added `public/ccip/context7.json` for the CCIP LLM full-context bundle.
- Added a new Astro route for language-scoped LLM bundles at `/:section/:lang/llms-full.txt`.
- Updated CRE Go and TypeScript full-context links from dashed filenames to language-scoped paths.
- Updated the right sidebar LLM link generator to use `/{section}/{lang}/llms-full.txt`.
- Updated CRE `llms.txt`, root `llms.txt`, CRE build-with-AI pages, generated CRE full-context files, and sitemap custom pages to reference the new CRE URLs.

## Validation

- `npm run typecheck` passed.
- LLM validation passed via `node --import tsx src/scripts/validate-llms.ts`.
- Direct route checks returned `200 text/plain` for:
  - `/cre/ts/llms-full.txt`
  - `/cre/go/llms-full.txt`
- Full Astro build progressed past these route changes but later failed on a restricted network fetch to `docs.chain.link/files/json/feeds-aptos-testnet.json`, unrelated to this PR.