### PR TITLE
Data Feeds: Tempo integration

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -403,6 +403,14 @@
   },
   "data": [
     {
+      "category": "integration",
+      "date": "2026-07-22",
+      "description": "Chainlink Data Feeds is available on Tempo Mainnet. View the available price feed information on the [Price Feed Addresses](https://docs.chain.link/data-feeds/price-feeds/addresses?network=tempo&page=1) page.",
+      "relatedNetworks": ["tempo"],
+      "title": "Data Feeds Expands to Tempo Mainnet",
+      "topic": "Data Feeds"
+    },
+    {
       "category": "release",
       "date": "2026-07-16",
       "description": "CRE CLI version 1.26.0 is now available. Deployment access request messaging is clearer. Simulation error messages now show the correct workflow directory path.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.25.0...v1.26.0)",

--- a/src/components/QuickLinks/data/productChainLinks.ts
+++ b/src/components/QuickLinks/data/productChainLinks.ts
@@ -174,6 +174,7 @@ export const productChainLinks: ProductChainLinks = {
       soneium: "/data-feeds/price-feeds/addresses?page=1&network=soneium#networks",
       sonic: "/data-feeds/price-feeds/addresses?page=1&network=sonic#networks",
       starknet: "/data-feeds/price-feeds/addresses?page=1&network=starknet#networks",
+      tempo: "/data-feeds/price-feeds/addresses?page=1&network=tempo#networks",
       tron: "/data-feeds/price-feeds/addresses?page=1&network=tron#networks",
       unichain: "/data-feeds/price-feeds/addresses?page=1&network=unichain#networks",
       xlayer: "/data-feeds/price-feeds/addresses?page=1&network=xlayer#networks",

--- a/src/features/data/chains.ts
+++ b/src/features/data/chains.ts
@@ -779,6 +779,24 @@ export const CHAINS: Chain[] = [
     ],
   },
   {
+    page: "tempo",
+    label: "Tempo",
+    title: "Tempo Data Feeds",
+    img: "/assets/chains/tempo.svg",
+    networkStatusUrl: "https://explore.tempo.xyz/",
+    tags: ["default"],
+    supportedFeatures: ["feeds"],
+    networks: [
+      {
+        name: "Tempo Mainnet",
+        explorerUrl: "https://explore.tempo.xyz/address/%s",
+        networkType: "mainnet",
+        rddUrl: "https://reference-data-directory.vercel.app/feeds-tempo-mainnet.json",
+        queryString: "tempo-mainnet",
+      },
+    ],
+  },
+  {
     page: "tron",
     label: "TRON",
     title: "TRON Data Feeds",

--- a/src/scripts/data/detect-new-data.ts
+++ b/src/scripts/data/detect-new-data.ts
@@ -52,6 +52,7 @@ const NETWORK_ENDPOINTS: Record<string, string> = {
   hyperevm: "https://reference-data-directory.vercel.app/feeds-hyperliquid-mainnet.json",
   megaeth: "https://reference-data-directory.vercel.app/feeds-megaeth-mainnet.json",
   robinhood: "https://reference-data-directory.vercel.app/feeds-robinhood-mainnet.json",
+  tempo: "https://reference-data-directory.vercel.app/feeds-tempo-mainnet.json",
 }
 
 const STREAM_DEPRECATION_ENDPOINTS: Array<{ network: string; networkType: "mainnet" | "testnet"; url: string }> = [


### PR DESCRIPTION
This pull request adds support for the Tempo network and its data feeds across the application. The main changes introduce Tempo as a supported chain, update quick links and network endpoints, and announce the integration in the changelog.

**Tempo Network Integration:**

* Added a new entry for the Tempo network in the `CHAINS` array, including its metadata, explorer URL, and support for data feeds. (`src/features/data/chains.ts`)
* Added the Tempo network to the `productChainLinks` mapping, enabling quick access to its price feed addresses. (`src/components/QuickLinks/data/productChainLinks.ts`)
* Added the Tempo network's reference data directory endpoint to the `NETWORK_ENDPOINTS` object, ensuring data feed detection scripts support Tempo. (`src/scripts/data/detect-new-data.ts`)

**Changelog Update:**

* Added a changelog entry announcing the availability of Chainlink Data Feeds on Tempo Mainnet, with a link to the price feed addresses. (`public/changelog.json`)