### PR TITLE
Data Streams: fix to support stellar testnet/mainnet

### DIFF
--- a/src/features/feeds/components/Tables.tsx
+++ b/src/features/feeds/components/Tables.tsx
@@ -1110,7 +1110,7 @@ export const StreamsNetworkAddressesTable = ({
 
   const tableContent = (
     <>
-      {showNetworkTypeFilter && isHydrated && (
+      {(showNetworkTypeFilter || lockSearch) && isHydrated && (
         <div className={feedList.streamNetworkSelector} style={{ padding: "0.5rem 0.5rem 0" }}>
           <span className={feedList.streamNetworkSelectorLabel}>Environment</span>
           <div className={feedList.streamNetworkToggleGroup} role="group" aria-label="Select network environment">

--- a/src/features/feeds/data/StreamsNetworksData.ts
+++ b/src/features/feeds/data/StreamsNetworksData.ts
@@ -702,12 +702,12 @@ export const StreamsNetworksData: NetworkData[] = [
     mainnet: {
       label: "Stellar Mainnet",
       verifierProxy: "CAKA3NBYPC6OBEUEGNIYGNYG3ES2GPQK736B5SR7ASGUXRDAKXI2JCQI",
-      explorerUrl: "https://stellarchain.io/contracts/%s",
+      explorerUrl: "https://stellar.expert/explorer/mainnet/contract/%s",
     },
     testnet: {
       label: "Stellar Testnet",
       verifierProxy: "CA7GVHWH4GRHE6GI7MHEKQZAOYO4GE7KRGSU3EOS3HYJRVLX3XEA4ONQ",
-      explorerUrl: "https://stellarchain.io/contracts/%s",
+      explorerUrl: "https://stellar.expert/explorer/testnet/contract/%s",
     },
   },
   {


### PR DESCRIPTION
This pull request introduces a minor UI improvement and updates the explorer URLs for Stellar networks. The most important changes are:

UI improvements:
* Updated the logic in `StreamsNetworkAddressesTable` to show the network type filter when either `showNetworkTypeFilter` or `lockSearch` is true, improving flexibility in the table display.

Network configuration updates:
* Changed the `explorerUrl` for both Stellar Mainnet and Testnet in `StreamsNetworksData` to use `stellar.expert` instead of `stellarchain.io`, ensuring users are directed to the correct explorer.