### PR TITLE
SVR: Update SVR detection, table display, filtering, and onboarding pages

### DIFF
--- a/src/content/data-feeds/llms-full.txt
+++ b/src/content/data-feeds/llms-full.txt
@@ -5588,7 +5588,7 @@ Dedicated SVR feeds exclusively for the Aave protocol.
 
 ### SVR-Backup (Legacy)
 
-Legacy shared SVR feeds. New integrations should use the [SVR (Shared)](#svr-shared) feeds instead.
+Legacy shared SVR feeds that are still actively used by existing applications. Searchers should continue to monitor these feeds. New integrations should use the [SVR (Shared)](#svr-shared) feeds instead.
 
 ## Default SVR Activation
 

--- a/src/content/data-feeds/llms-full.txt
+++ b/src/content/data-feeds/llms-full.txt
@@ -5459,9 +5459,9 @@ try {
 const response = await fetch(rddUrl)
 const data = await response.json()
 
-    // Find all feeds that have SVR variants (either Aave or Shared SVR) and are not hidden
+    // Find all feeds that have SVR variants and are not hidden
     const svrFeeds = data.filter(
-      (feed) => feed.secondaryProxyAddress && !feed.docs?.hidden && (isAaveSVR(feed) || isSharedSVR(feed))
+      (feed) => feed.secondaryProxyAddress && !feed.docs?.hidden
     )
 
     // Group feeds by their base name (e.g., "BTC/USD", "ETH/USD")
@@ -5474,14 +5474,17 @@ const data = await response.json()
         feedGroups[baseName] = {
           name: baseName,
           aaveAddress: null,
-          svrAddress: null
+          svrAddress: null,
+          svrBackupAddress: null,
         }
       }
 
       if (isAaveSVR(feed)) {
         feedGroups[baseName].aaveAddress = feed.contractAddress
-      } else if (isSharedSVR(feed)) {
+      } else if (isNewSharedSVR(feed)) {
         feedGroups[baseName].svrAddress = feed.contractAddress
+      } else if (isSharedSVR(feed)) {
+        feedGroups[baseName].svrBackupAddress = feed.contractAddress
       }
     })
 
@@ -5573,11 +5576,19 @@ If the **private route** fails or times out, the SVR feed automatically **revert
 
 ## SVR Feed Variants
 
-Chainlink SVR Feeds are available as standard feeds for general use and specialized [Aave SVR Feeds](#aave-svr-feeds) for the Aave protocol. More specialized SVR feeds may be developed in the future for other protocols.
+Chainlink SVR Feeds are available in three variants:
+
+### SVR (Shared)
+
+Canonical shared SVR feeds for use by any protocol. These are the recommended feeds for new integrations.
 
 ### Aave SVR Feeds
 
-Aave SVR feeds are specifically tailored for the Aave protocol and are only intended for use by Aave.
+Dedicated SVR feeds exclusively for the Aave protocol.
+
+### SVR-Backup (Legacy)
+
+Legacy shared SVR feeds. New integrations should use the [SVR (Shared)](#svr-shared) feeds instead.
 
 ## Default SVR Activation
 
@@ -5648,7 +5659,7 @@ This split provides DeFi protocols with an additional revenue stream while also 
 
 ---
 
-# SVR Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain, Monad)
+# SVR Searcher Onboarding: Atlas
 Source: https://docs.chain.link/data-feeds/svr-feeds/searcher-onboarding-atlas
 
 export const contracts = {
@@ -5669,46 +5680,6 @@ export const contracts = {
     dappControl: "0xa40d9f38621b4ffb2181508b973519e8133951c0",
   },
 }
-
-export const arbitrumFeeds = [
-  { asset: "AAVE-USD", type: "Aave-SVR", aggregator: "0xc1720A8240Dbd992d95D6c865A15e490901879B1" },
-  { asset: "ARB-USD", type: "Aave-SVR", aggregator: "0xB72359B2dc04Ff363e094648DF78247c98297c20" },
-  { asset: "ARB-USD", type: "SVR", aggregator: "0x62619470FcBA2Ae5c2dc22c18CF5251C09c1E618" },
-  { asset: "BTC-USD", type: "Aave-SVR", aggregator: "0xE7c522c60bA7f1b5E398D2312593713e2B19aeb0" },
-  { asset: "BTC-USD", type: "SVR", aggregator: "0xA686Fa6122d30EBc51843847fEf4a0ae759fBac1" },
-  { asset: "DAI-USD", type: "Aave-SVR", aggregator: "0xFBe1C9F4297d509b4D0ECcbc098df7Db29DA2918" },
-  { asset: "DAI-USD", type: "SVR", aggregator: "0xa1c0bD64AFFAF53E7674E2A6C5df6b80A4FB80d3" },
-  { asset: "ETH-USD", type: "Aave-SVR", aggregator: "0xa5E1a36938769cbd5a26f5e19D8FCB379f597c83" },
-  { asset: "ETH-USD", type: "SVR", aggregator: "0x0b6eaC11aAD4211AD686d1Ece56C071E306Bd29B" },
-  { asset: "EURC-USD", type: "Aave-SVR", aggregator: "0x333399F03B84678Ec22842Cd467c8Fe089E3Ef27" },
-  { asset: "EURC-USD", type: "SVR", aggregator: "0xa0e9a602B8060E1828Be7eE4626e086bDdbD2F99" },
-  { asset: "FRAX-USD", type: "Aave-SVR", aggregator: "0x674a6D60637891C63116218c38a9a49BE07D21bc" },
-  { asset: "FRAX-USD", type: "SVR", aggregator: "0x7399107Df5344E0b928e75f3ACfa90569eC20848" },
-  { asset: "GHO-USD", type: "Aave-SVR", aggregator: "0x0309C05449070AC1aB244B99955EA5fEdEB79E6A" },
-  { asset: "LINK-USD", type: "Aave-SVR", aggregator: "0x4c76F02E484e8ce9B6C2358CF9624BabC5531E9e" },
-  { asset: "LINK-USD", type: "SVR", aggregator: "0x355E12F02C59B31AfF1ae2775352dC2Ac1f5C829" },
-  { asset: "USDC-USD", type: "Aave-SVR", aggregator: "0x16c0e73906CDa7AC1F137B0F513a00b84c8f7A4E" },
-  { asset: "USDC-USD", type: "SVR", aggregator: "0x01065f4726bBbCE2ef1a4Bebc04Af3209357c71e" },
-  { asset: "USDT-USD", type: "Aave-SVR", aggregator: "0x12b8916e7B6297f31C99e3A8e2BDa661f27c676A" },
-  { asset: "USDT-USD", type: "SVR", aggregator: "0x41F14AfB0eB605097c5950D2458415437A3d2Bcd" },
-]
-
-export const monadFeeds = [
-  { asset: "APRMON-MON Exchange Rate", type: "SVR", aggregator: "0x124FE2b4a19bC618d6cF0a64e2BBE85C7e3C6ED9" },
-  { asset: "AUSD-USD", type: "SVR", aggregator: "0x253c95994246DE5A83AAFE82909681522DA051Af" },
-  { asset: "BTC-USD", type: "SVR", aggregator: "0x9d8b2A6b6A8748bB5e557505d2dDC9d44b6fd2Dd" },
-  { asset: "CBBTC-USD", type: "SVR", aggregator: "0x5cB59A1E12c781793b1799D99d1F31eA4e79eCE9" },
-  { asset: "EARNAUSD-AUSD Exchange Rate", type: "SVR", aggregator: "0xb95fa18a1892045F671bC1723d452618f3FC0355" },
-  { asset: "ETH-USD", type: "SVR", aggregator: "0xeF3c6C938F82BE8ba983a52F5b0f47eE820DCeb2" },
-  { asset: "EZETH-ETH Exchange Rate", type: "SVR", aggregator: "0x521F749F78dA5d58f70f79aD44f73fDEAA5dc538" },
-  { asset: "GMON-MON Exchange Rate", type: "SVR", aggregator: "0xAF165Ea49569528ff543640834Eb6819f0d9601f" },
-  { asset: "MON-USD", type: "SVR", aggregator: "0x810d5E3dB355bFd2C80c06D89F08523111c6d0F1" },
-  { asset: "SHMON-MON Exchange Rate", type: "SVR", aggregator: "0xE3F1906C6b6EEA63dCc0C016C4ec6746c69e7476" },
-  { asset: "SMON-MON Exchange Rate", type: "SVR", aggregator: "0x0Ebdee66Cdd6ffe566d39eD9F876EE04920E25D4" },
-  { asset: "SYZUSD-YZUSD Exchange Rate", type: "SVR", aggregator: "0x18278ef950F120Cb89960C0c07e965bbAc389cfC" },
-  { asset: "USDC-USD", type: "SVR", aggregator: "0xdE1FE319F71E446143BEC6eEc02d89286E7265ed" },
-  { asset: "USDT0-USD", type: "SVR", aggregator: "0x9e921eC9C5ef689045af16a95569F3644bB41FD3" },
-]
 
 <Aside type="note" title="Searcher Onboarding">
   SVR on Atlas (every chain outside of ETH mainnet) uses a reputation system with **two groups**. Unless otherwise specified for a chain, Atlas includes up to **2 searcher bids** per transaction for on-chain settlement:
@@ -6478,55 +6449,6 @@ If the solver operation reverts for any reason, the query API will communicate e
 # SVR Searcher Onboarding: Ethereum Mainnet
 Source: https://docs.chain.link/data-feeds/svr-feeds/searcher-onboarding-ethereum
 
-export async function getFeeds() {
-  const ethereumMainnet = CHAINS.find((chain) => chain.page === "ethereum")?.networks.find(
-    (network) => network.networkType === "mainnet"
-  )
-
-const rddUrl = ethereumMainnet?.rddUrl
-
-if (!rddUrl) {
-return []
-}
-
-try {
-const response = await fetch(rddUrl)
-const data = await response.json()
-
-    const svrFeeds = data.filter(
-      (feed) => feed.secondaryProxyAddress && !feed.docs?.hidden && (isAaveSVR(feed) || isSharedSVR(feed))
-    )
-
-    const feedGroups = {}
-
-    svrFeeds.forEach(feed => {
-      const baseName = feed.name.replace(" / ", "/")
-
-      if (!feedGroups[baseName]) {
-        feedGroups[baseName] = {
-          name: baseName,
-          aaveAddress: null,
-          svrAddress: null
-        }
-      }
-
-      if (isAaveSVR(feed)) {
-        feedGroups[baseName].aaveAddress = feed.contractAddress
-      } else if (isSharedSVR(feed)) {
-        feedGroups[baseName].svrAddress = feed.contractAddress
-      }
-    })
-
-    const combinedFeeds = Object.values(feedGroups)
-      .sort((a, b) => a.name.localeCompare(b.name))
-
-    return combinedFeeds
-
-} catch (error) {
-return []
-}
-}
-
 <Aside type="note" title="Searcher Onboarding">
   To onboard as a searcher to SVR, reach out to [devrel@smartcontract.com](mailto:devrel@smartcontract.com). Searchers
   can [subscribe here](https://chainlinkcommunity.typeform.com/to/s55Hu2tK) to receive timely Chainlink SVR updates.
@@ -6550,9 +6472,13 @@ For more background on how Aave liquidations work, see [Aave Documentation](http
 
 ### Price Update, Auction, and Liquidation Execution Flow
 
-### How to Participate as a Searcher
+## Feed Aggregator Addresses
 
-#### 1. High-Level Steps for Searchers
+<Aside type="note" />
+
+## How to Participate as a Searcher
+
+### 1. High-Level Steps for Searchers
 
 1. **Monitor and Identify SVR Price Updates**: Chainlink SVR sends oracle reports through Flashbots Protect (MEV-Share). Your searcher node must watch private transactions, not just the public mempool. It must also filter by these SVR data feed update events, and determine which feed address the update is for.
 
@@ -6562,7 +6488,7 @@ For more background on how Aave liquidations work, see [Aave Documentation](http
 
 3. **Execute Liquidation**: If your bundle is selected, your liquidation happens **immediately after** the fresh price arrives onchain, capturing the liquidation bonus. Based on the results of the auction, a portion of the MEV is recaptured and split between Aave and the Chainlink Network, while the rest goes to you.
 
-#### 2. Listen for Events on MEV Share
+### 2. Listen for Events on MEV Share
 
 Chainlink SVR uses forwarder contracts to route feed updates. You typically see **one transaction per event**, which calls the function `forward(address to, bytes callData)` with the function selector `6fadcf72`. This method, in turn, calls the SVR aggregator's `transmitSecondary()` function with the new price data.
 
@@ -6609,7 +6535,7 @@ The event stream is also expected to occasionally transmit transaction bundles. 
 }
 ```
 
-#### 3. Decode `callData` for `forward` and `transmitSecondary`
+### 3. Decode `callData` for `forward` and `transmitSecondary`
 
 Once you've identified a potential SVR feed update transaction, you'll need to decode its payload. This step allows you to extract:
 
@@ -6684,11 +6610,11 @@ The following code samples demonstrate the complete decoding process, including 
 3. Parse the report bytes using the `Report` struct
 4. Access the median observation (the updated price)
 
-#### 4. Detect SVR-enabled Feeds
+### 4. Detect SVR-enabled Feeds
 
-When processing forward calls, verify that the `to` address from the code sample above (the destination of the forward call) matches one of these feed addresses. This tells you which SVR data feed the price update is for:
+When processing forward calls, verify that the `to` address from the code sample above (the destination of the forward call) matches one of the SVR feed aggregator addresses listed in the [Feed Aggregator Addresses](#feed-aggregator-addresses) section above.
 
-#### 5. Calculate Updated Price
+### 5. Calculate Updated Price
 
 After successfully decoding the transaction data, you need to extract the median price from the `observations` array inside the decoded `report`:
 
@@ -6700,7 +6626,7 @@ This formula retrieves the median value from the sorted array of price observati
 
 To use this price effectively, convert it to the appropriate decimal representation for the asset pair.
 
-#### 6. Bidding With Flashbots MEV-Share
+### 6. Bidding With Flashbots MEV-Share
 
 Once you've detected an SVR update and identified a profitable liquidation opportunity, you need to construct and submit a bundle to Flashbots. Consider these key aspects when preparing your submission:
 
@@ -6761,14 +6687,14 @@ Bidding for bundle events is very similar to single transaction events. As a sea
 }
 ```
 
-#### 7. Considerations
+### 7. Considerations
 
 - **Competition**: Multiple searchers might detect the same liquidation. The best bid typically wins.
 - **Profit-Sharing**: A portion of liquidation MEV is recaptured and redirected to the integrating DeFi protocol and the Chainlink Network.
 - **Gas Efficiency**: Bundles that are too costly might erode the profitability of the proposed transaction. Optimize carefully.
 - **Non-SVR `forward` calls**: There are other events on the MEV-Share event stream that have the same `forward` function signature. Be sure to filter for the ones that call `transmitSecondary` on the listed SVR feeds.
 
-#### 8. Next Steps for Searchers
+### 8. Next Steps for Searchers
 
 1. **Set Up Your Searcher Node**
    - Integrate with [Flashbots MEV-Share](/data-feeds/svr-feeds/searcher-onboarding-ethereum) to read private transactions.

--- a/src/content/data-feeds/svr-feeds/index.mdx
+++ b/src/content/data-feeds/svr-feeds/index.mdx
@@ -15,7 +15,7 @@ whatsnext:
 
 import { Aside, ClickToZoom, CopyText } from "@components"
 import { CHAINS } from "@features/data/chains"
-import { isSharedSVR, isAaveSVR } from "~/features/feeds/utils/svrDetection.ts"
+import { isSharedSVR, isAaveSVR, isNewSharedSVR } from "~/features/feeds/utils/svrDetection.ts"
 
 export async function getFeeds() {
   const ethereumMainnet = CHAINS.find((chain) => chain.page === "ethereum")?.networks.find(
@@ -32,9 +32,9 @@ try {
 const response = await fetch(rddUrl)
 const data = await response.json()
 
-    // Find all feeds that have SVR variants (either Aave or Shared SVR) and are not hidden
+    // Find all feeds that have SVR variants and are not hidden
     const svrFeeds = data.filter(
-      (feed) => feed.secondaryProxyAddress && !feed.docs?.hidden && (isAaveSVR(feed) || isSharedSVR(feed))
+      (feed) => feed.secondaryProxyAddress && !feed.docs?.hidden
     )
 
     // Group feeds by their base name (e.g., "BTC/USD", "ETH/USD")
@@ -47,14 +47,17 @@ const data = await response.json()
         feedGroups[baseName] = {
           name: baseName,
           aaveAddress: null,
-          svrAddress: null
+          svrAddress: null,
+          svrBackupAddress: null,
         }
       }
 
       if (isAaveSVR(feed)) {
         feedGroups[baseName].aaveAddress = feed.contractAddress
-      } else if (isSharedSVR(feed)) {
+      } else if (isNewSharedSVR(feed)) {
         feedGroups[baseName].svrAddress = feed.contractAddress
+      } else if (isSharedSVR(feed)) {
+        feedGroups[baseName].svrBackupAddress = feed.contractAddress
       }
     })
 
@@ -164,11 +167,19 @@ If the **private route** fails or times out, the SVR feed automatically **revert
 
 ## SVR Feed Variants
 
-Chainlink SVR Feeds are available as standard feeds for general use and specialized [Aave SVR Feeds](#aave-svr-feeds) for the Aave protocol. More specialized SVR feeds may be developed in the future for other protocols.
+Chainlink SVR Feeds are available in three variants:
+
+### SVR (Shared)
+
+Canonical shared SVR feeds for use by any protocol. These are the recommended feeds for new integrations.
 
 ### Aave SVR Feeds
 
-Aave SVR feeds are specifically tailored for the Aave protocol and are only intended for use by Aave.
+Dedicated SVR feeds exclusively for the Aave protocol.
+
+### SVR-Backup (Legacy)
+
+Legacy shared SVR feeds. New integrations should use the [SVR (Shared)](#svr-shared) feeds instead.
 
 ## Default SVR Activation
 

--- a/src/content/data-feeds/svr-feeds/index.mdx
+++ b/src/content/data-feeds/svr-feeds/index.mdx
@@ -179,7 +179,7 @@ Dedicated SVR feeds exclusively for the Aave protocol.
 
 ### SVR-Backup (Legacy)
 
-Legacy shared SVR feeds. New integrations should use the [SVR (Shared)](#svr-shared) feeds instead.
+Legacy shared SVR feeds that are still actively used by existing applications. Searchers should continue to monitor these feeds. New integrations should use the [SVR (Shared)](#svr-shared) feeds instead.
 
 ## Default SVR Activation
 

--- a/src/content/data-feeds/svr-feeds/searcher-onboarding-atlas.mdx
+++ b/src/content/data-feeds/svr-feeds/searcher-onboarding-atlas.mdx
@@ -1,7 +1,7 @@
 ---
 section: dataFeeds
 date: Last Modified
-title: "SVR Searcher Onboarding: Atlas (Base, Arbitrum, BNB Chain, Monad)"
+title: "SVR Searcher Onboarding: Atlas"
 whatsnext:
   {
     "SVR Feeds Overview": "/data-feeds/svr-feeds",
@@ -12,6 +12,7 @@ whatsnext:
 
 import { Aside, CopyText } from "@components"
 import { Tabs } from "@components/Tabs"
+import { FeedList } from "~/features/feeds/components/FeedList.tsx"
 
 export const contracts = {
   base: {
@@ -31,101 +32,6 @@ export const contracts = {
     dappControl: "0xa40d9f38621b4ffb2181508b973519e8133951c0",
   },
 }
-
-export const baseFeeds = [
-  { asset: "AAVE-USD", type: "Aave-SVR", aggregator: "0x4b6F092e0e13B94fFAF2C59aAbDEb85a5342e9C1" },
-  { asset: "BTC-USD", type: "Aave-SVR", aggregator: "0x137233996b6586a110bb7a753248e26CC0307b1B" },
-  { asset: "BTC-USD", type: "SVR", aggregator: "0xeb3Ad4395924b76eB64b3d6aBabA0B62875b1A1f" },
-  { asset: "ETH-USD", type: "Aave-SVR", aggregator: "0xD772F6D9b7A35cb96fDdFE569964ab1C05017BF9" },
-  { asset: "ETH-USD", type: "SVR", aggregator: "0x83f3425A5b32655DC645f7f4e422DD60E9741794" },
-  { asset: "EURC-USD", type: "Aave-SVR", aggregator: "0x042fc0bA0684eDE99b751b0931B6D1F590758994" },
-  { asset: "EURC-USD", type: "SVR", aggregator: "0xa9c061D7f744796b29025a50Ec7eb55971ca587d" },
-  { asset: "GHO-USD", type: "Aave-SVR", aggregator: "0x68358e8E49138E89af9d3E55Cc66Bc44f6025d0f" },
-  { asset: "USDC-USD", type: "Aave-SVR", aggregator: "0x0fB39aE1d48Faf8CA5ea8DbF7e134e07386A7877" },
-  { asset: "USDC-USD", type: "SVR", aggregator: "0x7F73eB1ae276Ef4d155f9Cf9a81986DB343CF1CA" },
-  { asset: "USDT-USD", type: "Aave-SVR", aggregator: "0xA7f8123688b9d7cf2f91cb926B2a3f44Cc229d0A" },
-  { asset: "USDT-USD", type: "SVR", aggregator: "0xcc7cC8513BD52E443cEA0E63599d47Db56149817" },
-  { asset: "ezETH-ETH Exchange Rate", type: "Aave-SVR", aggregator: "0x9eF2826f41563b1375a3188C33040E697981F7C5" },
-  { asset: "LBTC-BTC Exchange Rate", type: "Aave-SVR", aggregator: "0x8Bd94C7616fa88cc2ab59A66540bcEaf034ef304" },
-  { asset: "rsETH-ETH Exchange Rate", type: "Aave-SVR", aggregator: "0xf1A51Dc55e6707F5aEE7D426110CA50119A5314B" },
-  { asset: "weETH-eETH Exchange Rate", type: "Aave-SVR", aggregator: "0x6D96F90d0Db82903406E97Dda54969EA58a82ec8" },
-  { asset: "wstETH-stETH Exchange Rate", type: "Aave-SVR", aggregator: "0x926E0bbA53F2deEb8a2BD0138fDd3Dc675830399" },
-]
-
-export const arbitrumFeeds = [
-  { asset: "AAVE-USD", type: "Aave-SVR", aggregator: "0xc1720A8240Dbd992d95D6c865A15e490901879B1" },
-  { asset: "ARB-USD", type: "Aave-SVR", aggregator: "0xB72359B2dc04Ff363e094648DF78247c98297c20" },
-  { asset: "ARB-USD", type: "SVR", aggregator: "0x62619470FcBA2Ae5c2dc22c18CF5251C09c1E618" },
-  { asset: "BTC-USD", type: "Aave-SVR", aggregator: "0xE7c522c60bA7f1b5E398D2312593713e2B19aeb0" },
-  { asset: "BTC-USD", type: "SVR", aggregator: "0xA686Fa6122d30EBc51843847fEf4a0ae759fBac1" },
-  { asset: "DAI-USD", type: "Aave-SVR", aggregator: "0xFBe1C9F4297d509b4D0ECcbc098df7Db29DA2918" },
-  { asset: "DAI-USD", type: "SVR", aggregator: "0xa1c0bD64AFFAF53E7674E2A6C5df6b80A4FB80d3" },
-  { asset: "ETH-USD", type: "Aave-SVR", aggregator: "0xa5E1a36938769cbd5a26f5e19D8FCB379f597c83" },
-  { asset: "ETH-USD", type: "SVR", aggregator: "0x0b6eaC11aAD4211AD686d1Ece56C071E306Bd29B" },
-  { asset: "EURC-USD", type: "Aave-SVR", aggregator: "0x333399F03B84678Ec22842Cd467c8Fe089E3Ef27" },
-  { asset: "EURC-USD", type: "SVR", aggregator: "0xa0e9a602B8060E1828Be7eE4626e086bDdbD2F99" },
-  { asset: "FRAX-USD", type: "Aave-SVR", aggregator: "0x674a6D60637891C63116218c38a9a49BE07D21bc" },
-  { asset: "FRAX-USD", type: "SVR", aggregator: "0x7399107Df5344E0b928e75f3ACfa90569eC20848" },
-  { asset: "GHO-USD", type: "Aave-SVR", aggregator: "0x0309C05449070AC1aB244B99955EA5fEdEB79E6A" },
-  { asset: "LINK-USD", type: "Aave-SVR", aggregator: "0x4c76F02E484e8ce9B6C2358CF9624BabC5531E9e" },
-  { asset: "LINK-USD", type: "SVR", aggregator: "0x355E12F02C59B31AfF1ae2775352dC2Ac1f5C829" },
-  { asset: "USDC-USD", type: "Aave-SVR", aggregator: "0x16c0e73906CDa7AC1F137B0F513a00b84c8f7A4E" },
-  { asset: "USDC-USD", type: "SVR", aggregator: "0x01065f4726bBbCE2ef1a4Bebc04Af3209357c71e" },
-  { asset: "USDT-USD", type: "Aave-SVR", aggregator: "0x12b8916e7B6297f31C99e3A8e2BDa661f27c676A" },
-  { asset: "USDT-USD", type: "SVR", aggregator: "0x41F14AfB0eB605097c5950D2458415437A3d2Bcd" },
-]
-
-export const bnbFeeds = [
-  { asset: "AAVE-USD", type: "SVR", aggregator: "0x703741CFe0ff0eAd093B317D79577fD85B259efb" },
-  { asset: "ADA-USD", type: "SVR", aggregator: "0x82836D0B28a8BDa21d3dE13520776918a8055DD9" },
-  { asset: "BCH-USD", type: "SVR", aggregator: "0xcff3236AF9e56e0AD26469911BdAd5DC116dc999" },
-  { asset: "BNB-USD", type: "SVR", aggregator: "0x494aE7aFbE8A4cc90adB6b574e2C63b79a574A42" },
-  { asset: "BNB-USD", type: "Aave-SVR", aggregator: "0xb6D12f1a49a7935A53EE520b3883e28271E95aac" },
-  { asset: "BTC-USD", type: "SVR", aggregator: "0x10cAD61aF7b534F18DB2E39e9b8515a78B116433" },
-  { asset: "BTC-USD", type: "Aave-SVR", aggregator: "0x75366e3D729B2B0c1C313265AA46C29221c3b51B" },
-  { asset: "CAKE-USD", type: "SVR", aggregator: "0x9f62D4C1B9581FAf48a3690f87F558bCBf9b2Aaf" },
-  { asset: "DAI-USD", type: "SVR", aggregator: "0x81534A1964b5aF6198dfFD93aA5cc1c45296E57F" },
-  { asset: "DOGE-USD", type: "SVR", aggregator: "0x2493e08824CEF5a467B927059489f016913e977D" },
-  { asset: "ETH-USD", type: "SVR", aggregator: "0x290a47E6B5e2021f8fD47DA5784F57C144683ff2" },
-  { asset: "ETH-USD", type: "Aave-SVR", aggregator: "0x5C1ca0D1CaF8F663Fa4F89D1C8301B6037831B07" },
-  { asset: "FIL-USD", type: "SVR", aggregator: "0xE44468fff3f870a14E99114E3DE257938C56e088" },
-  { asset: "FUSD-USD", type: "SVR", aggregator: "0xAC91cfb2531002a48cbC5348245A6C7CC9Ce9384" },
-  { asset: "LINK-USD", type: "SVR", aggregator: "0x3333A2df25C26EEa361Dd7FD6Afc43A15D89b595" },
-  { asset: "LTC-USD", type: "SVR", aggregator: "0x5A69d0948b0607401cC821704b7E99916bc9452E" },
-  { asset: "SOL-USD", type: "SVR", aggregator: "0x1df4D7704b1bB87D95eE3Cf6763d1E934b0D8a3C" },
-  { asset: "SUSDE-USDE", type: "SVR", aggregator: "0x9f0CfC9A81B06C1b8Fb3Fc6e2f11f3bAF7DDfC71" },
-  { asset: "TRX-USD", type: "SVR", aggregator: "0x3Cf2fEe3CaA34D4D5C6c0E7c840c77Ba9422bE6c" },
-  { asset: "TUSD-USD", type: "SVR", aggregator: "0x99fdb9088d643509d2D8Dc3BfD5DfC8529a28992" },
-  { asset: "TWT-BNB", type: "SVR", aggregator: "0x653AF94dd711019dED4b3Da3342A23a895eeEAA9" },
-  { asset: "UNI-USD", type: "SVR", aggregator: "0x1B98955233D396D5A347D081a5B79AaE9591a594" },
-  { asset: "USD1-USD", type: "SVR", aggregator: "0xd4C7fd2175953346a249E38535D3565D23826482" },
-  { asset: "USDC-USD", type: "Aave-SVR", aggregator: "0xdc94188A6deb8B9D39e4ACBcED5395D5Ce118502" },
-  { asset: "USDC-USD", type: "SVR", aggregator: "0xe1BFc770C664Db8FAc0c0c4175D20b4F2E2CFc55" },
-  { asset: "USDE-USD", type: "SVR", aggregator: "0x2e37755453BAA5FC1d6B2431A64a6DDd2a3C5454" },
-  { asset: "USDT-USD", type: "SVR", aggregator: "0xAa41Cb7a230BBA5a317F77bA60030960341e186D" },
-  { asset: "USDT-USD", type: "Aave-SVR", aggregator: "0xdaEaB3108483458cd1C441a753009D2f2c020292" },
-  { asset: "WSTETH-STETH", type: "Aave-SVR", aggregator: "0x5b3b1E268c4dAA1819739157e5e0CafA594f99aa" },
-  { asset: "XRP-USD", type: "SVR", aggregator: "0xE39712410F824e7b46d4f2409eaD5246C4294A95" },
-  { asset: "XSOLVBTC-SOLVBTC", type: "SVR", aggregator: "0xDDd5c6C8b9EF8106438Ddd3634D4892d906CF7D2" },
-  { asset: "XVS-USD", type: "SVR", aggregator: "0x182a1DC5Eb5A8bfF82e324eCB69ED1FFbd5a3FF3" },
-]
-
-export const monadFeeds = [
-  { asset: "APRMON-MON Exchange Rate", type: "SVR", aggregator: "0x124FE2b4a19bC618d6cF0a64e2BBE85C7e3C6ED9" },
-  { asset: "AUSD-USD", type: "SVR", aggregator: "0x253c95994246DE5A83AAFE82909681522DA051Af" },
-  { asset: "BTC-USD", type: "SVR", aggregator: "0x9d8b2A6b6A8748bB5e557505d2dDC9d44b6fd2Dd" },
-  { asset: "CBBTC-USD", type: "SVR", aggregator: "0x5cB59A1E12c781793b1799D99d1F31eA4e79eCE9" },
-  { asset: "EARNAUSD-AUSD Exchange Rate", type: "SVR", aggregator: "0xb95fa18a1892045F671bC1723d452618f3FC0355" },
-  { asset: "ETH-USD", type: "SVR", aggregator: "0xeF3c6C938F82BE8ba983a52F5b0f47eE820DCeb2" },
-  { asset: "EZETH-ETH Exchange Rate", type: "SVR", aggregator: "0x521F749F78dA5d58f70f79aD44f73fDEAA5dc538" },
-  { asset: "GMON-MON Exchange Rate", type: "SVR", aggregator: "0xAF165Ea49569528ff543640834Eb6819f0d9601f" },
-  { asset: "MON-USD", type: "SVR", aggregator: "0x810d5E3dB355bFd2C80c06D89F08523111c6d0F1" },
-  { asset: "SHMON-MON Exchange Rate", type: "SVR", aggregator: "0xE3F1906C6b6EEA63dCc0C016C4ec6746c69e7476" },
-  { asset: "SMON-MON Exchange Rate", type: "SVR", aggregator: "0x0Ebdee66Cdd6ffe566d39eD9F876EE04920E25D4" },
-  { asset: "SYZUSD-YZUSD Exchange Rate", type: "SVR", aggregator: "0x18278ef950F120Cb89960C0c07e965bbAc389cfC" },
-  { asset: "USDC-USD", type: "SVR", aggregator: "0xdE1FE319F71E446143BEC6eEc02d89286E7265ed" },
-  { asset: "USDT0-USD", type: "SVR", aggregator: "0x9e921eC9C5ef689045af16a95569F3644bB41FD3" },
-]
 
 <Aside type="note" title="Searcher Onboarding">
   SVR on Atlas (every chain outside of ETH mainnet) uses a reputation system with **two groups**. Unless otherwise specified for a chain, Atlas includes up to **2 searcher bids** per transaction for on-chain settlement:
@@ -278,113 +184,13 @@ The following contracts are deployed at version **v1.6.4**.
   <p>
     Searchers need to listen to the **Aggregator address** for price reports, not the proxy address. You can find the
     aggregator address by reading `aggregator` in the proxy contract. For convenience, we've included the aggregator
-    address in the table below. Use **Aave-SVR** type feeds for Aave and **SVR** type feeds for other protocols. For the
-    full list of SVR feeds, see the [SVR Feeds page](/data-feeds/svr-feeds).
+    address in the table below. Use **Aave-SVR** type feeds for Aave, **SVR** type feeds for other protocols, and
+    **SVR-Backup** for the legacy shared feeds. For the full list of SVR feeds, see the [SVR Feeds
+    page](/data-feeds/svr-feeds).
   </p>
 </Aside>
 
-<Tabs client:visible>
-  <Fragment slot="tab.1">Base</Fragment>
-  <Fragment slot="tab.2">Arbitrum</Fragment>
-  <Fragment slot="tab.3">BNB Chain</Fragment>
-  <Fragment slot="tab.4">Monad</Fragment>
-  <Fragment slot="panel.1">
-    <table>
-      <thead>
-        <tr>
-          <th>Asset</th>
-          <th>Type</th>
-          <th>Aggregator Address</th>
-        </tr>
-      </thead>
-      <tbody>
-        {baseFeeds.map((feed, i) => (
-          <tr key={i}>
-            <td>
-              <strong>{feed.asset}</strong>
-            </td>
-            <td>{feed.type}</td>
-            <td>
-              <CopyText text={feed.aggregator} code />
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  </Fragment>
-  <Fragment slot="panel.2">
-    <table>
-      <thead>
-        <tr>
-          <th>Asset</th>
-          <th>Type</th>
-          <th>Aggregator Address</th>
-        </tr>
-      </thead>
-      <tbody>
-        {arbitrumFeeds.map((feed, i) => (
-          <tr key={i}>
-            <td>
-              <strong>{feed.asset}</strong>
-            </td>
-            <td>{feed.type}</td>
-            <td>
-              <CopyText text={feed.aggregator} code />
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  </Fragment>
-  <Fragment slot="panel.3">
-    <table>
-      <thead>
-        <tr>
-          <th>Asset</th>
-          <th>Type</th>
-          <th>Aggregator Address</th>
-        </tr>
-      </thead>
-      <tbody>
-        {bnbFeeds.map((feed, i) => (
-          <tr key={i}>
-            <td>
-              <strong>{feed.asset}</strong>
-            </td>
-            <td>{feed.type}</td>
-            <td>
-              <CopyText text={feed.aggregator} code />
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  </Fragment>
-  <Fragment slot="panel.4">
-    <table>
-      <thead>
-        <tr>
-          <th>Asset</th>
-          <th>Type</th>
-          <th>Aggregator Address</th>
-        </tr>
-      </thead>
-      <tbody>
-        {monadFeeds.map((feed, i) => (
-          <tr key={i}>
-            <td>
-              <strong>{feed.asset}</strong>
-            </td>
-            <td>{feed.type}</td>
-            <td>
-              <CopyText text={feed.aggregator} code />
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  </Fragment>
-</Tabs>
+<FeedList client:idle initialNetwork="base" dataFeedType="svrAtlas" />
 
 ## Guide
 

--- a/src/content/data-feeds/svr-feeds/searcher-onboarding-ethereum.mdx
+++ b/src/content/data-feeds/svr-feeds/searcher-onboarding-ethereum.mdx
@@ -12,59 +12,7 @@ whatsnext:
 
 import { Aside, ClickToZoom, CodeSample, CopyText } from "@components"
 import { Tabs } from "@components/Tabs"
-import { CHAINS } from "@features/data/chains"
-import { isSharedSVR, isAaveSVR } from "~/features/feeds/utils/svrDetection.ts"
-
-export async function getFeeds() {
-  const ethereumMainnet = CHAINS.find((chain) => chain.page === "ethereum")?.networks.find(
-    (network) => network.networkType === "mainnet"
-  )
-
-const rddUrl = ethereumMainnet?.rddUrl
-
-if (!rddUrl) {
-return []
-}
-
-try {
-const response = await fetch(rddUrl)
-const data = await response.json()
-
-    const svrFeeds = data.filter(
-      (feed) => feed.secondaryProxyAddress && !feed.docs?.hidden && (isAaveSVR(feed) || isSharedSVR(feed))
-    )
-
-    const feedGroups = {}
-
-    svrFeeds.forEach(feed => {
-      const baseName = feed.name.replace(" / ", "/")
-
-      if (!feedGroups[baseName]) {
-        feedGroups[baseName] = {
-          name: baseName,
-          aaveAddress: null,
-          svrAddress: null
-        }
-      }
-
-      if (isAaveSVR(feed)) {
-        feedGroups[baseName].aaveAddress = feed.contractAddress
-      } else if (isSharedSVR(feed)) {
-        feedGroups[baseName].svrAddress = feed.contractAddress
-      }
-    })
-
-    const combinedFeeds = Object.values(feedGroups)
-      .sort((a, b) => a.name.localeCompare(b.name))
-
-    return combinedFeeds
-
-} catch (error) {
-return []
-}
-}
-
-export const feeds = await getFeeds()
+import { FeedList } from "~/features/feeds/components/FeedList.tsx"
 
 <Aside type="note" title="Searcher Onboarding">
   To onboard as a searcher to SVR, reach out to [devrel@smartcontract.com](mailto:devrel@smartcontract.com). Searchers
@@ -91,9 +39,23 @@ For more background on how Aave liquidations work, see [Aave Documentation](http
 
 <ClickToZoom src="/images/data-feed/svr/svr-price-update-auction-liquidation-flow.webp" />
 
-### How to Participate as a Searcher
+## Feed Aggregator Addresses
 
-#### 1. High-Level Steps for Searchers
+<Aside type="note">
+  <p>
+    Searchers need to listen to the **Aggregator address** for price reports, not the proxy address. You can find the
+    aggregator address by reading `aggregator` in the proxy contract. For convenience, we've included the aggregator
+    address in the table below. Use **Aave-SVR** type feeds for Aave, **SVR** type feeds for other protocols, and
+    **SVR-Backup** for the legacy shared feeds. For the full list of SVR feeds, see the [SVR Feeds
+    page](/data-feeds/svr-feeds).
+  </p>
+</Aside>
+
+<FeedList client:idle initialNetwork="ethereum-mainnet" dataFeedType="svr" />
+
+## How to Participate as a Searcher
+
+### 1. High-Level Steps for Searchers
 
 1. **Monitor and Identify SVR Price Updates**: Chainlink SVR sends oracle reports through Flashbots Protect (MEV-Share). Your searcher node must watch private transactions, not just the public mempool. It must also filter by these SVR data feed update events, and determine which feed address the update is for.
 
@@ -103,7 +65,7 @@ For more background on how Aave liquidations work, see [Aave Documentation](http
 
 1. **Execute Liquidation**: If your bundle is selected, your liquidation happens **immediately after** the fresh price arrives onchain, capturing the liquidation bonus. Based on the results of the auction, a portion of the MEV is recaptured and split between Aave and the Chainlink Network, while the rest goes to you.
 
-#### 2. Listen for Events on MEV Share
+### 2. Listen for Events on MEV Share
 
 Chainlink SVR uses forwarder contracts to route feed updates. You typically see **one transaction per event**, which calls the function `forward(address to, bytes callData)` with the function selector `6fadcf72`. This method, in turn, calls the SVR aggregator's `transmitSecondary()` function with the new price data.
 
@@ -134,7 +96,7 @@ The event stream is also expected to occasionally transmit transaction bundles. 
 
 <CodeSample src="samples/DataFeeds/SVR/bundle-transaction-event.json" />
 
-#### 3. Decode `callData` for `forward` and `transmitSecondary`
+### 3. Decode `callData` for `forward` and `transmitSecondary`
 
 Once you've identified a potential SVR feed update transaction, you'll need to decode its payload. This step allows you to extract:
 
@@ -194,50 +156,11 @@ The following code samples demonstrate the complete decoding process, including 
   </Fragment>
 </Tabs>
 
-#### 4. Detect SVR-enabled Feeds
+### 4. Detect SVR-enabled Feeds
 
-When processing forward calls, verify that the `to` address from the code sample above (the destination of the forward call) matches one of these feed addresses. This tells you which SVR data feed the price update is for:
+When processing forward calls, verify that the `to` address from the code sample above (the destination of the forward call) matches one of the SVR feed aggregator addresses listed in the [Feed Aggregator Addresses](#feed-aggregator-addresses) section above.
 
-<table>
-  <thead>
-    <tr>
-      <th>Feed</th>
-      <th>SVR Feed</th>
-      <th>Aave Dedicated SVR Feed</th>
-    </tr>
-  </thead>
-  <tbody>
-    {feeds &&
-      feeds.map((feed) => (
-        <tr key={feed.name}>
-          <td>
-            <strong>{feed.name}</strong>
-          </td>
-          <td>
-            {feed.svrAddress ? (
-              <CopyText text={feed.svrAddress} code />
-            ) : (
-              <span style={{ color: "#888" }}>Not available</span>
-            )}
-          </td>
-          <td>
-            {feed.aaveAddress ? (
-              <CopyText text={feed.aaveAddress} code />
-            ) : (
-              <span style={{ color: "#888" }}>Not available</span>
-            )}
-          </td>
-        </tr>
-      ))}
-    {(!feeds || feeds.length === 0) && (
-      <tr>
-        <td colSpan="3">No SVR feeds found.</td>
-      </tr>
-    )}
-  </tbody>
-</table>
-
-#### 5. Calculate Updated Price
+### 5. Calculate Updated Price
 
 After successfully decoding the transaction data, you need to extract the median price from the `observations` array inside the decoded `report`:
 
@@ -249,7 +172,7 @@ This formula retrieves the median value from the sorted array of price observati
 
 To use this price effectively, convert it to the appropriate decimal representation for the asset pair.
 
-#### 6. Bidding With Flashbots MEV-Share
+### 6. Bidding With Flashbots MEV-Share
 
 Once you've detected an SVR update and identified a profitable liquidation opportunity, you need to construct and submit a bundle to Flashbots. Consider these key aspects when preparing your submission:
 
@@ -297,14 +220,14 @@ Bidding for bundle events is very similar to single transaction events. As a sea
 
 <CodeSample src="samples/DataFeeds/SVR/bundle-bid.json" />
 
-#### 7. Considerations
+### 7. Considerations
 
 - **Competition**: Multiple searchers might detect the same liquidation. The best bid typically wins.
 - **Profit-Sharing**: A portion of liquidation MEV is recaptured and redirected to the integrating DeFi protocol and the Chainlink Network.
 - **Gas Efficiency**: Bundles that are too costly might erode the profitability of the proposed transaction. Optimize carefully.
 - **Non-SVR `forward` calls**: There are other events on the MEV-Share event stream that have the same `forward` function signature. Be sure to filter for the ones that call `transmitSecondary` on the listed SVR feeds.
 
-#### 8. Next Steps for Searchers
+### 8. Next Steps for Searchers
 
 1. **Set Up Your Searcher Node**
    - Integrate with [Flashbots MEV-Share](/data-feeds/svr-feeds/searcher-onboarding-ethereum) to read private transactions.

--- a/src/features/data/chains.ts
+++ b/src/features/data/chains.ts
@@ -4,7 +4,15 @@ import { ChainMetadata } from "./api/index.ts"
 export const POR_MVR_FEEDS_URL = "https://reference-data-directory.vercel.app/por-data-feeds.json"
 
 type ChainTags = (
-  "default" | "smartData" | "rates" | "streams" | "usGovernmentMacroeconomicData" | "tokenizedEquity" | "extendedHours"
+  | "default"
+  | "smartData"
+  | "rates"
+  | "streams"
+  | "usGovernmentMacroeconomicData"
+  | "tokenizedEquity"
+  | "extendedHours"
+  | "svr"
+  | "svrAtlas"
 )[]
 export interface ChainNetwork {
   name: string
@@ -76,7 +84,7 @@ export const CHAINS: Chain[] = [
     title: "Arbitrum Data Feeds",
     img: "/assets/chains/arbitrum.svg",
     networkStatusUrl: "https://arbiscan.freshstatus.io/",
-    tags: ["default", "rates", "streams", "smartData", "usGovernmentMacroeconomicData"],
+    tags: ["default", "rates", "streams", "smartData", "usGovernmentMacroeconomicData", "svrAtlas"],
     supportedFeatures: ["vrfSubscription", "vrfDirectFunding", "feeds"],
     l2SequencerFeed: true,
     networks: [
@@ -134,7 +142,7 @@ export const CHAINS: Chain[] = [
     title: "Base Data Feeds",
     img: "/assets/chains/base.svg",
     networkStatusUrl: "https://basescan.statuspage.io/",
-    tags: ["default", "smartData", "usGovernmentMacroeconomicData", "tokenizedEquity", "extendedHours"],
+    tags: ["default", "smartData", "usGovernmentMacroeconomicData", "tokenizedEquity", "extendedHours", "svrAtlas"],
     supportedFeatures: ["feeds"],
     l2SequencerFeed: true,
     networks: [
@@ -161,7 +169,7 @@ export const CHAINS: Chain[] = [
     title: "BNB Chain Data Feeds",
     img: "/assets/chains/bnb-chain.svg",
     networkStatusUrl: "https://bscscan.freshstatus.io/",
-    tags: ["default", "smartData", "usGovernmentMacroeconomicData"],
+    tags: ["default", "smartData", "usGovernmentMacroeconomicData", "svrAtlas"],
     supportedFeatures: ["vrfSubscription", "vrfDirectFunding", "feeds"],
     networks: [
       {
@@ -256,7 +264,7 @@ export const CHAINS: Chain[] = [
     title: "Data Feeds",
     img: "/assets/chains/ethereum.svg",
     networkStatusUrl: "https://ethstats.dev/",
-    tags: ["default", "smartData", "rates", "usGovernmentMacroeconomicData", "tokenizedEquity", "extendedHours"],
+    tags: ["default", "smartData", "rates", "usGovernmentMacroeconomicData", "tokenizedEquity", "extendedHours", "svr"],
     supportedFeatures: ["vrfSubscription", "vrfDirectFunding", "feeds"],
     networks: [
       {
@@ -480,7 +488,7 @@ export const CHAINS: Chain[] = [
     label: "Monad",
     img: "/assets/chains/monad.svg",
     networkStatusUrl: "https://monadvision.com/",
-    tags: ["default", "smartData"],
+    tags: ["default", "smartData", "svrAtlas"],
     supportedFeatures: ["feeds"],
     networks: [
       {

--- a/src/features/feeds/components/FeedList.tsx
+++ b/src/features/feeds/components/FeedList.tsx
@@ -19,7 +19,7 @@ import {
   networkHasVisibleFeeds,
   type ExtendedHoursCategory,
 } from "../utils/feedVisibility.ts"
-import { chainHasSvrFeeds } from "../utils/svrDetection.ts"
+import { chainHasSvrFeeds, getSvrType, type SvrFeedType } from "../utils/svrDetection.ts"
 import {
   filterChainsByFeedTypeTag,
   networkMatchesFeedTypeTag,
@@ -172,7 +172,7 @@ export const FeedList = ({
   forceExtendedHoursCategory?: ExtendedHoursCategory
 }) => {
   const feedTypeFlags = getFeedTypeFlags(dataFeedType)
-  const { isStreams, isSmartData, isRates, isUSGovernmentMacroeconomicData } = feedTypeFlags
+  const { isStreams, isSmartData, isRates, isUSGovernmentMacroeconomicData, isSvr } = feedTypeFlags
   const isDeprecating = ecosystem === "deprecating"
   const chains = isDeprecating && isStreams ? ALL_CHAINS : CHAINS
 
@@ -336,8 +336,10 @@ export const FeedList = ({
   }
 
   const [showSvrParam, setShowSvrParam] = useQueryString("showSvr")
-  const showOnlySVR = showSvrParam === "true"
+  // When dataFeedType is "svr", always show only SVR feeds (locked)
+  const showOnlySVR = isSvr ? true : showSvrParam === "true"
   const setShowOnlySVR = (value: boolean) => {
+    if (isSvr) return // locked
     setShowSvrParam(value ? "true" : "")
     updateUrlClean({ showSvr: value || undefined })
     if (value) paginate(1)
@@ -348,6 +350,8 @@ export const FeedList = ({
   const [showOnlyMVRFeedsTestnet, setShowOnlyMVRFeedsTestnet] = useState(false)
   const [showOnlyDEXFeeds, setShowOnlyDEXFeeds] = useState(false)
   const [showOnlyDEXFeedsTestnet, setShowOnlyDEXFeedsTestnet] = useState(false)
+  // SVR type filters (only used when dataFeedType === "svr")
+  const [svrTypeFilters, setSvrTypeFilters] = useState<Set<SvrFeedType>>(new Set())
   const [showOnlyDatalinkFeeds, setShowOnlyDatalinkFeeds] = useState(false)
   const [showOnlyDatalinkFeedsTestnet, setShowOnlyDatalinkFeedsTestnet] = useState(false)
   const [show24x5FeedsParam, setShow24x5FeedsParam] = useQueryString("show24x5")
@@ -1466,6 +1470,8 @@ export const FeedList = ({
                   searchValue={typeof searchValue === "string" ? searchValue : ""}
                   tokenizedEquityProvider={tokenizedEquityProvider}
                   forceExtendedHoursCategory={forceExtendedHoursCategory}
+                  isSvr={isSvr}
+                  svrTypeFilters={svrTypeFilters}
                 />
               ))
             ) : (
@@ -1790,7 +1796,7 @@ export const FeedList = ({
                       )}
                       <div className={feedList.tableFilters}>
                         <div className={feedList.filterControls}>
-                          {!isStreams && !isSmartData && availableAssetTypes.length > 1 && (
+                          {!isStreams && !isSmartData && !isSvr && availableAssetTypes.length > 1 && (
                             <details class={feedList.filterDropdown_details}>
                               <summary class="text-200" onClick={() => setShowCategoriesDropdown((prev) => !prev)}>
                                 Asset Type
@@ -1863,7 +1869,7 @@ export const FeedList = ({
                               Show Multiple-Variable Response (MVR) feeds
                             </label>
                           )}
-                          {!isStreams && !isSmartData && !isUSGovernmentMacroeconomicData && chainHasSvr && (
+                          {!isStreams && !isSmartData && !isUSGovernmentMacroeconomicData && chainHasSvr && !isSvr && (
                             <span className={feedList.filterCheckboxGroup}>
                               <label className={feedList.detailsLabel}>
                                 <input
@@ -1883,6 +1889,91 @@ export const FeedList = ({
                                 ?
                               </a>
                             </span>
+                          )}
+                          {isSvr && (
+                            <>
+                              <span className={feedList.filterCheckboxGroup}>
+                                <label className={feedList.detailsLabel}>
+                                  <input
+                                    type="checkbox"
+                                    className={feedList.feedCheckbox}
+                                    checked={!svrTypeFilters.has("Aave-SVR")}
+                                    onChange={() => {
+                                      setSvrTypeFilters((prev) => {
+                                        const next = new Set(prev)
+                                        if (next.has("Aave-SVR")) next.delete("Aave-SVR")
+                                        else next.add("Aave-SVR")
+                                        return next
+                                      })
+                                      setCurrentPage("1")
+                                    }}
+                                  />
+                                  Aave-SVR
+                                </label>
+                                <a
+                                  href="/data-feeds/svr-feeds#aave-svr-feeds"
+                                  className={feedList.filterHelpLink}
+                                  title="Dedicated SVR feeds exclusively for the Aave protocol"
+                                  aria-label="Learn about Aave-SVR feeds"
+                                >
+                                  ?
+                                </a>
+                              </span>
+                              <span className={feedList.filterCheckboxGroup}>
+                                <label className={feedList.detailsLabel}>
+                                  <input
+                                    type="checkbox"
+                                    className={feedList.feedCheckbox}
+                                    checked={!svrTypeFilters.has("SVR")}
+                                    onChange={() => {
+                                      setSvrTypeFilters((prev) => {
+                                        const next = new Set(prev)
+                                        if (next.has("SVR")) next.delete("SVR")
+                                        else next.add("SVR")
+                                        return next
+                                      })
+                                      setCurrentPage("1")
+                                    }}
+                                  />
+                                  SVR
+                                </label>
+                                <a
+                                  href="/data-feeds/svr-feeds#svr-shared"
+                                  className={feedList.filterHelpLink}
+                                  title="Canonical shared SVR feeds for use by any protocol"
+                                  aria-label="Learn about SVR feeds"
+                                >
+                                  ?
+                                </a>
+                              </span>
+                              <span className={feedList.filterCheckboxGroup}>
+                                <label className={feedList.detailsLabel}>
+                                  <input
+                                    type="checkbox"
+                                    className={feedList.feedCheckbox}
+                                    checked={!svrTypeFilters.has("SVR-Backup")}
+                                    onChange={() => {
+                                      setSvrTypeFilters((prev) => {
+                                        const next = new Set(prev)
+                                        if (next.has("SVR-Backup")) next.delete("SVR-Backup")
+                                        else next.add("SVR-Backup")
+                                        return next
+                                      })
+                                      setCurrentPage("1")
+                                    }}
+                                  />
+                                  SVR-Backup
+                                </label>
+                                <a
+                                  href="/data-feeds/svr-feeds#svr-backup-legacy"
+                                  className={feedList.filterHelpLink}
+                                  title="Legacy shared SVR feeds. New integrations should use SVR feeds instead."
+                                  aria-label="Learn about SVR-Backup feeds"
+                                >
+                                  ?
+                                </a>
+                              </span>
+                            </>
                           )}
                         </div>
                         <form class={clsx(feedList.tableSearch, feedList.filterDropdown_search)}>
@@ -1941,6 +2032,8 @@ export const FeedList = ({
                         searchValue={typeof searchValue === "string" ? searchValue : ""}
                         tokenizedEquityProvider={tokenizedEquityProvider}
                         forceExtendedHoursCategory={forceExtendedHoursCategory}
+                        isSvr={isSvr}
+                        svrTypeFilters={svrTypeFilters}
                       />
                     </>
                   ) : (

--- a/src/features/feeds/components/Tables.tsx
+++ b/src/features/feeds/components/Tables.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource preact */
-import { useEffect, useState } from "preact/hooks"
+import { useEffect, useState, useMemo } from "preact/hooks"
 import { Fragment, render } from "preact"
 import feedList from "./FeedList.module.css"
 import { clsx } from "~/lib/clsx/clsx.ts"
@@ -18,7 +18,13 @@ import {
 import type { MarketPricingRiskProduct } from "../content/marketPricingRiskTerms.ts"
 import { REPORT_SCHEMA_DEFINITIONS, type SchemaDefinition } from "./reportSchemaData.ts"
 import schemaFieldsTableStyles from "../../data-streams/common/schemaFieldsTable.module.css"
-import { isSharedSVR, isAaveSVR } from "~/features/feeds/utils/svrDetection.ts"
+import {
+  isSharedSVR,
+  isAaveSVR,
+  isNewSharedSVR,
+  getSvrType,
+  type SvrFeedType,
+} from "~/features/feeds/utils/svrDetection.ts"
 import { ExpandableTableWrapper } from "./ExpandableTableWrapper.tsx"
 import {
   shouldHideAddress,
@@ -456,11 +462,13 @@ const DefaultTHead = ({
   networkName,
   dataFeedType,
   showRiskColumn = true,
+  isSvr = false,
 }: {
   showExtraDetails: boolean
   networkName: string
   dataFeedType: string
   showRiskColumn?: boolean
+  isSvr?: boolean
 }) => {
   const isAptosNetwork = networkName === "Aptos Mainnet" || networkName === "Aptos Testnet"
   const isUSGovernmentMacroeconomicData = dataFeedType === "usGovernmentMacroeconomicData"
@@ -473,7 +481,7 @@ const DefaultTHead = ({
         <th style={{ display: showExtraDetails ? "table-cell" : "none" }}>Deviation</th>
         <th style={{ display: showExtraDetails ? "table-cell" : "none" }}>Heartbeat</th>
         <th style={{ display: showExtraDetails ? "table-cell" : "none" }}>Dec</th>
-        <th>{isAptosNetwork ? "Feed ID and info" : "Address and info"}</th>
+        <th>{isSvr ? "Aggregator and info" : isAptosNetwork ? "Feed ID and info" : "Address and info"}</th>
       </tr>
     </thead>
   )
@@ -504,6 +512,7 @@ const DefaultTr = ({
   batchedCategoryData,
   dataFeedType,
   showRiskColumn = true,
+  isSvr = false,
 }) => {
   // Use the pre-computed finalCategory from enriched metadata
   // (already includes deprecating status and Supabase risk tier)
@@ -542,20 +551,12 @@ const DefaultTr = ({
           {metadata.secondaryProxyAddress && (
             <div style={{ marginTop: "5px" }}>
               <a
-                href={
-                  isAaveSVR(metadata)
-                    ? "/data-feeds/svr-feeds#aave-svr-feeds"
-                    : isSharedSVR(metadata)
-                      ? "/data-feeds/svr-feeds"
-                      : "/data-feeds/svr-feeds"
-                }
+                href="/data-feeds/svr-feeds"
                 target="_blank"
                 className={tableStyles.feedVariantBadge}
-                title={
-                  isAaveSVR(metadata) ? "Aave Dedicated SVR Feed" : isSharedSVR(metadata) ? " SVR Feed" : "SVR Feed"
-                }
+                title={`${getSvrType(metadata)} Feed`}
               >
-                {isAaveSVR(metadata) ? "Aave SVR" : isSharedSVR(metadata) ? "SVR" : "SVR"}
+                {getSvrType(metadata)}
               </a>
             </div>
           )}
@@ -616,26 +617,33 @@ const DefaultTr = ({
         <div>
           <dl className={tableStyles.listContainer}>
             <div className={tableStyles.definitionGroup}>
-              {metadata.secondaryProxyAddress && (
+              {metadata.secondaryProxyAddress && !isSvr && (
                 <dt>
                   <span className="label">Standard Proxy:</span>
                 </dt>
               )}
+              {isSvr && (
+                <dt>
+                  <span className="label">Aggregator:</span>
+                </dt>
+              )}
               <dd>
-                {hideAddress ? (
+                {hideAddress && !isSvr ? (
                   <HiddenAddressContact className={tableStyles.addressLink} />
                 ) : (
                   <div className={tableStyles.assetAddress}>
                     <button
                       className={clsx(tableStyles.copyBtn, "copy-iconbutton")}
-                      data-clipboard-text={metadata.proxyAddress ?? metadata.transmissionsAccount}
+                      data-clipboard-text={
+                        isSvr ? metadata.contractAddress : (metadata.proxyAddress ?? metadata.transmissionsAccount)
+                      }
                       onClick={(e) =>
                         handleClick(e, {
                           product: "FEEDS",
                           action: "feedId_copied",
                           extraInfo1: network.name,
                           extraInfo2: metadata.name,
-                          extraInfo3: metadata.proxyAddress,
+                          extraInfo3: isSvr ? metadata.contractAddress : metadata.proxyAddress,
                         })
                       }
                     >
@@ -643,10 +651,13 @@ const DefaultTr = ({
                     </button>
                     <a
                       className={tableStyles.addressLink}
-                      href={network.explorerUrl.replace("%s", metadata.proxyAddress ?? metadata.transmissionsAccount)}
+                      href={network.explorerUrl.replace(
+                        "%s",
+                        isSvr ? metadata.contractAddress : (metadata.proxyAddress ?? metadata.transmissionsAccount)
+                      )}
                       target="_blank"
                     >
-                      {metadata.proxyAddress ?? metadata.transmissionsAccount}
+                      {isSvr ? metadata.contractAddress : (metadata.proxyAddress ?? metadata.transmissionsAccount)}
                     </a>
                   </div>
                 )}
@@ -688,7 +699,7 @@ const DefaultTr = ({
                 <div className={tableStyles.separator} />
                 <div className={tableStyles.assetAddress}>
                   <dt>
-                    <span className="label">{isAaveSVR(metadata) ? "AAVE SVR Proxy:" : "SVR Proxy:"}</span>
+                    <span className="label">{getSvrType(metadata)} Proxy:</span>
                   </dt>
                   <dd>
                     {hideAddress ? (
@@ -731,9 +742,19 @@ const DefaultTr = ({
                     .
                   </div>
                 )}
-                {isSharedSVR(metadata) && !hideAddress && (
+                {isNewSharedSVR(metadata) && !hideAddress && (
                   <div className={clsx(tableStyles.sharedCallout)}>
                     <strong>🔗 SVR Feed:</strong> This SVR proxy feed is usable by any protocol. Learn more about{" "}
+                    <a href="/data-feeds/svr-feeds" target="_blank">
+                      SVR Feeds
+                    </a>
+                    .
+                  </div>
+                )}
+                {isSharedSVR(metadata) && !hideAddress && (
+                  <div className={clsx(tableStyles.sharedCallout)}>
+                    <strong>🔗 SVR-Backup Feed:</strong> This is a legacy SVR proxy feed. New integrations should use
+                    the <strong>SVR</strong> feeds. Learn more about{" "}
                     <a href="/data-feeds/svr-feeds" target="_blank">
                       SVR Feeds
                     </a>
@@ -1633,6 +1654,8 @@ export const MainnetTable = ({
   searchValue,
   tokenizedEquityProvider,
   forceExtendedHoursCategory,
+  isSvr,
+  svrTypeFilters,
 }: {
   network: ChainNetwork
   showExtraDetails: boolean
@@ -1657,6 +1680,8 @@ export const MainnetTable = ({
   searchValue: string
   tokenizedEquityProvider?: string
   forceExtendedHoursCategory?: ExtendedHoursCategory
+  isSvr?: boolean
+  svrTypeFilters?: Set<SvrFeedType>
 }) => {
   if (!network.metadata) return null
 
@@ -1686,7 +1711,16 @@ export const MainnetTable = ({
     },
   })
 
-  const slicedFilteredMetadata = filteredMetadata.slice(firstAddr, lastAddr)
+  // Apply SVR type filters when in SVR mode
+  const typeFilteredMetadata = useMemo(() => {
+    if (!isSvr || !svrTypeFilters || svrTypeFilters.size === 0) return filteredMetadata
+    return filteredMetadata.filter((m) => {
+      const svrType = getSvrType(m)
+      return svrType && !svrTypeFilters.has(svrType)
+    })
+  }, [filteredMetadata, isSvr, svrTypeFilters])
+
+  const slicedFilteredMetadata = typeFilteredMetadata.slice(firstAddr, lastAddr)
 
   if (isBatchLoading) {
     return <p style="font-style: italic;">Loading...</p>
@@ -1739,6 +1773,7 @@ export const MainnetTable = ({
                         showExtraDetails={showExtraDetails}
                         batchedCategoryData={batchedCategoryData}
                         dataFeedType={dataFeedType}
+                        isSvr={isSvr}
                       />
                     )}
                   </>

--- a/src/features/feeds/types.ts
+++ b/src/features/feeds/types.ts
@@ -12,6 +12,8 @@ export type DataFeedType =
   | "usGovernmentMacroeconomicData"
   | "tokenizedEquity"
   | "extendedHours"
+  | "svr"
+  | "svrAtlas"
   | "streamsCrypto"
   | "streamsRwa"
   | "streamsNav"
@@ -28,7 +30,8 @@ export interface FeedTypeFlags {
   isSmartData: boolean
   isRates: boolean
   isUSGovernmentMacroeconomicData: boolean
-  /** Standard price feeds table (excludes streams/smartdata/macro; testnet also excludes rates). */
+  isSvr: boolean
+  /** Standard price feeds table (excludes streams/smartdata/macro/svr; testnet also excludes rates). */
   isDefaultTable: boolean
 }
 
@@ -42,11 +45,12 @@ export function getFeedTypeFlags(dataFeedType: string, environment: "mainnet" | 
   const isSmartData = dataFeedType === "smartdata"
   const isRates = dataFeedType === "rates"
   const isUSGovernmentMacroeconomicData = dataFeedType === "usGovernmentMacroeconomicData"
+  const isSvr = dataFeedType === "svr" || dataFeedType === "svrAtlas"
 
   const isDefaultTable =
     environment === "testnet"
       ? !isSmartData && !isRates && !isStreams && !isUSGovernmentMacroeconomicData
       : !isStreams && !isSmartData && !isUSGovernmentMacroeconomicData
 
-  return { isStreams, isSmartData, isRates, isUSGovernmentMacroeconomicData, isDefaultTable }
+  return { isStreams, isSmartData, isRates, isUSGovernmentMacroeconomicData, isSvr, isDefaultTable }
 }

--- a/src/features/feeds/utils/chainFilters.ts
+++ b/src/features/feeds/utils/chainFilters.ts
@@ -10,6 +10,8 @@ const FEED_TYPE_TAG: Partial<Record<DataFeedType, string>> = {
   usGovernmentMacroeconomicData: "usGovernmentMacroeconomicData",
   tokenizedEquity: "tokenizedEquity",
   extendedHours: "extendedHours",
+  svr: "svr",
+  svrAtlas: "svrAtlas",
 }
 
 export function chainMatchesFeedTypeTag(chain: Taggable, dataFeedType: DataFeedType): boolean {
@@ -65,6 +67,8 @@ export function shouldFilterSelectableChainsByVisibleFeeds(dataFeedType: DataFee
     dataFeedType === "rates" ||
     dataFeedType === "usGovernmentMacroeconomicData" ||
     dataFeedType === "tokenizedEquity" ||
-    dataFeedType === "extendedHours"
+    dataFeedType === "extendedHours" ||
+    dataFeedType === "svr" ||
+    dataFeedType === "svrAtlas"
   )
 }

--- a/src/features/feeds/utils/feedVisibility.ts
+++ b/src/features/feeds/utils/feedVisibility.ts
@@ -129,7 +129,8 @@ export function isFeedVisible(
   // ===========================================================================
   const isTokenizedEquity = dataFeedType === "tokenizedEquity"
   const isExtendedHours = dataFeedType === "extendedHours"
-  if (feed.docs?.hidden && !isTokenizedEquity && !isExtendedHours) return false
+  const isSvr = dataFeedType === "svr" || dataFeedType === "svrAtlas"
+  if (feed.docs?.hidden && !isTokenizedEquity && !isExtendedHours && !isSvr) return false
 
   const isDeprecating = ecosystem === "deprecating"
   const isStreams =
@@ -214,6 +215,9 @@ export function isFeedVisible(
     if (isVisible && options.extendedHoursCategory) {
       isVisible = EXTENDED_HOURS_FEED_CATEGORIES[options.extendedHoursCategory].has(proxy)
     }
+  } else if (isSvr) {
+    // SVR feeds are identified by having a secondaryProxyAddress
+    isVisible = !!feed.secondaryProxyAddress
   } else {
     isVisible =
       !feed.docs?.porType &&

--- a/src/features/feeds/utils/svrDetection.ts
+++ b/src/features/feeds/utils/svrDetection.ts
@@ -2,8 +2,15 @@ import { type ChainMetadata } from "~/features/data/api/index.ts"
 import type { DataFeedType } from "../types.ts"
 import { type FeedVisibilityOptions, isFeedVisible } from "./feedVisibility.ts"
 
-// This file contains *temporary* functions to detect SVR feeds based on their metadata
-// These functions are used to identify specific types of SVR feeds based on their metadata properties
+// This file contains functions to detect and classify SVR feeds based on their metadata.
+// SVR feeds are identified by the presence of a secondaryProxyAddress.
+//
+// Classification (based on path suffix):
+//   *-svr (no "shared")        → Aave-SVR    (dedicated to Aave)
+//   *-shared-svr-2             → SVR         (new shared, canonical)
+//   *-shared-svr (no "-2")     → SVR-Backup  (legacy shared)
+
+export type SvrFeedType = "Aave-SVR" | "SVR" | "SVR-Backup"
 
 export function isSvrFeed(metadata: ChainMetadata): boolean {
   return !!metadata?.secondaryProxyAddress
@@ -35,20 +42,35 @@ export function chainHasSvrFeeds(
 }
 
 /**
- * Determines if a feed is a Shared SVR feed based on its path
- * @param metadata - The feed metadata object
- * @returns true if the feed is a shared SVR feed
+ * Determines if a feed is a legacy shared SVR feed (SVR-Backup).
+ * Path ends with "-shared-svr" but NOT "-shared-svr-2".
  */
 export const isSharedSVR = (metadata: ChainMetadata): boolean => {
-  // Check the path field for feeds ending with "-shared-svr"
   return typeof metadata.path === "string" && /-shared-svr$/.test(metadata.path)
 }
 
 /**
- * Determines if a feed is an Aave dedicated SVR feed
- * @param metadata - The feed metadata object
- * @returns true if the feed has a secondary proxy address but is not a shared SVR feed
+ * Determines if a feed is a new shared SVR feed (canonical SVR).
+ * Path ends with "-shared-svr-2".
+ */
+export const isNewSharedSVR = (metadata: ChainMetadata): boolean => {
+  return typeof metadata.path === "string" && /-shared-svr-2$/.test(metadata.path)
+}
+
+/**
+ * Determines if a feed is an Aave dedicated SVR feed.
+ * Has a secondary proxy address but is neither a shared nor new-shared SVR feed.
  */
 export const isAaveSVR = (metadata: ChainMetadata): boolean => {
-  return !!metadata?.secondaryProxyAddress && !isSharedSVR(metadata)
+  return !!metadata?.secondaryProxyAddress && !isSharedSVR(metadata) && !isNewSharedSVR(metadata)
+}
+
+/**
+ * Returns the SVR feed type label for a given feed metadata.
+ */
+export const getSvrType = (metadata: ChainMetadata): SvrFeedType | null => {
+  if (!metadata?.secondaryProxyAddress) return null
+  if (isNewSharedSVR(metadata)) return "SVR"
+  if (isSharedSVR(metadata)) return "SVR-Backup"
+  return "Aave-SVR"
 }


### PR DESCRIPTION
- Added `svr` and `svrAtlas` data types, plumbs through to tag feeds appropriately for searcher onboarding guides
- Updated svr detection with three way classification: aave-svr, svr, and svr-backup
- Replaced hardcoded feed tables on the onboarder guides with dynamic tables
- Added svr type filter checkboxes
- Updated index page to describe the three variants, mentioning users should upgrade off of svr backup if possible on their chain