### PR TITLE
CRE Template Hub - Remove CLI install option for 3 CRE conf workflow templates

### DIFF
--- a/src/content/cre-templates/ai-audit-firewall.mdx
+++ b/src/content/cre-templates/ai-audit-firewall.mdx
@@ -4,11 +4,6 @@ description: "Automatically analyze and screen smart contract interactions befor
 author: "Chainlink Labs"
 excerpt: "Gate transactions with dual-model AI audits inside a TEE and deliver the verdict onchain in TypeScript or Go."
 image: "thumbnail.jpg"
-cliTemplateIds:
-  - label: "TypeScript"
-    id: "ai-audit-firewall-ts"
-  - label: "Go"
-    id: "ai-audit-firewall-go"
 tags:
   - "confidential"
   - "ai"

--- a/src/content/cre-templates/automated-liquidation-protection.mdx
+++ b/src/content/cre-templates/automated-liquidation-protection.mdx
@@ -4,11 +4,6 @@ description: "Automatically protect DeFi lending positions by continuously monit
 author: "Chainlink Labs"
 excerpt: "Run policy-constrained liquidation defense confidentially with CRE and TEE execution in TypeScript or Go."
 image: "thumbnail.jpg"
-cliTemplateIds:
-  - label: "TypeScript"
-    id: "automated-liquidation-protection-ts"
-  - label: "Go"
-    id: "automated-liquidation-protection-go"
 tags:
   - "confidential"
   - "liquidation"

--- a/src/content/cre-templates/automated-portfolio-rebalancing.mdx
+++ b/src/content/cre-templates/automated-portfolio-rebalancing.mdx
@@ -4,11 +4,6 @@ description: "Automatically rebalance crypto portfolios by continuously monitori
 author: "Chainlink Labs"
 excerpt: "Rebalance a portfolio confidentially with policy-constrained, LLM-assisted trade execution in TypeScript or Go."
 image: "thumbnail.jpg"
-cliTemplateIds:
-  - label: "TypeScript"
-    id: "automated-portfolio-rebalancing-ts"
-  - label: "Go"
-    id: "automated-portfolio-rebalancing-go"
 tags:
   - "confidential"
   - "rebalancing"


### PR DESCRIPTION
## Summary
- Removes the cliTemplateIds frontmatter from ai-audit-firewall, automated-liquidation-protection, and automated-portfolio-rebalancing templates — these are not available via cre init and shouldn't show the "Install with CLI" section.
- Matches the existing pattern used by other non-installable templates (e.g. stablecoin-ace-ccip), where omitting cliTemplateIds hides the CLI section in CRETemplateOverview.astro.