### PR TITLE
docs(ccip): link OpenChainBench live latency measurement on execution-latency page

### DIFF
--- a/src/content/ccip/ccip-execution-latency.mdx
+++ b/src/content/ccip/ccip-execution-latency.mdx
@@ -169,6 +169,10 @@ This section provides an overview of the finality methods CCIP uses to determine
 | Zircuit           | Finality tag                              | 21 minutes                  |
 | ZKsync            | [Block depth](#block-depth) (1200 blocks) | 20 minutes                  |
 
+## Observed end-to-end latency
+
+The finality times listed above are the source-chain component of CCIP's total execution time. For a live measurement of the full pipeline (source transaction to destination `Execute` including DON commit, RMN verification, and executor delivery), see the [OpenChainBench Chainlink CCIP latency benchmark](https://openchainbench.com/benchmarks/chainlink-ccip-latency). The benchmark polls the public [CCIP Tools API](https://docs.chain.link/ccip/tools/api) every 60 seconds, computes per-source-chain p50/p90/p99 over a 24-hour window from `receiptTimestamp - sendTimestamp` on `status: SUCCESS` messages, and exposes both the raw distribution and the source code of the observer.
+
 This page provides details on the expected latency for a cross-chain transaction using CCIP, covering the different stages of transaction processing and the factors that influence overall execution times.
 
 For a comprehensive understanding of CCIP's architecture and how messages flow through the system, refer to the [CCIP detailed architecture](/ccip/concepts/architecture/overview) documentation.


### PR DESCRIPTION
The `ccip-execution-latency.mdx` page documents the theoretical source-chain finality component of CCIP's total execution time (finality tags, block depth, etc.). This PR adds a small "Observed end-to-end latency" section pointing readers to a live third-party measurement of the full source-to-destination pipeline.

The linked benchmark polls the public [CCIP Tools API](https://docs.chain.link/ccip/tools/api), filters to `status: SUCCESS` mainnet messages, and publishes per-source-chain p50/p90/p99 over a rolling 24h window. The methodology explicitly frames the source-chain finality wait as a security tradeoff (matching this doc's framing) rather than a performance limitation. Harness source is open in the linked repo so readers can audit the query and sampling.

Placed at the end of the finality table so it reads as complementary observational data, not a replacement for the architectural explanation above it.