### PR TITLE
CRE: Confidential Workflow improvements

### DIFF
--- a/src/content/cre/concepts/confidential-workflows.mdx
+++ b/src/content/cre/concepts/confidential-workflows.mdx
@@ -90,30 +90,25 @@ Confidential Workflows apply anywhere the computation behind a decision—not ju
 
 A workflow monitors a leveraged position's collateral health and closes or adjusts it before liquidation. Running the risk thresholds and defensive strategy inside the enclave is designed to prevent them from being predicted and front-run.
 
-<Aside type="tip" title="Reference example available">
-  See the complete [Automated Liquidation Protection
-  example](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/automated-liquidation-protection)
-  (TypeScript).
+<Aside type="tip" title="Reference template available">
+  See the [Automated Liquidation Protection template](/cre-templates/automated-liquidation-protection) (TypeScript).
 </Aside>
 
 ### Automated portfolio rebalancing
 
 A workflow rebalances a portfolio toward target allocations once drift crosses a threshold. Running the allocation policy and trade-sizing decisions inside the enclave is designed to prevent the rebalance from being anticipated and traded against.
 
-<Aside type="tip" title="Reference example available">
-  See the complete [Automated Portfolio Rebalancing
-  example](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/automated-portfolio-rebalancing)
-  (TypeScript).
+<Aside type="tip" title="Reference template available">
+  See the [Automated Portfolio Rebalancing template](/cre-templates/automated-portfolio-rebalancing) (TypeScript).
 </Aside>
 
 ### LLM smart contract audit firewall
 
 A workflow evaluates a proposed transaction or contract against one or more LLMs for risk signals before allowing it to proceed. The evaluation criteria and third-party API credentials stay inside the enclave.
 
-<Aside type="tip" title="Reference example available">
-  See the complete [AI Smart Contract Audit Firewall
-  example](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/ai-audit-firewall) (TypeScript,
-  with optional onchain delivery via `EVMClient`).
+<Aside type="tip" title="Reference template available">
+  See the [AI Smart Contract Audit Firewall template](/cre-templates/ai-audit-firewall) (TypeScript, with optional
+  onchain delivery via `EVMClient`).
 </Aside>
 
 ### Proprietary or confidential data computation

--- a/src/content/cre/concepts/confidential-workflows.mdx
+++ b/src/content/cre/concepts/confidential-workflows.mdx
@@ -38,7 +38,7 @@ Functionally, running a workflow confidentially means moving execution of the se
 1. **Declare a confidential handler:** Register the handler that should run inside a TEE, specifying which TEE types/regions your workflow accepts.
 2. **Trigger fires:** The Workflow DON hands the triggered request to an enclave instead of executing the callback locally.
 3. **Enclave execution:** Your callback runs inside the enclave, receiving a runtime built for confidential execution instead of the regular DON runtime.
-4. **Dynamic secret fetch:** Secrets are requested and decrypted inside the enclave at the moment your code needs them—there's no upfront declaration.
+4. **Dynamic secret fetch:** Secrets are requested and decrypted inside the enclave at the moment your code needs them.
 5. **In-enclave capability calls:** Capabilities that support it can execute directly from inside the enclave; trust comes from enclave attestation rather than DON-level consensus.
 6. **Crossing back to the DON:** For anything that needs Workflow DON consensus—like generating a signed report—you explicitly cross back out to a regular DON runtime. Once data passes through that runtime, it's handled like any non-confidential capability call.
 
@@ -48,7 +48,7 @@ See the [step-by-step guide](/cre/guides/workflow/using-confidential-workflows) 
 
 ## Confidentiality boundary
 
-Confidential Workflows protects specific things by default. Everything else is left to your explicit workflow design—understanding the boundary matters for reasoning about what's actually intended to remain confidential from node operators.
+Confidential Workflows protect specific things by default. Everything else is left to your explicit workflow design.
 
 | Protected by default                                                                    | Not automatically protected                                                                                              |
 | :-------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
@@ -57,15 +57,25 @@ Confidential Workflows protects specific things by default. Everything else is l
 | Capability calls made from inside the enclave (see [How it works](#how-it-works))       | Capability requests and responses that aren't routed through the enclave, unless that capability adds its own protection |
 | Enclave execution memory, for as long as your computation runs inside it                | Reports, transaction calldata, and any output you deliver outside the enclave boundary                                   |
 
-Your handler's source code and compiled binary are **not** confidential just because part of its logic runs inside an enclave—only the computation itself, while it's executing inside the enclave, and the secrets and sensitive inputs it processes there, are designed to remain confidential from node operators. If your workflow's logic is sensitive on its own (a scoring formula, a risk threshold), design so that logic actually runs inside the enclave; don't rely on the deployed binary being unreadable, since it isn't protected. You remain responsible for not leaking confidential information back out through logs, workflow outputs, external API requests, or blockchain transactions.
+You remain responsible for not leaking confidential information back out through logs, workflow outputs, external API requests, or blockchain transactions.
 
-"Protected" here means designed to remain confidential from Workflow DON node operators—it does not mean isolated from other confidential workloads. A single enclave can execute confidential workflows from multiple customers concurrently, sharing the same execution memory.
+<Aside type="caution" title="Workflow logic is not confidential">
+  Your handler's source code and compiled binary are not confidential just because part of its logic runs inside an
+  enclave. Confidential Workflows protect only the confidential data processed during execution inside the enclave,
+  including Vault DON secrets (such as API keys), sensitive HTTP response payloads, and intermediate values that are not
+  explicitly shared outside the enclave. Support for confidential logic or workflow is planned as a future enhancement,
+  not part of the current beta.
+</Aside>
 
-<Aside type="caution" title="Workflow execution isolation within the enclave is not currently supported">
-  A single enclave isn't dedicated to one customer or workflow: it can execute confidential workflows from different
-  customers concurrently, sharing the same execution memory. Isolating separate confidential executions from each other
-  within a shared enclave is not currently supported. This is planned as a future enhancement, not part of the current
-  beta.
+<Aside type="caution" title="Multiple confidential workflows may execute within the same enclave">
+  Workflows are isolated from one another by Wasmtime. Dedicated per-workflow enclave isolation is planned as a future
+  enhancement.
+</Aside>
+
+<Aside type="caution" title="Don't log in production Confidential Workflows">
+  Logging within enclave execution logic should be avoided in production workflows. For debugging purposes, logging may
+  be used in simulation environments. Anything you log from inside a Confidential Workflow handler could leak data the
+  enclave is meant to protect—remove or gate log statements before deploying.
 </Aside>
 
 ## Choosing Confidential Workflows
@@ -75,14 +85,6 @@ Use a regular capability when nothing about the request, response, or logic is s
 ## Use cases
 
 Confidential Workflows apply anywhere the computation behind a decision—not just a workflow's API calls—needs to remain confidential from node operators.
-
-<Aside type="note" title="Full logic isolation between workflows is on the roadmap">
-  The examples below describe workflows where keeping sensitive computation confidential from Workflow DON node
-  operators has real value. Isolating that same computation from *other* confidential workflows—since a single enclave
-  can run workloads from multiple parties concurrently—isn't guaranteed today; see [Confidentiality
-  boundary](#confidentiality-boundary). Full isolation between tenants is planned as a future enhancement, not part of
-  the current beta.
-</Aside>
 
 ### Automated liquidation protection
 

--- a/src/content/cre/guides/workflow/using-confidential-workflows/index.mdx
+++ b/src/content/cre/guides/workflow/using-confidential-workflows/index.mdx
@@ -27,15 +27,15 @@ For **why** you might need a Confidential Workflow, see [Confidential Workflows 
 - **[Making a Workflow Confidential](/cre/guides/workflow/using-confidential-workflows/making-workflow-confidential)**: Register a TEE handler, fetch secrets dynamically, and cross back to the DON for anything that needs consensus.
 
 <Aside type="note" title="Minimal example">
-  This guide covers the core mechanics with a minimal example. For complete, production-shaped workflows, see the
-  example workflows below.
+  This guide covers the core mechanics with a minimal example. See the [Hello Confidential Workflows
+  template](/cre-templates/hello-confidential-workflows) for the complete code, or the example workflows below for
+  production-shaped workflows.
 </Aside>
 
 ## Example workflows
 
-Complete TypeScript reference implementations, in
-[`smartcontractkit/confidential-compute-examples`](https://github.com/smartcontractkit/confidential-compute-examples):
+Complete TypeScript reference implementations, available as templates:
 
-- **[Automated Liquidation Protection](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/automated-liquidation-protection)**: Fetches exchange and model secrets, reads policy and risk state, asks an LLM for defensive actions, enforces policy constraints, and executes approved actions.
-- **[Automated Portfolio Rebalancing](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/automated-portfolio-rebalancing)**: Reads policy, holdings, prices, and volatility, asks an LLM for trade proposals, enforces slippage and reserve-floor constraints, and routes approved trades.
-- **[AI Smart Contract Audit Firewall](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/ai-audit-firewall)**: Runs two independent LLM audits on a proposed transaction, merges risk flags into an ALLOW/DENY/MANUAL_REVIEW verdict, and optionally delivers the verdict onchain with `EVMClient`.
+- **[Automated Liquidation Protection](/cre-templates/automated-liquidation-protection)**: Fetches exchange and model secrets, reads policy and risk state, asks an LLM for defensive actions, enforces policy constraints, and executes approved actions.
+- **[Automated Portfolio Rebalancing](/cre-templates/automated-portfolio-rebalancing)**: Reads policy, holdings, prices, and volatility, asks an LLM for trade proposals, enforces slippage and reserve-floor constraints, and routes approved trades.
+- **[AI Smart Contract Audit Firewall](/cre-templates/ai-audit-firewall)**: Runs two independent LLM audits on a proposed transaction, merges risk flags into an ALLOW/DENY/MANUAL_REVIEW verdict, and optionally delivers the verdict onchain with `EVMClient`.

--- a/src/content/cre/guides/workflow/using-confidential-workflows/making-workflow-confidential-go.mdx
+++ b/src/content/cre/guides/workflow/using-confidential-workflows/making-workflow-confidential-go.mdx
@@ -147,7 +147,7 @@ Workflow DON execution—for example, generating a signed report:
 }
 ```
 
-See [Generating Reports: Single Values](/cre/guides/workflow/using-evm-client/onchain-write/generating-reports-single-values) for the full delivery flow (encoding, `WriteReport`, etc.). For a complete example that crosses to the DON runtime and delivers a report onchain with `evmClient.writeReport()`, see the [AI Smart Contract Audit Firewall example](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/ai-audit-firewall) (TypeScript; the same pattern applies in Go).
+See [Generating Reports: Single Values](/cre/guides/workflow/using-evm-client/onchain-write/generating-reports-single-values) for the full delivery flow (encoding, `WriteReport`, etc.). For a complete example that crosses to the DON runtime and delivers a report onchain with `evmClient.writeReport()`, see the [AI Smart Contract Audit Firewall template](/cre-templates/ai-audit-firewall) (TypeScript; the same pattern applies in Go).
 
 <Aside type="caution" title="Data passed to UsingTheDons() is no longer confidential">
   Once you pass a value into a capability call on the runtime returned by

--- a/src/content/cre/guides/workflow/using-confidential-workflows/making-workflow-confidential-ts.mdx
+++ b/src/content/cre/guides/workflow/using-confidential-workflows/making-workflow-confidential-ts.mdx
@@ -124,7 +124,7 @@ runtime.log("Confidential workflow complete")
 return text(response)
 ```
 
-See [Generating Reports: Single Values](/cre/guides/workflow/using-evm-client/onchain-write/generating-reports-single-values) for the full delivery flow (encoding, `writeReport`, etc.). For a complete example that encodes a payload with the `hexToBase64` helper and delivers it onchain with `evmClient.writeReport(donRuntime, ...)`, see the [AI Smart Contract Audit Firewall example](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/ai-audit-firewall).
+See [Generating Reports: Single Values](/cre/guides/workflow/using-evm-client/onchain-write/generating-reports-single-values) for the full delivery flow (encoding, `writeReport`, etc.). For a complete example that encodes a payload with the `hexToBase64` helper and delivers it onchain with `evmClient.writeReport(donRuntime, ...)`, see the [AI Smart Contract Audit Firewall template](/cre-templates/ai-audit-firewall).
 
 <Aside type="caution" title="Data passed to usingTheDons() is no longer confidential">
   Once you pass a value into a capability call on the runtime returned by

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -8393,7 +8393,7 @@ Functionally, running a workflow confidentially means moving execution of the se
 1. **Declare a confidential handler:** Register the handler that should run inside a TEE, specifying which TEE types/regions your workflow accepts.
 2. **Trigger fires:** The Workflow DON hands the triggered request to an enclave instead of executing the callback locally.
 3. **Enclave execution:** Your callback runs inside the enclave, receiving a runtime built for confidential execution instead of the regular DON runtime.
-4. **Dynamic secret fetch:** Secrets are requested and decrypted inside the enclave at the moment your code needs them—there's no upfront declaration.
+4. **Dynamic secret fetch:** Secrets are requested and decrypted inside the enclave at the moment your code needs them.
 5. **In-enclave capability calls:** Capabilities that support it can execute directly from inside the enclave; trust comes from enclave attestation rather than DON-level consensus.
 6. **Crossing back to the DON:** For anything that needs Workflow DON consensus—like generating a signed report—you explicitly cross back out to a regular DON runtime. Once data passes through that runtime, it's handled like any non-confidential capability call.
 
@@ -8403,7 +8403,7 @@ See the [step-by-step guide](/cre/guides/workflow/using-confidential-workflows) 
 
 ## Confidentiality boundary
 
-Confidential Workflows protects specific things by default. Everything else is left to your explicit workflow design—understanding the boundary matters for reasoning about what's actually intended to remain confidential from node operators.
+Confidential Workflows protect specific things by default. Everything else is left to your explicit workflow design.
 
 | Protected by default                                                                    | Not automatically protected                                                                                              |
 | :-------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
@@ -8412,15 +8412,25 @@ Confidential Workflows protects specific things by default. Everything else is l
 | Capability calls made from inside the enclave (see [How it works](#how-it-works))       | Capability requests and responses that aren't routed through the enclave, unless that capability adds its own protection |
 | Enclave execution memory, for as long as your computation runs inside it                | Reports, transaction calldata, and any output you deliver outside the enclave boundary                                   |
 
-Your handler's source code and compiled binary are **not** confidential just because part of its logic runs inside an enclave—only the computation itself, while it's executing inside the enclave, and the secrets and sensitive inputs it processes there, are designed to remain confidential from node operators. If your workflow's logic is sensitive on its own (a scoring formula, a risk threshold), design so that logic actually runs inside the enclave; don't rely on the deployed binary being unreadable, since it isn't protected. You remain responsible for not leaking confidential information back out through logs, workflow outputs, external API requests, or blockchain transactions.
+You remain responsible for not leaking confidential information back out through logs, workflow outputs, external API requests, or blockchain transactions.
 
-"Protected" here means designed to remain confidential from Workflow DON node operators—it does not mean isolated from other confidential workloads. A single enclave can execute confidential workflows from multiple customers concurrently, sharing the same execution memory.
+<Aside type="caution" title="Workflow logic is not confidential">
+  Your handler's source code and compiled binary are not confidential just because part of its logic runs inside an
+  enclave. Confidential Workflows protect only the confidential data processed during execution inside the enclave,
+  including Vault DON secrets (such as API keys), sensitive HTTP response payloads, and intermediate values that are not
+  explicitly shared outside the enclave. Support for confidential logic or workflow is planned as a future enhancement,
+  not part of the current beta.
+</Aside>
 
-<Aside type="caution" title="Workflow execution isolation within the enclave is not currently supported">
-  A single enclave isn't dedicated to one customer or workflow: it can execute confidential workflows from different
-  customers concurrently, sharing the same execution memory. Isolating separate confidential executions from each other
-  within a shared enclave is not currently supported. This is planned as a future enhancement, not part of the current
-  beta.
+<Aside type="caution" title="Multiple confidential workflows may execute within the same enclave">
+  Workflows are isolated from one another by Wasmtime. Dedicated per-workflow enclave isolation is planned as a future
+  enhancement.
+</Aside>
+
+<Aside type="caution" title="Don't log in production Confidential Workflows">
+  Logging within enclave execution logic should be avoided in production workflows. For debugging purposes, logging may
+  be used in simulation environments. Anything you log from inside a Confidential Workflow handler could leak data the
+  enclave is meant to protect—remove or gate log statements before deploying.
 </Aside>
 
 ## Choosing Confidential Workflows
@@ -8430,14 +8440,6 @@ Use a regular capability when nothing about the request, response, or logic is s
 ## Use cases
 
 Confidential Workflows apply anywhere the computation behind a decision—not just a workflow's API calls—needs to remain confidential from node operators.
-
-<Aside type="note" title="Full logic isolation between workflows is on the roadmap">
-  The examples below describe workflows where keeping sensitive computation confidential from Workflow DON node
-  operators has real value. Isolating that same computation from *other* confidential workflows—since a single enclave
-  can run workloads from multiple parties concurrently—isn't guaranteed today; see [Confidentiality
-  boundary](#confidentiality-boundary). Full isolation between tenants is planned as a future enhancement, not part of
-  the current beta.
-</Aside>
 
 ### Automated liquidation protection
 

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -5083,18 +5083,18 @@ For **why** you might need a Confidential Workflow, see [Confidential Workflows 
 - **[Making a Workflow Confidential](/cre/guides/workflow/using-confidential-workflows/making-workflow-confidential)**: Register a TEE handler, fetch secrets dynamically, and cross back to the DON for anything that needs consensus.
 
 <Aside type="note" title="Minimal example">
-  This guide covers the core mechanics with a minimal example. For complete, production-shaped workflows, see the
-  example workflows below.
+  This guide covers the core mechanics with a minimal example. See the [Hello Confidential Workflows
+  template](/cre-templates/hello-confidential-workflows) for the complete code, or the example workflows below for
+  production-shaped workflows.
 </Aside>
 
 ## Example workflows
 
-Complete TypeScript reference implementations, in
-[`smartcontractkit/confidential-compute-examples`](https://github.com/smartcontractkit/confidential-compute-examples):
+Complete TypeScript reference implementations, available as templates:
 
-- **[Automated Liquidation Protection](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/automated-liquidation-protection)**: Fetches exchange and model secrets, reads policy and risk state, asks an LLM for defensive actions, enforces policy constraints, and executes approved actions.
-- **[Automated Portfolio Rebalancing](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/automated-portfolio-rebalancing)**: Reads policy, holdings, prices, and volatility, asks an LLM for trade proposals, enforces slippage and reserve-floor constraints, and routes approved trades.
-- **[AI Smart Contract Audit Firewall](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/ai-audit-firewall)**: Runs two independent LLM audits on a proposed transaction, merges risk flags into an ALLOW/DENY/MANUAL_REVIEW verdict, and optionally delivers the verdict onchain with `EVMClient`.
+- **[Automated Liquidation Protection](/cre-templates/automated-liquidation-protection)**: Fetches exchange and model secrets, reads policy and risk state, asks an LLM for defensive actions, enforces policy constraints, and executes approved actions.
+- **[Automated Portfolio Rebalancing](/cre-templates/automated-portfolio-rebalancing)**: Reads policy, holdings, prices, and volatility, asks an LLM for trade proposals, enforces slippage and reserve-floor constraints, and routes approved trades.
+- **[AI Smart Contract Audit Firewall](/cre-templates/ai-audit-firewall)**: Runs two independent LLM audits on a proposed transaction, merges risk flags into an ALLOW/DENY/MANUAL_REVIEW verdict, and optionally delivers the verdict onchain with `EVMClient`.
 
 ---
 
@@ -8445,30 +8445,25 @@ Confidential Workflows apply anywhere the computation behind a decision—not ju
 
 A workflow monitors a leveraged position's collateral health and closes or adjusts it before liquidation. Running the risk thresholds and defensive strategy inside the enclave is designed to prevent them from being predicted and front-run.
 
-<Aside type="tip" title="Reference example available">
-  See the complete [Automated Liquidation Protection
-  example](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/automated-liquidation-protection)
-  (TypeScript).
+<Aside type="tip" title="Reference template available">
+  See the [Automated Liquidation Protection template](/cre-templates/automated-liquidation-protection) (TypeScript).
 </Aside>
 
 ### Automated portfolio rebalancing
 
 A workflow rebalances a portfolio toward target allocations once drift crosses a threshold. Running the allocation policy and trade-sizing decisions inside the enclave is designed to prevent the rebalance from being anticipated and traded against.
 
-<Aside type="tip" title="Reference example available">
-  See the complete [Automated Portfolio Rebalancing
-  example](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/automated-portfolio-rebalancing)
-  (TypeScript).
+<Aside type="tip" title="Reference template available">
+  See the [Automated Portfolio Rebalancing template](/cre-templates/automated-portfolio-rebalancing) (TypeScript).
 </Aside>
 
 ### LLM smart contract audit firewall
 
 A workflow evaluates a proposed transaction or contract against one or more LLMs for risk signals before allowing it to proceed. The evaluation criteria and third-party API credentials stay inside the enclave.
 
-<Aside type="tip" title="Reference example available">
-  See the complete [AI Smart Contract Audit Firewall
-  example](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/ai-audit-firewall) (TypeScript,
-  with optional onchain delivery via `EVMClient`).
+<Aside type="tip" title="Reference template available">
+  See the [AI Smart Contract Audit Firewall template](/cre-templates/ai-audit-firewall) (TypeScript, with optional
+  onchain delivery via `EVMClient`).
 </Aside>
 
 ### Proprietary or confidential data computation
@@ -14031,7 +14026,7 @@ Workflow DON execution—for example, generating a signed report:
 }
 ```
 
-See [Generating Reports: Single Values](/cre/guides/workflow/using-evm-client/onchain-write/generating-reports-single-values) for the full delivery flow (encoding, `WriteReport`, etc.). For a complete example that crosses to the DON runtime and delivers a report onchain with `evmClient.writeReport()`, see the [AI Smart Contract Audit Firewall example](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/ai-audit-firewall) (TypeScript; the same pattern applies in Go).
+See [Generating Reports: Single Values](/cre/guides/workflow/using-evm-client/onchain-write/generating-reports-single-values) for the full delivery flow (encoding, `WriteReport`, etc.). For a complete example that crosses to the DON runtime and delivers a report onchain with `evmClient.writeReport()`, see the [AI Smart Contract Audit Firewall template](/cre-templates/ai-audit-firewall) (TypeScript; the same pattern applies in Go).
 
 <Aside type="caution" title="Data passed to UsingTheDons() is no longer confidential">
   Once you pass a value into a capability call on the runtime returned by

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -4392,18 +4392,18 @@ For **why** you might need a Confidential Workflow, see [Confidential Workflows 
 - **[Making a Workflow Confidential](/cre/guides/workflow/using-confidential-workflows/making-workflow-confidential)**: Register a TEE handler, fetch secrets dynamically, and cross back to the DON for anything that needs consensus.
 
 <Aside type="note" title="Minimal example">
-  This guide covers the core mechanics with a minimal example. For complete, production-shaped workflows, see the
-  example workflows below.
+  This guide covers the core mechanics with a minimal example. See the [Hello Confidential Workflows
+  template](/cre-templates/hello-confidential-workflows) for the complete code, or the example workflows below for
+  production-shaped workflows.
 </Aside>
 
 ## Example workflows
 
-Complete TypeScript reference implementations, in
-[`smartcontractkit/confidential-compute-examples`](https://github.com/smartcontractkit/confidential-compute-examples):
+Complete TypeScript reference implementations, available as templates:
 
-- **[Automated Liquidation Protection](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/automated-liquidation-protection)**: Fetches exchange and model secrets, reads policy and risk state, asks an LLM for defensive actions, enforces policy constraints, and executes approved actions.
-- **[Automated Portfolio Rebalancing](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/automated-portfolio-rebalancing)**: Reads policy, holdings, prices, and volatility, asks an LLM for trade proposals, enforces slippage and reserve-floor constraints, and routes approved trades.
-- **[AI Smart Contract Audit Firewall](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/ai-audit-firewall)**: Runs two independent LLM audits on a proposed transaction, merges risk flags into an ALLOW/DENY/MANUAL_REVIEW verdict, and optionally delivers the verdict onchain with `EVMClient`.
+- **[Automated Liquidation Protection](/cre-templates/automated-liquidation-protection)**: Fetches exchange and model secrets, reads policy and risk state, asks an LLM for defensive actions, enforces policy constraints, and executes approved actions.
+- **[Automated Portfolio Rebalancing](/cre-templates/automated-portfolio-rebalancing)**: Reads policy, holdings, prices, and volatility, asks an LLM for trade proposals, enforces slippage and reserve-floor constraints, and routes approved trades.
+- **[AI Smart Contract Audit Firewall](/cre-templates/ai-audit-firewall)**: Runs two independent LLM audits on a proposed transaction, merges risk flags into an ALLOW/DENY/MANUAL_REVIEW verdict, and optionally delivers the verdict onchain with `EVMClient`.
 
 ---
 
@@ -8268,30 +8268,25 @@ Confidential Workflows apply anywhere the computation behind a decision—not ju
 
 A workflow monitors a leveraged position's collateral health and closes or adjusts it before liquidation. Running the risk thresholds and defensive strategy inside the enclave is designed to prevent them from being predicted and front-run.
 
-<Aside type="tip" title="Reference example available">
-  See the complete [Automated Liquidation Protection
-  example](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/automated-liquidation-protection)
-  (TypeScript).
+<Aside type="tip" title="Reference template available">
+  See the [Automated Liquidation Protection template](/cre-templates/automated-liquidation-protection) (TypeScript).
 </Aside>
 
 ### Automated portfolio rebalancing
 
 A workflow rebalances a portfolio toward target allocations once drift crosses a threshold. Running the allocation policy and trade-sizing decisions inside the enclave is designed to prevent the rebalance from being anticipated and traded against.
 
-<Aside type="tip" title="Reference example available">
-  See the complete [Automated Portfolio Rebalancing
-  example](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/automated-portfolio-rebalancing)
-  (TypeScript).
+<Aside type="tip" title="Reference template available">
+  See the [Automated Portfolio Rebalancing template](/cre-templates/automated-portfolio-rebalancing) (TypeScript).
 </Aside>
 
 ### LLM smart contract audit firewall
 
 A workflow evaluates a proposed transaction or contract against one or more LLMs for risk signals before allowing it to proceed. The evaluation criteria and third-party API credentials stay inside the enclave.
 
-<Aside type="tip" title="Reference example available">
-  See the complete [AI Smart Contract Audit Firewall
-  example](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/ai-audit-firewall) (TypeScript,
-  with optional onchain delivery via `EVMClient`).
+<Aside type="tip" title="Reference template available">
+  See the [AI Smart Contract Audit Firewall template](/cre-templates/ai-audit-firewall) (TypeScript, with optional
+  onchain delivery via `EVMClient`).
 </Aside>
 
 ### Proprietary or confidential data computation
@@ -14036,7 +14031,7 @@ runtime.log("Confidential workflow complete")
 return text(response)
 ```
 
-See [Generating Reports: Single Values](/cre/guides/workflow/using-evm-client/onchain-write/generating-reports-single-values) for the full delivery flow (encoding, `writeReport`, etc.). For a complete example that encodes a payload with the `hexToBase64` helper and delivers it onchain with `evmClient.writeReport(donRuntime, ...)`, see the [AI Smart Contract Audit Firewall example](https://github.com/smartcontractkit/confidential-compute-examples/tree/main/ai-audit-firewall).
+See [Generating Reports: Single Values](/cre/guides/workflow/using-evm-client/onchain-write/generating-reports-single-values) for the full delivery flow (encoding, `writeReport`, etc.). For a complete example that encodes a payload with the `hexToBase64` helper and delivers it onchain with `evmClient.writeReport(donRuntime, ...)`, see the [AI Smart Contract Audit Firewall template](/cre-templates/ai-audit-firewall).
 
 <Aside type="caution" title="Data passed to usingTheDons() is no longer confidential">
   Once you pass a value into a capability call on the runtime returned by

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -8216,7 +8216,7 @@ Functionally, running a workflow confidentially means moving execution of the se
 1. **Declare a confidential handler:** Register the handler that should run inside a TEE, specifying which TEE types/regions your workflow accepts.
 2. **Trigger fires:** The Workflow DON hands the triggered request to an enclave instead of executing the callback locally.
 3. **Enclave execution:** Your callback runs inside the enclave, receiving a runtime built for confidential execution instead of the regular DON runtime.
-4. **Dynamic secret fetch:** Secrets are requested and decrypted inside the enclave at the moment your code needs them—there's no upfront declaration.
+4. **Dynamic secret fetch:** Secrets are requested and decrypted inside the enclave at the moment your code needs them.
 5. **In-enclave capability calls:** Capabilities that support it can execute directly from inside the enclave; trust comes from enclave attestation rather than DON-level consensus.
 6. **Crossing back to the DON:** For anything that needs Workflow DON consensus—like generating a signed report—you explicitly cross back out to a regular DON runtime. Once data passes through that runtime, it's handled like any non-confidential capability call.
 
@@ -8226,7 +8226,7 @@ See the [step-by-step guide](/cre/guides/workflow/using-confidential-workflows) 
 
 ## Confidentiality boundary
 
-Confidential Workflows protects specific things by default. Everything else is left to your explicit workflow design—understanding the boundary matters for reasoning about what's actually intended to remain confidential from node operators.
+Confidential Workflows protect specific things by default. Everything else is left to your explicit workflow design.
 
 | Protected by default                                                                    | Not automatically protected                                                                                              |
 | :-------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- |
@@ -8235,15 +8235,25 @@ Confidential Workflows protects specific things by default. Everything else is l
 | Capability calls made from inside the enclave (see [How it works](#how-it-works))       | Capability requests and responses that aren't routed through the enclave, unless that capability adds its own protection |
 | Enclave execution memory, for as long as your computation runs inside it                | Reports, transaction calldata, and any output you deliver outside the enclave boundary                                   |
 
-Your handler's source code and compiled binary are **not** confidential just because part of its logic runs inside an enclave—only the computation itself, while it's executing inside the enclave, and the secrets and sensitive inputs it processes there, are designed to remain confidential from node operators. If your workflow's logic is sensitive on its own (a scoring formula, a risk threshold), design so that logic actually runs inside the enclave; don't rely on the deployed binary being unreadable, since it isn't protected. You remain responsible for not leaking confidential information back out through logs, workflow outputs, external API requests, or blockchain transactions.
+You remain responsible for not leaking confidential information back out through logs, workflow outputs, external API requests, or blockchain transactions.
 
-"Protected" here means designed to remain confidential from Workflow DON node operators—it does not mean isolated from other confidential workloads. A single enclave can execute confidential workflows from multiple customers concurrently, sharing the same execution memory.
+<Aside type="caution" title="Workflow logic is not confidential">
+  Your handler's source code and compiled binary are not confidential just because part of its logic runs inside an
+  enclave. Confidential Workflows protect only the confidential data processed during execution inside the enclave,
+  including Vault DON secrets (such as API keys), sensitive HTTP response payloads, and intermediate values that are not
+  explicitly shared outside the enclave. Support for confidential logic or workflow is planned as a future enhancement,
+  not part of the current beta.
+</Aside>
 
-<Aside type="caution" title="Workflow execution isolation within the enclave is not currently supported">
-  A single enclave isn't dedicated to one customer or workflow: it can execute confidential workflows from different
-  customers concurrently, sharing the same execution memory. Isolating separate confidential executions from each other
-  within a shared enclave is not currently supported. This is planned as a future enhancement, not part of the current
-  beta.
+<Aside type="caution" title="Multiple confidential workflows may execute within the same enclave">
+  Workflows are isolated from one another by Wasmtime. Dedicated per-workflow enclave isolation is planned as a future
+  enhancement.
+</Aside>
+
+<Aside type="caution" title="Don't log in production Confidential Workflows">
+  Logging within enclave execution logic should be avoided in production workflows. For debugging purposes, logging may
+  be used in simulation environments. Anything you log from inside a Confidential Workflow handler could leak data the
+  enclave is meant to protect—remove or gate log statements before deploying.
 </Aside>
 
 ## Choosing Confidential Workflows
@@ -8253,14 +8263,6 @@ Use a regular capability when nothing about the request, response, or logic is s
 ## Use cases
 
 Confidential Workflows apply anywhere the computation behind a decision—not just a workflow's API calls—needs to remain confidential from node operators.
-
-<Aside type="note" title="Full logic isolation between workflows is on the roadmap">
-  The examples below describe workflows where keeping sensitive computation confidential from Workflow DON node
-  operators has real value. Isolating that same computation from *other* confidential workflows—since a single enclave
-  can run workloads from multiple parties concurrently—isn't guaranteed today; see [Confidentiality
-  boundary](#confidentiality-boundary). Full isolation between tenants is planned as a future enhancement, not part of
-  the current beta.
-</Aside>
 
 ### Automated liquidation protection
 

--- a/src/pages/cre-templates/index.astro
+++ b/src/pages/cre-templates/index.astro
@@ -3,8 +3,8 @@ import { getCollection } from "astro:content"
 import BaseLayout from "~/layouts/BaseLayout.astro"
 import TemplateCard from "~/components/CRETemplate/TemplateCard.astro"
 
-const templates = (await getCollection("cre-templates")).sort(
-  (a, b) => (b.data.datePublished ?? "").localeCompare(a.data.datePublished ?? "")
+const templates = (await getCollection("cre-templates")).sort((a, b) =>
+  (b.data.datePublished ?? "").localeCompare(a.data.datePublished ?? "")
 )
 const featuredTemplate = templates.find((t) => t.data.featured)
 


### PR DESCRIPTION
This pull request updates documentation for Confidential Workflows to clarify the confidentiality boundary, improve explanations about what is and isn't protected, and add cautionary guidance for workflow authors. It also removes outdated roadmap notes and reorganizes caution messages for better readability. Additionally, there is a small code formatting change in the templates page.

**Documentation improvements:**

* Expanded and clarified the confidentiality boundary section in `confidential-workflows.mdx`, `llms-full-go.txt`, and `llms-full-ts.txt` to explicitly state that only data processed inside the enclave is confidential, not the handler's source code or binary. Added new caution asides explaining that logic isolation and per-workflow enclave isolation are future enhancements, and emphasized the need to avoid logging sensitive data. Outdated or redundant roadmap notes were removed for clarity. [[1]](diffhunk://#diff-d71b27a9890d08c7646d1754a820cad410699bbd64769574006015fd610f2295L60-R78) [[2]](diffhunk://#diff-d71b27a9890d08c7646d1754a820cad410699bbd64769574006015fd610f2295L51-R51) [[3]](diffhunk://#diff-d71b27a9890d08c7646d1754a820cad410699bbd64769574006015fd610f2295L79-L86) [[4]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8415-R8433) [[5]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8406-R8406) [[6]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8434-L8441) [[7]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L8238-R8256) [[8]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L8229-R8229) [[9]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L8257-L8264)
* Updated workflow execution steps to clarify dynamic secret fetching, removing the note about "no upfront declaration" for improved accuracy. [[1]](diffhunk://#diff-d71b27a9890d08c7646d1754a820cad410699bbd64769574006015fd610f2295L41-R41) [[2]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL8396-R8396) [[3]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L8219-R8219)

**Code formatting:**

* Minor formatting improvement in `src/pages/cre-templates/index.astro` for readability in the `sort` call.