### PR TITLE
docs(ccip-latency): add live per-chain finality observations reference

### DIFF
--- a/src/content/ccip/ccip-execution-latency.mdx
+++ b/src/content/ccip/ccip-execution-latency.mdx
@@ -169,6 +169,10 @@ This section provides an overview of the finality methods CCIP uses to determine
 | Zircuit           | Finality tag                              | 21 minutes                  |
 | ZKsync            | [Block depth](#block-depth) (1200 blocks) | 20 minutes                  |
 
+### Live per-chain finality observations
+
+The estimated finality times in the table above are averages that, as noted in the Aside above, can vary significantly with network conditions. For a live, continuously updated measurement of finality time across major L1 chains, see the [OpenChainBench L1 finality benchmark](https://openchainbench.com/benchmarks/l1-finality). It measures wall-clock seconds between latest and finalized blocks for 11 L1s (Ethereum, Solana, BNB, Avalanche, SUI, Stellar, TON, Bitcoin, Litecoin, TRON, Monero), refreshed every 10 seconds under an open methodology ([source, MIT](https://github.com/ChainBench/OpenChainBench), data CC-BY-4.0). Integrators building on CCIP can use it as an independent source to sanity-check the assumed finality window against current chain state.
+
 This page provides details on the expected latency for a cross-chain transaction using CCIP, covering the different stages of transaction processing and the factors that influence overall execution times.
 
 For a comprehensive understanding of CCIP's architecture and how messages flow through the system, refer to the [CCIP detailed architecture](/ccip/concepts/architecture/overview) documentation.


### PR DESCRIPTION
## Summary

Add a small subsection at the end of `src/content/ccip/ccip-execution-latency.mdx` (right before the closing paragraph) that points readers to a live third-party benchmark of L1 finality time. The existing `Finality by blockchain` table gives useful estimated averages and the accompanying Aside explicitly notes that "these times can vary significantly due to network conditions and other factors". This addition gives integrators a complementary live-data source to sanity-check their assumed finality window against current chain state.

## Why

`ccip-execution-latency.mdx` is centred on the impact of source-chain finality on CCIP end-to-end latency. The table lists ~45 supported chains with estimated finality times ranging from `< 1 second` (Avalanche, Solana) to `12 hours` (Corn). Devs building on CCIP often need to know whether those numbers still hold in current network conditions, especially:

- On chains where an upgrade or congestion event has changed finality behaviour recently
- On rollup chains where L1 finality drift affects total settlement time
- When choosing block-depth vs finality-tag security parameters

[OpenChainBench](https://openchainbench.com/benchmarks/l1-finality) measures wall-clock seconds between latest and finalized blocks for 11 L1s (Ethereum, Solana, BNB, Avalanche, SUI, Stellar, TON, Bitcoin, Litecoin, TRON, Monero), refreshed every 10 seconds. Not a replacement for the CCIP-specific finality methods documented above; a live sanity-check complement.

## About OpenChainBench

- Open methodology: https://openchainbench.com/methodology
- Source (MIT): https://github.com/ChainBench/OpenChainBench
- Data license: CC-BY-4.0
- Multi-region measurement (3 regions), 10 s refresh
- Not affiliated with Chainlink or Circle; measures the source chains CCIP supports among many others
- Funded by Mobula; all chains including funder-adjacent are measured with the same probe

## Test plan

- [x] Single-file addition, one `###` subsection appended before the existing closing paragraph
- [x] No structural change, no table modification, no existing content touched
- [x] Preserves the existing `Finality by blockchain` table and the Aside note above
- [x] Reference URLs verified live

Happy to reword, move to an `<Aside>`, or drop entirely if this does not fit the docs' tone.