### PR TITLE
CRE: Confidential workflow continued updates

### DIFF
--- a/src/content/cre/concepts/confidential-workflows.mdx
+++ b/src/content/cre/concepts/confidential-workflows.mdx
@@ -38,7 +38,7 @@ Functionally, running a workflow confidentially means moving execution of the se
 1. **Declare a confidential handler:** Register the handler that should run inside a TEE, specifying which TEE types/regions your workflow accepts.
 2. **Trigger fires:** The Workflow DON hands the triggered request to an enclave instead of executing the callback locally.
 3. **Enclave execution:** Your callback runs inside the enclave, receiving a runtime built for confidential execution instead of the regular DON runtime.
-4. **Dynamic secret fetch:** Secrets are requested and decrypted inside the enclave at the moment your code needs them—there's no upfront declaration.
+4. **Dynamic secret fetch:** Secrets are requested and decrypted inside the enclave at the moment your code needs them.
 5. **In-enclave capability calls:** Capabilities that support it can execute directly from inside the enclave; trust comes from enclave attestation rather than DON-level consensus.
 6. **Crossing back to the DON:** For anything that needs Workflow DON consensus—like generating a signed report—you explicitly cross back out to a regular DON runtime. Once data passes through that runtime, it's handled like any non-confidential capability call.
 
@@ -48,7 +48,7 @@ See the [step-by-step guide](/cre/guides/workflow/using-confidential-workflows) 
 
 ## Confidentiality boundary
 
-Confidential Workflows protects specific things by default. Everything else is left to your explicit workflow design—understanding the boundary matters for reasoning about what's actually intended to remain confidential from node operators.
+Confidential Workflows protect specific things by default. Everything else is left to your explicit workflow design.
 
 | Protected by default                                                                    | Not automatically protected                                                                                              |
 | :-------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
@@ -57,15 +57,25 @@ Confidential Workflows protects specific things by default. Everything else is l
 | Capability calls made from inside the enclave (see [How it works](#how-it-works))       | Capability requests and responses that aren't routed through the enclave, unless that capability adds its own protection |
 | Enclave execution memory, for as long as your computation runs inside it                | Reports, transaction calldata, and any output you deliver outside the enclave boundary                                   |
 
-Your handler's source code and compiled binary are **not** confidential just because part of its logic runs inside an enclave—only the computation itself, while it's executing inside the enclave, and the secrets and sensitive inputs it processes there, are designed to remain confidential from node operators. If your workflow's logic is sensitive on its own (a scoring formula, a risk threshold), design so that logic actually runs inside the enclave; don't rely on the deployed binary being unreadable, since it isn't protected. You remain responsible for not leaking confidential information back out through logs, workflow outputs, external API requests, or blockchain transactions.
+You remain responsible for not leaking confidential information back out through logs, workflow outputs, external API requests, or blockchain transactions.
 
-"Protected" here means designed to remain confidential from Workflow DON node operators—it does not mean isolated from other confidential workloads. A single enclave can execute confidential workflows from multiple customers concurrently, sharing the same execution memory.
+<Aside type="caution" title="Workflow logic is not confidential">
+  Your handler's source code and compiled binary are not confidential just because part of its logic runs inside an
+  enclave. Confidential Workflows protect only the confidential data processed during execution inside the enclave,
+  including Vault DON secrets (such as API keys), sensitive HTTP response payloads, and intermediate values that are not
+  explicitly shared outside the enclave. Support for confidential logic or workflow is planned as a future enhancement,
+  not part of the current beta.
+</Aside>
 
-<Aside type="caution" title="Workflow execution isolation within the enclave is not currently supported">
-  A single enclave isn't dedicated to one customer or workflow: it can execute confidential workflows from different
-  customers concurrently, sharing the same execution memory. Isolating separate confidential executions from each other
-  within a shared enclave is not currently supported. This is planned as a future enhancement, not part of the current
-  beta.
+<Aside type="caution" title="Multiple confidential workflows may execute within the same enclave">
+  Workflows are isolated from one another by Wasmtime. Dedicated per-workflow enclave isolation is planned as a future
+  enhancement.
+</Aside>
+
+<Aside type="caution" title="Don't log in production Confidential Workflows">
+  Logging within enclave execution logic should be avoided in production workflows. For debugging purposes, logging may
+  be used in simulation environments. Anything you log from inside a Confidential Workflow handler could leak data the
+  enclave is meant to protect—remove or gate log statements before deploying.
 </Aside>
 
 ## Choosing Confidential Workflows
@@ -75,14 +85,6 @@ Use a regular capability when nothing about the request, response, or logic is s
 ## Use cases
 
 Confidential Workflows apply anywhere the computation behind a decision—not just a workflow's API calls—needs to remain confidential from node operators.
-
-<Aside type="note" title="Full logic isolation between workflows is on the roadmap">
-  The examples below describe workflows where keeping sensitive computation confidential from Workflow DON node
-  operators has real value. Isolating that same computation from *other* confidential workflows—since a single enclave
-  can run workloads from multiple parties concurrently—isn't guaranteed today; see [Confidentiality
-  boundary](#confidentiality-boundary). Full isolation between tenants is planned as a future enhancement, not part of
-  the current beta.
-</Aside>
 
 ### Automated liquidation protection
 

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -8393,7 +8393,7 @@ Functionally, running a workflow confidentially means moving execution of the se
 1. **Declare a confidential handler:** Register the handler that should run inside a TEE, specifying which TEE types/regions your workflow accepts.
 2. **Trigger fires:** The Workflow DON hands the triggered request to an enclave instead of executing the callback locally.
 3. **Enclave execution:** Your callback runs inside the enclave, receiving a runtime built for confidential execution instead of the regular DON runtime.
-4. **Dynamic secret fetch:** Secrets are requested and decrypted inside the enclave at the moment your code needs them—there's no upfront declaration.
+4. **Dynamic secret fetch:** Secrets are requested and decrypted inside the enclave at the moment your code needs them.
 5. **In-enclave capability calls:** Capabilities that support it can execute directly from inside the enclave; trust comes from enclave attestation rather than DON-level consensus.
 6. **Crossing back to the DON:** For anything that needs Workflow DON consensus—like generating a signed report—you explicitly cross back out to a regular DON runtime. Once data passes through that runtime, it's handled like any non-confidential capability call.
 
@@ -8403,7 +8403,7 @@ See the [step-by-step guide](/cre/guides/workflow/using-confidential-workflows) 
 
 ## Confidentiality boundary
 
-Confidential Workflows protects specific things by default. Everything else is left to your explicit workflow design—understanding the boundary matters for reasoning about what's actually intended to remain confidential from node operators.
+Confidential Workflows protect specific things by default. Everything else is left to your explicit workflow design.
 
 | Protected by default                                                                    | Not automatically protected                                                                                              |
 | :-------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
@@ -8412,15 +8412,25 @@ Confidential Workflows protects specific things by default. Everything else is l
 | Capability calls made from inside the enclave (see [How it works](#how-it-works))       | Capability requests and responses that aren't routed through the enclave, unless that capability adds its own protection |
 | Enclave execution memory, for as long as your computation runs inside it                | Reports, transaction calldata, and any output you deliver outside the enclave boundary                                   |
 
-Your handler's source code and compiled binary are **not** confidential just because part of its logic runs inside an enclave—only the computation itself, while it's executing inside the enclave, and the secrets and sensitive inputs it processes there, are designed to remain confidential from node operators. If your workflow's logic is sensitive on its own (a scoring formula, a risk threshold), design so that logic actually runs inside the enclave; don't rely on the deployed binary being unreadable, since it isn't protected. You remain responsible for not leaking confidential information back out through logs, workflow outputs, external API requests, or blockchain transactions.
+You remain responsible for not leaking confidential information back out through logs, workflow outputs, external API requests, or blockchain transactions.
 
-"Protected" here means designed to remain confidential from Workflow DON node operators—it does not mean isolated from other confidential workloads. A single enclave can execute confidential workflows from multiple customers concurrently, sharing the same execution memory.
+<Aside type="caution" title="Workflow logic is not confidential">
+  Your handler's source code and compiled binary are not confidential just because part of its logic runs inside an
+  enclave. Confidential Workflows protect only the confidential data processed during execution inside the enclave,
+  including Vault DON secrets (such as API keys), sensitive HTTP response payloads, and intermediate values that are not
+  explicitly shared outside the enclave. Support for confidential logic or workflow is planned as a future enhancement,
+  not part of the current beta.
+</Aside>
 
-<Aside type="caution" title="Workflow execution isolation within the enclave is not currently supported">
-  A single enclave isn't dedicated to one customer or workflow: it can execute confidential workflows from different
-  customers concurrently, sharing the same execution memory. Isolating separate confidential executions from each other
-  within a shared enclave is not currently supported. This is planned as a future enhancement, not part of the current
-  beta.
+<Aside type="caution" title="Multiple confidential workflows may execute within the same enclave">
+  Workflows are isolated from one another by Wasmtime. Dedicated per-workflow enclave isolation is planned as a future
+  enhancement.
+</Aside>
+
+<Aside type="caution" title="Don't log in production Confidential Workflows">
+  Logging within enclave execution logic should be avoided in production workflows. For debugging purposes, logging may
+  be used in simulation environments. Anything you log from inside a Confidential Workflow handler could leak data the
+  enclave is meant to protect—remove or gate log statements before deploying.
 </Aside>
 
 ## Choosing Confidential Workflows
@@ -8430,14 +8440,6 @@ Use a regular capability when nothing about the request, response, or logic is s
 ## Use cases
 
 Confidential Workflows apply anywhere the computation behind a decision—not just a workflow's API calls—needs to remain confidential from node operators.
-
-<Aside type="note" title="Full logic isolation between workflows is on the roadmap">
-  The examples below describe workflows where keeping sensitive computation confidential from Workflow DON node
-  operators has real value. Isolating that same computation from *other* confidential workflows—since a single enclave
-  can run workloads from multiple parties concurrently—isn't guaranteed today; see [Confidentiality
-  boundary](#confidentiality-boundary). Full isolation between tenants is planned as a future enhancement, not part of
-  the current beta.
-</Aside>
 
 ### Automated liquidation protection
 

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -8216,7 +8216,7 @@ Functionally, running a workflow confidentially means moving execution of the se
 1. **Declare a confidential handler:** Register the handler that should run inside a TEE, specifying which TEE types/regions your workflow accepts.
 2. **Trigger fires:** The Workflow DON hands the triggered request to an enclave instead of executing the callback locally.
 3. **Enclave execution:** Your callback runs inside the enclave, receiving a runtime built for confidential execution instead of the regular DON runtime.
-4. **Dynamic secret fetch:** Secrets are requested and decrypted inside the enclave at the moment your code needs them—there's no upfront declaration.
+4. **Dynamic secret fetch:** Secrets are requested and decrypted inside the enclave at the moment your code needs them.
 5. **In-enclave capability calls:** Capabilities that support it can execute directly from inside the enclave; trust comes from enclave attestation rather than DON-level consensus.
 6. **Crossing back to the DON:** For anything that needs Workflow DON consensus—like generating a signed report—you explicitly cross back out to a regular DON runtime. Once data passes through that runtime, it's handled like any non-confidential capability call.
 
@@ -8226,7 +8226,7 @@ See the [step-by-step guide](/cre/guides/workflow/using-confidential-workflows) 
 
 ## Confidentiality boundary
 
-Confidential Workflows protects specific things by default. Everything else is left to your explicit workflow design—understanding the boundary matters for reasoning about what's actually intended to remain confidential from node operators.
+Confidential Workflows protect specific things by default. Everything else is left to your explicit workflow design.
 
 | Protected by default                                                                    | Not automatically protected                                                                                              |
 | :-------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
@@ -8235,15 +8235,25 @@ Confidential Workflows protects specific things by default. Everything else is l
 | Capability calls made from inside the enclave (see [How it works](#how-it-works))       | Capability requests and responses that aren't routed through the enclave, unless that capability adds its own protection |
 | Enclave execution memory, for as long as your computation runs inside it                | Reports, transaction calldata, and any output you deliver outside the enclave boundary                                   |
 
-Your handler's source code and compiled binary are **not** confidential just because part of its logic runs inside an enclave—only the computation itself, while it's executing inside the enclave, and the secrets and sensitive inputs it processes there, are designed to remain confidential from node operators. If your workflow's logic is sensitive on its own (a scoring formula, a risk threshold), design so that logic actually runs inside the enclave; don't rely on the deployed binary being unreadable, since it isn't protected. You remain responsible for not leaking confidential information back out through logs, workflow outputs, external API requests, or blockchain transactions.
+You remain responsible for not leaking confidential information back out through logs, workflow outputs, external API requests, or blockchain transactions.
 
-"Protected" here means designed to remain confidential from Workflow DON node operators—it does not mean isolated from other confidential workloads. A single enclave can execute confidential workflows from multiple customers concurrently, sharing the same execution memory.
+<Aside type="caution" title="Workflow logic is not confidential">
+  Your handler's source code and compiled binary are not confidential just because part of its logic runs inside an
+  enclave. Confidential Workflows protect only the confidential data processed during execution inside the enclave,
+  including Vault DON secrets (such as API keys), sensitive HTTP response payloads, and intermediate values that are not
+  explicitly shared outside the enclave. Support for confidential logic or workflow is planned as a future enhancement,
+  not part of the current beta.
+</Aside>
 
-<Aside type="caution" title="Workflow execution isolation within the enclave is not currently supported">
-  A single enclave isn't dedicated to one customer or workflow: it can execute confidential workflows from different
-  customers concurrently, sharing the same execution memory. Isolating separate confidential executions from each other
-  within a shared enclave is not currently supported. This is planned as a future enhancement, not part of the current
-  beta.
+<Aside type="caution" title="Multiple confidential workflows may execute within the same enclave">
+  Workflows are isolated from one another by Wasmtime. Dedicated per-workflow enclave isolation is planned as a future
+  enhancement.
+</Aside>
+
+<Aside type="caution" title="Don't log in production Confidential Workflows">
+  Logging within enclave execution logic should be avoided in production workflows. For debugging purposes, logging may
+  be used in simulation environments. Anything you log from inside a Confidential Workflow handler could leak data the
+  enclave is meant to protect—remove or gate log statements before deploying.
 </Aside>
 
 ## Choosing Confidential Workflows
@@ -8253,14 +8263,6 @@ Use a regular capability when nothing about the request, response, or logic is s
 ## Use cases
 
 Confidential Workflows apply anywhere the computation behind a decision—not just a workflow's API calls—needs to remain confidential from node operators.
-
-<Aside type="note" title="Full logic isolation between workflows is on the roadmap">
-  The examples below describe workflows where keeping sensitive computation confidential from Workflow DON node
-  operators has real value. Isolating that same computation from *other* confidential workflows—since a single enclave
-  can run workloads from multiple parties concurrently—isn't guaranteed today; see [Confidentiality
-  boundary](#confidentiality-boundary). Full isolation between tenants is planned as a future enhancement, not part of
-  the current beta.
-</Aside>
 
 ### Automated liquidation protection
 


### PR DESCRIPTION
This pull request updates the documentation for Confidential Workflows to clarify the confidentiality boundaries, improve cautionary guidance, and remove outdated or redundant notes. The changes make it clearer what is and isn’t protected, emphasize user responsibility regarding confidential data, and outline current and future isolation guarantees.

**Documentation clarifications and improvements:**

* Clarified that Confidential Workflows protect only specific data by default, and that users are responsible for their workflow design and for not leaking confidential information through logs or outputs (`src/content/cre/concepts/confidential-workflows.mdx`, `llms-full-go.txt`, `llms-full-ts.txt`). [[1]](diffhunk://#diff-d71b27a9890d08c7646d1754a820cad410699bbd64769574006015fd610f2295L51-R51) [[2]](diffhunk://#diff-d71b27a9890d08c7646d1754a820cad410699bbd64769574006015fd610f2295L60-R78) [[3]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8406-R8406) [[4]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8415-R8433) [[5]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L8229-R8229) [[6]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L8238-R8256)

* Added prominent caution asides explaining:
  - Workflow logic (source/binary) is not confidential—only runtime data inside the enclave is protected.
  - Multiple confidential workflows may run concurrently in the same enclave, with isolation provided by Wasmtime, and dedicated isolation planned for the future.
  - Logging inside confidential handlers can leak protected data and should be avoided in production. [[1]](diffhunk://#diff-d71b27a9890d08c7646d1754a820cad410699bbd64769574006015fd610f2295L60-R78) [[2]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8415-R8433) [[3]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L8238-R8256)

**Simplification and removal of outdated notes:**

* Removed redundant or outdated cautionary notes about the lack of full logic isolation between workflows, replacing them with up-to-date asides about current and planned isolation mechanisms. [[1]](diffhunk://#diff-d71b27a9890d08c7646d1754a820cad410699bbd64769574006015fd610f2295L79-L86) [[2]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8434-L8441) [[3]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L8257-L8264)

**Minor text edits for clarity:**

* Removed the phrase about “no upfront declaration” from the description of dynamic secret fetching for conciseness. [[1]](diffhunk://#diff-d71b27a9890d08c7646d1754a820cad410699bbd64769574006015fd610f2295L41-R41) [[2]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8396-R8396) [[3]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L8219-R8219)