### PR TITLE
add monad config for svr

### DIFF
--- a/src/config/sidebar.ts
+++ b/src/config/sidebar.ts
@@ -870,7 +870,7 @@ export const SIDEBAR: Partial<Record<Sections, SectionEntry[]>> = {
                   url: "data-feeds/svr-feeds/searcher-onboarding-ethereum",
                 },
                 {
-                  title: "Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain)",
+                  title: "Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain, Monad)",
                   url: "data-feeds/svr-feeds/searcher-onboarding-atlas",
                 },
               ],

--- a/src/content/data-feeds/llms-full.txt
+++ b/src/content/data-feeds/llms-full.txt
@@ -5566,10 +5566,10 @@ This code sample is essentially the same as reading from a standard Chainlink Pr
 
 Chainlink SVR supports two auction paths depending on the network:
 
-| Network                   | Auction System      | Guide                                                                                                     |
-| ------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------- |
-| Ethereum Mainnet          | Flashbots MEV-Share | [Searcher Onboarding: Ethereum Mainnet](/data-feeds/svr-feeds/searcher-onboarding-ethereum)               |
-| Base, Arbitrum, BNB Chain | Atlas               | [Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain)](/data-feeds/svr-feeds/searcher-onboarding-atlas) |
+| Network                          | Auction System      | Guide                                                                                                            |
+| -------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Ethereum Mainnet                 | Flashbots MEV-Share | [Searcher Onboarding: Ethereum Mainnet](/data-feeds/svr-feeds/searcher-onboarding-ethereum)                      |
+| Base, Arbitrum, BNB Chain, Monad | Atlas               | [Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain, Monad)](/data-feeds/svr-feeds/searcher-onboarding-atlas) |
 
 ## Economics and Revenue Split
 
@@ -5588,7 +5588,7 @@ This split provides DeFi protocols with an additional revenue stream while also 
 
 ---
 
-# SVR Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain)
+# SVR Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain, Monad)
 Source: https://docs.chain.link/data-feeds/svr-feeds/searcher-onboarding-atlas
 
 export const contracts = {
@@ -5603,6 +5603,10 @@ export const contracts = {
   bnb: {
     atlas: "0x21B7d28B882772A1Cfe633Daee6f42ebb95DeC4E",
     dappControl: "0x7D50b32444609A9B53BcF208c159C8d0d0767835",
+  },
+  monad: {
+    atlas: "0x006DD7813C90CaB67c1Dc185c21Abb2C7414b061",
+    dappControl: "0xa40d9f38621b4ffb2181508b973519e8133951c0",
   },
 }
 
@@ -5629,6 +5633,23 @@ export const arbitrumFeeds = [
   { asset: "USDT-USD", type: "SVR", aggregator: "0x41F14AfB0eB605097c5950D2458415437A3d2Bcd" },
 ]
 
+export const monadFeeds = [
+  { asset: "APRMON-MON Exchange Rate", type: "SVR", aggregator: "0x124FE2b4a19bC618d6cF0a64e2BBE85C7e3C6ED9" },
+  { asset: "AUSD-USD", type: "SVR", aggregator: "0x253c95994246DE5A83AAFE82909681522DA051Af" },
+  { asset: "BTC-USD", type: "SVR", aggregator: "0x9d8b2A6b6A8748bB5e557505d2dDC9d44b6fd2Dd" },
+  { asset: "CBBTC-USD", type: "SVR", aggregator: "0x5cB59A1E12c781793b1799D99d1F31eA4e79eCE9" },
+  { asset: "EARNAUSD-AUSD Exchange Rate", type: "SVR", aggregator: "0xb95fa18a1892045F671bC1723d452618f3FC0355" },
+  { asset: "ETH-USD", type: "SVR", aggregator: "0xeF3c6C938F82BE8ba983a52F5b0f47eE820DCeb2" },
+  { asset: "EZETH-ETH Exchange Rate", type: "SVR", aggregator: "0x521F749F78dA5d58f70f79aD44f73fDEAA5dc538" },
+  { asset: "GMON-MON Exchange Rate", type: "SVR", aggregator: "0xAF165Ea49569528ff543640834Eb6819f0d9601f" },
+  { asset: "MON-USD", type: "SVR", aggregator: "0x810d5E3dB355bFd2C80c06D89F08523111c6d0F1" },
+  { asset: "SHMON-MON Exchange Rate", type: "SVR", aggregator: "0xE3F1906C6b6EEA63dCc0C016C4ec6746c69e7476" },
+  { asset: "SMON-MON Exchange Rate", type: "SVR", aggregator: "0x0Ebdee66Cdd6ffe566d39eD9F876EE04920E25D4" },
+  { asset: "SYZUSD-YZUSD Exchange Rate", type: "SVR", aggregator: "0x18278ef950F120Cb89960C0c07e965bbAc389cfC" },
+  { asset: "USDC-USD", type: "SVR", aggregator: "0xdE1FE319F71E446143BEC6eEc02d89286E7265ed" },
+  { asset: "USDT0-USD", type: "SVR", aggregator: "0x9e921eC9C5ef689045af16a95569F3644bB41FD3" },
+]
+
 <Aside type="note" title="Searcher Onboarding">
   SVR on Atlas (every chain outside of ETH mainnet) uses a reputation system with **two groups**. Unless otherwise specified for a chain, Atlas includes up to **2 searcher bids** per transaction for on-chain settlement:
 
@@ -5642,7 +5663,7 @@ export const arbitrumFeeds = [
   Searchers can [subscribe here](https://chainlinkcommunity.typeform.com/to/s55Hu2tK) to receive timely Chainlink SVR updates.
 </Aside>
 
-[Chainlink Smart Value Recapture (SVR)](/data-feeds/svr-feeds) has expanded to Base, Arbitrum, and BNB Chain with a new auction system, **Atlas**. This guide provides existing Chainlink SVR searchers with the technical specifications and integration requirements for participating in all non-ETH mainnet SVR auctions.
+[Chainlink Smart Value Recapture (SVR)](/data-feeds/svr-feeds) has expanded to Base, Arbitrum, BNB Chain, and Monad with a new auction system, **Atlas**. This guide provides existing Chainlink SVR searchers with the technical specifications and integration requirements for participating in all non-ETH mainnet SVR auctions.
 
 ## Core Components
 

--- a/src/content/data-feeds/svr-feeds/index.mdx
+++ b/src/content/data-feeds/svr-feeds/index.mdx
@@ -209,10 +209,10 @@ This code sample is essentially the same as reading from a standard Chainlink Pr
 
 Chainlink SVR supports two auction paths depending on the network:
 
-| Network                   | Auction System      | Guide                                                                                                     |
-| ------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------- |
-| Ethereum Mainnet          | Flashbots MEV-Share | [Searcher Onboarding: Ethereum Mainnet](/data-feeds/svr-feeds/searcher-onboarding-ethereum)               |
-| Base, Arbitrum, BNB Chain | Atlas               | [Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain)](/data-feeds/svr-feeds/searcher-onboarding-atlas) |
+| Network                          | Auction System      | Guide                                                                                                            |
+| -------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Ethereum Mainnet                 | Flashbots MEV-Share | [Searcher Onboarding: Ethereum Mainnet](/data-feeds/svr-feeds/searcher-onboarding-ethereum)                      |
+| Base, Arbitrum, BNB Chain, Monad | Atlas               | [Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain, Monad)](/data-feeds/svr-feeds/searcher-onboarding-atlas) |
 
 ## Economics and Revenue Split
 

--- a/src/content/data-feeds/svr-feeds/searcher-onboarding-atlas.mdx
+++ b/src/content/data-feeds/svr-feeds/searcher-onboarding-atlas.mdx
@@ -1,7 +1,7 @@
 ---
 section: dataFeeds
 date: Last Modified
-title: "SVR Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain)"
+title: "SVR Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain, Monad)"
 whatsnext:
   {
     "SVR Feeds Overview": "/data-feeds/svr-feeds",
@@ -25,6 +25,10 @@ export const contracts = {
   bnb: {
     atlas: "0x21B7d28B882772A1Cfe633Daee6f42ebb95DeC4E",
     dappControl: "0x7D50b32444609A9B53BcF208c159C8d0d0767835",
+  },
+  monad: {
+    atlas: "0x006DD7813C90CaB67c1Dc185c21Abb2C7414b061",
+    dappControl: "0xa40d9f38621b4ffb2181508b973519e8133951c0",
   },
 }
 
@@ -106,6 +110,23 @@ export const bnbFeeds = [
   { asset: "XVS-USD", type: "SVR", aggregator: "0x182a1DC5Eb5A8bfF82e324eCB69ED1FFbd5a3FF3" },
 ]
 
+export const monadFeeds = [
+  { asset: "APRMON-MON Exchange Rate", type: "SVR", aggregator: "0x124FE2b4a19bC618d6cF0a64e2BBE85C7e3C6ED9" },
+  { asset: "AUSD-USD", type: "SVR", aggregator: "0x253c95994246DE5A83AAFE82909681522DA051Af" },
+  { asset: "BTC-USD", type: "SVR", aggregator: "0x9d8b2A6b6A8748bB5e557505d2dDC9d44b6fd2Dd" },
+  { asset: "CBBTC-USD", type: "SVR", aggregator: "0x5cB59A1E12c781793b1799D99d1F31eA4e79eCE9" },
+  { asset: "EARNAUSD-AUSD Exchange Rate", type: "SVR", aggregator: "0xb95fa18a1892045F671bC1723d452618f3FC0355" },
+  { asset: "ETH-USD", type: "SVR", aggregator: "0xeF3c6C938F82BE8ba983a52F5b0f47eE820DCeb2" },
+  { asset: "EZETH-ETH Exchange Rate", type: "SVR", aggregator: "0x521F749F78dA5d58f70f79aD44f73fDEAA5dc538" },
+  { asset: "GMON-MON Exchange Rate", type: "SVR", aggregator: "0xAF165Ea49569528ff543640834Eb6819f0d9601f" },
+  { asset: "MON-USD", type: "SVR", aggregator: "0x810d5E3dB355bFd2C80c06D89F08523111c6d0F1" },
+  { asset: "SHMON-MON Exchange Rate", type: "SVR", aggregator: "0xE3F1906C6b6EEA63dCc0C016C4ec6746c69e7476" },
+  { asset: "SMON-MON Exchange Rate", type: "SVR", aggregator: "0x0Ebdee66Cdd6ffe566d39eD9F876EE04920E25D4" },
+  { asset: "SYZUSD-YZUSD Exchange Rate", type: "SVR", aggregator: "0x18278ef950F120Cb89960C0c07e965bbAc389cfC" },
+  { asset: "USDC-USD", type: "SVR", aggregator: "0xdE1FE319F71E446143BEC6eEc02d89286E7265ed" },
+  { asset: "USDT0-USD", type: "SVR", aggregator: "0x9e921eC9C5ef689045af16a95569F3644bB41FD3" },
+]
+
 <Aside type="note" title="Searcher Onboarding">
   SVR on Atlas (every chain outside of ETH mainnet) uses a reputation system with **two groups**. Unless otherwise specified for a chain, Atlas includes up to **2 searcher bids** per transaction for on-chain settlement:
   - One slot is always reserved for the high-reputation set
@@ -119,7 +140,7 @@ Searchers can [subscribe here](https://chainlinkcommunity.typeform.com/to/s55Hu2
 
 </Aside>
 
-[Chainlink Smart Value Recapture (SVR)](/data-feeds/svr-feeds) has expanded to Base, Arbitrum, and BNB Chain with a new auction system, **Atlas**. This guide provides existing Chainlink SVR searchers with the technical specifications and integration requirements for participating in all non-ETH mainnet SVR auctions.
+[Chainlink Smart Value Recapture (SVR)](/data-feeds/svr-feeds) has expanded to Base, Arbitrum, BNB Chain, and Monad with a new auction system, **Atlas**. This guide provides existing Chainlink SVR searchers with the technical specifications and integration requirements for participating in all non-ETH mainnet SVR auctions.
 
 ## Core Components
 
@@ -152,6 +173,7 @@ The following contracts are deployed at version **v1.6.4**.
   <Fragment slot="tab.1">Base</Fragment>
   <Fragment slot="tab.2">Arbitrum</Fragment>
   <Fragment slot="tab.3">BNB Chain</Fragment>
+  <Fragment slot="tab.4">Monad</Fragment>
   <Fragment slot="panel.1">
     <table>
       <thead>
@@ -224,6 +246,30 @@ The following contracts are deployed at version **v1.6.4**.
       </tbody>
     </table>
   </Fragment>
+  <Fragment slot="panel.4">
+    <table>
+      <thead>
+        <tr>
+          <th>Contract</th>
+          <th>Address</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Atlas (v1.6.4)</td>
+          <td>
+            <CopyText text={contracts.monad.atlas} code />
+          </td>
+        </tr>
+        <tr>
+          <td>DappControl</td>
+          <td>
+            <CopyText text={contracts.monad.dappControl} code />
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Fragment>
 </Tabs>
 
 ## Feed Aggregator Addresses
@@ -241,6 +287,7 @@ The following contracts are deployed at version **v1.6.4**.
   <Fragment slot="tab.1">Base</Fragment>
   <Fragment slot="tab.2">Arbitrum</Fragment>
   <Fragment slot="tab.3">BNB Chain</Fragment>
+  <Fragment slot="tab.4">Monad</Fragment>
   <Fragment slot="panel.1">
     <table>
       <thead>
@@ -300,6 +347,30 @@ The following contracts are deployed at version **v1.6.4**.
       </thead>
       <tbody>
         {bnbFeeds.map((feed, i) => (
+          <tr key={i}>
+            <td>
+              <strong>{feed.asset}</strong>
+            </td>
+            <td>{feed.type}</td>
+            <td>
+              <CopyText text={feed.aggregator} code />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </Fragment>
+  <Fragment slot="panel.4">
+    <table>
+      <thead>
+        <tr>
+          <th>Asset</th>
+          <th>Type</th>
+          <th>Aggregator Address</th>
+        </tr>
+      </thead>
+      <tbody>
+        {monadFeeds.map((feed, i) => (
           <tr key={i}>
             <td>
               <strong>{feed.asset}</strong>


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.Any change needs to be discussed before proceeding.**

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #3991 

...

## Description

<!-- Please provide enough information so that others can review your pull request: -->
Adds Monad network support to the Atlas SVR searcher onboarding page, alongside the existing Base, Arbitrum, and BNB Chain networks.
...

## Changes

<!--Explain the **details** for making this change. What existing problem does the pull request solve? -->

### `src/content/data-feeds/svr-feeds/searcher-onboarding-atlas.mdx`
- Updated frontmatter `title` and page introduction to include Monad.
- Added Monad Atlas and DappControl contract addresses to the `contracts` object.
- Added a `monadFeeds` array with 14 SVR feed aggregator addresses for Monad.
- Added a Monad tab (tab.4) and panel to the Contract References section.
- Added a Monad tab (tab.4) and panel to the Feed Aggregator Addresses section.

### `src/config/sidebar.ts`
- Updated the sidebar title from "Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain)" to "Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain, Monad)".

### `src/content/data-feeds/svr-feeds/index.mdx`
- Updated the Searcher Guides table to include Monad in the Atlas auction system row.

## Monad Contracts

| Contract | Address |
| --- | --- |
| Atlas (v1.6.4) | `0x006DD7813C90CaB67c1Dc185c21Abb2C7414b061` |
| DappControl | `0xa40d9f38621b4ffb2181508b973519e8133951c0` |

## Monad SVR Feeds

14 feeds added, including MON/USD, ETH/USD, BTC/USD, USDC/USD, and various exchange rate feeds (APRMON/MON, AUSD/USD, CBBTC/USD, EARNAUSD/AUSD, EZETH/ETH, GMON/MON, SHMON/MON, SMON/MON, SYZUSD/YZUSD, USDT0/USD).