### PR TITLE
Sort CRE templates by publish date

### DIFF
--- a/src/pages/cre-templates/index.astro
+++ b/src/pages/cre-templates/index.astro
@@ -3,7 +3,9 @@ import { getCollection } from "astro:content"
 import BaseLayout from "~/layouts/BaseLayout.astro"
 import TemplateCard from "~/components/CRETemplate/TemplateCard.astro"
 
-const templates = await getCollection("cre-templates")
+const templates = (await getCollection("cre-templates")).sort(
+  (a, b) => (b.data.datePublished ?? "").localeCompare(a.data.datePublished ?? "")
+)
 const featuredTemplate = templates.find((t) => t.data.featured)
 
 const pageTitle = "CRE Templates Hub | Chainlink Documentation"


### PR DESCRIPTION
## Tracking issue

None.

## Description

Sort the CRE template collection by descending `datePublished` so newly published templates render first on `/cre-templates`.

## Verification

- Evaluated the comparator against all CRE template frontmatter. The four templates dated `2026-08-04` sort before the older templates.

