### PR TITLE
Data Feeds: Update Default SVR Activation

### DIFF
--- a/src/content/data-feeds/llms-full.txt
+++ b/src/content/data-feeds/llms-full.txt
@@ -5581,11 +5581,11 @@ Aave SVR feeds are specifically tailored for the Aave protocol and are only inte
 
 ## Default SVR Activation
 
-Chainlink SVR is activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, feeds transmit price updates once through the public mempool as usual, and once through the SVR auction system, which then settles to the chain. This allows protocols to recapture Oracle Extractable Value (OEV) during activities such as liquidations, while maintaining a maximum price delay of 10 seconds—in practice, average delays are closer to 4-6 seconds.
+In coordination with blockchain ecosystem partners, Chainlink SVR may be activated by default for BTC, ETH, XRP, SOL, DOGE, LTC, and ADA Data Feeds on Base. Where SVR is active by default, new and existing lending market deployments will recapture oracle-related MEV (OEV) through the SVR flow from day one without additional integration work.
 
-Integrators should expect zero service disruption during activation, and no action is needed on their part.
+Teams deploying applications that use these feeds on networks where SVR is active by default should contact [chainlink_data_feeds@smartcontract.com](mailto:chainlink_data_feeds@smartcontract.com), as recaptured OEV is shared with integrating DeFi protocols as described in [Economics and Revenue Split](#economics-and-revenue-split).
 
-For any questions, contact [chainlink_data_feeds@smartcontract.com](mailto:chainlink_data_feeds@smartcontract.com). Protocols can also opt out at any time by reading from the "Standard" proxy that complements every SVR proxy for the relevant feed.
+Protocols that prefer not to use SVR can opt out at any time by reading from the "Standard" proxy that complements every SVR proxy for the relevant feed.
 
 ## How Protocols Can Utilize SVR Feeds
 

--- a/src/content/data-feeds/svr-feeds/index.mdx
+++ b/src/content/data-feeds/svr-feeds/index.mdx
@@ -172,11 +172,11 @@ Aave SVR feeds are specifically tailored for the Aave protocol and are only inte
 
 ## Default SVR Activation
 
-Chainlink SVR is activated by default for all Chainlink Data Feeds live on certain blockchain networks. Where SVR is active by default, feeds transmit price updates once through the public mempool as usual, and once through the SVR auction system, which then settles to the chain. This allows protocols to recapture Oracle Extractable Value (OEV) during activities such as liquidations, while maintaining a maximum price delay of 10 seconds—in practice, average delays are closer to 4-6 seconds.
+In coordination with blockchain ecosystem partners, Chainlink SVR may be activated by default for BTC, ETH, XRP, SOL, DOGE, LTC, and ADA Data Feeds on Base. Where SVR is active by default, new and existing lending market deployments will recapture oracle-related MEV (OEV) through the SVR flow from day one without additional integration work.
 
-Integrators should expect zero service disruption during activation, and no action is needed on their part.
+Teams deploying applications that use these feeds on networks where SVR is active by default should contact [chainlink_data_feeds@smartcontract.com](mailto:chainlink_data_feeds@smartcontract.com), as recaptured OEV is shared with integrating DeFi protocols as described in [Economics and Revenue Split](#economics-and-revenue-split).
 
-For any questions, contact [chainlink_data_feeds@smartcontract.com](mailto:chainlink_data_feeds@smartcontract.com). Protocols can also opt out at any time by reading from the "Standard" proxy that complements every SVR proxy for the relevant feed.
+Protocols that prefer not to use SVR can opt out at any time by reading from the "Standard" proxy that complements every SVR proxy for the relevant feed.
 
 ## How Protocols Can Utilize SVR Feeds
 


### PR DESCRIPTION
This pull request updates the documentation for the default activation of Chainlink SVR, clarifying which feeds are affected and providing updated guidance for integrators. The main changes are focused on describing the new scope of default SVR activation and the recommended actions for teams using these feeds.

**Documentation updates regarding SVR activation:**

* Clarified that Chainlink SVR may be activated by default for BTC, ETH, XRP, SOL, DOGE, LTC, and ADA Data Feeds on Base, instead of all feeds on certain networks. This narrows the scope of default activation. [[1]](diffhunk://#diff-f3c5f7403a3f7af339d5c2831e47af654f1db0d11036b121065cb7129ebfe92eL5584-R5588) [[2]](diffhunk://#diff-4a633440ae44eadbb92356019c861bafd458abf28adaf357ae02756d34dc6405L175-R179)
* Updated guidance for integrators: teams deploying applications using these feeds are now advised to contact Chainlink if SVR is active by default, as recaptured OEV is shared with integrating DeFi protocols. [[1]](diffhunk://#diff-f3c5f7403a3f7af339d5c2831e47af654f1db0d11036b121065cb7129ebfe92eL5584-R5588) [[2]](diffhunk://#diff-4a633440ae44eadbb92356019c861bafd458abf28adaf357ae02756d34dc6405L175-R179)
* Clarified opt-out instructions, specifying that protocols can opt out at any time by reading from the "Standard" proxy, and removed redundant contact instructions. [[1]](diffhunk://#diff-f3c5f7403a3f7af339d5c2831e47af654f1db0d11036b121065cb7129ebfe92eL5584-R5588) [[2]](diffhunk://#diff-4a633440ae44eadbb92356019c861bafd458abf28adaf357ae02756d34dc6405L175-R179)