### PR TITLE
Data Feeds: add warning to l2 sequencer feed page - no new network expansion

### DIFF
--- a/src/content/data-feeds/l2-sequencer-feeds.mdx
+++ b/src/content/data-feeds/l2-sequencer-feeds.mdx
@@ -7,6 +7,11 @@ title: "L2 Sequencer Uptime Feeds"
 import { ClickToZoom, CodeSample } from "@components"
 import { Aside } from "@components"
 
+<Aside type="caution" title="Availability notice">
+  Chainlink is no longer expanding L2 Sequencer Uptime Feeds to additional networks. Existing feeds on the supported
+  networks listed below will continue to operate and be supported.
+</Aside>
+
 Optimistic rollups (e.g., Arbitrum, Optimism) and many ZK-rollups rely on sequencers to efficiently manage transaction ordering, execution, and batching before submitting them to Layer 1 (L1) blockchains like Ethereum. The sequencer plays a crucial role in optimizing transaction throughput, reducing fees, and ensuring fast transaction confirmations on L2 networks, making it a key component of their scalability and performance.
 
 However, if the sequencer becomes unavailable, users will lose access to the standard read/write APIs, preventing them from interacting with applications on the L2 network. Although the L2 chain's security and state commitments remain enforced by Layer 1, no new batched blocks will be produced by the sequencer. Users with sufficient technical expertise can still interact directly with the network through the underlying rollup contracts on L1. However, this process is more complex and costly, creating an unfair advantage for those who can bypass the sequencer. This imbalance in access can lead to disruptions or distortions in applications, such as liquidations or market operations that rely on timely transactions.

--- a/src/content/data-feeds/llms-full.txt
+++ b/src/content/data-feeds/llms-full.txt
@@ -1688,6 +1688,11 @@ To learn more about the heartbeat and deviation threshold, read the [Decentraliz
 # L2 Sequencer Uptime Feeds
 Source: https://docs.chain.link/data-feeds/l2-sequencer-feeds
 
+<Aside type="caution" title="Availability notice">
+  Chainlink is no longer expanding L2 Sequencer Uptime Feeds to additional networks. Existing feeds on the supported
+  networks listed below will continue to operate and be supported.
+</Aside>
+
 Optimistic rollups (e.g., Arbitrum, Optimism) and many ZK-rollups rely on sequencers to efficiently manage transaction ordering, execution, and batching before submitting them to Layer 1 (L1) blockchains like Ethereum. The sequencer plays a crucial role in optimizing transaction throughput, reducing fees, and ensuring fast transaction confirmations on L2 networks, making it a key component of their scalability and performance.
 
 However, if the sequencer becomes unavailable, users will lose access to the standard read/write APIs, preventing them from interacting with applications on the L2 network. Although the L2 chain's security and state commitments remain enforced by Layer 1, no new batched blocks will be produced by the sequencer. Users with sufficient technical expertise can still interact directly with the network through the underlying rollup contracts on L1. However, this process is more complex and costly, creating an unfair advantage for those who can bypass the sequencer. This imbalance in access can lead to disruptions or distortions in applications, such as liquidations or market operations that rely on timely transactions.


### PR DESCRIPTION
This pull request adds a caution notice to the L2 Sequencer Uptime Feeds documentation, informing users that Chainlink will not be expanding these feeds to additional networks, but will continue to support existing feeds.

Documentation update:

* Added an `<Aside type="caution">` notice at the top of both `l2-sequencer-feeds.mdx` and `llms-full.txt` to clarify that no new L2 Sequencer Uptime Feeds will be launched, though current feeds on supported networks remain operational. [[1]](diffhunk://#diff-b5766cc989e9bc37854d37178a62d142ab3a5831af2944c25c4ac4c16e57bad7R10-R14) [[2]](diffhunk://#diff-f3c5f7403a3f7af339d5c2831e47af654f1db0d11036b121065cb7129ebfe92eR1691-R1695)