### PR TITLE
Data Streams: favor schema prop over inference

### DIFF
--- a/src/features/feeds/components/Tables.tsx
+++ b/src/features/feeds/components/Tables.tsx
@@ -70,21 +70,29 @@ const getMaxSubmissionValueBound = (
 
 const getSchemaDefinitionKey = (metadata: any): string | undefined => {
   const feedType = metadata.feedType || metadata.docs?.feedType
-
-  if (metadata.feedType === "Crypto-DEX") return "v3-dex"
-  if (metadata.feedType === "Crypto" && metadata.docs?.productTypeCode !== "ExRate") return "v3-crypto"
-
   const schemaVersion = getSchemaVersion(metadata)
+
+  // Explicit docs.schema (or clicProductName suffix) takes precedence over feedType heuristics.
+  if (schemaVersion === "v9") return "v9"
+  if (schemaVersion === "v12") return "v12"
+  if (schemaVersion === "v8") return "v8"
+  if (schemaVersion === "v10") return "v10"
+  if (schemaVersion === "v11") {
+    return isApacEquitiesStreamFeed(metadata) ? "v11-apac" : "v11"
+  }
+  if (schemaVersion === "v7") return "v7"
+  if (schemaVersion === "v3") {
+    return feedType === "Crypto-DEX" ? "v3-dex" : "v3-crypto"
+  }
+
+  if (feedType === "Crypto-DEX") return "v3-dex"
+  if (feedType === "Crypto" && metadata.docs?.productTypeCode !== "ExRate") return "v3-crypto"
+
   if (feedType === "Equities" || feedType === "Forex" || feedType === "Datalink") {
-    if (schemaVersion === "v11") {
-      return isApacEquitiesStreamFeed(metadata) ? "v11-apac" : "v11"
-    }
-    if (schemaVersion === "v8") return "v8"
     return undefined
   }
 
   if (metadata.docs?.productTypeCode === "ExRate") return "v7"
-  if (schemaVersion === "v9") return "v9"
   if (feedType === "Tokenized Equities") return "v10"
 
   return undefined


### PR DESCRIPTION
This pull request refactors the logic for determining the schema definition key in the `getSchemaDefinitionKey` function within `Tables.tsx`. The main change is to prioritize explicit schema version checks over feed type heuristics, making the function more predictable and maintainable.

Schema version precedence and feed type logic:

* Updated `getSchemaDefinitionKey` to check for explicit `schemaVersion` values (`v9`, `v12`, `v8`, `v10`, `v11`, `v7`, `v3`) before falling back to feed type heuristics, ensuring that explicit schema information takes precedence.
* Adjusted the handling of `v3` schema to distinguish between `"Crypto-DEX"` and other crypto feed types, returning `"v3-dex"` or `"v3-crypto"` accordingly.
* Retained previous feed type checks for `"Crypto-DEX"`, `"Crypto"`, `"Equities"`, `"Forex"`, and `"Datalink"` as fallbacks if schema version is not explicitly set.