### PR TITLE
CRE: CLI 1.24.0

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -404,6 +404,13 @@
   "data": [
     {
       "category": "release",
+      "date": "2026-07-09",
+      "description": "CRE CLI version 1.24.0 is now available. New [`cre execution`](https://docs.chain.link/cre/reference/cli/execution) commands (`list`, `status`, `events`, `logs`) let you inspect workflow runs from the terminal. [`cre workflow get`](https://docs.chain.link/cre/reference/cli/workflow#cre-workflow-get) now shows deployment health and the most recent execution. Solana Write is supported: workflows can submit DON-signed reports to Solana programs on Mainnet and Devnet via the Keystone Forwarder, with CLI tooling for `CRE_SOLANA_PRIVATE_KEY`, `cre generate-bindings solana`, and local write simulation.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.23.0...v1.24.0)",
+      "title": "CRE CLI v1.24.0 — Execution Observability and Solana Write",
+      "topic": "CRE"
+    },
+    {
+      "category": "release",
       "date": "2026-07-02",
       "description": "CRE CLI version 1.23.0 is now available. The local simulator now enforces rate limits during workflow execution, aligning simulation behavior more closely with production. When a rate limit is reached the workflow is not terminated — execution continues within the allowed limits.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.22.0...v1.23.0)",
       "title": "CRE CLI v1.23.0 — Simulator Rate Limits",

--- a/src/config/sidebar.ts
+++ b/src/config/sidebar.ts
@@ -640,6 +640,7 @@ export const SIDEBAR: Partial<Record<Sections, SectionEntry[]>> = {
             },
             { title: "Account Management", url: "cre/reference/cli/account" },
             { title: "Workflow Commands", url: "cre/reference/cli/workflow" },
+            { title: "Execution Commands", url: "cre/reference/cli/execution" },
             { title: "Registry Commands", url: "cre/reference/cli/registry" },
             { title: "Secrets Management", url: "cre/reference/cli/secrets" },
             { title: "Template Sources", url: "cre/reference/cli/templates" },

--- a/src/config/versions/index.ts
+++ b/src/config/versions/index.ts
@@ -77,8 +77,9 @@ export const VERSIONS = {
   },
   // CRE CLI Versions — update LATEST here for each new release
   "cre-cli": {
-    LATEST: "v1.23.0",
+    LATEST: "v1.24.0",
     ALL: [
+      "v1.24.0",
       "v1.23.0",
       "v1.22.0",
       "v1.21.0",
@@ -97,6 +98,7 @@ export const VERSIONS = {
       "v1.8.0",
     ] as const,
     RELEASE_DATES: {
+      "v1.24.0": "2026-07-09T00:00:00Z",
       "v1.23.0": "2026-07-02T00:00:00Z",
       "v1.22.0": "2026-06-25T00:00:00Z",
       "v1.21.0": "2026-06-18T00:00:00Z",

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -514,9 +514,24 @@ To help us assist you faster, please include:
 
 # Release Notes
 Source: https://docs.chain.link/cre/release-notes
-Last Updated: 2026-07-02
+Last Updated: 2026-07-09
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.24.0 - July 9, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.24.0" target="_blank">CRE CLI version 1.24.0</a> is now available.**
+
+- **Execution observability from the CLI**: New [`cre execution`](/cre/reference/cli/execution) commands let you inspect deployed workflow runs without opening the UI — `list` for recent executions (filter by status and time range), `status` for a single run, `events` for the capability timeline, and `logs` for emitted log lines. All support `--output json` for scripting.
+- **Enhanced `cre workflow get`**: [`cre workflow get`](/cre/reference/cli/workflow#cre-workflow-get) now resolves the workflow from your `workflow.yaml` settings and shows deployment health plus the most recent execution, not just registry metadata.
+- **Solana Write capability**: Workflows can now submit DON-consensus signed reports to Solana programs on Mainnet and Devnet via the Keystone Forwarder — the same secure write model as EVM. The CLI adds the tooling to build and test these workflows: `CRE_SOLANA_PRIVATE_KEY` for signing, `cre generate-bindings solana` for Go and TypeScript bindings from Anchor IDLs, and local write simulation with `cre workflow simulate` (dry run or `--broadcast`).
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.23.0...v1.24.0)
 
 ## CLI v1.23.0 - July 2, 2026
 
@@ -8443,7 +8458,7 @@ See the [repository README](https://github.com/smartcontractkit/cre-gcp-predicti
 
 # CLI Reference
 Source: https://docs.chain.link/cre/reference/cli
-Last Updated: 2026-05-14
+Last Updated: 2026-07-09
 
 export const CRE_CLI_VERSION = VERSIONS["cre-cli"].LATEST
 
@@ -8469,6 +8484,7 @@ These flags can be used with any `cre` command.
 | `-v, --verbose`          | Enables verbose logging to print `DEBUG` level logs                                                                                                                                                                     |
 | `--non-interactive`      | Fails instead of prompting; provide all required inputs with flags or environment variables. Use this for CI/CD, scripts, and other headless environments                                                               |
 | `--allow-unknown-chains` | Skips chain-name validation against the chain-selectors registry for `cre workflow simulate` and `cre workflow deploy`. Use for experimental or unlisted chains. Chain-selector and RPC availability are still enforced |
+| `--allow-insecure-rpc`   | Allows non-localhost HTTP RPC URLs. By default, the CLI blocks cleartext RPC endpoints to reduce accidental secret exposure over insecure connections                                                                   |
 
 
 <Aside type="note" title="Non-interactive authentication">
@@ -8494,7 +8510,7 @@ Manage your authentication and account credentials.
 Initialize projects and generate contract bindings (Go only).
 
 - [**`cre init`**](/cre/reference/cli/project-setup) — Initialize a new CRE project (interactive wizard or **`--non-interactive`** with flags for CI/CD)
-- **`cre generate-bindings`** (Go only) — Generate Go bindings from contract ABI files for type-safe contract interactions
+- **`cre generate-bindings`** — Generate contract bindings from ABI or Anchor IDL files (Go and TypeScript for Solana)
 
 [View project setup commands →](/cre/reference/cli/project-setup)
 
@@ -8525,11 +8541,24 @@ Manage workflows throughout their entire lifecycle.
 - **`cre workflow pause`** — Pause a workflow on the Workflow Registry contract
 - **`cre workflow delete`** — Delete all versions of a workflow from the Workflow Registry
 - **`cre workflow list`** — List workflows deployed for your organization; use `--output json` for scripts
-- **`cre workflow get`** — Show metadata for the workflow configured in `workflow.yaml`
+- **`cre workflow get`** — Show deployment health and the most recent execution for the workflow configured in `workflow.yaml`
 - **`cre workflow supported-chains`** — List chain names the CLI supports for local simulation; use `--output json` for scripts
 - **`cre workflow custom-build`** — Convert a workflow to use a custom self-compiled WASM build
 
 [View workflow commands →](/cre/reference/cli/workflow)
+
+***
+
+### Execution Commands
+
+Inspect deployed workflow runs from the terminal.
+
+- **`cre execution list`** — List recent executions; filter by workflow, status, and time range
+- **`cre execution status`** — Show detailed status for a single execution
+- **`cre execution events`** — Show the capability event timeline for an execution
+- **`cre execution logs`** — Show log lines emitted during an execution
+
+[View execution commands →](/cre/reference/cli/execution)
 
 ***
 
@@ -8953,7 +8982,7 @@ When you run this command, the CLI will:
 
 # Workflow Commands
 Source: https://docs.chain.link/cre/reference/cli/workflow
-Last Updated: 2026-06-11
+Last Updated: 2026-07-09
 
 The `cre workflow` commands manage workflows throughout their entire lifecycle, from local testing to deployment and ongoing management.
 
@@ -9425,7 +9454,7 @@ cre workflow list [flags]
   in with the CLI](/cre/account/cli-login) for further details.
 </Aside>
 
-Shows metadata for the workflow configured in `workflow.yaml`. The command reads the workflow name for the selected `--target`, searches the CRE platform for matching workflow metadata, and filters results to the workflow's configured `deployment-registry` by default.
+Shows deployment health and the most recent execution for the workflow configured in `workflow.yaml`. The command reads the workflow name for the selected `--target`, resolves the workflow on the CRE platform (scoped to the configured `deployment-registry` by default), and prints deployment health plus the latest execution.
 
 **Usage:**
 
@@ -9439,25 +9468,33 @@ cre workflow get <workflow-folder-path> [flags]
 
 **Flags:**
 
-| Flag               | Description                                                              |
-| ------------------ | ------------------------------------------------------------------------ |
-| `--all-registries` | Do not filter results by the workflow's configured `deployment-registry` |
+| Flag                | Description                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------ |
+| `--all-registries`  | Resolve the workflow across every registry instead of the configured `deployment-registry` |
+| `--output <string>` | Output format. Use `json` to print JSON to stdout for scripting                            |
+| `--json`            | Shorthand for `--output=json`                                                              |
 
 **Examples:**
 
-- Show metadata for the workflow configured for a target
+- Show deployment health and recent execution for the workflow configured for a target
 
   ```bash
   cre workflow get ./my-workflow --target staging-settings
   ```
 
-- Search across all registries in your organization
+- Resolve across all registries in your organization
 
   ```bash
   cre workflow get ./my-workflow --target staging-settings --all-registries
   ```
 
-The command prints the same human-readable workflow metadata fields as [`cre workflow list`](#cre-workflow-list): workflow name, workflow ID, owner address, status, registry, and registry address when available.
+- Export as JSON
+
+  ```bash
+  cre workflow get ./my-workflow --target staging-settings --output json
+  ```
+
+For a full execution history, use [`cre execution list`](/cre/reference/cli/execution#cre-execution-list).
 
 ***
 
@@ -9622,6 +9659,161 @@ The typical workflow lifecycle uses these commands in sequence:
 - [Activating & Pausing Workflows](/cre/guides/operations/activating-pausing-workflows) — Managing workflow state
 - [Updating Deployed Workflows](/cre/guides/operations/updating-deployed-workflows) — Version management
 - [Deleting Workflows](/cre/guides/operations/deleting-workflows) — Cleanup and removal
+
+---
+
+# Execution Commands
+Source: https://docs.chain.link/cre/reference/cli/execution
+Last Updated: 2026-07-09
+
+The `cre execution` commands query workflow execution history from the CRE platform. Use them to debug failures, review capability timelines, and pull log lines without opening the web UI.
+
+
+<Aside type="note" title="Authentication required">
+  Running `cre execution` commands requires you to be logged in. Run `cre whoami` to verify your session, or `cre login` to authenticate. See [Logging in with the CLI](/cre/account/cli-login) for details.
+</Aside>
+
+
+<Aside type="note" title="Global flags">
+  All `cre` commands support [global flags](/cre/reference/cli#global-flags) like `--env`, `--target`, `--project-root`, and `--verbose`.
+</Aside>
+
+For a quick health check on the workflow configured in your project, see [`cre workflow get`](/cre/reference/cli/workflow#cre-workflow-get), which shows deployment health and the most recent execution.
+
+## `cre execution list`
+
+Lists recent workflow executions from the CRE platform.
+
+**Usage:**
+
+```bash
+cre execution list [workflow-id-or-name] [flags]
+```
+
+**Arguments:**
+
+- `[workflow-id-or-name]` — (Optional) On-chain workflow ID (64-char hex, visible in [`cre workflow list`](/cre/reference/cli/workflow#cre-workflow-list)) or workflow name. When omitted, executions across all workflows are returned.
+
+**Flags:**
+
+| Flag                | Description                                                                     |
+| ------------------- | ------------------------------------------------------------------------------- |
+| `--status <string>` | Filter by execution status: `TRIGGERED`, `IN_PROGRESS`, `SUCCESS`, or `FAILURE` |
+| `--start <string>`  | Start of time range in ISO8601 format (e.g. `2026-01-01T00:00:00Z`)             |
+| `--end <string>`    | End of time range in ISO8601 format (e.g. `2026-01-02T00:00:00Z`)               |
+| `--limit <int>`     | Maximum number of executions to return (max 100, default 20)                    |
+| `--output <string>` | Output format. Use `json` to print a JSON array to stdout for scripting         |
+| `--json`            | Shorthand for `--output=json`                                                   |
+
+**Examples:**
+
+```bash
+cre execution list
+cre execution list my-workflow
+cre execution list my-workflow --status FAILURE
+cre execution list my-workflow --start 2026-01-01T00:00:00Z --end 2026-01-02T00:00:00Z
+cre execution list my-workflow --limit 50 --output json
+```
+
+***
+
+## `cre execution status`
+
+Shows detailed status for a single workflow execution, including top-level errors when the run has failed.
+
+**Usage:**
+
+```bash
+cre execution status <execution-uuid> [flags]
+```
+
+**Arguments:**
+
+- `<execution-uuid>` — (Required) Execution UUID from `cre execution list` or the CRE UI
+
+**Flags:**
+
+| Flag                | Description                                       |
+| ------------------- | ------------------------------------------------- |
+| `--output <string>` | Output format. Use `json` to print JSON to stdout |
+| `--json`            | Shorthand for `--output=json`                     |
+
+**Examples:**
+
+```bash
+cre execution status 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g
+cre execution status 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --output json
+```
+
+***
+
+## `cre execution events`
+
+Shows the ordered capability event timeline for a workflow execution, including per-event status, method, duration, and errors.
+
+**Usage:**
+
+```bash
+cre execution events <execution-uuid> [flags]
+```
+
+**Arguments:**
+
+- `<execution-uuid>` — (Required) Execution UUID
+
+**Flags:**
+
+| Flag                    | Description                                               |
+| ----------------------- | --------------------------------------------------------- |
+| `--capability <string>` | Filter events to a specific capability ID                 |
+| `--status <string>`     | Filter events by status (e.g. `FAILURE`)                  |
+| `--output <string>`     | Output format. Use `json` to print a JSON array to stdout |
+| `--json`                | Shorthand for `--output=json`                             |
+
+**Examples:**
+
+```bash
+cre execution events 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g
+cre execution events 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --capability fetch-price
+cre execution events 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --status FAILURE --output json
+```
+
+***
+
+## `cre execution logs`
+
+Shows log lines emitted during a workflow execution.
+
+**Usage:**
+
+```bash
+cre execution logs <execution-uuid> [flags]
+```
+
+**Arguments:**
+
+- `<execution-uuid>` — (Required) Execution UUID
+
+**Flags:**
+
+| Flag                | Description                                                        |
+| ------------------- | ------------------------------------------------------------------ |
+| `--node <string>`   | Filter logs to a specific node or capability ID (case-insensitive) |
+| `--output <string>` | Output format. Use `json` to print a JSON array to stdout          |
+| `--json`            | Shorthand for `--output=json`                                      |
+
+**Examples:**
+
+```bash
+cre execution logs 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g
+cre execution logs 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --node ProcessData
+cre execution logs 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --output json
+```
+
+## Learn more
+
+- [Monitoring & Debugging Workflows](/cre/guides/operations/monitoring-workflows) — Web UI monitoring dashboard
+- [`cre workflow get`](/cre/reference/cli/workflow#cre-workflow-get) — Deployment health and recent execution for the workflow in `workflow.yaml`
 
 ---
 

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -514,9 +514,24 @@ To help us assist you faster, please include:
 
 # Release Notes
 Source: https://docs.chain.link/cre/release-notes
-Last Updated: 2026-07-02
+Last Updated: 2026-07-09
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.24.0 - July 9, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.24.0" target="_blank">CRE CLI version 1.24.0</a> is now available.**
+
+- **Execution observability from the CLI**: New [`cre execution`](/cre/reference/cli/execution) commands let you inspect deployed workflow runs without opening the UI — `list` for recent executions (filter by status and time range), `status` for a single run, `events` for the capability timeline, and `logs` for emitted log lines. All support `--output json` for scripting.
+- **Enhanced `cre workflow get`**: [`cre workflow get`](/cre/reference/cli/workflow#cre-workflow-get) now resolves the workflow from your `workflow.yaml` settings and shows deployment health plus the most recent execution, not just registry metadata.
+- **Solana Write capability**: Workflows can now submit DON-consensus signed reports to Solana programs on Mainnet and Devnet via the Keystone Forwarder — the same secure write model as EVM. The CLI adds the tooling to build and test these workflows: `CRE_SOLANA_PRIVATE_KEY` for signing, `cre generate-bindings solana` for Go and TypeScript bindings from Anchor IDLs, and local write simulation with `cre workflow simulate` (dry run or `--broadcast`).
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.23.0...v1.24.0)
 
 ## CLI v1.23.0 - July 2, 2026
 
@@ -8045,7 +8060,7 @@ See the [repository README](https://github.com/smartcontractkit/cre-gcp-predicti
 
 # CLI Reference
 Source: https://docs.chain.link/cre/reference/cli
-Last Updated: 2026-05-14
+Last Updated: 2026-07-09
 
 export const CRE_CLI_VERSION = VERSIONS["cre-cli"].LATEST
 
@@ -8071,6 +8086,7 @@ These flags can be used with any `cre` command.
 | `-v, --verbose`          | Enables verbose logging to print `DEBUG` level logs                                                                                                                                                                     |
 | `--non-interactive`      | Fails instead of prompting; provide all required inputs with flags or environment variables. Use this for CI/CD, scripts, and other headless environments                                                               |
 | `--allow-unknown-chains` | Skips chain-name validation against the chain-selectors registry for `cre workflow simulate` and `cre workflow deploy`. Use for experimental or unlisted chains. Chain-selector and RPC availability are still enforced |
+| `--allow-insecure-rpc`   | Allows non-localhost HTTP RPC URLs. By default, the CLI blocks cleartext RPC endpoints to reduce accidental secret exposure over insecure connections                                                                   |
 
 
 <Aside type="note" title="Non-interactive authentication">
@@ -8096,7 +8112,7 @@ Manage your authentication and account credentials.
 Initialize projects and generate contract bindings (Go only).
 
 - [**`cre init`**](/cre/reference/cli/project-setup) — Initialize a new CRE project (interactive wizard or **`--non-interactive`** with flags for CI/CD)
-- **`cre generate-bindings`** (Go only) — Generate Go bindings from contract ABI files for type-safe contract interactions
+- **`cre generate-bindings`** — Generate contract bindings from ABI or Anchor IDL files (Go and TypeScript for Solana)
 
 [View project setup commands →](/cre/reference/cli/project-setup)
 
@@ -8127,11 +8143,24 @@ Manage workflows throughout their entire lifecycle.
 - **`cre workflow pause`** — Pause a workflow on the Workflow Registry contract
 - **`cre workflow delete`** — Delete all versions of a workflow from the Workflow Registry
 - **`cre workflow list`** — List workflows deployed for your organization; use `--output json` for scripts
-- **`cre workflow get`** — Show metadata for the workflow configured in `workflow.yaml`
+- **`cre workflow get`** — Show deployment health and the most recent execution for the workflow configured in `workflow.yaml`
 - **`cre workflow supported-chains`** — List chain names the CLI supports for local simulation; use `--output json` for scripts
 - **`cre workflow custom-build`** — Convert a workflow to use a custom self-compiled WASM build
 
 [View workflow commands →](/cre/reference/cli/workflow)
+
+***
+
+### Execution Commands
+
+Inspect deployed workflow runs from the terminal.
+
+- **`cre execution list`** — List recent executions; filter by workflow, status, and time range
+- **`cre execution status`** — Show detailed status for a single execution
+- **`cre execution events`** — Show the capability event timeline for an execution
+- **`cre execution logs`** — Show log lines emitted during an execution
+
+[View execution commands →](/cre/reference/cli/execution)
 
 ***
 
@@ -8555,7 +8584,7 @@ When you run this command, the CLI will:
 
 # Workflow Commands
 Source: https://docs.chain.link/cre/reference/cli/workflow
-Last Updated: 2026-06-11
+Last Updated: 2026-07-09
 
 The `cre workflow` commands manage workflows throughout their entire lifecycle, from local testing to deployment and ongoing management.
 
@@ -9027,7 +9056,7 @@ cre workflow list [flags]
   in with the CLI](/cre/account/cli-login) for further details.
 </Aside>
 
-Shows metadata for the workflow configured in `workflow.yaml`. The command reads the workflow name for the selected `--target`, searches the CRE platform for matching workflow metadata, and filters results to the workflow's configured `deployment-registry` by default.
+Shows deployment health and the most recent execution for the workflow configured in `workflow.yaml`. The command reads the workflow name for the selected `--target`, resolves the workflow on the CRE platform (scoped to the configured `deployment-registry` by default), and prints deployment health plus the latest execution.
 
 **Usage:**
 
@@ -9041,25 +9070,33 @@ cre workflow get <workflow-folder-path> [flags]
 
 **Flags:**
 
-| Flag               | Description                                                              |
-| ------------------ | ------------------------------------------------------------------------ |
-| `--all-registries` | Do not filter results by the workflow's configured `deployment-registry` |
+| Flag                | Description                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------ |
+| `--all-registries`  | Resolve the workflow across every registry instead of the configured `deployment-registry` |
+| `--output <string>` | Output format. Use `json` to print JSON to stdout for scripting                            |
+| `--json`            | Shorthand for `--output=json`                                                              |
 
 **Examples:**
 
-- Show metadata for the workflow configured for a target
+- Show deployment health and recent execution for the workflow configured for a target
 
   ```bash
   cre workflow get ./my-workflow --target staging-settings
   ```
 
-- Search across all registries in your organization
+- Resolve across all registries in your organization
 
   ```bash
   cre workflow get ./my-workflow --target staging-settings --all-registries
   ```
 
-The command prints the same human-readable workflow metadata fields as [`cre workflow list`](#cre-workflow-list): workflow name, workflow ID, owner address, status, registry, and registry address when available.
+- Export as JSON
+
+  ```bash
+  cre workflow get ./my-workflow --target staging-settings --output json
+  ```
+
+For a full execution history, use [`cre execution list`](/cre/reference/cli/execution#cre-execution-list).
 
 ***
 
@@ -9224,6 +9261,161 @@ The typical workflow lifecycle uses these commands in sequence:
 - [Activating & Pausing Workflows](/cre/guides/operations/activating-pausing-workflows) — Managing workflow state
 - [Updating Deployed Workflows](/cre/guides/operations/updating-deployed-workflows) — Version management
 - [Deleting Workflows](/cre/guides/operations/deleting-workflows) — Cleanup and removal
+
+---
+
+# Execution Commands
+Source: https://docs.chain.link/cre/reference/cli/execution
+Last Updated: 2026-07-09
+
+The `cre execution` commands query workflow execution history from the CRE platform. Use them to debug failures, review capability timelines, and pull log lines without opening the web UI.
+
+
+<Aside type="note" title="Authentication required">
+  Running `cre execution` commands requires you to be logged in. Run `cre whoami` to verify your session, or `cre login` to authenticate. See [Logging in with the CLI](/cre/account/cli-login) for details.
+</Aside>
+
+
+<Aside type="note" title="Global flags">
+  All `cre` commands support [global flags](/cre/reference/cli#global-flags) like `--env`, `--target`, `--project-root`, and `--verbose`.
+</Aside>
+
+For a quick health check on the workflow configured in your project, see [`cre workflow get`](/cre/reference/cli/workflow#cre-workflow-get), which shows deployment health and the most recent execution.
+
+## `cre execution list`
+
+Lists recent workflow executions from the CRE platform.
+
+**Usage:**
+
+```bash
+cre execution list [workflow-id-or-name] [flags]
+```
+
+**Arguments:**
+
+- `[workflow-id-or-name]` — (Optional) On-chain workflow ID (64-char hex, visible in [`cre workflow list`](/cre/reference/cli/workflow#cre-workflow-list)) or workflow name. When omitted, executions across all workflows are returned.
+
+**Flags:**
+
+| Flag                | Description                                                                     |
+| ------------------- | ------------------------------------------------------------------------------- |
+| `--status <string>` | Filter by execution status: `TRIGGERED`, `IN_PROGRESS`, `SUCCESS`, or `FAILURE` |
+| `--start <string>`  | Start of time range in ISO8601 format (e.g. `2026-01-01T00:00:00Z`)             |
+| `--end <string>`    | End of time range in ISO8601 format (e.g. `2026-01-02T00:00:00Z`)               |
+| `--limit <int>`     | Maximum number of executions to return (max 100, default 20)                    |
+| `--output <string>` | Output format. Use `json` to print a JSON array to stdout for scripting         |
+| `--json`            | Shorthand for `--output=json`                                                   |
+
+**Examples:**
+
+```bash
+cre execution list
+cre execution list my-workflow
+cre execution list my-workflow --status FAILURE
+cre execution list my-workflow --start 2026-01-01T00:00:00Z --end 2026-01-02T00:00:00Z
+cre execution list my-workflow --limit 50 --output json
+```
+
+***
+
+## `cre execution status`
+
+Shows detailed status for a single workflow execution, including top-level errors when the run has failed.
+
+**Usage:**
+
+```bash
+cre execution status <execution-uuid> [flags]
+```
+
+**Arguments:**
+
+- `<execution-uuid>` — (Required) Execution UUID from `cre execution list` or the CRE UI
+
+**Flags:**
+
+| Flag                | Description                                       |
+| ------------------- | ------------------------------------------------- |
+| `--output <string>` | Output format. Use `json` to print JSON to stdout |
+| `--json`            | Shorthand for `--output=json`                     |
+
+**Examples:**
+
+```bash
+cre execution status 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g
+cre execution status 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --output json
+```
+
+***
+
+## `cre execution events`
+
+Shows the ordered capability event timeline for a workflow execution, including per-event status, method, duration, and errors.
+
+**Usage:**
+
+```bash
+cre execution events <execution-uuid> [flags]
+```
+
+**Arguments:**
+
+- `<execution-uuid>` — (Required) Execution UUID
+
+**Flags:**
+
+| Flag                    | Description                                               |
+| ----------------------- | --------------------------------------------------------- |
+| `--capability <string>` | Filter events to a specific capability ID                 |
+| `--status <string>`     | Filter events by status (e.g. `FAILURE`)                  |
+| `--output <string>`     | Output format. Use `json` to print a JSON array to stdout |
+| `--json`                | Shorthand for `--output=json`                             |
+
+**Examples:**
+
+```bash
+cre execution events 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g
+cre execution events 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --capability fetch-price
+cre execution events 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --status FAILURE --output json
+```
+
+***
+
+## `cre execution logs`
+
+Shows log lines emitted during a workflow execution.
+
+**Usage:**
+
+```bash
+cre execution logs <execution-uuid> [flags]
+```
+
+**Arguments:**
+
+- `<execution-uuid>` — (Required) Execution UUID
+
+**Flags:**
+
+| Flag                | Description                                                        |
+| ------------------- | ------------------------------------------------------------------ |
+| `--node <string>`   | Filter logs to a specific node or capability ID (case-insensitive) |
+| `--output <string>` | Output format. Use `json` to print a JSON array to stdout          |
+| `--json`            | Shorthand for `--output=json`                                      |
+
+**Examples:**
+
+```bash
+cre execution logs 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g
+cre execution logs 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --node ProcessData
+cre execution logs 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --output json
+```
+
+## Learn more
+
+- [Monitoring & Debugging Workflows](/cre/guides/operations/monitoring-workflows) — Web UI monitoring dashboard
+- [`cre workflow get`](/cre/reference/cli/workflow#cre-workflow-get) — Deployment health and recent execution for the workflow in `workflow.yaml`
 
 ---
 

--- a/src/content/cre/reference/cli/execution.mdx
+++ b/src/content/cre/reference/cli/execution.mdx
@@ -1,0 +1,160 @@
+---
+section: cre
+date: Last Modified
+title: "Execution Commands"
+metadata:
+  description: "Inspect deployed workflow executions from the CLI: list runs, view status, events, and logs."
+  datePublished: "2026-07-09"
+  lastModified: "2026-07-09"
+---
+
+import { Aside } from "@components"
+
+The `cre execution` commands query workflow execution history from the CRE platform. Use them to debug failures, review capability timelines, and pull log lines without opening the web UI.
+
+{/* prettier-ignore */}
+<Aside type="note" title="Authentication required">
+  Running `cre execution` commands requires you to be logged in. Run `cre whoami` to verify your session, or `cre login` to authenticate. See [Logging in with the CLI](/cre/account/cli-login) for details.
+</Aside>
+
+{/* prettier-ignore */}
+<Aside type="note" title="Global flags">
+  All `cre` commands support [global flags](/cre/reference/cli#global-flags) like `--env`, `--target`, `--project-root`, and `--verbose`.
+</Aside>
+
+For a quick health check on the workflow configured in your project, see [`cre workflow get`](/cre/reference/cli/workflow#cre-workflow-get), which shows deployment health and the most recent execution.
+
+## `cre execution list`
+
+Lists recent workflow executions from the CRE platform.
+
+**Usage:**
+
+```bash
+cre execution list [workflow-id-or-name] [flags]
+```
+
+**Arguments:**
+
+- `[workflow-id-or-name]` — (Optional) On-chain workflow ID (64-char hex, visible in [`cre workflow list`](/cre/reference/cli/workflow#cre-workflow-list)) or workflow name. When omitted, executions across all workflows are returned.
+
+**Flags:**
+
+| <div style={{ width: "170px" }}>Flag</div> | Description                                                                     |
+| ------------------------------------------ | ------------------------------------------------------------------------------- |
+| `--status <string>`                        | Filter by execution status: `TRIGGERED`, `IN_PROGRESS`, `SUCCESS`, or `FAILURE` |
+| `--start <string>`                         | Start of time range in ISO8601 format (e.g. `2026-01-01T00:00:00Z`)             |
+| `--end <string>`                           | End of time range in ISO8601 format (e.g. `2026-01-02T00:00:00Z`)               |
+| `--limit <int>`                            | Maximum number of executions to return (max 100, default 20)                    |
+| `--output <string>`                        | Output format. Use `json` to print a JSON array to stdout for scripting         |
+| `--json`                                   | Shorthand for `--output=json`                                                   |
+
+**Examples:**
+
+```bash
+cre execution list
+cre execution list my-workflow
+cre execution list my-workflow --status FAILURE
+cre execution list my-workflow --start 2026-01-01T00:00:00Z --end 2026-01-02T00:00:00Z
+cre execution list my-workflow --limit 50 --output json
+```
+
+---
+
+## `cre execution status`
+
+Shows detailed status for a single workflow execution, including top-level errors when the run has failed.
+
+**Usage:**
+
+```bash
+cre execution status <execution-uuid> [flags]
+```
+
+**Arguments:**
+
+- `<execution-uuid>` — (Required) Execution UUID from `cre execution list` or the CRE UI
+
+**Flags:**
+
+| <div style={{ width: "170px" }}>Flag</div> | Description                                       |
+| ------------------------------------------ | ------------------------------------------------- |
+| `--output <string>`                        | Output format. Use `json` to print JSON to stdout |
+| `--json`                                   | Shorthand for `--output=json`                     |
+
+**Examples:**
+
+```bash
+cre execution status 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g
+cre execution status 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --output json
+```
+
+---
+
+## `cre execution events`
+
+Shows the ordered capability event timeline for a workflow execution, including per-event status, method, duration, and errors.
+
+**Usage:**
+
+```bash
+cre execution events <execution-uuid> [flags]
+```
+
+**Arguments:**
+
+- `<execution-uuid>` — (Required) Execution UUID
+
+**Flags:**
+
+| <div style={{ width: "170px" }}>Flag</div> | Description                                               |
+| ------------------------------------------ | --------------------------------------------------------- |
+| `--capability <string>`                    | Filter events to a specific capability ID                 |
+| `--status <string>`                        | Filter events by status (e.g. `FAILURE`)                  |
+| `--output <string>`                        | Output format. Use `json` to print a JSON array to stdout |
+| `--json`                                   | Shorthand for `--output=json`                             |
+
+**Examples:**
+
+```bash
+cre execution events 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g
+cre execution events 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --capability fetch-price
+cre execution events 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --status FAILURE --output json
+```
+
+---
+
+## `cre execution logs`
+
+Shows log lines emitted during a workflow execution.
+
+**Usage:**
+
+```bash
+cre execution logs <execution-uuid> [flags]
+```
+
+**Arguments:**
+
+- `<execution-uuid>` — (Required) Execution UUID
+
+**Flags:**
+
+| <div style={{ width: "170px" }}>Flag</div> | Description                                                        |
+| ------------------------------------------ | ------------------------------------------------------------------ |
+| `--node <string>`                          | Filter logs to a specific node or capability ID (case-insensitive) |
+| `--output <string>`                        | Output format. Use `json` to print a JSON array to stdout          |
+| `--json`                                   | Shorthand for `--output=json`                                      |
+
+**Examples:**
+
+```bash
+cre execution logs 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g
+cre execution logs 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --node ProcessData
+cre execution logs 7f3d8a12-b1c2-4d3e-9f0a-1b2c3d4e5f6g --output json
+```
+
+## Learn more
+
+- [Monitoring & Debugging Workflows](/cre/guides/operations/monitoring-workflows) — Web UI monitoring dashboard
+- [`cre workflow get`](/cre/reference/cli/workflow#cre-workflow-get) — Deployment health and recent execution for the workflow in `workflow.yaml`

--- a/src/content/cre/reference/cli/index.mdx
+++ b/src/content/cre/reference/cli/index.mdx
@@ -6,7 +6,7 @@ isIndex: true
 metadata:
   description: "Explore all CRE CLI commands: complete reference for project setup, workflow deployment, account management, and development tools."
   datePublished: "2025-11-04"
-  lastModified: "2026-05-14"
+  lastModified: "2026-07-09"
 ---
 
 import { Aside } from "@components"
@@ -36,6 +36,7 @@ These flags can be used with any `cre` command.
 | `-v, --verbose`                       | Enables verbose logging to print `DEBUG` level logs                                                                                                                                                                     |
 | `--non-interactive`                   | Fails instead of prompting; provide all required inputs with flags or environment variables. Use this for CI/CD, scripts, and other headless environments                                                               |
 | `--allow-unknown-chains`              | Skips chain-name validation against the chain-selectors registry for `cre workflow simulate` and `cre workflow deploy`. Use for experimental or unlisted chains. Chain-selector and RPC availability are still enforced |
+| `--allow-insecure-rpc`                | Allows non-localhost HTTP RPC URLs. By default, the CLI blocks cleartext RPC endpoints to reduce accidental secret exposure over insecure connections                                                                   |
 
 {/* prettier-ignore */}
 <Aside type="note" title="Non-interactive authentication">
@@ -61,7 +62,7 @@ Manage your authentication and account credentials.
 Initialize projects and generate contract bindings (Go only).
 
 - [**`cre init`**](/cre/reference/cli/project-setup) — Initialize a new CRE project (interactive wizard or **`--non-interactive`** with flags for CI/CD)
-- **`cre generate-bindings`** (Go only) — Generate Go bindings from contract ABI files for type-safe contract interactions
+- **`cre generate-bindings`** — Generate contract bindings from ABI or Anchor IDL files (Go and TypeScript for Solana)
 
 [View project setup commands →](/cre/reference/cli/project-setup)
 
@@ -92,11 +93,24 @@ Manage workflows throughout their entire lifecycle.
 - **`cre workflow pause`** — Pause a workflow on the Workflow Registry contract
 - **`cre workflow delete`** — Delete all versions of a workflow from the Workflow Registry
 - **`cre workflow list`** — List workflows deployed for your organization; use `--output json` for scripts
-- **`cre workflow get`** — Show metadata for the workflow configured in `workflow.yaml`
+- **`cre workflow get`** — Show deployment health and the most recent execution for the workflow configured in `workflow.yaml`
 - **`cre workflow supported-chains`** — List chain names the CLI supports for local simulation; use `--output json` for scripts
 - **`cre workflow custom-build`** — Convert a workflow to use a custom self-compiled WASM build
 
 [View workflow commands →](/cre/reference/cli/workflow)
+
+---
+
+### Execution Commands
+
+Inspect deployed workflow runs from the terminal.
+
+- **`cre execution list`** — List recent executions; filter by workflow, status, and time range
+- **`cre execution status`** — Show detailed status for a single execution
+- **`cre execution events`** — Show the capability event timeline for an execution
+- **`cre execution logs`** — Show log lines emitted during an execution
+
+[View execution commands →](/cre/reference/cli/execution)
 
 ---
 

--- a/src/content/cre/reference/cli/workflow.mdx
+++ b/src/content/cre/reference/cli/workflow.mdx
@@ -5,7 +5,7 @@ title: "Workflow Commands"
 metadata:
   description: "Manage workflows with CLI: complete command reference for simulating, deploying, activating, pausing, and deleting workflows."
   datePublished: "2025-11-04"
-  lastModified: "2026-06-11"
+  lastModified: "2026-07-09"
 ---
 
 import { Aside } from "@components"
@@ -481,7 +481,7 @@ cre workflow list [flags]
   in with the CLI](/cre/account/cli-login) for further details.
 </Aside>
 
-Shows metadata for the workflow configured in `workflow.yaml`. The command reads the workflow name for the selected `--target`, searches the CRE platform for matching workflow metadata, and filters results to the workflow's configured `deployment-registry` by default.
+Shows deployment health and the most recent execution for the workflow configured in `workflow.yaml`. The command reads the workflow name for the selected `--target`, resolves the workflow on the CRE platform (scoped to the configured `deployment-registry` by default), and prints deployment health plus the latest execution.
 
 **Usage:**
 
@@ -495,25 +495,33 @@ cre workflow get <workflow-folder-path> [flags]
 
 **Flags:**
 
-| <div style={{ width: "170px" }}>Flag</div> | Description                                                              |
-| ------------------------------------------ | ------------------------------------------------------------------------ |
-| `--all-registries`                         | Do not filter results by the workflow's configured `deployment-registry` |
+| <div style={{ width: "170px" }}>Flag</div> | Description                                                                                |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `--all-registries`                         | Resolve the workflow across every registry instead of the configured `deployment-registry` |
+| `--output <string>`                        | Output format. Use `json` to print JSON to stdout for scripting                            |
+| `--json`                                   | Shorthand for `--output=json`                                                              |
 
 **Examples:**
 
-- Show metadata for the workflow configured for a target
+- Show deployment health and recent execution for the workflow configured for a target
 
   ```bash
   cre workflow get ./my-workflow --target staging-settings
   ```
 
-- Search across all registries in your organization
+- Resolve across all registries in your organization
 
   ```bash
   cre workflow get ./my-workflow --target staging-settings --all-registries
   ```
 
-The command prints the same human-readable workflow metadata fields as [`cre workflow list`](#cre-workflow-list): workflow name, workflow ID, owner address, status, registry, and registry address when available.
+- Export as JSON
+
+  ```bash
+  cre workflow get ./my-workflow --target staging-settings --output json
+  ```
+
+For a full execution history, use [`cre execution list`](/cre/reference/cli/execution#cre-execution-list).
 
 ---
 

--- a/src/content/cre/release-notes.mdx
+++ b/src/content/cre/release-notes.mdx
@@ -5,12 +5,27 @@ date: Last Modified
 metadata:
   description: "Discover what's new in CRE: latest features, changes, and improvements in each release of the Chainlink Runtime Environment."
   datePublished: "2025-11-04"
-  lastModified: "2026-07-02"
+  lastModified: "2026-07-09"
 ---
 
 import { Aside } from "@components"
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.24.0 - July 9, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.24.0" target="_blank">CRE CLI version 1.24.0</a> is now available.**
+
+- **Execution observability from the CLI**: New [`cre execution`](/cre/reference/cli/execution) commands let you inspect deployed workflow runs without opening the UI — `list` for recent executions (filter by status and time range), `status` for a single run, `events` for the capability timeline, and `logs` for emitted log lines. All support `--output json` for scripting.
+- **Enhanced `cre workflow get`**: [`cre workflow get`](/cre/reference/cli/workflow#cre-workflow-get) now resolves the workflow from your `workflow.yaml` settings and shows deployment health plus the most recent execution, not just registry metadata.
+- **Solana Write capability**: Workflows can now submit DON-consensus signed reports to Solana programs on Mainnet and Devnet via the Keystone Forwarder — the same secure write model as EVM. The CLI adds the tooling to build and test these workflows: `CRE_SOLANA_PRIVATE_KEY` for signing, `cre generate-bindings solana` for Go and TypeScript bindings from Anchor IDLs, and local write simulation with `cre workflow simulate` (dry run or `--broadcast`).
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.23.0...v1.24.0)
 
 ## CLI v1.23.0 - July 2, 2026
 


### PR DESCRIPTION
Note: CRE solana write docs are still undergoing review. It's a part of this release, but the guide is in [this PR](https://github.com/smartcontractkit/documentation/pull/3944)


This pull request updates the documentation to reflect the release of CRE CLI v1.24.0, introducing major new features for workflow execution observability and Solana Write support. It adds comprehensive docs for the new `cre execution` command group, updates the CLI version throughout the site, and refines several command descriptions and global flag explanations.

**Release and Versioning Updates:**

* Added release notes for CRE CLI v1.24.0, highlighting new `cre execution` commands, enhancements to `cre workflow get`, and Solana Write support with CLI tooling. [[1]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL517-R535) [[2]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L517-R535) [[3]](diffhunk://#diff-5323f35752748a8eb45ef9c8e62cda3a9d5b83c420d2feb0e307e66676bb2558R405-R411)
* Updated the latest CLI version to `v1.24.0` in all version config files and added the corresponding release date. [[1]](diffhunk://#diff-11892e6b40841ca0f483f57267775d1ae2ccf579daa451f843c66de7f1558b3aL80-R82) [[2]](diffhunk://#diff-11892e6b40841ca0f483f57267775d1ae2ccf579daa451f843c66de7f1558b3aR101)
* Updated "Last Updated" dates on all relevant documentation pages to 2026-07-09. [[1]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8446-R8461) [[2]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8956-R8985) [[3]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L8048-R8063)

**New Features and Command Documentation:**

* Added a new "Execution Commands" section to the sidebar and CLI reference, with full documentation for `cre execution list`, `status`, `events`, and `logs` commands, including flags and usage examples. [[1]](diffhunk://#diff-d6089daa2dd1e8916f282347f13c40b762a0617e7524ae687640f7a1d685a8b2R643) [[2]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8528-R8564) [[3]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeR9665-R9819)
* Updated the global flags table to document the new `--allow-insecure-rpc` flag. [[1]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeR8487) [[2]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4R8089)

**Enhancements to Existing Commands:**

* Updated `cre workflow get` documentation to reflect that it now shows deployment health and the most recent execution, not just registry metadata, and clarified flag usage. [[1]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8528-R8564) [[2]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL9428-R9457) [[3]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL9443-R9497)
* Clarified that `cre generate-bindings` now supports both Go and TypeScript bindings from ABI or Anchor IDL files (for Solana). [[1]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8497-R8513) [[2]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L8099-R8115)

These changes ensure the documentation is up-to-date with the latest CLI capabilities and provides clear guidance for users adopting the new features.