### PR TITLE
CRE: Updated account access info for confidential WFs

### DIFF
--- a/src/content/cre/account/confidential-workflows-access.mdx
+++ b/src/content/cre/account/confidential-workflows-access.mdx
@@ -14,6 +14,6 @@ metadata:
 
 Submit the [Confidential Workflows access request form](https://docs.google.com/forms/d/e/1FAIpQLSdk8mxDZAXpEX1PHgjzCoBeKxSoQysoO9sxOb-gpBrDrjOhtA/viewform?usp=header) to request enrollment in the Confidential Workflows private beta. Let us know which use case you're building toward—this helps route your request to the right team.
 
-The Go and TypeScript CRE SDKs ship Confidential Workflows on their standard release line, so no separate SDK version is needed—once your request is approved, your account is enabled to simulate and deploy Confidential Workflows.
+After submitting your request, you don't need to wait for early access. Your CRE organization can run Confidential Workflows using the local simulator. Get started with the [reference confidential workflows](https://docs.chain.link/cre/guides/workflow/using-confidential-workflows).
 
 See [Confidential Workflows in CRE](/cre/concepts/confidential-workflows) for a conceptual overview, and [Making a Workflow Confidential](/cre/guides/workflow/using-confidential-workflows/making-workflow-confidential) to get started once you're enrolled.

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -7445,7 +7445,7 @@ Last Updated: 2026-07-28
 
 Submit the [Confidential Workflows access request form](https://docs.google.com/forms/d/e/1FAIpQLSdk8mxDZAXpEX1PHgjzCoBeKxSoQysoO9sxOb-gpBrDrjOhtA/viewform?usp=header) to request enrollment in the Confidential Workflows private beta. Let us know which use case you're building toward—this helps route your request to the right team.
 
-The Go and TypeScript CRE SDKs ship Confidential Workflows on their standard release line, so no separate SDK version is needed—once your request is approved, your account is enabled to simulate and deploy Confidential Workflows.
+After submitting your request, you don't need to wait for early access. Your CRE organization can run Confidential Workflows using the local simulator. Get started with the [reference confidential workflows](https://docs.chain.link/cre/guides/workflow/using-confidential-workflows).
 
 See [Confidential Workflows in CRE](/cre/concepts/confidential-workflows) for a conceptual overview, and [Making a Workflow Confidential](/cre/guides/workflow/using-confidential-workflows/making-workflow-confidential) to get started once you're enrolled.
 

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -7207,7 +7207,7 @@ Last Updated: 2026-07-28
 
 Submit the [Confidential Workflows access request form](https://docs.google.com/forms/d/e/1FAIpQLSdk8mxDZAXpEX1PHgjzCoBeKxSoQysoO9sxOb-gpBrDrjOhtA/viewform?usp=header) to request enrollment in the Confidential Workflows private beta. Let us know which use case you're building toward—this helps route your request to the right team.
 
-The Go and TypeScript CRE SDKs ship Confidential Workflows on their standard release line, so no separate SDK version is needed—once your request is approved, your account is enabled to simulate and deploy Confidential Workflows.
+After submitting your request, you don't need to wait for early access. Your CRE organization can run Confidential Workflows using the local simulator. Get started with the [reference confidential workflows](https://docs.chain.link/cre/guides/workflow/using-confidential-workflows).
 
 See [Confidential Workflows in CRE](/cre/concepts/confidential-workflows) for a conceptual overview, and [Making a Workflow Confidential](/cre/guides/workflow/using-confidential-workflows/making-workflow-confidential) to get started once you're enrolled.
 


### PR DESCRIPTION
This pull request updates the documentation for Confidential Workflows access in the Chainlink CRE platform. The changes clarify that after submitting an access request, users can immediately start using the local simulator for Confidential Workflows without waiting for early access approval. This improves the onboarding experience and makes it clearer how to get started.

**Documentation improvements:**

* Updated the instructions in `src/content/cre/account/confidential-workflows-access.mdx`, `src/content/cre/llms-full-go.txt`, and `src/content/cre/llms-full-ts.txt` to clarify that users can use the local simulator for Confidential Workflows immediately after submitting the access request, without waiting for early access approval. The new guidance also provides a direct link to the reference confidential workflows guide. [[1]](diffhunk://#diff-a4b260adab6d96209b9148ca4e35004d3d68fe152d99be47997c030dcee97e7eL17-R17) [[2]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL7448-R7448) [[3]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L7210-R7210)