### PR TITLE
Experimental: Improve Vercel preview deployment speed

### DIFF
--- a/src/components/CCIP/Token/Token.astro
+++ b/src/components/CCIP/Token/Token.astro
@@ -140,8 +140,6 @@ const tokenStructuredData = generateTokenStructuredData(token, environment, chai
             if (!explorer) throw new Error(`Explorer not found for ${key}`)
             const { chainType } = getChainTypeAndFamily(supportedChain)
 
-            console.log("token data for", key, data[key])
-
             return {
               name: title,
               key: key,

--- a/src/features/data/api/backend.ts
+++ b/src/features/data/api/backend.ts
@@ -6,31 +6,35 @@ export const getServerSideChainMetadata = async (
   chains: Chain[],
   skipCache = false
 ): Promise<Record<string, ChainMetadata>> => {
-  const cache = {}
-
-  for (const chain of chains) {
-    const requests = chain.networks.map((nw) =>
-      nw?.rddUrl
-        ? EleventyFetch(nw?.rddUrl, {
-            duration: skipCache ? "0s" : "1d",
-            type: "json",
-          })
-            .then((metadata) => ({
-              ...nw,
-              metadata: metadata.filter(
-                (meta) => meta.docs?.hidden !== true && (meta.proxyAddress || meta.transmissionsAccount || meta.feedId)
-              ),
-            }))
-            .catch((error) => {
-              console.warn(`[getServerSideChainMetadata] Failed to fetch ${nw.rddUrl}: ${error?.message ?? error}`)
-              return { ...nw, metadata: [] }
+  // Fetch all chains in parallel instead of sequentially. Each chain's networks
+  // are already fetched in parallel via Promise.all below.
+  const cache: Record<string, any> = {}
+  await Promise.all(
+    chains.map(async (chain) => {
+      const requests = chain.networks.map((nw) =>
+        nw?.rddUrl
+          ? EleventyFetch(nw?.rddUrl, {
+              duration: skipCache ? "0s" : "1d",
+              type: "json",
             })
-        : undefined
-    )
-    const networks = await Promise.all(requests)
+              .then((metadata) => ({
+                ...nw,
+                metadata: metadata.filter(
+                  (meta) =>
+                    meta.docs?.hidden !== true && (meta.proxyAddress || meta.transmissionsAccount || meta.feedId)
+                ),
+              }))
+              .catch((error) => {
+                console.warn(`[getServerSideChainMetadata] Failed to fetch ${nw.rddUrl}: ${error?.message ?? error}`)
+                return { ...nw, metadata: [] }
+              })
+          : undefined
+      )
+      const networks = await Promise.all(requests)
 
-    cache[chain.page] = { ...chain, networks }
-  }
+      cache[chain.page] = { ...chain, networks }
+    })
+  )
 
   try {
     const mvrFeeds = await EleventyFetch(POR_MVR_FEEDS_URL, {

--- a/src/pages/[product]/api-reference/[...id].astro
+++ b/src/pages/[product]/api-reference/[...id].astro
@@ -3,7 +3,7 @@ import { getCollection, render } from "astro:content"
 import type { CollectionEntry } from "astro:content"
 import DocsLayout from "~/layouts/DocsLayout.astro"
 import { VERSIONS, type VMVersionConfig } from "@config/versions/index.ts"
-import type { Collection } from "~/content.config.ts"
+import { collections, type Collection } from "~/content.config.ts"
 
 interface RouteParams {
   params: { product: Collection; id: string }
@@ -107,6 +107,9 @@ export async function getStaticPaths(): Promise<RouteParams[]> {
   }
 
   for (const [product, productConfig] of Object.entries(VERSIONS)) {
+    // Skip non-collection entries (e.g. "cre-cli" is a version config, not a content collection)
+    if (!(product in collections)) continue
+
     const entries = await getCollection(product as Collection)
     const apiEntries = entries.filter((entry) => entry.id.startsWith("api-reference/"))
 


### PR DESCRIPTION
This pull request introduces several improvements to data fetching performance, code clarity, and content collection handling. The most significant change is parallelizing the fetching of chain metadata to improve efficiency. Additional changes include minor code cleanups, improved type imports, and more robust handling of content collections.

**Performance improvements:**

* [`src/features/data/api/backend.ts`](diffhunk://#diff-9818e17d6899487eaca4dc788b0c570827f21ed5fe79ed1b80f1207ca9b79200L9-R13): Refactored `getServerSideChainMetadata` to fetch all chains in parallel using `Promise.all`, significantly improving data fetching efficiency. [[1]](diffhunk://#diff-9818e17d6899487eaca4dc788b0c570827f21ed5fe79ed1b80f1207ca9b79200L9-R13) [[2]](diffhunk://#diff-9818e17d6899487eaca4dc788b0c570827f21ed5fe79ed1b80f1207ca9b79200L33-R37)

**Code clarity and cleanup:**

* [`src/components/CCIP/Token/Token.astro`](diffhunk://#diff-b0ab1532cb1a41655e301e3fa2374dab17955801942a5497d609626a5ab068fdL143-L144): Removed an unnecessary `console.log` statement for cleaner output.
* [`src/features/data/api/backend.ts`](diffhunk://#diff-9818e17d6899487eaca4dc788b0c570827f21ed5fe79ed1b80f1207ca9b79200L21-R24): Improved code formatting in the metadata filtering function for better readability.

**Content collection handling:**

* `src/pages/[product]/api-reference/[...id].astro`: Improved the import of `collections` from `~/content.config.ts` and updated logic in `getStaticPaths` to skip non-collection entries, preventing errors when iterating over `VERSIONS`. ([src/pages/[product]/api-reference/[...id].astroL6-R6](diffhunk://#diff-cceafd5eba2c717ef6a825e1b5b063b7c8e2a4c681553c1d7f18c4d8ec66431bL6-R6), [src/pages/[product]/api-reference/[...id].astroR110-R112](diffhunk://#diff-cceafd5eba2c717ef6a825e1b5b063b7c8e2a4c681553c1d7f18c4d8ec66431bR110-R112))