### PR TITLE
CRE: update CRE docs with monad mainnet support

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1200,8 +1200,8 @@
     {
       "category": "release",
       "date": "2026-08-07",
-      "description": "CRE CLI version 1.29.0 is now available. Monad mainnet is now supported for local simulation via `cre workflow simulate`. Confidential Workflows let you designate parts of your workflow to run inside a secure enclave (TEE), keeping secrets, sensitive inputs, and computation confidential from node operators during execution.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.28.0...v1.29.0)",
-      "title": "CRE CLI v1.29.0 — Monad Mainnet Simulation and Confidential Workflows",
+      "description": "CRE CLI version 1.29.0 is now available. Monad mainnet is now supported for local simulation via `cre workflow simulate` and for production onchain writes. Confidential Workflows let you designate parts of your workflow to run inside a secure enclave (TEE), keeping secrets, sensitive inputs, and computation confidential from node operators during execution.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.28.0...v1.29.0)",
+      "title": "CRE CLI v1.29.0 — Monad Mainnet Support and Confidential Workflows",
       "topic": "CRE"
     },
     {

--- a/src/content/cre/guides/workflow/using-evm-client/forwarder-directory-go.mdx
+++ b/src/content/cre/guides/workflow/using-evm-client/forwarder-directory-go.mdx
@@ -7,7 +7,7 @@ pageId: "evm-forwarder-directory"
 metadata:
   description: "Find forwarder contract addresses for CRE workflows on supported EVM networks."
   datePublished: "2025-11-04"
-  lastModified: "2026-08-21"
+  lastModified: "2026-08-26"
 ---
 
 import { Aside, CopyText } from "@components"
@@ -74,6 +74,7 @@ The tables below reflect chains commonly enabled for simulation. Your tenant may
 | Linea               | <CopyText text="ethereum-mainnet-linea-1" code/>      | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
 | Mantle              | <CopyText text="ethereum-mainnet-mantle-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
 | MegaETH             | <CopyText text="megaeth-mainnet" code/>               | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
+| Monad               | <CopyText text="monad-mainnet" code/>                 | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | OP Mainnet          | <CopyText text="ethereum-mainnet-optimism-1" code/>   | <CopyText text="0x9119a1501550ed94a3f2794038ed9258337afa18" code/> |
 | Pharos Mainnet      | <CopyText text="pharos-mainnet" code/>                | <CopyText text="0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" code/> |
 | Plasma              | <CopyText text="plasma-mainnet" code/>                | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
@@ -143,6 +144,7 @@ These `KeystoneForwarder` addresses are used by deployed workflows. Use these ad
 | <a href="https://lineascan.build/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Linea</a>                            | <CopyText text="ethereum-mainnet-linea-1" code/>      | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | <a href="https://mantlescan.xyz/address/0xB9F79d863261869B234c481D1f9A7af84AeAd192" target="_blank" rel="noopener noreferrer">Mantle</a>                            | <CopyText text="ethereum-mainnet-mantle-1" code/>     | <CopyText text="0xB9F79d863261869B234c481D1f9A7af84AeAd192" code/> |
 | <a href="https://mega.etherscan.io/address/0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" target="_blank" rel="noopener noreferrer">MegaETH</a>                        | <CopyText text="megaeth-mainnet" code/>               | <CopyText text="0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" code/> |
+| <a href="https://monadvision.com/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Monad</a>                            | <CopyText text="monad-mainnet" code/>                 | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 | <a href="https://optimistic.etherscan.io/address/0xF8344CFd5c43616a4366C34E3EEE75af79a74482" target="_blank" rel="noopener noreferrer">OP Mainnet</a>               | <CopyText text="ethereum-mainnet-optimism-1" code/>   | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
 | <a href="https://pharosscan.xyz/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Pharos Mainnet</a>                    | <CopyText text="pharos-mainnet" code/>                | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 | <a href="https://plasmascan.to/address/0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" target="_blank" rel="noopener noreferrer">Plasma</a>                             | <CopyText text="plasma-mainnet" code/>                | <CopyText text="0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" code/> |

--- a/src/content/cre/guides/workflow/using-evm-client/forwarder-directory-ts.mdx
+++ b/src/content/cre/guides/workflow/using-evm-client/forwarder-directory-ts.mdx
@@ -7,7 +7,7 @@ pageId: "evm-forwarder-directory"
 metadata:
   description: "Find forwarder contract addresses for CRE workflows on supported EVM networks."
   datePublished: "2025-11-04"
-  lastModified: "2026-08-21"
+  lastModified: "2026-08-26"
 ---
 
 import { Aside, CopyText } from "@components"
@@ -74,6 +74,7 @@ The tables below reflect chains commonly enabled for simulation. Your tenant may
 | Linea               | <CopyText text="ethereum-mainnet-linea-1" code/>      | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
 | Mantle              | <CopyText text="ethereum-mainnet-mantle-1" code/>     | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
 | MegaETH             | <CopyText text="megaeth-mainnet" code/>               | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
+| Monad               | <CopyText text="monad-mainnet" code/>                 | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | OP Mainnet          | <CopyText text="ethereum-mainnet-optimism-1" code/>   | <CopyText text="0x9119a1501550ed94a3f2794038ed9258337afa18" code/> |
 | Pharos Mainnet      | <CopyText text="pharos-mainnet" code/>                | <CopyText text="0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4" code/> |
 | Plasma              | <CopyText text="plasma-mainnet" code/>                | <CopyText text="0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1" code/> |
@@ -143,6 +144,7 @@ These `KeystoneForwarder` addresses are used by deployed workflows. Use these ad
 | <a href="https://lineascan.build/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Linea</a>                            | <CopyText text="ethereum-mainnet-linea-1" code/>      | <CopyText text="0x9eF6468C5f37b976E57d52054c693269479A784d" code/> |
 | <a href="https://mantlescan.xyz/address/0xB9F79d863261869B234c481D1f9A7af84AeAd192" target="_blank" rel="noopener noreferrer">Mantle</a>                            | <CopyText text="ethereum-mainnet-mantle-1" code/>     | <CopyText text="0xB9F79d863261869B234c481D1f9A7af84AeAd192" code/> |
 | <a href="https://mega.etherscan.io/address/0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" target="_blank" rel="noopener noreferrer">MegaETH</a>                        | <CopyText text="megaeth-mainnet" code/>               | <CopyText text="0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" code/> |
+| <a href="https://monadvision.com/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Monad</a>                            | <CopyText text="monad-mainnet" code/>                 | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 | <a href="https://optimistic.etherscan.io/address/0xF8344CFd5c43616a4366C34E3EEE75af79a74482" target="_blank" rel="noopener noreferrer">OP Mainnet</a>               | <CopyText text="ethereum-mainnet-optimism-1" code/>   | <CopyText text="0xF8344CFd5c43616a4366C34E3EEE75af79a74482" code/> |
 | <a href="https://pharosscan.xyz/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Pharos Mainnet</a>                    | <CopyText text="pharos-mainnet" code/>                | <CopyText text="0x76c9cf548b4179F8901cda1f8623568b58215E62" code/> |
 | <a href="https://plasmascan.to/address/0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" target="_blank" rel="noopener noreferrer">Plasma</a>                             | <CopyText text="plasma-mainnet" code/>                | <CopyText text="0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" code/> |

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -534,7 +534,7 @@ To help us assist you faster, please include:
 
 # Release Notes
 Source: https://docs.chain.link/cre/release-notes
-Last Updated: 2026-08-21
+Last Updated: 2026-08-26
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
 
@@ -571,7 +571,7 @@ This page provides detailed release notes for CRE. It includes information on ne
 
 **<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.29.0" target="_blank">CRE CLI version 1.29.0</a> is now available.**
 
-- **Monad mainnet simulation**: Monad mainnet is now supported for local simulation via `cre workflow simulate`. See [Supported Networks](/cre/supported-networks).
+- **Monad mainnet support**: Monad mainnet is now supported for local simulation via `cre workflow simulate` and for production onchain writes. See [Supported Networks](/cre/supported-networks).
 - **Confidential Workflows**: Designate parts of your workflow to run inside a secure enclave (TEE), keeping secrets, sensitive inputs, and computation confidential from node operators during execution. See [Confidential Workflows in CRE](/cre/concepts/confidential-workflows) and [Making a Workflow Confidential](/cre/guides/workflow/using-confidential-workflows).
 
 **How to update:**
@@ -14541,7 +14541,7 @@ For the full list of types and methods available on [`cre.TeeRuntime`](/cre/refe
 
 # Forwarder Directory
 Source: https://docs.chain.link/cre/guides/workflow/using-evm-client/forwarder-directory-go
-Last Updated: 2026-08-21
+Last Updated: 2026-08-26
 
 <Aside type="note" title="Looking for supported networks?">
   For a complete list of supported networks and version requirements, see [Supported Networks](/cre/supported-networks).
@@ -14605,6 +14605,7 @@ The tables below reflect chains commonly enabled for simulation. Your tenant may
 | Linea               | ethereum-mainnet-linea-1      | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
 | Mantle              | ethereum-mainnet-mantle-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
 | MegaETH             | megaeth-mainnet               | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
+| Monad               | monad-mainnet                 | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | OP Mainnet          | ethereum-mainnet-optimism-1   | 0x9119a1501550ed94a3f2794038ed9258337afa18 |
 | Pharos Mainnet      | pharos-mainnet                | 0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4 |
 | Plasma              | plasma-mainnet                | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
@@ -14674,6 +14675,7 @@ These `KeystoneForwarder` addresses are used by deployed workflows. Use these ad
 | <a href="https://lineascan.build/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Linea</a>                            | ethereum-mainnet-linea-1      | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | <a href="https://mantlescan.xyz/address/0xB9F79d863261869B234c481D1f9A7af84AeAd192" target="_blank" rel="noopener noreferrer">Mantle</a>                            | ethereum-mainnet-mantle-1     | 0xB9F79d863261869B234c481D1f9A7af84AeAd192 |
 | <a href="https://mega.etherscan.io/address/0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" target="_blank" rel="noopener noreferrer">MegaETH</a>                        | megaeth-mainnet               | 0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c |
+| <a href="https://monadvision.com/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Monad</a>                            | monad-mainnet                 | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 | <a href="https://optimistic.etherscan.io/address/0xF8344CFd5c43616a4366C34E3EEE75af79a74482" target="_blank" rel="noopener noreferrer">OP Mainnet</a>               | ethereum-mainnet-optimism-1   | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
 | <a href="https://pharosscan.xyz/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Pharos Mainnet</a>                    | pharos-mainnet                | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 | <a href="https://plasmascan.to/address/0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" target="_blank" rel="noopener noreferrer">Plasma</a>                             | plasma-mainnet                | 0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c |
@@ -23371,7 +23373,7 @@ This section provides a reference for the built-in trigger capabilities of the C
 
 # Supported Networks
 Source: https://docs.chain.link/cre/supported-networks-go
-Last Updated: 2026-08-21
+Last Updated: 2026-08-26
 
 This page lists networks supported by CRE workflows, along with the minimum CLI and SDK versions required for each network. CRE supports two [chain families](/cre/capabilities#chain-families): EVM-compatible chains and Solana.
 
@@ -23391,31 +23393,32 @@ Network support depends on your CLI and SDK versions. The tables below show the 
 
 ## Mainnets
 
-| Network             | CLI      | Go SDK   | TS SDK  |
-| ------------------- | -------- | -------- | ------- |
-| ADI Mainnet         | v1.16.0+ | v1.10.0+ | v1.8.0+ |
-| Arbitrum One        | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Avalanche           | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Base                | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| BNB Chain           | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Celo                | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Ethereum            | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Gnosis Chain        | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Hyperliquid Mainnet | v1.7.0+  | v1.7.0+  | v1.4.0+ |
-| Ink                 | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Jovay               | v1.3.0+  | v1.4.0+  | v1.3.1+ |
-| Linea               | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Mantle              | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| MegaETH             | v1.5.0+  | v1.6.0+  | v1.3.1+ |
-| OP Mainnet          | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Pharos              | v1.3.0+  | v1.4.0+  | v1.3.1+ |
-| Plasma              | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Polygon             | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Scroll              | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Sonic               | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| World Chain         | v1.0.11+ | v1.2.0+  | v1.0.9+ |
-| XLayer              | v1.3.0+  | v1.4.0+  | v1.1.3+ |
-| ZKSync Era          | v1.0.6+  | v1.1.3+  | v1.0.7+ |
+| Network             | CLI      | Go SDK   | TS SDK   |
+| ------------------- | -------- | -------- | -------- |
+| ADI Mainnet         | v1.16.0+ | v1.10.0+ | v1.8.0+  |
+| Arbitrum One        | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Avalanche           | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Base                | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| BNB Chain           | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Celo                | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Ethereum            | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Gnosis Chain        | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Hyperliquid Mainnet | v1.7.0+  | v1.7.0+  | v1.4.0+  |
+| Ink                 | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Jovay               | v1.3.0+  | v1.4.0+  | v1.3.1+  |
+| Linea               | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Mantle              | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| MegaETH             | v1.5.0+  | v1.6.0+  | v1.3.1+  |
+| Monad               | v1.29.0+ | v1.17.0+ | v1.18.0+ |
+| OP Mainnet          | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Pharos              | v1.3.0+  | v1.4.0+  | v1.3.1+  |
+| Plasma              | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Polygon             | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Scroll              | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Sonic               | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| World Chain         | v1.0.11+ | v1.2.0+  | v1.0.9+  |
+| XLayer              | v1.3.0+  | v1.4.0+  | v1.1.3+  |
+| ZKSync Era          | v1.0.6+  | v1.1.3+  | v1.0.7+  |
 
 ## Testnets
 

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -534,7 +534,7 @@ To help us assist you faster, please include:
 
 # Release Notes
 Source: https://docs.chain.link/cre/release-notes
-Last Updated: 2026-08-21
+Last Updated: 2026-08-26
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
 
@@ -571,7 +571,7 @@ This page provides detailed release notes for CRE. It includes information on ne
 
 **<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.29.0" target="_blank">CRE CLI version 1.29.0</a> is now available.**
 
-- **Monad mainnet simulation**: Monad mainnet is now supported for local simulation via `cre workflow simulate`. See [Supported Networks](/cre/supported-networks).
+- **Monad mainnet support**: Monad mainnet is now supported for local simulation via `cre workflow simulate` and for production onchain writes. See [Supported Networks](/cre/supported-networks).
 - **Confidential Workflows**: Designate parts of your workflow to run inside a secure enclave (TEE), keeping secrets, sensitive inputs, and computation confidential from node operators during execution. See [Confidential Workflows in CRE](/cre/concepts/confidential-workflows) and [Making a Workflow Confidential](/cre/guides/workflow/using-confidential-workflows).
 
 **How to update:**
@@ -14575,7 +14575,7 @@ For the full list of types and methods available on [`TeeRuntime`](/cre/referenc
 
 # Forwarder Directory
 Source: https://docs.chain.link/cre/guides/workflow/using-evm-client/forwarder-directory-ts
-Last Updated: 2026-08-21
+Last Updated: 2026-08-26
 
 <Aside type="note" title="Looking for supported networks?">
   For a complete list of supported networks and version requirements, see [Supported Networks](/cre/supported-networks).
@@ -14639,6 +14639,7 @@ The tables below reflect chains commonly enabled for simulation. Your tenant may
 | Linea               | ethereum-mainnet-linea-1      | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
 | Mantle              | ethereum-mainnet-mantle-1     | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
 | MegaETH             | megaeth-mainnet               | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
+| Monad               | monad-mainnet                 | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | OP Mainnet          | ethereum-mainnet-optimism-1   | 0x9119a1501550ed94a3f2794038ed9258337afa18 |
 | Pharos Mainnet      | pharos-mainnet                | 0x2B3068C4B288A2CD1f8B3613b8f33ef7cEecadC4 |
 | Plasma              | plasma-mainnet                | 0x6E9EE680ef59ef64Aa8C7371279c27E496b5eDc1 |
@@ -14708,6 +14709,7 @@ These `KeystoneForwarder` addresses are used by deployed workflows. Use these ad
 | <a href="https://lineascan.build/address/0x9eF6468C5f37b976E57d52054c693269479A784d" target="_blank" rel="noopener noreferrer">Linea</a>                            | ethereum-mainnet-linea-1      | 0x9eF6468C5f37b976E57d52054c693269479A784d |
 | <a href="https://mantlescan.xyz/address/0xB9F79d863261869B234c481D1f9A7af84AeAd192" target="_blank" rel="noopener noreferrer">Mantle</a>                            | ethereum-mainnet-mantle-1     | 0xB9F79d863261869B234c481D1f9A7af84AeAd192 |
 | <a href="https://mega.etherscan.io/address/0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" target="_blank" rel="noopener noreferrer">MegaETH</a>                        | megaeth-mainnet               | 0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c |
+| <a href="https://monadvision.com/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Monad</a>                            | monad-mainnet                 | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 | <a href="https://optimistic.etherscan.io/address/0xF8344CFd5c43616a4366C34E3EEE75af79a74482" target="_blank" rel="noopener noreferrer">OP Mainnet</a>               | ethereum-mainnet-optimism-1   | 0xF8344CFd5c43616a4366C34E3EEE75af79a74482 |
 | <a href="https://pharosscan.xyz/address/0x76c9cf548b4179F8901cda1f8623568b58215E62" target="_blank" rel="noopener noreferrer">Pharos Mainnet</a>                    | pharos-mainnet                | 0x76c9cf548b4179F8901cda1f8623568b58215E62 |
 | <a href="https://plasmascan.to/address/0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c" target="_blank" rel="noopener noreferrer">Plasma</a>                             | plasma-mainnet                | 0x7BCcaFBD064cB3658476066Cc33ceE3F3414c04c |
@@ -25222,7 +25224,7 @@ This section provides a reference for the built-in trigger capabilities of the C
 
 # Supported Networks
 Source: https://docs.chain.link/cre/supported-networks-ts
-Last Updated: 2026-08-21
+Last Updated: 2026-08-26
 
 This page lists networks supported by CRE workflows, along with the minimum CLI and SDK versions required for each network. CRE supports two [chain families](/cre/capabilities#chain-families): EVM-compatible chains and Solana.
 
@@ -25242,31 +25244,32 @@ Network support depends on your CLI and SDK versions. The tables below show the 
 
 ## Mainnets
 
-| Network             | CLI      | Go SDK   | TS SDK  |
-| ------------------- | -------- | -------- | ------- |
-| ADI Mainnet         | v1.16.0+ | v1.10.0+ | v1.8.0+ |
-| Arbitrum One        | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Avalanche           | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Base                | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| BNB Chain           | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Celo                | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Ethereum            | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Gnosis Chain        | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Hyperliquid Mainnet | v1.7.0+  | v1.7.0+  | v1.4.0+ |
-| Ink                 | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Jovay               | v1.3.0+  | v1.4.0+  | v1.3.1+ |
-| Linea               | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Mantle              | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| MegaETH             | v1.5.0+  | v1.6.0+  | v1.3.1+ |
-| OP Mainnet          | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Pharos              | v1.3.0+  | v1.4.0+  | v1.3.1+ |
-| Plasma              | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Polygon             | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Scroll              | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Sonic               | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| World Chain         | v1.0.11+ | v1.2.0+  | v1.0.9+ |
-| XLayer              | v1.3.0+  | v1.4.0+  | v1.1.3+ |
-| ZKSync Era          | v1.0.6+  | v1.1.3+  | v1.0.7+ |
+| Network             | CLI      | Go SDK   | TS SDK   |
+| ------------------- | -------- | -------- | -------- |
+| ADI Mainnet         | v1.16.0+ | v1.10.0+ | v1.8.0+  |
+| Arbitrum One        | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Avalanche           | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Base                | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| BNB Chain           | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Celo                | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Ethereum            | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Gnosis Chain        | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Hyperliquid Mainnet | v1.7.0+  | v1.7.0+  | v1.4.0+  |
+| Ink                 | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Jovay               | v1.3.0+  | v1.4.0+  | v1.3.1+  |
+| Linea               | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Mantle              | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| MegaETH             | v1.5.0+  | v1.6.0+  | v1.3.1+  |
+| Monad               | v1.29.0+ | v1.17.0+ | v1.18.0+ |
+| OP Mainnet          | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Pharos              | v1.3.0+  | v1.4.0+  | v1.3.1+  |
+| Plasma              | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Polygon             | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Scroll              | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Sonic               | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| World Chain         | v1.0.11+ | v1.2.0+  | v1.0.9+  |
+| XLayer              | v1.3.0+  | v1.4.0+  | v1.1.3+  |
+| ZKSync Era          | v1.0.6+  | v1.1.3+  | v1.0.7+  |
 
 ## Testnets
 

--- a/src/content/cre/release-notes.mdx
+++ b/src/content/cre/release-notes.mdx
@@ -5,7 +5,7 @@ date: Last Modified
 metadata:
   description: "Discover what's new in CRE: latest features, changes, and improvements in each release of the Chainlink Runtime Environment."
   datePublished: "2025-11-04"
-  lastModified: "2026-08-21"
+  lastModified: "2026-08-26"
 ---
 
 import { Aside } from "@components"
@@ -45,7 +45,7 @@ This page provides detailed release notes for CRE. It includes information on ne
 
 **<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.29.0" target="_blank">CRE CLI version 1.29.0</a> is now available.**
 
-- **Monad mainnet simulation**: Monad mainnet is now supported for local simulation via `cre workflow simulate`. See [Supported Networks](/cre/supported-networks).
+- **Monad mainnet support**: Monad mainnet is now supported for local simulation via `cre workflow simulate` and for production onchain writes. See [Supported Networks](/cre/supported-networks).
 - **Confidential Workflows**: Designate parts of your workflow to run inside a secure enclave (TEE), keeping secrets, sensitive inputs, and computation confidential from node operators during execution. See [Confidential Workflows in CRE](/cre/concepts/confidential-workflows) and [Making a Workflow Confidential](/cre/guides/workflow/using-confidential-workflows).
 
 **How to update:**

--- a/src/content/cre/supported-networks-go.mdx
+++ b/src/content/cre/supported-networks-go.mdx
@@ -7,7 +7,7 @@ pageId: "supported-networks"
 metadata:
   description: "View all networks supported by CRE workflows — EVM and Solana — including required CLI and SDK versions for each network."
   datePublished: "2026-02-03"
-  lastModified: "2026-08-21"
+  lastModified: "2026-08-26"
 ---
 
 import { Aside } from "@components"
@@ -30,31 +30,32 @@ Network support depends on your CLI and SDK versions. The tables below show the 
 
 ## Mainnets
 
-| Network             | CLI      | Go SDK   | TS SDK  |
-| ------------------- | -------- | -------- | ------- |
-| ADI Mainnet         | v1.16.0+ | v1.10.0+ | v1.8.0+ |
-| Arbitrum One        | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Avalanche           | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Base                | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| BNB Chain           | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Celo                | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Ethereum            | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Gnosis Chain        | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Hyperliquid Mainnet | v1.7.0+  | v1.7.0+  | v1.4.0+ |
-| Ink                 | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Jovay               | v1.3.0+  | v1.4.0+  | v1.3.1+ |
-| Linea               | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Mantle              | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| MegaETH             | v1.5.0+  | v1.6.0+  | v1.3.1+ |
-| OP Mainnet          | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Pharos              | v1.3.0+  | v1.4.0+  | v1.3.1+ |
-| Plasma              | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Polygon             | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Scroll              | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Sonic               | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| World Chain         | v1.0.11+ | v1.2.0+  | v1.0.9+ |
-| XLayer              | v1.3.0+  | v1.4.0+  | v1.1.3+ |
-| ZKSync Era          | v1.0.6+  | v1.1.3+  | v1.0.7+ |
+| Network             | CLI      | Go SDK   | TS SDK   |
+| ------------------- | -------- | -------- | -------- |
+| ADI Mainnet         | v1.16.0+ | v1.10.0+ | v1.8.0+  |
+| Arbitrum One        | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Avalanche           | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Base                | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| BNB Chain           | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Celo                | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Ethereum            | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Gnosis Chain        | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Hyperliquid Mainnet | v1.7.0+  | v1.7.0+  | v1.4.0+  |
+| Ink                 | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Jovay               | v1.3.0+  | v1.4.0+  | v1.3.1+  |
+| Linea               | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Mantle              | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| MegaETH             | v1.5.0+  | v1.6.0+  | v1.3.1+  |
+| Monad               | v1.29.0+ | v1.17.0+ | v1.18.0+ |
+| OP Mainnet          | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Pharos              | v1.3.0+  | v1.4.0+  | v1.3.1+  |
+| Plasma              | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Polygon             | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Scroll              | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Sonic               | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| World Chain         | v1.0.11+ | v1.2.0+  | v1.0.9+  |
+| XLayer              | v1.3.0+  | v1.4.0+  | v1.1.3+  |
+| ZKSync Era          | v1.0.6+  | v1.1.3+  | v1.0.7+  |
 
 ## Testnets
 

--- a/src/content/cre/supported-networks-ts.mdx
+++ b/src/content/cre/supported-networks-ts.mdx
@@ -7,7 +7,7 @@ pageId: "supported-networks"
 metadata:
   description: "View all networks supported by CRE workflows — EVM and Solana — including required CLI and SDK versions for each network."
   datePublished: "2026-02-03"
-  lastModified: "2026-08-21"
+  lastModified: "2026-08-26"
 ---
 
 import { Aside } from "@components"
@@ -30,31 +30,32 @@ Network support depends on your CLI and SDK versions. The tables below show the 
 
 ## Mainnets
 
-| Network             | CLI      | Go SDK   | TS SDK  |
-| ------------------- | -------- | -------- | ------- |
-| ADI Mainnet         | v1.16.0+ | v1.10.0+ | v1.8.0+ |
-| Arbitrum One        | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Avalanche           | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Base                | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| BNB Chain           | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Celo                | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Ethereum            | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Gnosis Chain        | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Hyperliquid Mainnet | v1.7.0+  | v1.7.0+  | v1.4.0+ |
-| Ink                 | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Jovay               | v1.3.0+  | v1.4.0+  | v1.3.1+ |
-| Linea               | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Mantle              | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| MegaETH             | v1.5.0+  | v1.6.0+  | v1.3.1+ |
-| OP Mainnet          | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Pharos              | v1.3.0+  | v1.4.0+  | v1.3.1+ |
-| Plasma              | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Polygon             | v1.0.0+  | v1.0.0+  | v1.0.1+ |
-| Scroll              | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| Sonic               | v1.5.0+  | v1.6.0+  | v1.3.0+ |
-| World Chain         | v1.0.11+ | v1.2.0+  | v1.0.9+ |
-| XLayer              | v1.3.0+  | v1.4.0+  | v1.1.3+ |
-| ZKSync Era          | v1.0.6+  | v1.1.3+  | v1.0.7+ |
+| Network             | CLI      | Go SDK   | TS SDK   |
+| ------------------- | -------- | -------- | -------- |
+| ADI Mainnet         | v1.16.0+ | v1.10.0+ | v1.8.0+  |
+| Arbitrum One        | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Avalanche           | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Base                | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| BNB Chain           | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Celo                | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Ethereum            | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Gnosis Chain        | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Hyperliquid Mainnet | v1.7.0+  | v1.7.0+  | v1.4.0+  |
+| Ink                 | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Jovay               | v1.3.0+  | v1.4.0+  | v1.3.1+  |
+| Linea               | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Mantle              | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| MegaETH             | v1.5.0+  | v1.6.0+  | v1.3.1+  |
+| Monad               | v1.29.0+ | v1.17.0+ | v1.18.0+ |
+| OP Mainnet          | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Pharos              | v1.3.0+  | v1.4.0+  | v1.3.1+  |
+| Plasma              | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Polygon             | v1.0.0+  | v1.0.0+  | v1.0.1+  |
+| Scroll              | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| Sonic               | v1.5.0+  | v1.6.0+  | v1.3.0+  |
+| World Chain         | v1.0.11+ | v1.2.0+  | v1.0.9+  |
+| XLayer              | v1.3.0+  | v1.4.0+  | v1.1.3+  |
+| ZKSync Era          | v1.0.6+  | v1.1.3+  | v1.0.7+  |
 
 ## Testnets
 


### PR DESCRIPTION
This pull request adds Monad mainnet support to the CRE documentation and release notes, reflecting its availability for both simulation and production onchain writes. It also updates forwarder contract addresses and version requirements for Monad mainnet across Go and TypeScript documentation.

**Monad Mainnet Support:**

* Updated release notes and changelog to announce Monad mainnet support for both local simulation and production onchain writes in CRE CLI v1.29.0. [[1]](diffhunk://#diff-5323f35752748a8eb45ef9c8e62cda3a9d5b83c420d2feb0e307e66676bb2558L1203-R1204) [[2]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL574-R574) [[3]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L574-R574)
* Added Monad mainnet to the list of supported networks, specifying minimum required versions for CLI and SDKs.

**Forwarder Directory Updates:**

* Added Monad mainnet forwarder contract addresses to EVM forwarder directory tables and explorer links in both Go and TypeScript documentation. [[1]](diffhunk://#diff-4c35ef91b04013f57724894b21618880b50abe5cb5ec2a2d50f2c397051bfe93R77) [[2]](diffhunk://#diff-4c35ef91b04013f57724894b21618880b50abe5cb5ec2a2d50f2c397051bfe93R147) [[3]](diffhunk://#diff-51a11fa8c38ccb3786d2478984514d8b08df9145bfc23a9d22e3cf8c1038545cR77) [[4]](diffhunk://#diff-51a11fa8c38ccb3786d2478984514d8b08df9145bfc23a9d22e3cf8c1038545cR147) [[5]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeR14608) [[6]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeR14678) [[7]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4R14642) [[8]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4R14712)

**Documentation Maintenance:**

* Updated `lastModified` and `Last Updated` metadata fields to reflect the latest changes in all affected documentation files. [[1]](diffhunk://#diff-4c35ef91b04013f57724894b21618880b50abe5cb5ec2a2d50f2c397051bfe93L10-R10) [[2]](diffhunk://#diff-51a11fa8c38ccb3786d2478984514d8b08df9145bfc23a9d22e3cf8c1038545cL10-R10) [[3]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL537-R537) [[4]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL14544-R14544) [[5]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL23374-R23376) [[6]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L537-R537) [[7]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L14578-R14578)

These changes ensure Monad mainnet is fully documented as a supported chain for CRE workflows, with accurate addresses and version requirements.