### PR TITLE
Sort CRE templates by publication date

### DIFF
--- a/src/pages/cre-templates/index.astro
+++ b/src/pages/cre-templates/index.astro
@@ -3,7 +3,9 @@ import { getCollection } from "astro:content"
 import BaseLayout from "~/layouts/BaseLayout.astro"
 import TemplateCard from "~/components/CRETemplate/TemplateCard.astro"
 
-const templates = await getCollection("cre-templates")
+const templates = (await getCollection("cre-templates")).sort(
+  (a, b) => (b.data.datePublished ?? "").localeCompare(a.data.datePublished ?? "")
+)
 const featuredTemplate = templates.find((t) => t.data.featured)
 
 const pageTitle = "CRE Templates Hub | Chainlink Documentation"


### PR DESCRIPTION
## Description

Sort the CRE template collection by descending datePublished so newly published templates render first on /cre-templates.
