### PR TITLE
Clarify that deviation threshold is a trigger, not an accuracy bound

### DIFF
--- a/src/content/architecture-overview/architecture-decentralized-model.mdx
+++ b/src/content/architecture-overview/architecture-decentralized-model.mdx
@@ -13,7 +13,7 @@ metadata:
   image: "/files/OpenGraph_V3.png"
 ---
 
-import { ClickToZoom } from "@components"
+import { ClickToZoom, Aside } from "@components"
 
 This page describes how data aggregation is applied to produce Chainlink Data Feeds and provides more insight as to how Data Feeds are updated.
 
@@ -74,3 +74,12 @@ Aggregators receive updates from the oracle network only when the **Deviation Th
 
 - Deviation Threshold: A new aggregation round starts when a node identifies that the off-chain values deviate by more than the defined deviation threshold from the onchain value. Individual nodes monitor one or more data providers for each feed.
 - Heartbeat Threshold: A new aggregation round starts after a specified amount of time from the last update.
+
+<Aside type="note" title="What the deviation threshold does and does not mean">
+  The deviation threshold is the trigger that starts a new aggregation round — it is not a guarantee that the onchain
+  answer always stays within that percentage of a live market price. Reaching consensus and transmitting a new round
+  onchain takes time, and market prices continue to move during that process. As a result, the difference between the
+  onchain answer and any specific external reference price can exceed the deviation threshold, particularly during
+  fast-moving markets. Observing a gap larger than the configured deviation threshold does not necessarily indicate
+  that a feed is late, malfunctioning, or out of specification.
+</Aside>

--- a/src/content/data-feeds/index.mdx
+++ b/src/content/data-feeds/index.mdx
@@ -163,6 +163,14 @@ Configure your application to detect when the reported answer is close to reachi
 
 Chainlink Data Feeds do not provide streaming data. Rather, the aggregator updates its `latestAnswer` when the value deviates beyond a specified threshold or when the heartbeat idle time has passed. You can find the heartbeat and deviation values for each data feed at [data.chain.link](https://data.chain.link/) or in the [Contract Addresses](/data-feeds/price-feeds/addresses) lists.
 
+<Aside type="note" title="The deviation threshold is a trigger, not an accuracy bound">
+  The deviation threshold determines when a new update is triggered; it does not limit how far the onchain answer can
+  be from a live market price at any given moment. Consensus and onchain transmission take time, and reference prices
+  keep moving during that window, so the observed gap between the onchain answer and an external price can be larger
+  than the configured deviation threshold, especially during periods of high volatility. Do not assume that the
+  deviation threshold is the maximum error your application will ever see between updates.
+</Aside>
+
 Your application should track the `latestTimestamp` variable or use the `updatedAt` value from the `latestRoundData()` function to make sure that the latest answer is recent enough for your application to use it. If your application detects that the reported answer is not updated within the heartbeat or within time limits that you determine are acceptable for your application, pause operation or switch to an alternate operation mode while identifying the cause of the delay.
 
 When the node detects that the heartbeat is reached, it initiates the latest round. Depending on congestion and network conditions, there may be a slight delay for the latest round to get onchain.

--- a/src/content/data-feeds/selecting-data-feeds.mdx
+++ b/src/content/data-feeds/selecting-data-feeds.mdx
@@ -150,6 +150,17 @@ To help you prepare for unforeseen market events, you should take additional ste
 - **Soak testing:** Users are strongly advised to thoroughly test price feed integrations and incorporate a [soak period](https://en.wikipedia.org/wiki/Soak_testing) prior to providing access to end users or securing value.
 - **Provider/source dependency controls:** For single-source feeds, implement controls that detect stale, delayed, missing, or unexpected values from the underlying provider. Where possible, compare the feed against independent references, enforce value bounds or caps, and define fallback or pause behavior before securing value with the feed.
 
+<Aside type="note" title="Deviation threshold is a trigger, not an accuracy bound">
+  A feed's deviation threshold is the percentage move that triggers a new onchain update; it is not a promise that the
+  onchain answer will always stay within that percentage of a live market price. Reaching consensus and transmitting a
+  new round onchain takes time, and reference prices keep moving during that window. Because of this, the observed
+  gap between the onchain answer and any specific external price (such as a single exchange's price) can exceed the
+  configured deviation threshold, particularly in fast-moving markets. If you build monitoring, alerting, or risk
+  parameters around a feed's deviation threshold, treat it as the minimum move that causes an update, not the maximum
+  difference you should expect to observe between updates. To learn more about how the deviation threshold and
+  heartbeat interact, see [Aggregator](/architecture-overview/architecture-decentralized-model#aggregator).
+</Aside>
+
 For more detailed information about some of these examples, see the [Monitoring data feeds](/data-feeds/#monitoring-data-feeds) documentation.
 
 For important updates regarding the use of Chainlink Price Feeds, users should join the official Chainlink Discord and subscribe to the [data-feeds-user-notifications channel](https://discord.gg/Dqy5N9UbsR).


### PR DESCRIPTION
## Summary
- Users have interpreted a feed's deviation threshold (e.g. 0.15%) as a bound on how far the onchain price can drift from a live market reference between updates. In reality it's only the trigger that starts a new aggregation round — consensus + transmit latency plus continued market movement mean the observed gap can exceed the threshold without the feed being late or out of spec.
- Adds a short clarifying note to three pages where this is most likely to be misread:
  - Decentralized Data Model (the page that defines the deviation/heartbeat triggers)
  - Data Feeds overview (main integration-facing page, where `latestAnswer` update behavior is described)
  - Selecting Quality Data Feeds (right next to the monitoring/alerting guidance, where someone would otherwise build alerts assuming the threshold is an accuracy bound)

## Test plan
- [ ] Visually review rendered `Aside` blocks on each page
- [ ] `npm run build` / link check in CI