### PR TITLE
docs: add Default SVR Activation section to SVR Feeds page

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -403,6 +403,14 @@
   },
   "data": [
     {
+      "category": "release",
+      "date": "2026-08-25",
+      "description": "Starting Aug 26, 2026, Chainlink Smart Value Recapture (SVR) will be enabled by default for BTC, ETH, XRP, SOL and ADA Data Feeds on Base. We expect there to be zero service disruption during the switch and no action is needed.\n\nProtocols can opt out at any time by reading from the [\"Standard\" proxy address](https://docs.chain.link/data-feeds/svr-feeds#how-svr-works) that complements every SVR proxy. See [Chainlink SVR Feeds Documentation](https://docs.chain.link/data-feeds/svr-feeds) for details.",
+      "relatedNetworks": ["base"],
+      "title": "SVR enabled by default on Base",
+      "topic": "Data Feeds"
+    },
+    {
       "category": "integration",
       "date": "2026-08-21",
       "description": "New Data Streams available on all [supported networks](https://docs.chain.link/data-streams/crypto-streams):",

--- a/src/content/data-feeds/llms-full.txt
+++ b/src/content/data-feeds/llms-full.txt
@@ -5574,6 +5574,14 @@ Chainlink SVR Feeds are available as standard feeds for general use and speciali
 
 Aave SVR feeds are specifically tailored for the Aave protocol and are only intended for use by Aave.
 
+## Default SVR Activation
+
+Chainlink SVR is activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, feeds transmit price updates once through the public mempool as usual, and once through the SVR auction system, which then settles to the chain. This allows protocols to recapture Oracle Extractable Value (OEV) during activities such as liquidations, while maintaining a maximum price delay of 10 seconds—in practice, average delays are closer to 4-6 seconds.
+
+Integrators should expect zero service disruption during activation, and no action is needed on their part.
+
+For any questions, contact [chainlink_data_feeds@smartcontract.com](mailto:chainlink_data_feeds@smartcontract.com). Protocols can also opt out at any time by reading from the "Standard" proxy that complements every SVR proxy for the relevant feed.
+
 ## How Protocols Can Utilize SVR Feeds
 
 ### 1. Identify the SVR Feed Address

--- a/src/content/data-feeds/svr-feeds/index.mdx
+++ b/src/content/data-feeds/svr-feeds/index.mdx
@@ -170,6 +170,14 @@ Chainlink SVR Feeds are available as standard feeds for general use and speciali
 
 Aave SVR feeds are specifically tailored for the Aave protocol and are only intended for use by Aave.
 
+## Default SVR Activation
+
+In coordination with blockchain ecosystem partners, Chainlink SVR may be activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, new and existing lending market deployments will recapture oracle-related MEV (OEV) through the SVR flow from day one without additional integration work.
+
+Teams deploying applications that use these feeds on networks where SVR is active by default should contact [chainlink_data_feeds@smartcontract.com](mailto:chainlink_data_feeds@smartcontract.com), as recaptured OEV is shared with integrating DeFi protocols as described in [Economics and Revenue Split](#economics-and-revenue-split).
+
+Protocols that prefer not to use SVR can opt out at any time by reading from the "Standard" proxy that complements every SVR proxy for the relevant feed.
+
 ## How Protocols Can Utilize SVR Feeds
 
 ### 1. Identify the SVR Feed Address

--- a/src/content/data-feeds/svr-feeds/index.mdx
+++ b/src/content/data-feeds/svr-feeds/index.mdx
@@ -172,7 +172,7 @@ Aave SVR feeds are specifically tailored for the Aave protocol and are only inte
 
 ## Default SVR Activation
 
-Chainlink SVR may be activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, price updates flow via the SVR auction system in addition to the public mempool, so new and existing lending market deployments recapture oracle-related MEV (OEV) from day one with zero service disruption and no action needed on the part of integrators.
+Chainlink SVR may be activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, price updates flow via the SVR auction system in addition to the public mempool, so new and existing lending market deployments recapture oracle-related MEV (OEV) from day one without additional integration work. Integrators should expect zero service disruption during the switch, and no action is needed on their part.
 
 Teams deploying applications that use these feeds on networks where SVR is active by default should contact [chainlink_data_feeds@smartcontract.com](mailto:chainlink_data_feeds@smartcontract.com), as recaptured OEV is shared with integrating DeFi protocols as described in [Economics and Revenue Split](#economics-and-revenue-split).
 

--- a/src/content/data-feeds/svr-feeds/index.mdx
+++ b/src/content/data-feeds/svr-feeds/index.mdx
@@ -172,7 +172,9 @@ Aave SVR feeds are specifically tailored for the Aave protocol and are only inte
 
 ## Default SVR Activation
 
-Chainlink SVR may be activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, price updates flow via the SVR auction system in addition to the public mempool, so new and existing lending market deployments recapture oracle-related MEV (OEV) from day one without additional integration work. Integrators should expect zero service disruption during the switch, and no action is needed on their part.
+Chainlink SVR may be activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, feeds transmit price updates once through the public mempool as usual, and once through the SVR auction system, which then settles to the chain. This allows protocols to recapture Oracle Extractable Value (OEV) during activities such as liquidations, while maintaining a maximum price delay of 10 seconds—in practice, average delays are closer to 4-6 seconds.
+
+New and existing lending market deployments recapture OEV from day one, without any additional integration work. Integrators should expect zero service disruption during activation, and no action is needed on their part.
 
 Teams deploying applications that use these feeds on networks where SVR is active by default should contact [chainlink_data_feeds@smartcontract.com](mailto:chainlink_data_feeds@smartcontract.com), as recaptured OEV is shared with integrating DeFi protocols as described in [Economics and Revenue Split](#economics-and-revenue-split).
 

--- a/src/content/data-feeds/svr-feeds/index.mdx
+++ b/src/content/data-feeds/svr-feeds/index.mdx
@@ -172,7 +172,7 @@ Aave SVR feeds are specifically tailored for the Aave protocol and are only inte
 
 ## Default SVR Activation
 
-Chainlink SVR may be activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, new and existing lending market deployments will recapture oracle-related MEV (OEV) through the SVR flow from day one without additional integration work.
+Chainlink SVR may be activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, price updates flow via the SVR auction system in addition to the public mempool, so new and existing lending market deployments recapture oracle-related MEV (OEV) from day one with zero service disruption and no action needed on the part of integrators.
 
 Teams deploying applications that use these feeds on networks where SVR is active by default should contact [chainlink_data_feeds@smartcontract.com](mailto:chainlink_data_feeds@smartcontract.com), as recaptured OEV is shared with integrating DeFi protocols as described in [Economics and Revenue Split](#economics-and-revenue-split).
 

--- a/src/content/data-feeds/svr-feeds/index.mdx
+++ b/src/content/data-feeds/svr-feeds/index.mdx
@@ -172,7 +172,7 @@ Aave SVR feeds are specifically tailored for the Aave protocol and are only inte
 
 ## Default SVR Activation
 
-In coordination with blockchain ecosystem partners, Chainlink SVR may be activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, new and existing lending market deployments will recapture oracle-related MEV (OEV) through the SVR flow from day one without additional integration work.
+Chainlink SVR may be activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, new and existing lending market deployments will recapture oracle-related MEV (OEV) through the SVR flow from day one without additional integration work.
 
 Teams deploying applications that use these feeds on networks where SVR is active by default should contact [chainlink_data_feeds@smartcontract.com](mailto:chainlink_data_feeds@smartcontract.com), as recaptured OEV is shared with integrating DeFi protocols as described in [Economics and Revenue Split](#economics-and-revenue-split).
 

--- a/src/content/data-feeds/svr-feeds/index.mdx
+++ b/src/content/data-feeds/svr-feeds/index.mdx
@@ -172,13 +172,11 @@ Aave SVR feeds are specifically tailored for the Aave protocol and are only inte
 
 ## Default SVR Activation
 
-Chainlink SVR may be activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, feeds transmit price updates once through the public mempool as usual, and once through the SVR auction system, which then settles to the chain. This allows protocols to recapture Oracle Extractable Value (OEV) during activities such as liquidations, while maintaining a maximum price delay of 10 seconds—in practice, average delays are closer to 4-6 seconds.
+Chainlink SVR is activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, feeds transmit price updates once through the public mempool as usual, and once through the SVR auction system, which then settles to the chain. This allows protocols to recapture Oracle Extractable Value (OEV) during activities such as liquidations, while maintaining a maximum price delay of 10 seconds—in practice, average delays are closer to 4-6 seconds.
 
-New and existing lending market deployments recapture OEV from day one, without any additional integration work. Integrators should expect zero service disruption during activation, and no action is needed on their part.
+Integrators should expect zero service disruption during activation, and no action is needed on their part.
 
-Teams deploying applications that use these feeds on networks where SVR is active by default should contact [chainlink_data_feeds@smartcontract.com](mailto:chainlink_data_feeds@smartcontract.com), as recaptured OEV is shared with integrating DeFi protocols as described in [Economics and Revenue Split](#economics-and-revenue-split).
-
-Protocols that prefer not to use SVR can opt out at any time by reading from the "Standard" proxy that complements every SVR proxy for the relevant feed.
+For any questions, contact [chainlink_data_feeds@smartcontract.com](mailto:chainlink_data_feeds@smartcontract.com). Protocols can also opt out at any time by reading from the "Standard" proxy that complements every SVR proxy for the relevant feed.
 
 ## How Protocols Can Utilize SVR Feeds
 


### PR DESCRIPTION
## Summary
- Adds a new "Default SVR Activation" section to the SVR Feeds documentation page explaining that Chainlink SVR is activated by default on certain networks, how the dual public-mempool/auction transmission works, and typical settlement delay.
- Documents that integrators see zero service disruption and no action is required on default-activated networks.
- Points questions to chainlink_data_feeds@smartcontract.com and documents the opt-out path via the "Standard" proxy.

## Test plan
- [ ] Preview the `/data-feeds/svr-feeds` page and confirm the new section renders correctly between "Aave SVR Feeds" and "How Protocols Can Utilize SVR Feeds"