### PR TITLE
Data Feeds: Add LTC to Base SVR changelog notice

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -405,7 +405,7 @@
     {
       "category": "release",
       "date": "2026-08-25",
-      "description": "Starting Aug 26, 2026, Chainlink Smart Value Recapture (SVR) will be enabled by default for BTC, ETH, XRP, SOL and ADA Data Feeds on Base. We expect there to be zero service disruption during the switch and no action is needed.\n\nProtocols can opt out at any time by reading from the [\"Standard\" proxy address](https://docs.chain.link/data-feeds/svr-feeds#how-svr-works) that complements every SVR proxy. See [Chainlink SVR Feeds Documentation](https://docs.chain.link/data-feeds/svr-feeds) for details.",
+      "description": "Starting Aug 26, 2026, Chainlink Smart Value Recapture (SVR) will be enabled by default for BTC, ETH, LTC, XRP, SOL and ADA Data Feeds on Base. We expect there to be zero service disruption during the switch and no action is needed.\n\nProtocols can opt out at any time by reading from the [\"Standard\" proxy address](https://docs.chain.link/data-feeds/svr-feeds#how-svr-works) that complements every SVR proxy. See [Chainlink SVR Feeds Documentation](https://docs.chain.link/data-feeds/svr-feeds) for details.",
       "relatedNetworks": ["base"],
       "title": "SVR enabled by default on Base",
       "topic": "Data Feeds"


### PR DESCRIPTION
This pull request updates the changelog to clarify the list of assets affected by the SVR default enablement on Base. The main change is the addition of `LTC` to the list of Data Feeds.

Changelog update:

* Added `LTC` to the list of Data Feeds (BTC, ETH, LTC, XRP, SOL, ADA) that will have Chainlink Smart Value Recapture (SVR) enabled by default on Base, starting Aug 26, 2026.