### PR TITLE
Data Feeds: remove monad testnet from data feed tables

### DIFF
--- a/src/features/data/chains.ts
+++ b/src/features/data/chains.ts
@@ -489,14 +489,6 @@ export const CHAINS: Chain[] = [
         queryString: "monad-mainnet",
         tags: ["smartData"],
       },
-      {
-        name: "Monad Testnet",
-        explorerUrl: "https://testnet.monadvision.com/address/%s",
-        networkType: "testnet",
-        rddUrl: "https://reference-data-directory.vercel.app/feeds-monad-testnet.json",
-        queryString: "monad-testnet",
-        tags: ["smartData"],
-      },
     ],
   },
   {


### PR DESCRIPTION
This pull request removes the "Monad Testnet" chain configuration from the `CHAINS` array in `src/features/data/chains.ts`. This is a straightforward change to eliminate support or references to the Monad Testnet network.

* Removed the `Monad Testnet` entry from the `CHAINS` array, including its explorer URL, network type, RDD URL, query string, and tags.