### PR TITLE
Data Streams: update robinhood chain status

### DIFF
--- a/src/features/data/chains.ts
+++ b/src/features/data/chains.ts
@@ -595,7 +595,7 @@ export const CHAINS: Chain[] = [
     label: "Robinhood Chain",
     title: "Robinhood Chain Data Feeds",
     img: "/assets/chains/robinhood-chain.svg",
-    networkStatusUrl: "https://docs.robinhood.com/chain/",
+    networkStatusUrl: "https://status.robinhoodchain.offchain.io/",
     tags: ["default", "tokenizedEquity"],
     supportedFeatures: ["feeds"],
     networks: [

--- a/src/features/feeds/data/StreamsNetworksData.ts
+++ b/src/features/feeds/data/StreamsNetworksData.ts
@@ -571,11 +571,12 @@ export const StreamsNetworksData: NetworkData[] = [
   },
   {
     network: "Robinhood Chain",
+    networkStatus: "https://status.robinhoodchain.offchain.io/",
     logoUrl: "/assets/chains/robinhood-chain.svg",
     mainnet: {
       label: "Robinhood Chain Mainnet",
       verifierProxy: "0xcE73c8ad08CBDEaCa6078BF0627C8fe0a9a536E7",
-      explorerUrl: "https://explorer.chain.robinhood.com/address/%s",
+      explorerUrl: "https://robinhoodchain.blockscout.com/address/%s",
     },
     testnet: {
       label: "Robinhood Chain Testnet",


### PR DESCRIPTION
This pull request updates the Robinhood Chain configuration to use the latest status and explorer URLs, ensuring users are directed to the correct resources for network monitoring and address exploration.

Robinhood Chain configuration updates:

* Updated the `networkStatusUrl` for Robinhood Chain in `chains.ts` to point to `https://status.robinhoodchain.offchain.io/` instead of the documentation page.
* Updated the `networkStatus` and `explorerUrl` for Robinhood Chain in `StreamsNetworksData.ts` to use the new status page and Blockscout explorer.