### PR TITLE
Add Hong Kong to APAC equities market-hours allowlist

### DIFF
--- a/src/features/feeds/utils/feedMetadata.ts
+++ b/src/features/feeds/utils/feedMetadata.ts
@@ -148,7 +148,7 @@ export function matches24x5StreamFilter(
 }
 
 /** APAC exchange market-hours tags as they appear in the RDD `docs.marketHours` field. */
-const APAC_MARKET_HOURS_TAGS = new Set(["Tokyo", "Seoul", "Taiwan", "Taipei", "Shanghai", "Shenzhen"])
+const APAC_MARKET_HOURS_TAGS = new Set(["Tokyo", "Seoul", "Taiwan", "Taipei", "Shanghai", "Shenzhen", "Hong Kong"])
 
 export function isApacEquitiesStreamFeed(metadata: FeedMetadata): boolean {
   const feedType = metadata.feedType || metadata.docs?.feedType

--- a/src/features/feeds/utils/feedMetadata.ts
+++ b/src/features/feeds/utils/feedMetadata.ts
@@ -148,7 +148,7 @@ export function matches24x5StreamFilter(
 }
 
 /** APAC exchange market-hours tags as they appear in the RDD `docs.marketHours` field. */
-const APAC_MARKET_HOURS_TAGS = new Set(["Tokyo", "Seoul", "Taiwan", "Taipei", "Shanghai", "Shenzhen", "Hong Kong"])
+const APAC_MARKET_HOURS_TAGS = new Set(["Tokyo", "Seoul", "Taiwan", "Taipei", "Shanghai", "Shenzhen", "HK"])
 
 export function isApacEquitiesStreamFeed(metadata: FeedMetadata): boolean {
   const feedType = metadata.feedType || metadata.docs?.feedType


### PR DESCRIPTION
## Summary
- The "Available streams" table on the [APAC Equities](https://docs.chain.link/data-streams/rwa-streams/apac-equities) docs page is filtered client-side by `isApacEquitiesStreamFeed()` in `src/features/feeds/utils/feedMetadata.ts`, which checks each feed's `docs.marketHours` string against a hardcoded `APAC_MARKET_HOURS_TAGS` Set.
- `"Hong Kong"` was missing from that Set, even though Hong Kong Exchange (HKEX) is listed as an available exchange on the same page and the page's risk-considerations copy specifically documents HKEX's lunch-break schedule and trade-data behavior.
- Any feed tagged `docs.marketHours === "Hong Kong"` was therefore silently dropped from both the Mainnet and Testnet stream tables.
- This adds `"Hong Kong"` to the allowlist so HK-tagged feeds render like the other APAC exchanges (Tokyo, Seoul, Taiwan/Taipei, Shanghai, Shenzhen).

## Test plan
- [ ] Confirm any HK-tagged feed(s) in the RDD/feeds registry now appear in the Mainnet/Testnet "Available streams" tables on the APAC Equities page
- [ ] Confirm existing Tokyo/Seoul/Shanghai/Shenzhen/Taiwan entries are unaffected