### PR TITLE
Data Feeds: Display Robinhood Proxy Addresses for Tokenized Equities

### DIFF
--- a/src/features/feeds/utils/feedVisibility.ts
+++ b/src/features/feeds/utils/feedVisibility.ts
@@ -23,6 +23,11 @@ export const CONTACT_EMAIL_PROXY_ADDRESSES = new Set<string>([
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function shouldHideAddress(feed: any, riskTier?: string | null): boolean {
+  // Robinhood tokenized equity feeds display their proxy address directly.
+  if (feed.docs?.blockchainName === "Robinhood" && feed.docs?.productTypeCode === "primaryTokenizedPrice") {
+    return false
+  }
+
   if (feed.docs?.productSubType === "calculatedPrice") return true
   const proxy: string | null | undefined = feed.proxyAddress
   if (proxy != null && CONTACT_EMAIL_PROXY_ADDRESSES.has(proxy.toLowerCase())) return true


### PR DESCRIPTION
This pull request updates the logic for hiding addresses in the `shouldHideAddress` function. The main change is to ensure that Robinhood tokenized equity feeds with a specific product type always display their proxy address, overriding previous hiding logic.

Feed visibility logic updates:

* Updated `shouldHideAddress` in `feedVisibility.ts` to always show the proxy address for feeds where `blockchainName` is `"Robinhood"` and `productTypeCode` is `"primaryTokenizedPrice"`, ensuring these are not hidden by other conditions.