### PR TITLE
add note about faucet ETH mainnet LINK requirement

### DIFF
--- a/src/content/vrf/v2-5/getting-started.mdx
+++ b/src/content/vrf/v2-5/getting-started.mdx
@@ -340,6 +340,8 @@ You can choose to pay for your VRF requests in either Sepolia ETH or testnet LIN
 
 You can request both testnet LINK and testnet ETH from [faucets.chain.link/sepolia](https://faucets.chain.link/sepolia). Testnet ETH is also available from several [public faucets](https://faucetlink.to/sepolia).
 
+Note: The testnet ETH drip on faucets.chain.link requires your wallet to hold at least 1 LINK on Ethereum Mainnet as an anti-Sybil measure. If your wallet doesn't meet this requirement, the ETH request will fail. You can try one of the [public faucets](https://faucetlink.to/sepolia) instead, which may not have this requirement.
+
 This deployment is slightly different than the example in the [Deploy Your First Contract](/quickstarts/deploy-your-first-contract) guide. In this case, you pass in parameters to the constructor upon deployment.
 
 Once compiled, you'll see a dropdown menu that looks like this in the deploy pane:


### PR DESCRIPTION
## Closing issues
closes #4011

## Description
Adds a note to the VRF v2.5 Getting Started guide explaining that the testnet ETH faucet at faucets.chain.link requires holding at least 1 LINK on Ethereum Mainnet as an anti-Sybil measure. Without this note, new users following the guide can get stuck when their ETH request silently fails, with no explanation of why.

## Changes
- Added a **Note** after the faucet paragraph in `vrf/v2-5/getting-started.mdx`, explaining the mainnet LINK requirement and pointing to the public faucet alternative already linked on the same line.