### PR TITLE
Adding a new operational security page to recommend best practices for Handling CCT tokens in production

### DIFF
--- a/src/config/sidebar/__tests__/__snapshots__/ccip-dynamic.test.ts.snap
+++ b/src/config/sidebar/__tests__/__snapshots__/ccip-dynamic.test.ts.snap
@@ -635,6 +635,13 @@ exports[`CCIP Sidebar Configuration Snapshot should match the expected sidebar s
             "chainTypes": [
               "evm",
             ],
+            "title": "Operational Security",
+            "url": "ccip/tutorials/evm/cross-chain-tokens/operational-security",
+          },
+          {
+            "chainTypes": [
+              "evm",
+            ],
             "children": [
               {
                 "chainTypes": [

--- a/src/config/sidebar/ccip-dynamic.ts
+++ b/src/config/sidebar/ccip-dynamic.ts
@@ -467,6 +467,11 @@ export const CCIP_SIDEBAR_CONTENT: SectionEntry[] = [
         chainTypes: ["evm"],
         children: [
           {
+            title: "Operational Security",
+            url: "ccip/tutorials/evm/cross-chain-tokens/operational-security",
+            chainTypes: ["evm"],
+          },
+          {
             title: "Using Remix IDE",
             chainTypes: ["evm"],
             children: [

--- a/src/content/ccip/api-reference/evm/v1.6.1/rate-limiter.mdx
+++ b/src/content/ccip/api-reference/evm/v1.6.1/rate-limiter.mdx
@@ -32,20 +32,6 @@ This library provides rate limiting functionality with the following features:
 
 ## Events
 
-### TokensConsumed
-
-```solidity
-event TokensConsumed(uint256 tokens);
-```
-
-<Aside>Emitted when tokens are successfully consumed from the [`TokenBucket`](#tokenbucket).</Aside>
-
-**Parameters**
-
-| Name     | Type      | Description                   |
-| -------- | --------- | ----------------------------- |
-| `tokens` | `uint256` | The number of tokens consumed |
-
 ### ConfigChanged
 
 ```solidity
@@ -70,14 +56,6 @@ error BucketOverfilled();
 
 <Aside>Thrown when the [`TokenBucket`](#tokenbucket) contains more tokens than its capacity.</Aside>
 
-### OnlyCallableByAdminOrOwner
-
-```solidity
-error OnlyCallableByAdminOrOwner();
-```
-
-<Aside>Thrown when a restricted function is called by an unauthorized address.</Aside>
-
 ### TokenMaxCapacityExceeded
 
 ```solidity
@@ -96,31 +74,13 @@ error TokenRateLimitReached(uint256 minWaitInSeconds, uint256 available, address
   Thrown when attempting to consume more tokens than currently available in the [`TokenBucket`](#tokenbucket).
 </Aside>
 
-### AggregateValueMaxCapacityExceeded
-
-```solidity
-error AggregateValueMaxCapacityExceeded(uint256 capacity, uint256 requested);
-```
-
-<Aside>Thrown when attempting to consume more aggregate value than the [`TokenBucket`](#tokenbucket)'s capacity.</Aside>
-
-### AggregateValueRateLimitReached
-
-```solidity
-error AggregateValueRateLimitReached(uint256 minWaitInSeconds, uint256 available);
-```
-
-<Aside>
-  Thrown when attempting to consume more aggregate value than currently available in the [`TokenBucket`](#tokenbucket).
-</Aside>
-
 ### InvalidRateLimitRate
 
 ```solidity
 error InvalidRateLimitRate(Config rateLimiterConfig);
 ```
 
-<Aside>Thrown when the rate limit [`Config`](#config) is invalid (rate is zero or exceeds capacity).</Aside>
+<Aside>Thrown when the rate limit [`Config`](#config) is invalid (rate exceeds capacity).</Aside>
 
 ### DisabledNonZeroRateLimit
 
@@ -129,14 +89,6 @@ error DisabledNonZeroRateLimit(Config config);
 ```
 
 <Aside>Thrown when a disabled [`Config`](#config) has non-zero rate or capacity values.</Aside>
-
-### RateLimitMustBeDisabled
-
-```solidity
-error RateLimitMustBeDisabled();
-```
-
-<Aside>Thrown when attempting to enable rate limiting in a context where it must be disabled.</Aside>
 
 ## Structs
 
@@ -207,7 +159,6 @@ Key behaviors:
 - Skips execution if rate limiting is disabled or requestTokens is zero
 - Automatically refills tokens based on elapsed time
 - Enforces capacity and rate limits
-- Emits [`TokensConsumed`](#tokensconsumed) event for non-zero consumption
 - Reverts with [`TokenMaxCapacityExceeded`](#tokenmaxcapacityexceeded) or [`TokenRateLimitReached`](#tokenratelimitreached) on violations
 
 </Aside>
@@ -275,7 +226,7 @@ Configuration update process:
 Validates rate limiter configuration parameters.
 
 ```solidity
-function _validateTokenBucketConfig(Config memory config, bool mustBeDisabled) internal pure;
+function _validateTokenBucketConfig(Config memory config) internal pure;
 ```
 
 <Aside>
@@ -283,20 +234,18 @@ function _validateTokenBucketConfig(Config memory config, bool mustBeDisabled) i
 Validation rules:
 
 - For enabled configurations:
-  - Rate must be non-zero and less than capacity
-  - Validates against mustBeDisabled requirement
+  - Rate must be less than or equal to capacity
 - For disabled configurations:
   - Rate and capacity must be zero
-- May throw [`InvalidRateLimitRate`](#invalidratelimitrate), [`DisabledNonZeroRateLimit`](#disablednonzeroratelimit), or [`RateLimitMustBeDisabled`](#ratelimitmustbedisabled)
+- May throw [`InvalidRateLimitRate`](#invalidratelimitrate) or [`DisabledNonZeroRateLimit`](#disablednonzeroratelimit)
 
 </Aside>
 
 **Parameters**
 
-| Name             | Type                | Description                                |
-| ---------------- | ------------------- | ------------------------------------------ |
-| `config`         | [`Config`](#config) | The configuration to validate              |
-| `mustBeDisabled` | `bool`              | Whether the configuration must be disabled |
+| Name     | Type                | Description                   |
+| -------- | ------------------- | ----------------------------- |
+| `config` | [`Config`](#config) | The configuration to validate |
 
 ### \_calculateRefill
 

--- a/src/content/ccip/api-reference/evm/v1.6.2/rate-limiter.mdx
+++ b/src/content/ccip/api-reference/evm/v1.6.2/rate-limiter.mdx
@@ -32,20 +32,6 @@ This library provides rate limiting functionality with the following features:
 
 ## Events
 
-### TokensConsumed
-
-```solidity
-event TokensConsumed(uint256 tokens);
-```
-
-<Aside>Emitted when tokens are successfully consumed from the [`TokenBucket`](#tokenbucket).</Aside>
-
-**Parameters**
-
-| Name     | Type      | Description                   |
-| -------- | --------- | ----------------------------- |
-| `tokens` | `uint256` | The number of tokens consumed |
-
 ### ConfigChanged
 
 ```solidity
@@ -70,14 +56,6 @@ error BucketOverfilled();
 
 <Aside>Thrown when the [`TokenBucket`](#tokenbucket) contains more tokens than its capacity.</Aside>
 
-### OnlyCallableByAdminOrOwner
-
-```solidity
-error OnlyCallableByAdminOrOwner();
-```
-
-<Aside>Thrown when a restricted function is called by an unauthorized address.</Aside>
-
 ### TokenMaxCapacityExceeded
 
 ```solidity
@@ -96,31 +74,13 @@ error TokenRateLimitReached(uint256 minWaitInSeconds, uint256 available, address
   Thrown when attempting to consume more tokens than currently available in the [`TokenBucket`](#tokenbucket).
 </Aside>
 
-### AggregateValueMaxCapacityExceeded
-
-```solidity
-error AggregateValueMaxCapacityExceeded(uint256 capacity, uint256 requested);
-```
-
-<Aside>Thrown when attempting to consume more aggregate value than the [`TokenBucket`](#tokenbucket)'s capacity.</Aside>
-
-### AggregateValueRateLimitReached
-
-```solidity
-error AggregateValueRateLimitReached(uint256 minWaitInSeconds, uint256 available);
-```
-
-<Aside>
-  Thrown when attempting to consume more aggregate value than currently available in the [`TokenBucket`](#tokenbucket).
-</Aside>
-
 ### InvalidRateLimitRate
 
 ```solidity
 error InvalidRateLimitRate(Config rateLimiterConfig);
 ```
 
-<Aside>Thrown when the rate limit [`Config`](#config) is invalid (rate is zero or exceeds capacity).</Aside>
+<Aside>Thrown when the rate limit [`Config`](#config) is invalid (rate exceeds capacity).</Aside>
 
 ### DisabledNonZeroRateLimit
 
@@ -129,14 +89,6 @@ error DisabledNonZeroRateLimit(Config config);
 ```
 
 <Aside>Thrown when a disabled [`Config`](#config) has non-zero rate or capacity values.</Aside>
-
-### RateLimitMustBeDisabled
-
-```solidity
-error RateLimitMustBeDisabled();
-```
-
-<Aside>Thrown when attempting to enable rate limiting in a context where it must be disabled.</Aside>
 
 ## Structs
 
@@ -207,7 +159,6 @@ Key behaviors:
 - Skips execution if rate limiting is disabled or requestTokens is zero
 - Automatically refills tokens based on elapsed time
 - Enforces capacity and rate limits
-- Emits [`TokensConsumed`](#tokensconsumed) event for non-zero consumption
 - Reverts with [`TokenMaxCapacityExceeded`](#tokenmaxcapacityexceeded) or [`TokenRateLimitReached`](#tokenratelimitreached) on violations
 
 </Aside>
@@ -275,7 +226,7 @@ Configuration update process:
 Validates rate limiter configuration parameters.
 
 ```solidity
-function _validateTokenBucketConfig(Config memory config, bool mustBeDisabled) internal pure;
+function _validateTokenBucketConfig(Config memory config) internal pure;
 ```
 
 <Aside>
@@ -283,20 +234,18 @@ function _validateTokenBucketConfig(Config memory config, bool mustBeDisabled) i
 Validation rules:
 
 - For enabled configurations:
-  - Rate must be non-zero and less than capacity
-  - Validates against mustBeDisabled requirement
+  - Rate must be less than or equal to capacity
 - For disabled configurations:
   - Rate and capacity must be zero
-- May throw [`InvalidRateLimitRate`](#invalidratelimitrate), [`DisabledNonZeroRateLimit`](#disablednonzeroratelimit), or [`RateLimitMustBeDisabled`](#ratelimitmustbedisabled)
+- May throw [`InvalidRateLimitRate`](#invalidratelimitrate) or [`DisabledNonZeroRateLimit`](#disablednonzeroratelimit)
 
 </Aside>
 
 **Parameters**
 
-| Name             | Type                | Description                                |
-| ---------------- | ------------------- | ------------------------------------------ |
-| `config`         | [`Config`](#config) | The configuration to validate              |
-| `mustBeDisabled` | `bool`              | Whether the configuration must be disabled |
+| Name     | Type                | Description                   |
+| -------- | ------------------- | ----------------------------- |
+| `config` | [`Config`](#config) | The configuration to validate |
 
 ### \_calculateRefill
 

--- a/src/content/ccip/api-reference/evm/v1.6.3/rate-limiter.mdx
+++ b/src/content/ccip/api-reference/evm/v1.6.3/rate-limiter.mdx
@@ -32,20 +32,6 @@ This library provides rate limiting functionality with the following features:
 
 ## Events
 
-### TokensConsumed
-
-```solidity
-event TokensConsumed(uint256 tokens);
-```
-
-<Aside>Emitted when tokens are successfully consumed from the [`TokenBucket`](#tokenbucket).</Aside>
-
-**Parameters**
-
-| Name     | Type      | Description                   |
-| -------- | --------- | ----------------------------- |
-| `tokens` | `uint256` | The number of tokens consumed |
-
 ### ConfigChanged
 
 ```solidity
@@ -70,14 +56,6 @@ error BucketOverfilled();
 
 <Aside>Thrown when the [`TokenBucket`](#tokenbucket) contains more tokens than its capacity.</Aside>
 
-### OnlyCallableByAdminOrOwner
-
-```solidity
-error OnlyCallableByAdminOrOwner();
-```
-
-<Aside>Thrown when a restricted function is called by an unauthorized address.</Aside>
-
 ### TokenMaxCapacityExceeded
 
 ```solidity
@@ -96,31 +74,13 @@ error TokenRateLimitReached(uint256 minWaitInSeconds, uint256 available, address
   Thrown when attempting to consume more tokens than currently available in the [`TokenBucket`](#tokenbucket).
 </Aside>
 
-### AggregateValueMaxCapacityExceeded
-
-```solidity
-error AggregateValueMaxCapacityExceeded(uint256 capacity, uint256 requested);
-```
-
-<Aside>Thrown when attempting to consume more aggregate value than the [`TokenBucket`](#tokenbucket)'s capacity.</Aside>
-
-### AggregateValueRateLimitReached
-
-```solidity
-error AggregateValueRateLimitReached(uint256 minWaitInSeconds, uint256 available);
-```
-
-<Aside>
-  Thrown when attempting to consume more aggregate value than currently available in the [`TokenBucket`](#tokenbucket).
-</Aside>
-
 ### InvalidRateLimitRate
 
 ```solidity
 error InvalidRateLimitRate(Config rateLimiterConfig);
 ```
 
-<Aside>Thrown when the rate limit [`Config`](#config) is invalid (rate is zero or exceeds capacity).</Aside>
+<Aside>Thrown when the rate limit [`Config`](#config) is invalid (rate exceeds capacity).</Aside>
 
 ### DisabledNonZeroRateLimit
 
@@ -129,14 +89,6 @@ error DisabledNonZeroRateLimit(Config config);
 ```
 
 <Aside>Thrown when a disabled [`Config`](#config) has non-zero rate or capacity values.</Aside>
-
-### RateLimitMustBeDisabled
-
-```solidity
-error RateLimitMustBeDisabled();
-```
-
-<Aside>Thrown when attempting to enable rate limiting in a context where it must be disabled.</Aside>
 
 ## Structs
 
@@ -207,7 +159,6 @@ Key behaviors:
 - Skips execution if rate limiting is disabled or requestTokens is zero
 - Automatically refills tokens based on elapsed time
 - Enforces capacity and rate limits
-- Emits [`TokensConsumed`](#tokensconsumed) event for non-zero consumption
 - Reverts with [`TokenMaxCapacityExceeded`](#tokenmaxcapacityexceeded) or [`TokenRateLimitReached`](#tokenratelimitreached) on violations
 
 </Aside>
@@ -275,7 +226,7 @@ Configuration update process:
 Validates rate limiter configuration parameters.
 
 ```solidity
-function _validateTokenBucketConfig(Config memory config, bool mustBeDisabled) internal pure;
+function _validateTokenBucketConfig(Config memory config) internal pure;
 ```
 
 <Aside>
@@ -283,20 +234,18 @@ function _validateTokenBucketConfig(Config memory config, bool mustBeDisabled) i
 Validation rules:
 
 - For enabled configurations:
-  - Rate must be non-zero and less than capacity
-  - Validates against mustBeDisabled requirement
+  - Rate must be less than or equal to capacity
 - For disabled configurations:
   - Rate and capacity must be zero
-- May throw [`InvalidRateLimitRate`](#invalidratelimitrate), [`DisabledNonZeroRateLimit`](#disablednonzeroratelimit), or [`RateLimitMustBeDisabled`](#ratelimitmustbedisabled)
+- May throw [`InvalidRateLimitRate`](#invalidratelimitrate) or [`DisabledNonZeroRateLimit`](#disablednonzeroratelimit)
 
 </Aside>
 
 **Parameters**
 
-| Name             | Type                | Description                                |
-| ---------------- | ------------------- | ------------------------------------------ |
-| `config`         | [`Config`](#config) | The configuration to validate              |
-| `mustBeDisabled` | `bool`              | Whether the configuration must be disabled |
+| Name     | Type                | Description                   |
+| -------- | ------------------- | ----------------------------- |
+| `config` | [`Config`](#config) | The configuration to validate |
 
 ### \_calculateRefill
 

--- a/src/content/ccip/concepts/rate-limit-management/common-scenarios.mdx
+++ b/src/content/ccip/concepts/rate-limit-management/common-scenarios.mdx
@@ -4,6 +4,8 @@ date: Last Modified
 title: "Common Scenarios"
 ---
 
+import { Aside } from "@components"
+
 This page provides worked configuration scenarios for common rate limit use cases. These examples illustrate how capacity and refill values are calculated and applied for different token types and operational goals.
 
 All scenarios assume:
@@ -74,15 +76,39 @@ Use this pattern during incidents, investigations, or maintenance when transfers
 
 ### Configuration pattern
 
-To lock down a lane:
+The correct values depend on the deployed token pool version. Call `typeAndVersion()` on each pool before applying
+either pattern.
 
-- enable the rate limit
-- set capacity to `1`
-- set refill rate to `1`
+On pools reporting `1.6.1` or later (including development stamps such as `1.6.x-dev`), pause the lane by keeping the
+rate limit enabled and setting both values to zero:
 
-Apply this configuration to **both inbound and outbound** limits for the lane.
+- set `isEnabled` to `true`
+- set `capacity` to `0`
+- set `rate` to `0`
 
-This allows only a negligible transfer before capacity is exhausted, causing subsequent transfers to fail.
+This blocks all transfers in that direction until you restore normal values.
+
+On pools reporting versions before `1.6.1` (version strings `1.5.1` or lower — a pool built from the 1.6.0 contracts
+release reports `1.5.1`), an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`, so a full stop is
+not possible. Use the smallest accepted configuration:
+
+- set `isEnabled` to `true`
+- set `capacity` to `2`
+- set `rate` to `1`
+
+This allows only a negligible trickle before capacity is exhausted, causing subsequent transfers to fail. The trickle
+that remains possible can be material for tokens with few decimals.
+
+Apply the configuration to **both inbound and outbound** limits for the lane.
+
+<Aside type="caution">
+
+- Keep `isEnabled: true` when pausing. The same zeros with `isEnabled: false` turn rate limiting off entirely — the
+  flag decides what the zeros mean (see the removing rate limits scenario below).
+- On pools reporting `1.6.1` or later, do not set `rate: 0` with a non-zero capacity: validation accepts it, but once
+  the bucket depletes, transfers fail with an arithmetic panic instead of a clean rate-limit error.
+
+</Aside>
 
 ## Scenario: removing rate limits
 
@@ -101,6 +127,9 @@ To remove rate limits:
 - set `rate` to `0`
 
 Apply this configuration to both inbound and outbound limits.
+
+On pools reporting `1.6.1` or later, the same zeros with `isEnabled: true` pause the lane instead — the flag decides
+what the zeros mean.
 
 ## Important notes
 

--- a/src/content/ccip/concepts/rate-limit-management/emergency-actions.mdx
+++ b/src/content/ccip/concepts/rate-limit-management/emergency-actions.mdx
@@ -4,6 +4,8 @@ date: Last Modified
 title: "Emergency Actions (Incident Response Only)"
 ---
 
+import { Aside } from "@components"
+
 This page describes emergency actions that can be taken to **contain or halt cross-chain transfers on a specific CCIP lane** using rate limit configuration.
 
 These actions are intended for **incident response, maintenance, or risk containment** scenarios. They should not be used for routine configuration.
@@ -20,32 +22,67 @@ Emergency actions are scoped to a **specific token pool and lane**. They do not 
 
 ## Locking down a lane with minimal values
 
-To effectively stop bridging activity on a lane, you can configure rate limits with **very small capacity and refill values**.
+To stop bridging activity on a lane, configure rate limits with the smallest values your deployed pool version accepts.
 
-Because rate limits cannot be set to zero while enabled, the practical approach is to set:
+<Aside type="caution" title="Confirm your deployed TokenPool version">
 
-- **capacity** to the smallest transferable unit (for example, `1`)
-- **rate** to `1`
+Rate limit validation changed between TokenPool releases. Call `typeAndVersion()` on each deployed pool before you apply
+any configuration described on this page.
 
-This configuration allows only a negligible transfer before the bucket is depleted, causing subsequent transfers to fail.
+- **Pools reporting 1.6.1 or later** (including development stamps such as `1.6.x-dev`) — an enabled bucket is rejected
+  only when `rate > capacity`, so an enabled `capacity: 0`, `rate: 0` is accepted and pauses the lane.
+- **Pools reporting versions before 1.6.1** — an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`.
+  A configuration of `capacity: 1`, `rate: 1` reverts. Use at least `capacity: 2`, `rate: 1` on these releases. (Version
+  strings here are `1.5.1` or lower — a pool built from the 1.6.0 contracts release reports `1.5.1`.)
+- **All releases from 1.4.0 onward** — a disabled bucket must have `capacity: 0` and `rate: 0`, otherwise the call
+  reverts.
 
-## Example configuration
+</Aside>
 
-Conceptually, a lane can be locked down by calling `setChainRateLimiterConfig` with the following values:
+### Pools reporting 1.6.1 or later: pause the lane
+
+Pause the lane by keeping the rate limit **enabled** and setting both values to zero on the affected direction via
+`setChainRateLimiterConfig` (or `setChainRateLimiterConfigs` for several lanes at once):
 
 ```solidity
-outboundConfig = [true, 1, 1];
-inboundConfig  = [true, 1, 1];
+outboundConfig = [true, 0, 0];
+inboundConfig  = [true, 0, 0];
 ```
 
-Both inbound and outbound limits should be set to ensure transfers are blocked in both directions.
+This blocks all transfers in that direction — an inbound pause intentionally holds in-flight transfers — until you
+restore normal values.
+
+<Aside type="caution">
+
+- Keep `isEnabled: true` when pausing. A disabled bucket (which requires `capacity: 0`, `rate: 0`) turns rate limiting
+  off entirely — the opposite of a pause. The flag decides what the zeros mean.
+- Do not set `rate: 0` with a non-zero capacity: validation accepts it, but once the bucket depletes, transfers fail
+  with an arithmetic panic instead of a clean rate-limit error.
+
+</Aside>
+
+### Pools reporting versions before 1.6.1: use minimal values
+
+A full stop through rate limits is not possible on these pools: an enabled bucket is rejected when `rate >= capacity`
+or when `rate == 0`. Use the smallest accepted configuration, `capacity: 2`, `rate: 1`:
+
+```solidity
+outboundConfig = [true, 2, 1];
+inboundConfig  = [true, 2, 1];
+```
+
+This allows only a negligible trickle before the bucket is depleted, causing subsequent transfers to fail. The trickle
+that remains possible can be material for tokens with few decimals.
+
+In both cases, apply the configuration to **both inbound and outbound** limits so transfers are blocked in both
+directions.
 
 ## Important considerations
 
 When locking down a lane:
 
-- transfers may still succeed for a minimal amount before capacity is exhausted
-- behavior depends on the token's smallest unit
+- on pools reporting versions before 1.6.1, transfers may still succeed for a minimal amount, and behavior depends on
+  the token's smallest unit
 - the change takes effect immediately after the transaction is confirmed
 
 This approach is intended to **contain activity**, not to permanently disable rate limits.

--- a/src/content/ccip/llms-full.txt
+++ b/src/content/ccip/llms-full.txt
@@ -10437,27 +10437,21 @@ deployment and risk profile.
   Self-Administered Token Pools are deployed and managed directly by token developers, and are not controlled by Chainlink Labs, the Chainlink Foundation, or Chainlink node operators. Such token pools exist outside of the CCIP protocol and must be evaluated by users on a case-by-case basis. Please review [CCIP Service Responsibility](/ccip/service-responsibility) for more information.
 </Aside>
 
-<Aside type="note" title="How to read this page">
-  Items are grouped into two levels:
-
-  - **Critical:** apply these before you enable any production lane. Omitting them can lead to loss of funds,
-    permanently stuck transfers, or unauthorized control of your token.
-  - **Strongly recommended:** apply these as part of normal operation. Omitting them commonly causes incidents,
-    outages, or degraded transfers.
-</Aside>
-
 <Aside type="caution" title="Confirm your deployed TokenPool version">
-  Rate limit validation changed between TokenPool releases a while back. Call `typeAndVersion()` on each deployed pool before you apply
-  any configuration described on this page.
+  Rate limit validation changed between TokenPool releases a while back.
+  Users can call `typeAndVersion()` on each deployed pool before they apply any configuration described on this page.
 
-  - **Pools reporting 1.6.1 or later** (including development stamps such as `1.6.x-dev`): an enabled bucket is rejected
+  - **Pools reporting versions before 1.6.1**: an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`.
+    A configuration of `capacity: 1`, `rate: 1` will also revert.
+    Use at least `capacity: 2`, `rate: 1` on these releases. (Version strings here are `1.5.1` or lower: a pool built from the 1.6.0 contracts release reports `1.5.1`.)
+
+  - **Pools `1.6.1` or later**: an enabled bucket is rejected
     only when `rate > capacity`, so `capacity: 1`, `rate: 1` and an enabled `capacity: 0`, `rate: 0` are both accepted.
     For pausing a lane, see
     [Distinguish an intentional pause from a misconfiguration](#distinguish-an-intentional-pause-from-a-misconfiguration).
-    - A hard pause of the lane is allowed, with `0` tokens transferable.
-  - **Pools reporting versions before 1.6.1**: an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`.
-    A configuration of `capacity: 1`, `rate: 1` reverts. Use at least `capacity: 2`, `rate: 1` on these releases. (Version
-    strings here are `1.5.1` or lower: a pool built from the 1.6.0 contracts release reports `1.5.1`.)
+    - Basically, on versions `1.6.1` or later, a hard pause of the lane is allowed, with `0` tokens transferable. This is different from
+      earlier versions, where the minimum value of `rate` had to be at least `1`, thus preventing a hard pause, even if the amount allowed
+      was miniscule.
 </Aside>
 
 ## Critical
@@ -10465,21 +10459,24 @@ deployment and risk profile.
 ### Secure the roles that control your token and pools
 
 The token administrator, the token pool owner, and any address holding mint or burn rights can change how your token
-moves across chains. Each of these roles is held by whatever address you assign to it: an externally owned account
-(EOA), a multi-signature smart account, or another contract.
+moves across chains. Each of these roles is held by whatever address you assign to it:
+
+- an externally owned account (EOA),
+- a multi-signature smart account,
+- or another contract.
 
 **Risk:** A single compromised private key is enough to redirect transfers, mint unbacked supply, or take control of
-your pools, with no second party able to review or veto the action before it executes.
+your pools.
 
-**What to do:**
+**What should you do:**
 
 - Assign contract ownership, the CCIP administrator role, and mint and burn rights to a multi-signature smart account
   such as a [Safe Smart Account](https://github.com/safe-global/safe-smart-account), using a threshold of at least
-  3-of-n, commensurate with the value at risk.
-- Add a timelock so that critical actions must be proposed, reviewed, and can be cancelled before they execute.
-- Put this structure in place at deployment: the multi-signature account and timelock should own the token, the pools,
+  3-of-n, commensurate with the value at risk. We recommend a minimum of 5 signers to ensure sufficient decentralization and security.
+- Add a timelock so that critical actions may be reviewed and cancelled with a sufficient time buffer.
+- The multi-signature account and timelock should own the token, the pools,
   and any related contracts from day one, rather than being retrofitted after launch.
-- Remove departed or compromised signers promptly, and confirm at least quarterly that every remaining signer still
+- Remove departed or compromised signers promptly, and confirm routinely that every remaining signer still
   controls their key.
 - Distribute signers so a quorum is reachable quickly during an incident, rather than concentrating them in one team,
   location, or time zone.
@@ -10506,26 +10503,24 @@ chains. The locked balance is the only backing for that remote supply.
 **Risk:** If locked supply falls below the total minted across remote chains, transfers back to the issuing chain fail
 and users cannot withdraw until the shortfall is covered.
 
-**What to do:**
+**What should you do:**
 
 - Continuously compare the locked balance held by the pool on the issuing chain against the sum of total supply across
   every remote burn and mint chain.
 - Alert on the ratio between them, not only on the absolute balance, and set thresholds that trigger action well before
   the pool is exhausted.
-- Prefer Burn and Mint on all chains where your token design allows it. It is the simplest accounting model and removes
-  this class of risk entirely. Lock and Unlock across multiple chains is the most complex and fragments liquidity.
 - See [Tokens](/ccip/concepts/cross-chain-token/evm/tokens) and the
   [LockReleaseTokenPool API reference](/ccip/api-reference/evm/v1.6.1/lock-release-token-pool).
 
 ### Configure both sides of every lane symmetrically
 
-A lane works only when both pools agree about each other. Configuration is applied independently on each chain, so the
+A lane works only when both pools work in tandem with each other. The configuration for the remote pool on the other end is applied independently on each chain, so the
 two sides can drift apart without any error being raised at the time of the change.
 
 **Risk:** Mismatched configuration causes transfers to revert, or to become stuck in flight until the configuration is
 corrected.
 
-**What to do:**
+**What should you do:**
 
 - On the source pool, confirm the configured remote pool addresses (`getRemotePools`) resolve to the actual destination
   pool address.
@@ -10546,9 +10541,10 @@ any network other than its hub breaks that isolation.
 
 **Risk:** Cross-silo connections corrupt accounting and can result in stuck transfers or loss of funds.
 
-**What to do:** Review every remote chain configured on a siloed pool and remove any chain that is not the designated
-hub, using `applyChainUpdates` with the chain selector in the removal list. See the
-[TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool).
+**What should you do:**
+
+- Review every remote chain configured on a siloed pool and remove any chain that is not the designated
+  hub, using `applyChainUpdates` with the chain selector in the removal list.
 
 ### Account for decimal differences between chains
 
@@ -10558,10 +10554,10 @@ and rate limit values are denominated in the token's smallest unit on the chain 
 **Risk:** Mismatched decimals can cause transfers to fail, or cause a rate limit to throttle at a value orders of
 magnitude away from the one you intended to set.
 
-**What to do:**
+**What should you do:**
 
 - Use matching decimals on every chain where your token is deployed whenever you can.
-- Where decimals differ, size every rate limit in the smallest unit of the chain that bucket applies to, and verify the
+- Where decimals differ, configure every rate limit in the smallest unit of the chain that bucket applies to, and verify the
   resulting value against the amount you intended.
 - See [Token Units and Decimals](/ccip/concepts/rate-limit-management/token-units-and-decimals) and
   [Token Pools](/ccip/concepts/cross-chain-token/evm/token-pools).
@@ -10574,10 +10570,13 @@ destination chain when tokens are released or minted. They are separate buckets 
 **Risk:** A transfer that passes the source outbound limit but exceeds the destination inbound limit is stuck in flight
 until inbound capacity becomes available.
 
-**What to do:** Size destination inbound capacity to absorb the full outbound capacity of every source lane pointing at
-it, and re-verify the relationship after every change to either side. See
-[How Rate Limits Work](/ccip/concepts/rate-limit-management/how-rate-limits-work) and
-[Update Rate Limits](/ccip/concepts/rate-limit-management/update-rate-limits).
+**What should you do:**
+
+- Size destination inbound capacity to absorb the full outbound capacity of every source lane pointing at
+  it, and re-verify the relationship after every change to either side.
+
+- See [How Rate Limits Work](/ccip/concepts/rate-limit-management/how-rate-limits-work) and
+  [Update Rate Limits](/ccip/concepts/rate-limit-management/update-rate-limits).
 
 ### Enable rate limits on every production lane
 
@@ -10587,9 +10586,12 @@ A disabled bucket applies no volume ceiling in that direction.
 **Risk:** Without rate limits, a compromise elsewhere in your system can move the full transferable supply through CCIP
 before you are able to intervene.
 
-**What to do:** Enable both inbound and outbound rate limits on every production lane, and confirm the deployed values
-match what you intended. See [Rate Limit Management](/ccip/concepts/rate-limit-management/overview) and
-[Inspect Current Rate Limits](/ccip/concepts/rate-limit-management/inspect-current-rate-limits).
+**What should you do:**
+
+- Enable both inbound and outbound rate limits on every production lane, and confirm the deployed values
+  match what you intended.
+- See [Rate Limit Management](/ccip/concepts/rate-limit-management/overview) and
+  [Inspect Current Rate Limits](/ccip/concepts/rate-limit-management/inspect-current-rate-limits).
 
 ### Prepare an emergency pause path before you need it
 
@@ -10599,12 +10601,12 @@ The owner path behind a multi-signature account and timelock is slow by design.
 **Risk:** Without a prepared fast path, pausing a lane takes as long as your slowest governance process while an
 incident drains value in minutes.
 
-**What to do:**
+**What should you do:**
 
 - Give the rate limit admin role to signers who can execute within minutes. See
   [Delegate rate limit changes to the rate limit admin role](#delegate-rate-limit-changes-to-the-rate-limit-admin-role).
 - The role can raise limits as well as lower them, so scope what your fast path can do.
-- Write the pause runbook in advance: which lanes, which values for your deployed pool version (see
+- Prepare the logistics in advance: which lanes, which values for your deployed pool version (see
   [Distinguish an intentional pause from a misconfiguration](#distinguish-an-intentional-pause-from-a-misconfiguration)),
   who executes, and how the decision to lift it is made.
 - Rehearse the runbook on a testnet lane regularly.
@@ -10619,45 +10621,44 @@ messages from the previous pool can still be processed.
 **Risk:** A deprecated pool left configured continues to be accepted as a message source, and may contain faulty or
 unintended logic.
 
-**What to do:** Once all in-flight messages from the old pool have settled, remove the stale remote pool address with
-`removeRemotePool`. Confirm there are no pending or failed transactions referencing the old pool in the
-[CCIP Explorer](/ccip/tools-resources/ccip-explorer) before removing it. See
-[Upgradability](/ccip/concepts/cross-chain-token/evm/upgradability) and the
-[TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool).
+**What should you do:**
 
-### Clear an unintended pending token administrator
+- Once all in-flight messages from the old pool have settled, remove the stale remote pool address with
+  `removeRemotePool`.
+- Confirm there are no pending or failed transactions referencing the old pool in the
+  [CCIP Explorer](/ccip/tools-resources/ccip-explorer) before removing it.
+- Seen [Upgradability](/ccip/concepts/cross-chain-token/evm/upgradability) and the
+  [TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool).
 
-Transferring the token administrator role is a two-step process. Until the proposed address accepts, the transfer sits
+### Clear an unintended pending token administrator or owner
+
+Transferring the token administrator or owner role is a two-step process. Until the proposed address accepts, the transfer sits
 pending and can be accepted at any time.
 
-**Risk:** An address proposed in error, or one that is no longer trusted, can take the administrator role whenever it
+**Risk:** An address proposed in error, or one that is no longer trusted, can take the administrator or owner role whenever it
 chooses.
 
-**What to do:** Cancel an unintended transfer by calling `transferAdminRole(localToken, address(0))` on the
-TokenAdminRegistry. This clears the pending administrator without changing the active one. See the
-[TokenAdminRegistry API reference](/ccip/api-reference/evm/v1.6.1/token-admin-registry).
+**What should you do:**
 
-### Clear an unintended pending owner
-
-Token, token pool, and related contracts that use a two-step ownership transfer keep a proposed owner able to accept
-until the transfer is cleared.
-
-**Risk:** An address proposed in error can take ownership of the contract at any time.
-
-**What to do:** Cancel an unintended ownership transfer by re-initiating the transfer to the zero address. Audit every
-CCT-related contract you own for pending transfers, not only the pools.
+- Cancel an unintended transfer by calling `transferAdminRole(localToken, address(0))` on the
+  TokenAdminRegistry. This clears the pending administrator without changing the active one. See the
+  [TokenAdminRegistry API reference](/ccip/api-reference/evm/v1.6.1/token-admin-registry).
+- Cancel an unintended transfer of the owner role by calling `transferOwnership(address(0))` on the relevant contract.
+  This clears the pending owner without changing the active one. See the [Ownable API reference](https://docs.openzeppelin.com/contracts/4.x/api/access#Ownable).
 
 ### Restrict burn and mint rights to the active pool
 
-Mint and burn permissions on your token determine who can change supply. In a CCIP deployment, only the active token
+Mint and burn permissions on your token determine who can change the supply. In a CCIP deployment, only the active token
 pool needs them for cross-chain operation.
 
 **Risk:** Any additional address holding mint rights can create unbacked supply; any address holding burn rights can
 destroy user balances.
 
-**What to do:** Enumerate every address holding mint or burn permissions and revoke each one that is not the active
-token pool or an owner-like administrative role you have deliberately retained. Re-run this audit after every pool
-migration. See [Tokens](/ccip/concepts/cross-chain-token/evm/tokens).
+**What should you do:**
+
+- Enumerate every address holding mint or burn permissions and revoke each one that is not the active
+  token pool or an owner-like administrative role you have deliberately retained. Re-run this audit after every pool
+  migration. See [Tokens](/ccip/concepts/cross-chain-token/evm/tokens).
 
 ### Remove lanes pointing at chains the router does not support
 
@@ -10666,13 +10667,15 @@ A pool can be configured with a remote chain selector that the CCIP router does 
 **Risk:** The lane may appear configured while transfers revert. If that chain is later added to the router, the lane
 becomes live without a deliberate decision to enable it.
 
-**What to do:** Validate every configured chain selector against the [CCIP Directory](/ccip/directory), and remove any
-remote chain that was not intentionally configured.
+**What should you do:**
+
+- Validate every configured chain selector against the [CCIP Directory](/ccip/directory), and remove any
+  remote chain that was not intentionally configured.
 
 ### Keep `destGasOverhead` consistent across lanes
 
 `destGasOverhead` covers the gas your token pool consumes on the destination chain. It is part of the token transfer
-fee configuration that CCIP maintains for your token; for current pool versions, non-default values are applied by
+fee configuration that CCIP maintains for your token; for current pool versions (`<2.0`), non-default values are applied by
 Chainlink Labs on your behalf. Using a non-default value is justified only when your pool or token costs more to
 execute.
 
@@ -10680,7 +10683,7 @@ execute.
 unnecessarily high value causes users to overpay. Inconsistent values across lanes pointing at the same destination
 usually indicate a configuration error.
 
-**What to do:**
+**What should you do:**
 
 - Test that token transfers execute automatically on every configured lane before going to production.
 - Include first-time receivers in that test. An account that has never held your token can cost more gas.
@@ -10696,9 +10699,11 @@ flight, the destination bucket is also being consumed by other traffic and refil
 **Risk:** Transfers that arrive without enough inbound capacity require manual execution, or wait for the bucket to
 refill before they can be executed.
 
-**What to do:** Set destination inbound capacity above the corresponding source outbound capacity, sized against the
-destination refill rate and the latency of the lane. See
-[Common Scenarios](/ccip/concepts/rate-limit-management/common-scenarios).
+**What should you do:**
+
+- Set destination inbound capacity above the corresponding source outbound capacity, sized against the
+  destination refill rate and the latency of the lane. See
+  [Common Scenarios](/ccip/concepts/rate-limit-management/common-scenarios).
 
 ### Tune the refill rate for both availability and throttling
 
@@ -10707,21 +10712,21 @@ The refill rate determines how quickly a bucket returns to full capacity after b
 **Risk:** A refill rate that is too slow blocks legitimate transfers for extended periods. One that is too fast fails to
 throttle abnormal flows.
 
-**What to do:** Choose a refill rate that restores capacity fast enough for normal user activity but slow enough to
-constrain a sustained abnormal flow. Treat any starting point as an initial value to be revised: monitor transfer
-success rates and observed volume, and adjust as your traffic patterns become established. See
-[Common Scenarios](/ccip/concepts/rate-limit-management/common-scenarios) and
-[How Rate Limits Work](/ccip/concepts/rate-limit-management/how-rate-limits-work).
+**What should you do:**
+
+- Choose a refill rate that restores capacity fast enough for normal user activity but slow enough to
+  constrain a sustained abnormal flow.
+- See [Common Scenarios](/ccip/concepts/rate-limit-management/common-scenarios) and [How Rate Limits Work](/ccip/concepts/rate-limit-management/how-rate-limits-work).
+- The exact numbers will vary upon network choices and traffic patterns for your specific protocol. It is the responsibility of the protocol to designate sensible numbers.
 
 ### Distinguish an intentional pause from a misconfiguration
 
-A lane is paused through its rate limits, and a paused lane is also what an accidental misconfiguration looks like.
-Pause deliberately and record it.
+Understand how rate limit configurations differ across versions
 
 **Risk:** An accidental pause blocks users indefinitely, and a pause applied with the wrong values either fails to stop
 transfers or removes rate limiting entirely.
 
-**What to do:**
+**What should you do:**
 
 - On pools reporting `1.6.1` or later, pause a lane by setting `isEnabled: true`, `capacity: 0`, `rate: 0` on the
   affected direction via `setChainRateLimiterConfig` (or `setChainRateLimiterConfigs` for several lanes at once). This
@@ -10746,8 +10751,10 @@ the defaults.
 
 **Risk:** A configuration that is correct on one chain can cause failed execution or an outage on another.
 
-**What to do:** Read the guidance for each network before you enable a lane to it. See
-[Network Specific](/ccip/tools-resources/network-specific) and [Service Limits](/ccip/service-limits/evm).
+**What should you do:**
+
+- Read the guidance for each network before you enable a lane to it. See
+  [Network Specific](/ccip/tools-resources/network-specific) and [Service Limits](/ccip/service-limits/evm).
 
 ### Settle in-flight transfers before reducing inbound capacity
 
@@ -10757,28 +10764,30 @@ ones.
 **Risk:** In-flight transfers whose amounts exceed the new inbound capacity stall until an administrator intervenes or
 capacity refills.
 
-**What to do:**
+**What should you do:**
 
-1. Set the new outbound capacities on the source chains first.
-2. Check the [CCIP Explorer](/ccip/tools-resources/ccip-explorer) for in-flight messages whose amounts exceed the
-   inbound capacities you intend to set.
-3. Wait for those transfers to settle on their destination chains.
-4. Then reduce the inbound capacities.
+- Set the new outbound capacities on the source chains first.
+- Check the [CCIP Explorer](/ccip/tools-resources/ccip-explorer) for in-flight messages whose amounts exceed the
+  inbound capacities you intend to set.
+- Wait for those transfers to settle on their destination chains.
+- Then reduce the inbound capacities.
 
 See [Update Rate Limits](/ccip/concepts/rate-limit-management/update-rate-limits).
 
 ### Run the latest available TokenPool release
 
-Older TokenPool releases have limitations in decimal handling, rate limit enforcement, and upgradeability. Pools
-predating v1.5 add further complexity to configuration and management.
+We recommend using our latest pool versions for improved security, reliability, and access to the latest features.
 
-**Risk:** Operating on an older release exposes you to resolved issues and makes some remediation steps unavailable.
+**Risk:** Operating on an older release exposes you to issues that may have been resolved on newer versions.
 
-**What to do:** Confirm what you are running with `typeAndVersion()` on each pool, compare against the published
-releases of [`@chainlink/contracts-ccip`](https://www.npmjs.com/package/@chainlink/contracts-ccip?activeTab=versions),
-and upgrade when feasible. The on-chain version string does not always match the package release: a pool built from
-the `1.6.0` release reports `1.5.1`, and some releases report development stamps such as `1.6.x-dev`. See
-[Upgradability](/ccip/concepts/cross-chain-token/evm/upgradability).
+**What should you do:**
+
+- Confirm what you are running with `typeAndVersion()` on each pool, compare against the published
+  releases of [`@chainlink/contracts-ccip`](https://www.npmjs.com/package/@chainlink/contracts-ccip?activeTab=versions),
+  and upgrade when feasible.
+- The on-chain version string does not always match the package release: a pool built from
+  the `1.6.0` release reports `1.5.1`, and some releases report development stamps such as `1.6.x-dev`. See
+  [Upgradability](/ccip/concepts/cross-chain-token/evm/upgradability).
 
 ### Shut down lanes that carry little or no traffic
 
@@ -10787,9 +10796,11 @@ Every enabled lane is an active path into and out of your token.
 **Risk:** An unused lane contributes no benefit while remaining available during an incident on either of the chains it
 connects.
 
-**What to do:** Review traffic per lane periodically and remove remote chains serving lanes that do not justify the
-exposure. Where possible, consolidate toward a hub-and-spoke topology rather than connecting every chain to every
-other chain.
+**What should you do:**
+
+- Review traffic per lane periodically and remove remote chains serving lanes that do not justify the
+  exposure. Where possible, consolidate toward a hub-and-spoke topology rather than connecting every chain to every
+  other chain.
 
 ### Delegate rate limit changes to the rate limit admin role
 
@@ -10799,7 +10810,7 @@ limits but nothing else about the pool configuration.
 **Risk:** Rate limit changes are made relatively often, including under time pressure during an incident. Performing
 them with the pool owner key exposes your highest-privilege credential to routine use.
 
-**What to do:** Assign the rate limit admin role to a dedicated multi-party signer, or to a contract if you want to
+**What should you do:** Assign the rate limit admin role to a dedicated multi-party signer, or to a contract if you want to
 constrain it further to specific pre-defined adjustments. Keep the pool owner key reserved for changes that require
 it. See the [TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool) and
 [Prerequisites and Permissions](/ccip/concepts/rate-limit-management/prerequisites-and-permissions).

--- a/src/content/ccip/llms-full.txt
+++ b/src/content/ccip/llms-full.txt
@@ -5893,32 +5893,63 @@ Emergency actions are scoped to a **specific token pool and lane**. They do not 
 
 ## Locking down a lane with minimal values
 
-To effectively stop bridging activity on a lane, you can configure rate limits with **very small capacity and refill values**.
+To stop bridging activity on a lane, configure rate limits with the smallest values your deployed pool version accepts.
 
-Because rate limits cannot be set to zero while enabled, the practical approach is to set:
+<Aside type="caution" title="Confirm your deployed TokenPool version">
+  Rate limit validation changed between TokenPool releases. Call `typeAndVersion()` on each deployed pool before you apply
+  any configuration described on this page.
 
-- **capacity** to the smallest transferable unit (for example, `1`)
-- **rate** to `1`
+  - **Pools reporting 1.6.1 or later** (including development stamps such as `1.6.x-dev`) — an enabled bucket is rejected
+    only when `rate > capacity`, so an enabled `capacity: 0`, `rate: 0` is accepted and pauses the lane.
+  - **Pools reporting versions before 1.6.1** — an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`.
+    A configuration of `capacity: 1`, `rate: 1` reverts. Use at least `capacity: 2`, `rate: 1` on these releases. (Version
+    strings here are `1.5.1` or lower — a pool built from the 1.6.0 contracts release reports `1.5.1`.)
+  - **All releases from 1.4.0 onward** — a disabled bucket must have `capacity: 0` and `rate: 0`, otherwise the call
+    reverts.
+</Aside>
 
-This configuration allows only a negligible transfer before the bucket is depleted, causing subsequent transfers to fail.
+### Pools reporting 1.6.1 or later: pause the lane
 
-## Example configuration
-
-Conceptually, a lane can be locked down by calling `setChainRateLimiterConfig` with the following values:
+Pause the lane by keeping the rate limit **enabled** and setting both values to zero on the affected direction via
+`setChainRateLimiterConfig` (or `setChainRateLimiterConfigs` for several lanes at once):
 
 ```solidity
-outboundConfig = [true, 1, 1];
-inboundConfig  = [true, 1, 1];
+outboundConfig = [true, 0, 0];
+inboundConfig  = [true, 0, 0];
 ```
 
-Both inbound and outbound limits should be set to ensure transfers are blocked in both directions.
+This blocks all transfers in that direction — an inbound pause intentionally holds in-flight transfers — until you
+restore normal values.
+
+<Aside type="caution">
+  - Keep `isEnabled: true` when pausing. A disabled bucket (which requires `capacity: 0`, `rate: 0`) turns rate limiting
+    off entirely — the opposite of a pause. The flag decides what the zeros mean.
+  - Do not set `rate: 0` with a non-zero capacity: validation accepts it, but once the bucket depletes, transfers fail
+    with an arithmetic panic instead of a clean rate-limit error.
+</Aside>
+
+### Pools reporting versions before 1.6.1: use minimal values
+
+A full stop through rate limits is not possible on these pools: an enabled bucket is rejected when `rate >= capacity`
+or when `rate == 0`. Use the smallest accepted configuration, `capacity: 2`, `rate: 1`:
+
+```solidity
+outboundConfig = [true, 2, 1];
+inboundConfig  = [true, 2, 1];
+```
+
+This allows only a negligible trickle before the bucket is depleted, causing subsequent transfers to fail. The trickle
+that remains possible can be material for tokens with few decimals.
+
+In both cases, apply the configuration to **both inbound and outbound** limits so transfers are blocked in both
+directions.
 
 ## Important considerations
 
 When locking down a lane:
 
-- transfers may still succeed for a minimal amount before capacity is exhausted
-- behavior depends on the token's smallest unit
+- on pools reporting versions before 1.6.1, transfers may still succeed for a minimal amount, and behavior depends on
+  the token's smallest unit
 - the change takes effect immediately after the transaction is confirmed
 
 This approach is intended to **contain activity**, not to permanently disable rate limits.
@@ -6014,15 +6045,37 @@ Use this pattern during incidents, investigations, or maintenance when transfers
 
 ### Configuration pattern
 
-To lock down a lane:
+The correct values depend on the deployed token pool version. Call `typeAndVersion()` on each pool before applying
+either pattern.
 
-- enable the rate limit
-- set capacity to `1`
-- set refill rate to `1`
+On pools reporting `1.6.1` or later (including development stamps such as `1.6.x-dev`), pause the lane by keeping the
+rate limit enabled and setting both values to zero:
 
-Apply this configuration to **both inbound and outbound** limits for the lane.
+- set `isEnabled` to `true`
+- set `capacity` to `0`
+- set `rate` to `0`
 
-This allows only a negligible transfer before capacity is exhausted, causing subsequent transfers to fail.
+This blocks all transfers in that direction until you restore normal values.
+
+On pools reporting versions before `1.6.1` (version strings `1.5.1` or lower — a pool built from the 1.6.0 contracts
+release reports `1.5.1`), an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`, so a full stop is
+not possible. Use the smallest accepted configuration:
+
+- set `isEnabled` to `true`
+- set `capacity` to `2`
+- set `rate` to `1`
+
+This allows only a negligible trickle before capacity is exhausted, causing subsequent transfers to fail. The trickle
+that remains possible can be material for tokens with few decimals.
+
+Apply the configuration to **both inbound and outbound** limits for the lane.
+
+<Aside type="caution">
+  - Keep `isEnabled: true` when pausing. The same zeros with `isEnabled: false` turn rate limiting off entirely — the
+    flag decides what the zeros mean (see the removing rate limits scenario below).
+  - On pools reporting `1.6.1` or later, do not set `rate: 0` with a non-zero capacity: validation accepts it, but once
+    the bucket depletes, transfers fail with an arithmetic panic instead of a clean rate-limit error.
+</Aside>
 
 ## Scenario: removing rate limits
 
@@ -6041,6 +6094,9 @@ To remove rate limits:
 - set `rate` to `0`
 
 Apply this configuration to both inbound and outbound limits.
+
+On pools reporting `1.6.1` or later, the same zeros with `isEnabled: true` pause the lane instead — the flag decides
+what the zeros mean.
 
 ## Important notes
 
@@ -10357,6 +10413,404 @@ The tutorials will implement the logic of this process, which involves deploying
   Neither Chainlink Labs, the Chainlink Foundation, nor Chainlink node operators are responsible for unintended outputs
   that are generated due to errors in code.
 </Aside>
+
+---
+
+# Cross-Chain Token (CCT) Operational Security (EVM)
+Source: https://docs.chain.link/ccip/tutorials/evm/cross-chain-tokens/operational-security
+Last Updated: 2026-08-29
+
+<Aside type="note" title="Talk to a CCIP expert">
+  If you require technical advice or wish to consult on your project's implementation, please contact a CCIP expert. Our
+  dedicated team is ready to support your projects and ensure their success. For expert guidance, visit the [Chainlink
+  CCIP Contact form](https://chain.link/ccip-contact).
+</Aside>
+
+This page covers the best practices the Chainlink team recommends for Cross-Chain Token (CCT) deployments on EVM chains. It is written for
+token developers who are enabling a token for CCIP or already operating one in production.
+We strongly recommend following these practices for a CCT token in production to minimize the risk of loss, and maximize security.
+
+Guidance here assumes CCIP v1.6.1 token pools. You are responsible for assessing which items apply to your own
+deployment and risk profile.
+
+<Aside type="caution" title="Token Pool Ownership">
+  Self-Administered Token Pools are deployed and managed directly by token developers, and are not controlled by Chainlink Labs, the Chainlink Foundation, or Chainlink node operators. Such token pools exist outside of the CCIP protocol and must be evaluated by users on a case-by-case basis. Please review [CCIP Service Responsibility](/ccip/service-responsibility) for more information.
+</Aside>
+
+<Aside type="note" title="How to read this page">
+  Items are grouped into two levels:
+
+  - **Critical:** apply these before you enable any production lane. Omitting them can lead to loss of funds,
+    permanently stuck transfers, or unauthorized control of your token.
+  - **Strongly recommended:** apply these as part of normal operation. Omitting them commonly causes incidents,
+    outages, or degraded transfers. While not critical, these practices are still highly recommended, and should not be
+    an afterthought.
+</Aside>
+
+<Aside type="caution" title="Confirm your deployed TokenPool version">
+  Rate limit validation changed between TokenPool releases a while back. Call `typeAndVersion()` on each deployed pool before you apply
+  any configuration described on this page.
+
+  - **Pools reporting 1.6.1 or later** (including development stamps such as `1.6.x-dev`) — an enabled bucket is rejected
+    only when `rate > capacity`, so `capacity: 1`, `rate: 1` and an enabled `capacity: 0`, `rate: 0` are both accepted.
+    For pausing a lane, see
+    [Distinguish an intentional pause from a misconfiguration](#distinguish-an-intentional-pause-from-a-misconfiguration).
+    - This basically means that a hard pause of the lane, with absolutely `0` tokens being transferable, is allowed.
+  - **Pools reporting versions before 1.6.1** — an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`.
+    A configuration of `capacity: 1`, `rate: 1` reverts. Use at least `capacity: 2`, `rate: 1` on these releases. (Version
+    strings here are `1.5.1` or lower: a pool built from the 1.6.0 contracts release reports `1.5.1`.)
+</Aside>
+
+## Critical
+
+### Secure the roles that control your token and pools
+
+The token administrator, the token pool owner, and any address holding mint or burn rights can change how your token
+moves across chains. Each of these roles is held by whatever address you assign to it: an externally owned account
+(EOA), a multi-signature smart account, or another contract.
+
+**Risk:** A single compromised private key is enough to redirect transfers, mint unbacked supply, or take control of
+your pools, with no second party able to review or veto the action before it executes.
+
+**What to do:**
+
+- Assign contract ownership, the CCIP administrator role, and mint and burn rights to a multi-signature smart account
+  such as a [Safe Smart Account](https://github.com/safe-global/safe-smart-account), using a threshold of at least
+  3-of-n, commensurate with the value at risk.
+- Add a timelock so that critical actions must be proposed, reviewed, and can be cancelled before they execute.
+- Put this structure in place at deployment: the multi-signature account and timelock should own the token, the pools,
+  and any related contracts from day one, rather than being retrofitted after launch.
+- Remove departed or compromised signers promptly, and confirm at least quarterly that every remaining signer still
+  controls their key.
+- Distribute signers so a quorum is reachable quickly during an incident, rather than concentrating them in one team,
+  location, or time zone.
+- Assign and transfer the administrator role through the TokenAdminRegistry. See
+  [Registration and Administration](/ccip/concepts/cross-chain-token/evm/registration-administration) and the
+  [TokenAdminRegistry API reference](/ccip/api-reference/evm/v1.6.1/token-admin-registry).
+- For executing configuration changes from a multi-signature account, see
+  [Executing with a Multisig](/ccip/concepts/rate-limit-management/executing-with-a-multisig) and
+  [Prerequisites and Permissions](/ccip/concepts/rate-limit-management/prerequisites-and-permissions).
+
+| Risk        | Setup                                                                                                       |
+| ----------- | ----------------------------------------------------------------------------------------------------------- |
+| 🟢 Lowest   | Multi-signature smart account (3-of-n or higher) with a timelock providing a propose, review, cancel window |
+| 🟢 Low      | Multi-signature smart account, 3-of-n or higher, without a timelock                                         |
+| 🟡 Medium   | Smart contract with unclassified governance                                                                 |
+| 🔴 High     | EOA (single private key control)                                                                            |
+| 🔴 Critical | EOA holding mint rights                                                                                     |
+
+### Keep locked supply at or above remote minted supply
+
+In a Lock and Mint architecture, tokens are locked in a LockRelease pool on the issuing chain and minted on remote
+chains. The locked balance is the only backing for that remote supply.
+
+**Risk:** If locked supply falls below the total minted across remote chains, transfers back to the issuing chain fail
+and users cannot withdraw until the shortfall is covered.
+
+**What to do:**
+
+- Continuously compare the locked balance held by the pool on the issuing chain against the sum of total supply across
+  every remote burn and mint chain.
+- Alert on the ratio between them, not only on the absolute balance, and set thresholds that trigger action well before
+  the pool is exhausted.
+- Prefer Burn and Mint on all chains where your token design allows it. It is the simplest accounting model and removes
+  this class of risk entirely. Lock and Unlock across multiple chains is the most complex and fragments liquidity.
+- See [Tokens](/ccip/concepts/cross-chain-token/evm/tokens) and the
+  [LockReleaseTokenPool API reference](/ccip/api-reference/evm/v1.6.1/lock-release-token-pool).
+
+### Configure both sides of every lane symmetrically
+
+A lane works only when both pools agree about each other. Configuration is applied independently on each chain, so the
+two sides can drift apart without any error being raised at the time of the change.
+
+**Risk:** Mismatched configuration causes transfers to revert, or to become stuck in flight until the configuration is
+corrected.
+
+**What to do:**
+
+- On the source pool, confirm the configured remote pool addresses (`getRemotePools`) resolve to the actual destination
+  pool address.
+- On the source pool, confirm the configured remote token address (`getRemoteToken`) matches the token the destination
+  pool reports (`getToken`).
+- Confirm the destination chain has a pool registered against the token in the TokenAdminRegistry (`setPool`, verified
+  with `getPool`).
+- Apply chain updates on both pools (`applyChainUpdates`), with matching chain selectors, before enabling traffic on the
+  lane.
+- See [Registration and Administration](/ccip/concepts/cross-chain-token/evm/registration-administration), the
+  [TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool), and the
+  [TokenAdminRegistry API reference](/ccip/api-reference/evm/v1.6.1/token-admin-registry).
+
+### Keep siloed lanes isolated from non-hub chains
+
+A siloed liquidity design isolates each remote chain's liquidity to a designated hub chain. Connecting a siloed lane to
+any network other than its hub breaks that isolation.
+
+**Risk:** Cross-silo connections corrupt accounting and can result in stuck transfers or loss of funds.
+
+**What to do:** Review every remote chain configured on a siloed pool and remove any chain that is not the designated
+hub, using `applyChainUpdates` with the chain selector in the removal list. See the
+[TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool).
+
+### Account for decimal differences between chains
+
+Token decimals are set independently on each chain where your token is deployed. CCIP converts amounts during transfer,
+and rate limit values are denominated in the token's smallest unit on the chain the bucket applies to.
+
+**Risk:** Mismatched decimals can cause transfers to fail, or cause a rate limit to throttle at a value orders of
+magnitude away from the one you intended to set.
+
+**What to do:**
+
+- Use matching decimals on every chain where your token is deployed whenever you can.
+- Where decimals differ, size every rate limit in the smallest unit of the chain that bucket applies to, and verify the
+  resulting value against the amount you intended.
+- See [Token Units and Decimals](/ccip/concepts/rate-limit-management/token-units-and-decimals) and
+  [Token Pools](/ccip/concepts/cross-chain-token/evm/token-pools).
+
+### Do not let source outbound capacity exceed destination inbound capacity
+
+Outbound capacity is consumed on the source chain when tokens are locked or burned. Inbound capacity is consumed on the
+destination chain when tokens are released or minted. They are separate buckets and are configured independently.
+
+**Risk:** A transfer that passes the source outbound limit but exceeds the destination inbound limit is stuck in flight
+until inbound capacity becomes available.
+
+**What to do:** Size destination inbound capacity to absorb the full outbound capacity of every source lane pointing at
+it, and re-verify the relationship after every change to either side. See
+[How Rate Limits Work](/ccip/concepts/rate-limit-management/how-rate-limits-work) and
+[Update Rate Limits](/ccip/concepts/rate-limit-management/update-rate-limits).
+
+### Enable rate limits on every production lane
+
+Token pool rate limits are the primary in-protocol control over how much value can move on a lane within a given window.
+A disabled bucket applies no volume ceiling in that direction.
+
+**Risk:** Without rate limits, a compromise elsewhere in your system can move the full transferable supply through CCIP
+before you are able to intervene.
+
+**What to do:** Enable both inbound and outbound rate limits on every production lane, and confirm the deployed values
+match what you intended. See [Rate Limit Management](/ccip/concepts/rate-limit-management/overview) and
+[Inspect Current Rate Limits](/ccip/concepts/rate-limit-management/inspect-current-rate-limits).
+
+### Prepare an emergency pause path before you need it
+
+Rate limit changes are your main lever during an incident, and they are only useful if you can execute them quickly.
+The owner path behind a multi-signature account and timelock is slow by design.
+
+**Risk:** Without a prepared fast path, pausing a lane takes as long as your slowest governance process while an
+incident drains value in minutes.
+
+**What to do:**
+
+- Give the rate limit admin role to signers who can execute within minutes. See
+  [Delegate rate limit changes to the rate limit admin role](#delegate-rate-limit-changes-to-the-rate-limit-admin-role).
+- The role can raise limits as well as lower them, so scope what your fast path can do.
+- Write the pause runbook in advance: which lanes, which values for your deployed pool version (see
+  [Distinguish an intentional pause from a misconfiguration](#distinguish-an-intentional-pause-from-a-misconfiguration)),
+  who executes, and how the decision to lift it is made.
+- Rehearse the runbook on a testnet lane regularly.
+
+## Strongly recommended
+
+### Remove stale remote pool addresses after a migration
+
+Zero-downtime pool upgrades temporarily configure more than one remote pool address for a chain so that in-flight
+messages from the previous pool can still be processed.
+
+**Risk:** A deprecated pool left configured continues to be accepted as a message source, and may contain faulty or
+unintended logic.
+
+**What to do:** Once all in-flight messages from the old pool have settled, remove the stale remote pool address with
+`removeRemotePool`. Confirm there are no pending or failed transactions referencing the old pool in the
+[CCIP Explorer](/ccip/tools-resources/ccip-explorer) before removing it. See
+[Upgradability](/ccip/concepts/cross-chain-token/evm/upgradability) and the
+[TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool).
+
+### Clear an unintended pending token administrator
+
+Transferring the token administrator role is a two-step process. Until the proposed address accepts, the transfer sits
+pending and can be accepted at any time.
+
+**Risk:** An address proposed in error, or one that is no longer trusted, can take the administrator role whenever it
+chooses.
+
+**What to do:** Cancel an unintended transfer by calling `transferAdminRole(localToken, address(0))` on the
+TokenAdminRegistry. This clears the pending administrator without changing the active one. See the
+[TokenAdminRegistry API reference](/ccip/api-reference/evm/v1.6.1/token-admin-registry).
+
+### Clear an unintended pending owner
+
+Token, token pool, and related contracts that use a two-step ownership transfer keep a proposed owner able to accept
+until the transfer is cleared.
+
+**Risk:** An address proposed in error can take ownership of the contract at any time.
+
+**What to do:** Cancel an unintended ownership transfer by re-initiating the transfer to the zero address. Audit every
+CCT-related contract you own for pending transfers, not only the pools.
+
+### Restrict burn and mint rights to the active pool
+
+Mint and burn permissions on your token determine who can change supply. In a CCIP deployment, only the active token
+pool needs them for cross-chain operation.
+
+**Risk:** Any additional address holding mint rights can create unbacked supply; any address holding burn rights can
+destroy user balances.
+
+**What to do:** Enumerate every address holding mint or burn permissions and revoke each one that is not the active
+token pool or an owner-like administrative role you have deliberately retained. Re-run this audit after every pool
+migration. See [Tokens](/ccip/concepts/cross-chain-token/evm/tokens).
+
+### Remove lanes pointing at chains the router does not support
+
+A pool can be configured with a remote chain selector that the CCIP router does not currently serve.
+
+**Risk:** The lane may appear configured while transfers revert. If that chain is later added to the router, the lane
+becomes live without a deliberate decision to enable it.
+
+**What to do:** Validate every configured chain selector against the [CCIP Directory](/ccip/directory), and remove any
+remote chain that was not intentionally configured.
+
+### Keep `destGasOverhead` consistent across lanes
+
+`destGasOverhead` covers the gas your token pool consumes on the destination chain. It is part of the token transfer
+fee configuration that CCIP maintains for your token; for current pool versions, non-default values are applied by
+Chainlink Labs on your behalf. Using a non-default value is justified only when your pool or token costs more to
+execute.
+
+**Risk:** An insufficient value causes transfers to fail automatic execution and require manual execution. An
+unnecessarily high value causes users to overpay. Inconsistent values across lanes pointing at the same destination
+usually indicate a configuration error.
+
+**What to do:**
+
+- Test that token transfers execute automatically on every configured lane before going to production.
+- Include first-time receivers in that test — an account that has never held your token can cost more gas.
+- Use consistent values across lanes pointing at the same destination unless you have a documented reason not to.
+- See [Token Pools](/ccip/concepts/cross-chain-token/evm/token-pools) and
+  [Network Specific](/ccip/tools-resources/network-specific).
+
+### Give inbound capacity headroom over outbound
+
+Matching destination inbound capacity exactly to source outbound capacity leaves no margin. While a transfer is in
+flight, the destination bucket is also being consumed by other traffic and refilling at its own rate.
+
+**Risk:** Transfers that arrive without enough inbound capacity require manual execution, or wait for the bucket to
+refill before they can be executed.
+
+**What to do:** Set destination inbound capacity above the corresponding source outbound capacity, sized against the
+destination refill rate and the latency of the lane. See
+[Common Scenarios](/ccip/concepts/rate-limit-management/common-scenarios).
+
+### Tune the refill rate for both availability and throttling
+
+The refill rate determines how quickly a bucket returns to full capacity after being consumed.
+
+**Risk:** A refill rate that is too slow blocks legitimate transfers for extended periods. One that is too fast fails to
+throttle abnormal flows.
+
+**What to do:** Choose a refill rate that restores capacity fast enough for normal user activity but slow enough to
+constrain a sustained abnormal flow. Treat any starting point as an initial value to be revised: monitor transfer
+success rates and observed volume, and adjust as your traffic patterns become established. See
+[Common Scenarios](/ccip/concepts/rate-limit-management/common-scenarios) and
+[How Rate Limits Work](/ccip/concepts/rate-limit-management/how-rate-limits-work).
+
+### Distinguish an intentional pause from a misconfiguration
+
+A lane is paused through its rate limits, and a paused lane is also what an accidental misconfiguration looks like.
+Pause deliberately and record it.
+
+**Risk:** An accidental pause blocks users indefinitely, and a pause applied with the wrong values either fails to stop
+transfers or removes rate limiting entirely.
+
+**What to do:**
+
+- On pools reporting `1.6.1` or later, pause a lane by setting `isEnabled: true`, `capacity: 0`, `rate: 0` on the
+  affected direction via `setChainRateLimiterConfig` (or `setChainRateLimiterConfigs` for several lanes at once). This
+  blocks all transfers in that direction — an inbound pause intentionally holds in-flight transfers — until you restore
+  normal values.
+- On these same pools, do not set `rate: 0` with a non-zero capacity: validation accepts it, but once the bucket
+  depletes, transfers fail with an arithmetic panic instead of a clean rate-limit error.
+- Keep `isEnabled: true` when pausing. A disabled bucket (which requires `capacity: 0`, `rate: 0`) turns rate limiting
+  off entirely.
+- On pools reporting versions before `1.6.1`, a full stop through rate limits is not possible: use the smallest
+  accepted configuration, `capacity: 2`, `rate: 1`, and account for the small trickle that remains possible, which can
+  be material for tokens with few decimals.
+- Record every intentional pause, including who applied it and the condition for lifting it, and review paused lanes on
+  a fixed interval.
+
+See [Emergency Actions](/ccip/concepts/rate-limit-management/emergency-actions).
+
+### Review network-specific requirements before enabling a chain
+
+Some networks have configuration requirements, gas behavior, RPC characteristics, or service limits that differ from
+the defaults.
+
+**Risk:** A configuration that is correct on one chain can cause failed execution or an outage on another.
+
+**What to do:** Read the guidance for each network before you enable a lane to it. See
+[Network Specific](/ccip/tools-resources/network-specific) and [Service Limits](/ccip/service-limits/evm).
+
+### Settle in-flight transfers before reducing inbound capacity
+
+Reducing a destination inbound capacity affects messages that are already in flight toward that chain, not only future
+ones.
+
+**Risk:** In-flight transfers whose amounts exceed the new inbound capacity stall until an administrator intervenes or
+capacity refills.
+
+**What to do:**
+
+1. Set the new outbound capacities on the source chains first.
+2. Check the [CCIP Explorer](/ccip/tools-resources/ccip-explorer) for in-flight messages whose amounts exceed the
+   inbound capacities you intend to set.
+3. Wait for those transfers to settle on their destination chains.
+4. Then reduce the inbound capacities.
+
+See [Update Rate Limits](/ccip/concepts/rate-limit-management/update-rate-limits).
+
+### Run the latest available TokenPool release
+
+Older TokenPool releases have limitations in decimal handling, rate limit enforcement, and upgradeability. Pools
+predating v1.5 add further complexity to configuration and management.
+
+**Risk:** Operating on an older release exposes you to resolved issues and makes some remediation steps unavailable.
+
+**What to do:** Confirm what you are running with `typeAndVersion()` on each pool, compare against the published
+releases of [`@chainlink/contracts-ccip`](https://www.npmjs.com/package/@chainlink/contracts-ccip?activeTab=versions),
+and upgrade when feasible. The on-chain version string does not always match the package release: a pool built from
+the `1.6.0` release reports `1.5.1`, and some releases report development stamps such as `1.6.x-dev`. See
+[Upgradability](/ccip/concepts/cross-chain-token/evm/upgradability).
+
+### Shut down lanes that carry little or no traffic
+
+Every enabled lane is an active path into and out of your token.
+
+**Risk:** An unused lane contributes no benefit while remaining available during an incident on either of the chains it
+connects.
+
+**What to do:** Review traffic per lane periodically and remove remote chains serving lanes that do not justify the
+exposure. Where possible, consolidate toward a hub-and-spoke topology rather than connecting every chain to every
+other chain.
+
+### Delegate rate limit changes to the rate limit admin role
+
+The token pool owner can assign a separate rate limit admin (`setRateLimitAdmin`), an address permitted to change rate
+limits but nothing else about the pool configuration.
+
+**Risk:** Rate limit changes are made relatively often, including under time pressure during an incident. Performing
+them with the pool owner key exposes your highest-privilege credential to routine use.
+
+**What to do:** Assign the rate limit admin role to a dedicated multi-party signer, or to a contract if you want to
+constrain it further to specific pre-defined adjustments. Keep the pool owner key reserved for changes that require
+it. See the [TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool) and
+[Prerequisites and Permissions](/ccip/concepts/rate-limit-management/prerequisites-and-permissions).
+
+## Get help
+
+If you are assessing an existing CCT deployment, or want a second opinion on your authority structure or rate limit
+configuration, [contact Chainlink Labs](https://chain.link/ccip-contact). For the division of
+responsibilities between token developers, application developers, and Chainlink, see
+[CCIP Service Responsibility](/ccip/service-responsibility).
 
 ---
 
@@ -33674,20 +34128,6 @@ A library implementing the Token Bucket algorithm for rate limiting cross-chain 
 
 ## Events
 
-### TokensConsumed
-
-```solidity
-event TokensConsumed(uint256 tokens);
-```
-
-<Aside>Emitted when tokens are successfully consumed from the [`TokenBucket`](#tokenbucket).</Aside>
-
-**Parameters**
-
-| Name     | Type      | Description                   |
-| -------- | --------- | ----------------------------- |
-| `tokens` | `uint256` | The number of tokens consumed |
-
 ### ConfigChanged
 
 ```solidity
@@ -33712,14 +34152,6 @@ error BucketOverfilled();
 
 <Aside>Thrown when the [`TokenBucket`](#tokenbucket) contains more tokens than its capacity.</Aside>
 
-### OnlyCallableByAdminOrOwner
-
-```solidity
-error OnlyCallableByAdminOrOwner();
-```
-
-<Aside>Thrown when a restricted function is called by an unauthorized address.</Aside>
-
 ### TokenMaxCapacityExceeded
 
 ```solidity
@@ -33738,31 +34170,13 @@ error TokenRateLimitReached(uint256 minWaitInSeconds, uint256 available, address
   Thrown when attempting to consume more tokens than currently available in the [`TokenBucket`](#tokenbucket).
 </Aside>
 
-### AggregateValueMaxCapacityExceeded
-
-```solidity
-error AggregateValueMaxCapacityExceeded(uint256 capacity, uint256 requested);
-```
-
-<Aside>Thrown when attempting to consume more aggregate value than the [`TokenBucket`](#tokenbucket)'s capacity.</Aside>
-
-### AggregateValueRateLimitReached
-
-```solidity
-error AggregateValueRateLimitReached(uint256 minWaitInSeconds, uint256 available);
-```
-
-<Aside>
-  Thrown when attempting to consume more aggregate value than currently available in the [`TokenBucket`](#tokenbucket).
-</Aside>
-
 ### InvalidRateLimitRate
 
 ```solidity
 error InvalidRateLimitRate(Config rateLimiterConfig);
 ```
 
-<Aside>Thrown when the rate limit [`Config`](#config) is invalid (rate is zero or exceeds capacity).</Aside>
+<Aside>Thrown when the rate limit [`Config`](#config) is invalid (rate exceeds capacity).</Aside>
 
 ### DisabledNonZeroRateLimit
 
@@ -33771,14 +34185,6 @@ error DisabledNonZeroRateLimit(Config config);
 ```
 
 <Aside>Thrown when a disabled [`Config`](#config) has non-zero rate or capacity values.</Aside>
-
-### RateLimitMustBeDisabled
-
-```solidity
-error RateLimitMustBeDisabled();
-```
-
-<Aside>Thrown when attempting to enable rate limiting in a context where it must be disabled.</Aside>
 
 ## Structs
 
@@ -33844,7 +34250,6 @@ function _consume(TokenBucket storage s_bucket, uint256 requestTokens, address t
   - Skips execution if rate limiting is disabled or requestTokens is zero
   - Automatically refills tokens based on elapsed time
   - Enforces capacity and rate limits
-  - Emits [`TokensConsumed`](#tokensconsumed) event for non-zero consumption
   - Reverts with [`TokenMaxCapacityExceeded`](#tokenmaxcapacityexceeded) or [`TokenRateLimitReached`](#tokenratelimitreached) on violations
 </Aside>
 
@@ -33907,26 +34312,24 @@ function _setTokenBucketConfig(TokenBucket storage s_bucket, Config memory confi
 Validates rate limiter configuration parameters.
 
 ```solidity
-function _validateTokenBucketConfig(Config memory config, bool mustBeDisabled) internal pure;
+function _validateTokenBucketConfig(Config memory config) internal pure;
 ```
 
 <Aside>
   Validation rules:
 
   - For enabled configurations:
-    - Rate must be non-zero and less than capacity
-    - Validates against mustBeDisabled requirement
+    - Rate must be less than or equal to capacity
   - For disabled configurations:
     - Rate and capacity must be zero
-  - May throw [`InvalidRateLimitRate`](#invalidratelimitrate), [`DisabledNonZeroRateLimit`](#disablednonzeroratelimit), or [`RateLimitMustBeDisabled`](#ratelimitmustbedisabled)
+  - May throw [`InvalidRateLimitRate`](#invalidratelimitrate) or [`DisabledNonZeroRateLimit`](#disablednonzeroratelimit)
 </Aside>
 
 **Parameters**
 
-| Name             | Type                | Description                                |
-| ---------------- | ------------------- | ------------------------------------------ |
-| `config`         | [`Config`](#config) | The configuration to validate              |
-| `mustBeDisabled` | `bool`              | Whether the configuration must be disabled |
+| Name     | Type                | Description                   |
+| -------- | ------------------- | ----------------------------- |
+| `config` | [`Config`](#config) | The configuration to validate |
 
 ### _calculateRefill
 
@@ -59625,20 +60028,6 @@ A library implementing the Token Bucket algorithm for rate limiting cross-chain 
 
 ## Events
 
-### TokensConsumed
-
-```solidity
-event TokensConsumed(uint256 tokens);
-```
-
-<Aside>Emitted when tokens are successfully consumed from the [`TokenBucket`](#tokenbucket).</Aside>
-
-**Parameters**
-
-| Name     | Type      | Description                   |
-| -------- | --------- | ----------------------------- |
-| `tokens` | `uint256` | The number of tokens consumed |
-
 ### ConfigChanged
 
 ```solidity
@@ -59663,14 +60052,6 @@ error BucketOverfilled();
 
 <Aside>Thrown when the [`TokenBucket`](#tokenbucket) contains more tokens than its capacity.</Aside>
 
-### OnlyCallableByAdminOrOwner
-
-```solidity
-error OnlyCallableByAdminOrOwner();
-```
-
-<Aside>Thrown when a restricted function is called by an unauthorized address.</Aside>
-
 ### TokenMaxCapacityExceeded
 
 ```solidity
@@ -59689,31 +60070,13 @@ error TokenRateLimitReached(uint256 minWaitInSeconds, uint256 available, address
   Thrown when attempting to consume more tokens than currently available in the [`TokenBucket`](#tokenbucket).
 </Aside>
 
-### AggregateValueMaxCapacityExceeded
-
-```solidity
-error AggregateValueMaxCapacityExceeded(uint256 capacity, uint256 requested);
-```
-
-<Aside>Thrown when attempting to consume more aggregate value than the [`TokenBucket`](#tokenbucket)'s capacity.</Aside>
-
-### AggregateValueRateLimitReached
-
-```solidity
-error AggregateValueRateLimitReached(uint256 minWaitInSeconds, uint256 available);
-```
-
-<Aside>
-  Thrown when attempting to consume more aggregate value than currently available in the [`TokenBucket`](#tokenbucket).
-</Aside>
-
 ### InvalidRateLimitRate
 
 ```solidity
 error InvalidRateLimitRate(Config rateLimiterConfig);
 ```
 
-<Aside>Thrown when the rate limit [`Config`](#config) is invalid (rate is zero or exceeds capacity).</Aside>
+<Aside>Thrown when the rate limit [`Config`](#config) is invalid (rate exceeds capacity).</Aside>
 
 ### DisabledNonZeroRateLimit
 
@@ -59722,14 +60085,6 @@ error DisabledNonZeroRateLimit(Config config);
 ```
 
 <Aside>Thrown when a disabled [`Config`](#config) has non-zero rate or capacity values.</Aside>
-
-### RateLimitMustBeDisabled
-
-```solidity
-error RateLimitMustBeDisabled();
-```
-
-<Aside>Thrown when attempting to enable rate limiting in a context where it must be disabled.</Aside>
 
 ## Structs
 
@@ -59795,7 +60150,6 @@ function _consume(TokenBucket storage s_bucket, uint256 requestTokens, address t
   - Skips execution if rate limiting is disabled or requestTokens is zero
   - Automatically refills tokens based on elapsed time
   - Enforces capacity and rate limits
-  - Emits [`TokensConsumed`](#tokensconsumed) event for non-zero consumption
   - Reverts with [`TokenMaxCapacityExceeded`](#tokenmaxcapacityexceeded) or [`TokenRateLimitReached`](#tokenratelimitreached) on violations
 </Aside>
 
@@ -59858,26 +60212,24 @@ function _setTokenBucketConfig(TokenBucket storage s_bucket, Config memory confi
 Validates rate limiter configuration parameters.
 
 ```solidity
-function _validateTokenBucketConfig(Config memory config, bool mustBeDisabled) internal pure;
+function _validateTokenBucketConfig(Config memory config) internal pure;
 ```
 
 <Aside>
   Validation rules:
 
   - For enabled configurations:
-    - Rate must be non-zero and less than capacity
-    - Validates against mustBeDisabled requirement
+    - Rate must be less than or equal to capacity
   - For disabled configurations:
     - Rate and capacity must be zero
-  - May throw [`InvalidRateLimitRate`](#invalidratelimitrate), [`DisabledNonZeroRateLimit`](#disablednonzeroratelimit), or [`RateLimitMustBeDisabled`](#ratelimitmustbedisabled)
+  - May throw [`InvalidRateLimitRate`](#invalidratelimitrate) or [`DisabledNonZeroRateLimit`](#disablednonzeroratelimit)
 </Aside>
 
 **Parameters**
 
-| Name             | Type                | Description                                |
-| ---------------- | ------------------- | ------------------------------------------ |
-| `config`         | [`Config`](#config) | The configuration to validate              |
-| `mustBeDisabled` | `bool`              | Whether the configuration must be disabled |
+| Name     | Type                | Description                   |
+| -------- | ------------------- | ----------------------------- |
+| `config` | [`Config`](#config) | The configuration to validate |
 
 ### _calculateRefill
 
@@ -66348,20 +66700,6 @@ A library implementing the Token Bucket algorithm for rate limiting cross-chain 
 
 ## Events
 
-### TokensConsumed
-
-```solidity
-event TokensConsumed(uint256 tokens);
-```
-
-<Aside>Emitted when tokens are successfully consumed from the [`TokenBucket`](#tokenbucket).</Aside>
-
-**Parameters**
-
-| Name     | Type      | Description                   |
-| -------- | --------- | ----------------------------- |
-| `tokens` | `uint256` | The number of tokens consumed |
-
 ### ConfigChanged
 
 ```solidity
@@ -66386,14 +66724,6 @@ error BucketOverfilled();
 
 <Aside>Thrown when the [`TokenBucket`](#tokenbucket) contains more tokens than its capacity.</Aside>
 
-### OnlyCallableByAdminOrOwner
-
-```solidity
-error OnlyCallableByAdminOrOwner();
-```
-
-<Aside>Thrown when a restricted function is called by an unauthorized address.</Aside>
-
 ### TokenMaxCapacityExceeded
 
 ```solidity
@@ -66412,31 +66742,13 @@ error TokenRateLimitReached(uint256 minWaitInSeconds, uint256 available, address
   Thrown when attempting to consume more tokens than currently available in the [`TokenBucket`](#tokenbucket).
 </Aside>
 
-### AggregateValueMaxCapacityExceeded
-
-```solidity
-error AggregateValueMaxCapacityExceeded(uint256 capacity, uint256 requested);
-```
-
-<Aside>Thrown when attempting to consume more aggregate value than the [`TokenBucket`](#tokenbucket)'s capacity.</Aside>
-
-### AggregateValueRateLimitReached
-
-```solidity
-error AggregateValueRateLimitReached(uint256 minWaitInSeconds, uint256 available);
-```
-
-<Aside>
-  Thrown when attempting to consume more aggregate value than currently available in the [`TokenBucket`](#tokenbucket).
-</Aside>
-
 ### InvalidRateLimitRate
 
 ```solidity
 error InvalidRateLimitRate(Config rateLimiterConfig);
 ```
 
-<Aside>Thrown when the rate limit [`Config`](#config) is invalid (rate is zero or exceeds capacity).</Aside>
+<Aside>Thrown when the rate limit [`Config`](#config) is invalid (rate exceeds capacity).</Aside>
 
 ### DisabledNonZeroRateLimit
 
@@ -66445,14 +66757,6 @@ error DisabledNonZeroRateLimit(Config config);
 ```
 
 <Aside>Thrown when a disabled [`Config`](#config) has non-zero rate or capacity values.</Aside>
-
-### RateLimitMustBeDisabled
-
-```solidity
-error RateLimitMustBeDisabled();
-```
-
-<Aside>Thrown when attempting to enable rate limiting in a context where it must be disabled.</Aside>
 
 ## Structs
 
@@ -66518,7 +66822,6 @@ function _consume(TokenBucket storage s_bucket, uint256 requestTokens, address t
   - Skips execution if rate limiting is disabled or requestTokens is zero
   - Automatically refills tokens based on elapsed time
   - Enforces capacity and rate limits
-  - Emits [`TokensConsumed`](#tokensconsumed) event for non-zero consumption
   - Reverts with [`TokenMaxCapacityExceeded`](#tokenmaxcapacityexceeded) or [`TokenRateLimitReached`](#tokenratelimitreached) on violations
 </Aside>
 
@@ -66581,26 +66884,24 @@ function _setTokenBucketConfig(TokenBucket storage s_bucket, Config memory confi
 Validates rate limiter configuration parameters.
 
 ```solidity
-function _validateTokenBucketConfig(Config memory config, bool mustBeDisabled) internal pure;
+function _validateTokenBucketConfig(Config memory config) internal pure;
 ```
 
 <Aside>
   Validation rules:
 
   - For enabled configurations:
-    - Rate must be non-zero and less than capacity
-    - Validates against mustBeDisabled requirement
+    - Rate must be less than or equal to capacity
   - For disabled configurations:
     - Rate and capacity must be zero
-  - May throw [`InvalidRateLimitRate`](#invalidratelimitrate), [`DisabledNonZeroRateLimit`](#disablednonzeroratelimit), or [`RateLimitMustBeDisabled`](#ratelimitmustbedisabled)
+  - May throw [`InvalidRateLimitRate`](#invalidratelimitrate) or [`DisabledNonZeroRateLimit`](#disablednonzeroratelimit)
 </Aside>
 
 **Parameters**
 
-| Name             | Type                | Description                                |
-| ---------------- | ------------------- | ------------------------------------------ |
-| `config`         | [`Config`](#config) | The configuration to validate              |
-| `mustBeDisabled` | `bool`              | Whether the configuration must be disabled |
+| Name     | Type                | Description                   |
+| -------- | ------------------- | ----------------------------- |
+| `config` | [`Config`](#config) | The configuration to validate |
 
 ### _calculateRefill
 

--- a/src/content/ccip/llms-full.txt
+++ b/src/content/ccip/llms-full.txt
@@ -10427,8 +10427,8 @@ Last Updated: 2026-08-29
 </Aside>
 
 This page covers the best practices the Chainlink team recommends for Cross-Chain Token (CCT) deployments on EVM chains. It is written for
-token developers who are enabling a token for CCIP or already operating one in production.
-We strongly recommend following these practices for a CCT token in production to minimize the risk of loss, and maximize security.
+token developers who are enabling a token for CCIP or already operating one in production. Follow these practices for any
+CCT in production.
 
 Guidance here assumes CCIP v1.6.1 token pools. You are responsible for assessing which items apply to your own
 deployment and risk profile.
@@ -10443,20 +10443,19 @@ deployment and risk profile.
   - **Critical:** apply these before you enable any production lane. Omitting them can lead to loss of funds,
     permanently stuck transfers, or unauthorized control of your token.
   - **Strongly recommended:** apply these as part of normal operation. Omitting them commonly causes incidents,
-    outages, or degraded transfers. While not critical, these practices are still highly recommended, and should not be
-    an afterthought.
+    outages, or degraded transfers.
 </Aside>
 
 <Aside type="caution" title="Confirm your deployed TokenPool version">
   Rate limit validation changed between TokenPool releases a while back. Call `typeAndVersion()` on each deployed pool before you apply
   any configuration described on this page.
 
-  - **Pools reporting 1.6.1 or later** (including development stamps such as `1.6.x-dev`) — an enabled bucket is rejected
+  - **Pools reporting 1.6.1 or later** (including development stamps such as `1.6.x-dev`): an enabled bucket is rejected
     only when `rate > capacity`, so `capacity: 1`, `rate: 1` and an enabled `capacity: 0`, `rate: 0` are both accepted.
     For pausing a lane, see
     [Distinguish an intentional pause from a misconfiguration](#distinguish-an-intentional-pause-from-a-misconfiguration).
-    - This basically means that a hard pause of the lane, with absolutely `0` tokens being transferable, is allowed.
-  - **Pools reporting versions before 1.6.1** — an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`.
+    - A hard pause of the lane is allowed, with `0` tokens transferable.
+  - **Pools reporting versions before 1.6.1**: an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`.
     A configuration of `capacity: 1`, `rate: 1` reverts. Use at least `capacity: 2`, `rate: 1` on these releases. (Version
     strings here are `1.5.1` or lower: a pool built from the 1.6.0 contracts release reports `1.5.1`.)
 </Aside>
@@ -10684,7 +10683,7 @@ usually indicate a configuration error.
 **What to do:**
 
 - Test that token transfers execute automatically on every configured lane before going to production.
-- Include first-time receivers in that test — an account that has never held your token can cost more gas.
+- Include first-time receivers in that test. An account that has never held your token can cost more gas.
 - Use consistent values across lanes pointing at the same destination unless you have a documented reason not to.
 - See [Token Pools](/ccip/concepts/cross-chain-token/evm/token-pools) and
   [Network Specific](/ccip/tools-resources/network-specific).
@@ -10726,7 +10725,7 @@ transfers or removes rate limiting entirely.
 
 - On pools reporting `1.6.1` or later, pause a lane by setting `isEnabled: true`, `capacity: 0`, `rate: 0` on the
   affected direction via `setChainRateLimiterConfig` (or `setChainRateLimiterConfigs` for several lanes at once). This
-  blocks all transfers in that direction — an inbound pause intentionally holds in-flight transfers — until you restore
+  blocks all transfers in that direction (an inbound pause intentionally holds in-flight transfers) until you restore
   normal values.
 - On these same pools, do not set `rate: 0` with a non-zero capacity: validation accepts it, but once the bucket
   depletes, transfers fail with an arithmetic panic instead of a clean rate-limit error.

--- a/src/content/ccip/tutorials/evm/cross-chain-tokens/operational-security.mdx
+++ b/src/content/ccip/tutorials/evm/cross-chain-tokens/operational-security.mdx
@@ -25,30 +25,22 @@ deployment and risk profile.
 
 <CcipCommon callout="tokenPoolOwnership" />
 
-<Aside type="note" title="How to read this page">
-
-Items are grouped into two levels:
-
-- **Critical:** apply these before you enable any production lane. Omitting them can lead to loss of funds,
-  permanently stuck transfers, or unauthorized control of your token.
-- **Strongly recommended:** apply these as part of normal operation. Omitting them commonly causes incidents,
-  outages, or degraded transfers.
-
-</Aside>
-
 <Aside type="caution" title="Confirm your deployed TokenPool version">
 
-Rate limit validation changed between TokenPool releases a while back. Call `typeAndVersion()` on each deployed pool before you apply
-any configuration described on this page.
+Rate limit validation changed between TokenPool releases a while back.
+Users can call `typeAndVersion()` on each deployed pool before they apply any configuration described on this page.
 
-- **Pools reporting 1.6.1 or later** (including development stamps such as `1.6.x-dev`): an enabled bucket is rejected
+- **Pools reporting versions before 1.6.1**: an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`.
+  A configuration of `capacity: 1`, `rate: 1` will also revert.
+  Use at least `capacity: 2`, `rate: 1` on these releases. (Version strings here are `1.5.1` or lower: a pool built from the 1.6.0 contracts release reports `1.5.1`.)
+
+- **Pools `1.6.1` or later**: an enabled bucket is rejected
   only when `rate > capacity`, so `capacity: 1`, `rate: 1` and an enabled `capacity: 0`, `rate: 0` are both accepted.
   For pausing a lane, see
   [Distinguish an intentional pause from a misconfiguration](#distinguish-an-intentional-pause-from-a-misconfiguration).
-  - A hard pause of the lane is allowed, with `0` tokens transferable.
-- **Pools reporting versions before 1.6.1**: an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`.
-  A configuration of `capacity: 1`, `rate: 1` reverts. Use at least `capacity: 2`, `rate: 1` on these releases. (Version
-  strings here are `1.5.1` or lower: a pool built from the 1.6.0 contracts release reports `1.5.1`.)
+  - Basically, on versions `1.6.1` or later, a hard pause of the lane is allowed, with `0` tokens transferable. This is different from
+    earlier versions, where the minimum value of `rate` had to be at least `1`, thus preventing a hard pause, even if the amount allowed
+    was miniscule.
 
 </Aside>
 
@@ -57,21 +49,24 @@ any configuration described on this page.
 ### Secure the roles that control your token and pools
 
 The token administrator, the token pool owner, and any address holding mint or burn rights can change how your token
-moves across chains. Each of these roles is held by whatever address you assign to it: an externally owned account
-(EOA), a multi-signature smart account, or another contract.
+moves across chains. Each of these roles is held by whatever address you assign to it:
+
+- an externally owned account (EOA),
+- a multi-signature smart account,
+- or another contract.
 
 **Risk:** A single compromised private key is enough to redirect transfers, mint unbacked supply, or take control of
-your pools, with no second party able to review or veto the action before it executes.
+your pools.
 
-**What to do:**
+**What should you do:**
 
 - Assign contract ownership, the CCIP administrator role, and mint and burn rights to a multi-signature smart account
   such as a [Safe Smart Account](https://github.com/safe-global/safe-smart-account), using a threshold of at least
-  3-of-n, commensurate with the value at risk.
-- Add a timelock so that critical actions must be proposed, reviewed, and can be cancelled before they execute.
-- Put this structure in place at deployment: the multi-signature account and timelock should own the token, the pools,
+  3-of-n, commensurate with the value at risk. We recommend a minimum of 5 signers to ensure sufficient decentralization and security.
+- Add a timelock so that critical actions may be reviewed and cancelled with a sufficient time buffer.
+- The multi-signature account and timelock should own the token, the pools,
   and any related contracts from day one, rather than being retrofitted after launch.
-- Remove departed or compromised signers promptly, and confirm at least quarterly that every remaining signer still
+- Remove departed or compromised signers promptly, and confirm routinely that every remaining signer still
   controls their key.
 - Distribute signers so a quorum is reachable quickly during an incident, rather than concentrating them in one team,
   location, or time zone.
@@ -98,26 +93,24 @@ chains. The locked balance is the only backing for that remote supply.
 **Risk:** If locked supply falls below the total minted across remote chains, transfers back to the issuing chain fail
 and users cannot withdraw until the shortfall is covered.
 
-**What to do:**
+**What should you do:**
 
 - Continuously compare the locked balance held by the pool on the issuing chain against the sum of total supply across
   every remote burn and mint chain.
 - Alert on the ratio between them, not only on the absolute balance, and set thresholds that trigger action well before
   the pool is exhausted.
-- Prefer Burn and Mint on all chains where your token design allows it. It is the simplest accounting model and removes
-  this class of risk entirely. Lock and Unlock across multiple chains is the most complex and fragments liquidity.
 - See [Tokens](/ccip/concepts/cross-chain-token/evm/tokens) and the
   [LockReleaseTokenPool API reference](/ccip/api-reference/evm/v1.6.1/lock-release-token-pool).
 
 ### Configure both sides of every lane symmetrically
 
-A lane works only when both pools agree about each other. Configuration is applied independently on each chain, so the
+A lane works only when both pools work in tandem with each other. The configuration for the remote pool on the other end is applied independently on each chain, so the
 two sides can drift apart without any error being raised at the time of the change.
 
 **Risk:** Mismatched configuration causes transfers to revert, or to become stuck in flight until the configuration is
 corrected.
 
-**What to do:**
+**What should you do:**
 
 - On the source pool, confirm the configured remote pool addresses (`getRemotePools`) resolve to the actual destination
   pool address.
@@ -138,9 +131,10 @@ any network other than its hub breaks that isolation.
 
 **Risk:** Cross-silo connections corrupt accounting and can result in stuck transfers or loss of funds.
 
-**What to do:** Review every remote chain configured on a siloed pool and remove any chain that is not the designated
-hub, using `applyChainUpdates` with the chain selector in the removal list. See the
-[TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool).
+**What should you do:**
+
+- Review every remote chain configured on a siloed pool and remove any chain that is not the designated
+  hub, using `applyChainUpdates` with the chain selector in the removal list.
 
 ### Account for decimal differences between chains
 
@@ -150,10 +144,10 @@ and rate limit values are denominated in the token's smallest unit on the chain 
 **Risk:** Mismatched decimals can cause transfers to fail, or cause a rate limit to throttle at a value orders of
 magnitude away from the one you intended to set.
 
-**What to do:**
+**What should you do:**
 
 - Use matching decimals on every chain where your token is deployed whenever you can.
-- Where decimals differ, size every rate limit in the smallest unit of the chain that bucket applies to, and verify the
+- Where decimals differ, configure every rate limit in the smallest unit of the chain that bucket applies to, and verify the
   resulting value against the amount you intended.
 - See [Token Units and Decimals](/ccip/concepts/rate-limit-management/token-units-and-decimals) and
   [Token Pools](/ccip/concepts/cross-chain-token/evm/token-pools).
@@ -166,10 +160,13 @@ destination chain when tokens are released or minted. They are separate buckets 
 **Risk:** A transfer that passes the source outbound limit but exceeds the destination inbound limit is stuck in flight
 until inbound capacity becomes available.
 
-**What to do:** Size destination inbound capacity to absorb the full outbound capacity of every source lane pointing at
-it, and re-verify the relationship after every change to either side. See
-[How Rate Limits Work](/ccip/concepts/rate-limit-management/how-rate-limits-work) and
-[Update Rate Limits](/ccip/concepts/rate-limit-management/update-rate-limits).
+**What should you do:**
+
+- Size destination inbound capacity to absorb the full outbound capacity of every source lane pointing at
+  it, and re-verify the relationship after every change to either side.
+
+- See [How Rate Limits Work](/ccip/concepts/rate-limit-management/how-rate-limits-work) and
+  [Update Rate Limits](/ccip/concepts/rate-limit-management/update-rate-limits).
 
 ### Enable rate limits on every production lane
 
@@ -179,9 +176,12 @@ A disabled bucket applies no volume ceiling in that direction.
 **Risk:** Without rate limits, a compromise elsewhere in your system can move the full transferable supply through CCIP
 before you are able to intervene.
 
-**What to do:** Enable both inbound and outbound rate limits on every production lane, and confirm the deployed values
-match what you intended. See [Rate Limit Management](/ccip/concepts/rate-limit-management/overview) and
-[Inspect Current Rate Limits](/ccip/concepts/rate-limit-management/inspect-current-rate-limits).
+**What should you do:**
+
+- Enable both inbound and outbound rate limits on every production lane, and confirm the deployed values
+  match what you intended.
+- See [Rate Limit Management](/ccip/concepts/rate-limit-management/overview) and
+  [Inspect Current Rate Limits](/ccip/concepts/rate-limit-management/inspect-current-rate-limits).
 
 ### Prepare an emergency pause path before you need it
 
@@ -191,12 +191,12 @@ The owner path behind a multi-signature account and timelock is slow by design.
 **Risk:** Without a prepared fast path, pausing a lane takes as long as your slowest governance process while an
 incident drains value in minutes.
 
-**What to do:**
+**What should you do:**
 
 - Give the rate limit admin role to signers who can execute within minutes. See
   [Delegate rate limit changes to the rate limit admin role](#delegate-rate-limit-changes-to-the-rate-limit-admin-role).
 - The role can raise limits as well as lower them, so scope what your fast path can do.
-- Write the pause runbook in advance: which lanes, which values for your deployed pool version (see
+- Prepare the logistics in advance: which lanes, which values for your deployed pool version (see
   [Distinguish an intentional pause from a misconfiguration](#distinguish-an-intentional-pause-from-a-misconfiguration)),
   who executes, and how the decision to lift it is made.
 - Rehearse the runbook on a testnet lane regularly.
@@ -211,45 +211,44 @@ messages from the previous pool can still be processed.
 **Risk:** A deprecated pool left configured continues to be accepted as a message source, and may contain faulty or
 unintended logic.
 
-**What to do:** Once all in-flight messages from the old pool have settled, remove the stale remote pool address with
-`removeRemotePool`. Confirm there are no pending or failed transactions referencing the old pool in the
-[CCIP Explorer](/ccip/tools-resources/ccip-explorer) before removing it. See
-[Upgradability](/ccip/concepts/cross-chain-token/evm/upgradability) and the
-[TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool).
+**What should you do:**
 
-### Clear an unintended pending token administrator
+- Once all in-flight messages from the old pool have settled, remove the stale remote pool address with
+  `removeRemotePool`.
+- Confirm there are no pending or failed transactions referencing the old pool in the
+  [CCIP Explorer](/ccip/tools-resources/ccip-explorer) before removing it.
+- Seen [Upgradability](/ccip/concepts/cross-chain-token/evm/upgradability) and the
+  [TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool).
 
-Transferring the token administrator role is a two-step process. Until the proposed address accepts, the transfer sits
+### Clear an unintended pending token administrator or owner
+
+Transferring the token administrator or owner role is a two-step process. Until the proposed address accepts, the transfer sits
 pending and can be accepted at any time.
 
-**Risk:** An address proposed in error, or one that is no longer trusted, can take the administrator role whenever it
+**Risk:** An address proposed in error, or one that is no longer trusted, can take the administrator or owner role whenever it
 chooses.
 
-**What to do:** Cancel an unintended transfer by calling `transferAdminRole(localToken, address(0))` on the
-TokenAdminRegistry. This clears the pending administrator without changing the active one. See the
-[TokenAdminRegistry API reference](/ccip/api-reference/evm/v1.6.1/token-admin-registry).
+**What should you do:**
 
-### Clear an unintended pending owner
-
-Token, token pool, and related contracts that use a two-step ownership transfer keep a proposed owner able to accept
-until the transfer is cleared.
-
-**Risk:** An address proposed in error can take ownership of the contract at any time.
-
-**What to do:** Cancel an unintended ownership transfer by re-initiating the transfer to the zero address. Audit every
-CCT-related contract you own for pending transfers, not only the pools.
+- Cancel an unintended transfer by calling `transferAdminRole(localToken, address(0))` on the
+  TokenAdminRegistry. This clears the pending administrator without changing the active one. See the
+  [TokenAdminRegistry API reference](/ccip/api-reference/evm/v1.6.1/token-admin-registry).
+- Cancel an unintended transfer of the owner role by calling `transferOwnership(address(0))` on the relevant contract.
+  This clears the pending owner without changing the active one. See the [Ownable API reference](https://docs.openzeppelin.com/contracts/4.x/api/access#Ownable).
 
 ### Restrict burn and mint rights to the active pool
 
-Mint and burn permissions on your token determine who can change supply. In a CCIP deployment, only the active token
+Mint and burn permissions on your token determine who can change the supply. In a CCIP deployment, only the active token
 pool needs them for cross-chain operation.
 
 **Risk:** Any additional address holding mint rights can create unbacked supply; any address holding burn rights can
 destroy user balances.
 
-**What to do:** Enumerate every address holding mint or burn permissions and revoke each one that is not the active
-token pool or an owner-like administrative role you have deliberately retained. Re-run this audit after every pool
-migration. See [Tokens](/ccip/concepts/cross-chain-token/evm/tokens).
+**What should you do:**
+
+- Enumerate every address holding mint or burn permissions and revoke each one that is not the active
+  token pool or an owner-like administrative role you have deliberately retained. Re-run this audit after every pool
+  migration. See [Tokens](/ccip/concepts/cross-chain-token/evm/tokens).
 
 ### Remove lanes pointing at chains the router does not support
 
@@ -258,13 +257,15 @@ A pool can be configured with a remote chain selector that the CCIP router does 
 **Risk:** The lane may appear configured while transfers revert. If that chain is later added to the router, the lane
 becomes live without a deliberate decision to enable it.
 
-**What to do:** Validate every configured chain selector against the [CCIP Directory](/ccip/directory), and remove any
-remote chain that was not intentionally configured.
+**What should you do:**
+
+- Validate every configured chain selector against the [CCIP Directory](/ccip/directory), and remove any
+  remote chain that was not intentionally configured.
 
 ### Keep `destGasOverhead` consistent across lanes
 
 `destGasOverhead` covers the gas your token pool consumes on the destination chain. It is part of the token transfer
-fee configuration that CCIP maintains for your token; for current pool versions, non-default values are applied by
+fee configuration that CCIP maintains for your token; for current pool versions (`<2.0`), non-default values are applied by
 Chainlink Labs on your behalf. Using a non-default value is justified only when your pool or token costs more to
 execute.
 
@@ -272,7 +273,7 @@ execute.
 unnecessarily high value causes users to overpay. Inconsistent values across lanes pointing at the same destination
 usually indicate a configuration error.
 
-**What to do:**
+**What should you do:**
 
 - Test that token transfers execute automatically on every configured lane before going to production.
 - Include first-time receivers in that test. An account that has never held your token can cost more gas.
@@ -288,9 +289,11 @@ flight, the destination bucket is also being consumed by other traffic and refil
 **Risk:** Transfers that arrive without enough inbound capacity require manual execution, or wait for the bucket to
 refill before they can be executed.
 
-**What to do:** Set destination inbound capacity above the corresponding source outbound capacity, sized against the
-destination refill rate and the latency of the lane. See
-[Common Scenarios](/ccip/concepts/rate-limit-management/common-scenarios).
+**What should you do:**
+
+- Set destination inbound capacity above the corresponding source outbound capacity, sized against the
+  destination refill rate and the latency of the lane. See
+  [Common Scenarios](/ccip/concepts/rate-limit-management/common-scenarios).
 
 ### Tune the refill rate for both availability and throttling
 
@@ -299,21 +302,21 @@ The refill rate determines how quickly a bucket returns to full capacity after b
 **Risk:** A refill rate that is too slow blocks legitimate transfers for extended periods. One that is too fast fails to
 throttle abnormal flows.
 
-**What to do:** Choose a refill rate that restores capacity fast enough for normal user activity but slow enough to
-constrain a sustained abnormal flow. Treat any starting point as an initial value to be revised: monitor transfer
-success rates and observed volume, and adjust as your traffic patterns become established. See
-[Common Scenarios](/ccip/concepts/rate-limit-management/common-scenarios) and
-[How Rate Limits Work](/ccip/concepts/rate-limit-management/how-rate-limits-work).
+**What should you do:**
+
+- Choose a refill rate that restores capacity fast enough for normal user activity but slow enough to
+  constrain a sustained abnormal flow.
+- See [Common Scenarios](/ccip/concepts/rate-limit-management/common-scenarios) and [How Rate Limits Work](/ccip/concepts/rate-limit-management/how-rate-limits-work).
+- The exact numbers will vary upon network choices and traffic patterns for your specific protocol. It is the responsibility of the protocol to designate sensible numbers.
 
 ### Distinguish an intentional pause from a misconfiguration
 
-A lane is paused through its rate limits, and a paused lane is also what an accidental misconfiguration looks like.
-Pause deliberately and record it.
+Understand how rate limit configurations differ across versions
 
 **Risk:** An accidental pause blocks users indefinitely, and a pause applied with the wrong values either fails to stop
 transfers or removes rate limiting entirely.
 
-**What to do:**
+**What should you do:**
 
 - On pools reporting `1.6.1` or later, pause a lane by setting `isEnabled: true`, `capacity: 0`, `rate: 0` on the
   affected direction via `setChainRateLimiterConfig` (or `setChainRateLimiterConfigs` for several lanes at once). This
@@ -338,8 +341,10 @@ the defaults.
 
 **Risk:** A configuration that is correct on one chain can cause failed execution or an outage on another.
 
-**What to do:** Read the guidance for each network before you enable a lane to it. See
-[Network Specific](/ccip/tools-resources/network-specific) and [Service Limits](/ccip/service-limits/evm).
+**What should you do:**
+
+- Read the guidance for each network before you enable a lane to it. See
+  [Network Specific](/ccip/tools-resources/network-specific) and [Service Limits](/ccip/service-limits/evm).
 
 ### Settle in-flight transfers before reducing inbound capacity
 
@@ -349,28 +354,30 @@ ones.
 **Risk:** In-flight transfers whose amounts exceed the new inbound capacity stall until an administrator intervenes or
 capacity refills.
 
-**What to do:**
+**What should you do:**
 
-1. Set the new outbound capacities on the source chains first.
-2. Check the [CCIP Explorer](/ccip/tools-resources/ccip-explorer) for in-flight messages whose amounts exceed the
-   inbound capacities you intend to set.
-3. Wait for those transfers to settle on their destination chains.
-4. Then reduce the inbound capacities.
+- Set the new outbound capacities on the source chains first.
+- Check the [CCIP Explorer](/ccip/tools-resources/ccip-explorer) for in-flight messages whose amounts exceed the
+  inbound capacities you intend to set.
+- Wait for those transfers to settle on their destination chains.
+- Then reduce the inbound capacities.
 
 See [Update Rate Limits](/ccip/concepts/rate-limit-management/update-rate-limits).
 
 ### Run the latest available TokenPool release
 
-Older TokenPool releases have limitations in decimal handling, rate limit enforcement, and upgradeability. Pools
-predating v1.5 add further complexity to configuration and management.
+We recommend using our latest pool versions for improved security, reliability, and access to the latest features.
 
-**Risk:** Operating on an older release exposes you to resolved issues and makes some remediation steps unavailable.
+**Risk:** Operating on an older release exposes you to issues that may have been resolved on newer versions.
 
-**What to do:** Confirm what you are running with `typeAndVersion()` on each pool, compare against the published
-releases of [`@chainlink/contracts-ccip`](https://www.npmjs.com/package/@chainlink/contracts-ccip?activeTab=versions),
-and upgrade when feasible. The on-chain version string does not always match the package release: a pool built from
-the `1.6.0` release reports `1.5.1`, and some releases report development stamps such as `1.6.x-dev`. See
-[Upgradability](/ccip/concepts/cross-chain-token/evm/upgradability).
+**What should you do:**
+
+- Confirm what you are running with `typeAndVersion()` on each pool, compare against the published
+  releases of [`@chainlink/contracts-ccip`](https://www.npmjs.com/package/@chainlink/contracts-ccip?activeTab=versions),
+  and upgrade when feasible.
+- The on-chain version string does not always match the package release: a pool built from
+  the `1.6.0` release reports `1.5.1`, and some releases report development stamps such as `1.6.x-dev`. See
+  [Upgradability](/ccip/concepts/cross-chain-token/evm/upgradability).
 
 ### Shut down lanes that carry little or no traffic
 
@@ -379,9 +386,11 @@ Every enabled lane is an active path into and out of your token.
 **Risk:** An unused lane contributes no benefit while remaining available during an incident on either of the chains it
 connects.
 
-**What to do:** Review traffic per lane periodically and remove remote chains serving lanes that do not justify the
-exposure. Where possible, consolidate toward a hub-and-spoke topology rather than connecting every chain to every
-other chain.
+**What should you do:**
+
+- Review traffic per lane periodically and remove remote chains serving lanes that do not justify the
+  exposure. Where possible, consolidate toward a hub-and-spoke topology rather than connecting every chain to every
+  other chain.
 
 ### Delegate rate limit changes to the rate limit admin role
 
@@ -391,7 +400,7 @@ limits but nothing else about the pool configuration.
 **Risk:** Rate limit changes are made relatively often, including under time pressure during an incident. Performing
 them with the pool owner key exposes your highest-privilege credential to routine use.
 
-**What to do:** Assign the rate limit admin role to a dedicated multi-party signer, or to a contract if you want to
+**What should you do:** Assign the rate limit admin role to a dedicated multi-party signer, or to a contract if you want to
 constrain it further to specific pre-defined adjustments. Keep the pool owner key reserved for changes that require
 it. See the [TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool) and
 [Prerequisites and Permissions](/ccip/concepts/rate-limit-management/prerequisites-and-permissions).

--- a/src/content/ccip/tutorials/evm/cross-chain-tokens/operational-security.mdx
+++ b/src/content/ccip/tutorials/evm/cross-chain-tokens/operational-security.mdx
@@ -17,8 +17,8 @@ import CcipCommon from "@features/ccip/CcipCommon.astro"
 <CcipCommon callout="talkToExpert" />
 
 This page covers the best practices the Chainlink team recommends for Cross-Chain Token (CCT) deployments on EVM chains. It is written for
-token developers who are enabling a token for CCIP or already operating one in production.
-We strongly recommend following these practices for a CCT token in production to minimize the risk of loss, and maximize security.
+token developers who are enabling a token for CCIP or already operating one in production. Follow these practices for any
+CCT in production.
 
 Guidance here assumes CCIP v1.6.1 token pools. You are responsible for assessing which items apply to your own
 deployment and risk profile.
@@ -32,8 +32,7 @@ Items are grouped into two levels:
 - **Critical:** apply these before you enable any production lane. Omitting them can lead to loss of funds,
   permanently stuck transfers, or unauthorized control of your token.
 - **Strongly recommended:** apply these as part of normal operation. Omitting them commonly causes incidents,
-  outages, or degraded transfers. While not critical, these practices are still highly recommended, and should not be
-  an afterthought.
+  outages, or degraded transfers.
 
 </Aside>
 
@@ -42,12 +41,12 @@ Items are grouped into two levels:
 Rate limit validation changed between TokenPool releases a while back. Call `typeAndVersion()` on each deployed pool before you apply
 any configuration described on this page.
 
-- **Pools reporting 1.6.1 or later** (including development stamps such as `1.6.x-dev`) — an enabled bucket is rejected
+- **Pools reporting 1.6.1 or later** (including development stamps such as `1.6.x-dev`): an enabled bucket is rejected
   only when `rate > capacity`, so `capacity: 1`, `rate: 1` and an enabled `capacity: 0`, `rate: 0` are both accepted.
   For pausing a lane, see
   [Distinguish an intentional pause from a misconfiguration](#distinguish-an-intentional-pause-from-a-misconfiguration).
-  - This basically means that a hard pause of the lane, with absolutely `0` tokens being transferable, is allowed.
-- **Pools reporting versions before 1.6.1** — an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`.
+  - A hard pause of the lane is allowed, with `0` tokens transferable.
+- **Pools reporting versions before 1.6.1**: an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`.
   A configuration of `capacity: 1`, `rate: 1` reverts. Use at least `capacity: 2`, `rate: 1` on these releases. (Version
   strings here are `1.5.1` or lower: a pool built from the 1.6.0 contracts release reports `1.5.1`.)
 
@@ -276,7 +275,7 @@ usually indicate a configuration error.
 **What to do:**
 
 - Test that token transfers execute automatically on every configured lane before going to production.
-- Include first-time receivers in that test — an account that has never held your token can cost more gas.
+- Include first-time receivers in that test. An account that has never held your token can cost more gas.
 - Use consistent values across lanes pointing at the same destination unless you have a documented reason not to.
 - See [Token Pools](/ccip/concepts/cross-chain-token/evm/token-pools) and
   [Network Specific](/ccip/tools-resources/network-specific).
@@ -318,7 +317,7 @@ transfers or removes rate limiting entirely.
 
 - On pools reporting `1.6.1` or later, pause a lane by setting `isEnabled: true`, `capacity: 0`, `rate: 0` on the
   affected direction via `setChainRateLimiterConfig` (or `setChainRateLimiterConfigs` for several lanes at once). This
-  blocks all transfers in that direction — an inbound pause intentionally holds in-flight transfers — until you restore
+  blocks all transfers in that direction (an inbound pause intentionally holds in-flight transfers) until you restore
   normal values.
 - On these same pools, do not set `rate: 0` with a non-zero capacity: validation accepts it, but once the bucket
   depletes, transfers fail with an arithmetic panic instead of a clean rate-limit error.

--- a/src/content/ccip/tutorials/evm/cross-chain-tokens/operational-security.mdx
+++ b/src/content/ccip/tutorials/evm/cross-chain-tokens/operational-security.mdx
@@ -1,0 +1,405 @@
+---
+section: ccip
+date: Last Modified
+title: "Cross-Chain Token (CCT) Operational Security (EVM)"
+metadata:
+  description: "Operational security requirements for Cross-Chain Token (CCT) deployments on EVM chains: authority structure, pool and lane configuration, rate limits, administration, and versioning."
+  excerpt: "cct operational security token pool admin multisig timelock rate limits pool mappings supply accounting cross-silo burn mint rights destgasoverhead emergency pause"
+  datePublished: "2026-08-28"
+  lastModified: "2026-08-29"
+  difficulty: "intermediate"
+  estimatedTime: "25 minutes"
+---
+
+import { Aside } from "@components"
+import CcipCommon from "@features/ccip/CcipCommon.astro"
+
+<CcipCommon callout="talkToExpert" />
+
+This page covers the best practices the Chainlink team recommends for Cross-Chain Token (CCT) deployments on EVM chains. It is written for
+token developers who are enabling a token for CCIP or already operating one in production.
+We strongly recommend following these practices for a CCT token in production to minimize the risk of loss, and maximize security.
+
+Guidance here assumes CCIP v1.6.1 token pools. You are responsible for assessing which items apply to your own
+deployment and risk profile.
+
+<CcipCommon callout="tokenPoolOwnership" />
+
+<Aside type="note" title="How to read this page">
+
+Items are grouped into two levels:
+
+- **Critical:** apply these before you enable any production lane. Omitting them can lead to loss of funds,
+  permanently stuck transfers, or unauthorized control of your token.
+- **Strongly recommended:** apply these as part of normal operation. Omitting them commonly causes incidents,
+  outages, or degraded transfers. While not critical, these practices are still highly recommended, and should not be
+  an afterthought.
+
+</Aside>
+
+<Aside type="caution" title="Confirm your deployed TokenPool version">
+
+Rate limit validation changed between TokenPool releases a while back. Call `typeAndVersion()` on each deployed pool before you apply
+any configuration described on this page.
+
+- **Pools reporting 1.6.1 or later** (including development stamps such as `1.6.x-dev`) — an enabled bucket is rejected
+  only when `rate > capacity`, so `capacity: 1`, `rate: 1` and an enabled `capacity: 0`, `rate: 0` are both accepted.
+  For pausing a lane, see
+  [Distinguish an intentional pause from a misconfiguration](#distinguish-an-intentional-pause-from-a-misconfiguration).
+  - This basically means that a hard pause of the lane, with absolutely `0` tokens being transferable, is allowed.
+- **Pools reporting versions before 1.6.1** — an enabled bucket is rejected when `rate >= capacity` or when `rate == 0`.
+  A configuration of `capacity: 1`, `rate: 1` reverts. Use at least `capacity: 2`, `rate: 1` on these releases. (Version
+  strings here are `1.5.1` or lower: a pool built from the 1.6.0 contracts release reports `1.5.1`.)
+
+</Aside>
+
+## Critical
+
+### Secure the roles that control your token and pools
+
+The token administrator, the token pool owner, and any address holding mint or burn rights can change how your token
+moves across chains. Each of these roles is held by whatever address you assign to it: an externally owned account
+(EOA), a multi-signature smart account, or another contract.
+
+**Risk:** A single compromised private key is enough to redirect transfers, mint unbacked supply, or take control of
+your pools, with no second party able to review or veto the action before it executes.
+
+**What to do:**
+
+- Assign contract ownership, the CCIP administrator role, and mint and burn rights to a multi-signature smart account
+  such as a [Safe Smart Account](https://github.com/safe-global/safe-smart-account), using a threshold of at least
+  3-of-n, commensurate with the value at risk.
+- Add a timelock so that critical actions must be proposed, reviewed, and can be cancelled before they execute.
+- Put this structure in place at deployment: the multi-signature account and timelock should own the token, the pools,
+  and any related contracts from day one, rather than being retrofitted after launch.
+- Remove departed or compromised signers promptly, and confirm at least quarterly that every remaining signer still
+  controls their key.
+- Distribute signers so a quorum is reachable quickly during an incident, rather than concentrating them in one team,
+  location, or time zone.
+- Assign and transfer the administrator role through the TokenAdminRegistry. See
+  [Registration and Administration](/ccip/concepts/cross-chain-token/evm/registration-administration) and the
+  [TokenAdminRegistry API reference](/ccip/api-reference/evm/v1.6.1/token-admin-registry).
+- For executing configuration changes from a multi-signature account, see
+  [Executing with a Multisig](/ccip/concepts/rate-limit-management/executing-with-a-multisig) and
+  [Prerequisites and Permissions](/ccip/concepts/rate-limit-management/prerequisites-and-permissions).
+
+| Risk        | Setup                                                                                                       |
+| ----------- | ----------------------------------------------------------------------------------------------------------- |
+| 🟢 Lowest   | Multi-signature smart account (3-of-n or higher) with a timelock providing a propose, review, cancel window |
+| 🟢 Low      | Multi-signature smart account, 3-of-n or higher, without a timelock                                         |
+| 🟡 Medium   | Smart contract with unclassified governance                                                                 |
+| 🔴 High     | EOA (single private key control)                                                                            |
+| 🔴 Critical | EOA holding mint rights                                                                                     |
+
+### Keep locked supply at or above remote minted supply
+
+In a Lock and Mint architecture, tokens are locked in a LockRelease pool on the issuing chain and minted on remote
+chains. The locked balance is the only backing for that remote supply.
+
+**Risk:** If locked supply falls below the total minted across remote chains, transfers back to the issuing chain fail
+and users cannot withdraw until the shortfall is covered.
+
+**What to do:**
+
+- Continuously compare the locked balance held by the pool on the issuing chain against the sum of total supply across
+  every remote burn and mint chain.
+- Alert on the ratio between them, not only on the absolute balance, and set thresholds that trigger action well before
+  the pool is exhausted.
+- Prefer Burn and Mint on all chains where your token design allows it. It is the simplest accounting model and removes
+  this class of risk entirely. Lock and Unlock across multiple chains is the most complex and fragments liquidity.
+- See [Tokens](/ccip/concepts/cross-chain-token/evm/tokens) and the
+  [LockReleaseTokenPool API reference](/ccip/api-reference/evm/v1.6.1/lock-release-token-pool).
+
+### Configure both sides of every lane symmetrically
+
+A lane works only when both pools agree about each other. Configuration is applied independently on each chain, so the
+two sides can drift apart without any error being raised at the time of the change.
+
+**Risk:** Mismatched configuration causes transfers to revert, or to become stuck in flight until the configuration is
+corrected.
+
+**What to do:**
+
+- On the source pool, confirm the configured remote pool addresses (`getRemotePools`) resolve to the actual destination
+  pool address.
+- On the source pool, confirm the configured remote token address (`getRemoteToken`) matches the token the destination
+  pool reports (`getToken`).
+- Confirm the destination chain has a pool registered against the token in the TokenAdminRegistry (`setPool`, verified
+  with `getPool`).
+- Apply chain updates on both pools (`applyChainUpdates`), with matching chain selectors, before enabling traffic on the
+  lane.
+- See [Registration and Administration](/ccip/concepts/cross-chain-token/evm/registration-administration), the
+  [TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool), and the
+  [TokenAdminRegistry API reference](/ccip/api-reference/evm/v1.6.1/token-admin-registry).
+
+### Keep siloed lanes isolated from non-hub chains
+
+A siloed liquidity design isolates each remote chain's liquidity to a designated hub chain. Connecting a siloed lane to
+any network other than its hub breaks that isolation.
+
+**Risk:** Cross-silo connections corrupt accounting and can result in stuck transfers or loss of funds.
+
+**What to do:** Review every remote chain configured on a siloed pool and remove any chain that is not the designated
+hub, using `applyChainUpdates` with the chain selector in the removal list. See the
+[TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool).
+
+### Account for decimal differences between chains
+
+Token decimals are set independently on each chain where your token is deployed. CCIP converts amounts during transfer,
+and rate limit values are denominated in the token's smallest unit on the chain the bucket applies to.
+
+**Risk:** Mismatched decimals can cause transfers to fail, or cause a rate limit to throttle at a value orders of
+magnitude away from the one you intended to set.
+
+**What to do:**
+
+- Use matching decimals on every chain where your token is deployed whenever you can.
+- Where decimals differ, size every rate limit in the smallest unit of the chain that bucket applies to, and verify the
+  resulting value against the amount you intended.
+- See [Token Units and Decimals](/ccip/concepts/rate-limit-management/token-units-and-decimals) and
+  [Token Pools](/ccip/concepts/cross-chain-token/evm/token-pools).
+
+### Do not let source outbound capacity exceed destination inbound capacity
+
+Outbound capacity is consumed on the source chain when tokens are locked or burned. Inbound capacity is consumed on the
+destination chain when tokens are released or minted. They are separate buckets and are configured independently.
+
+**Risk:** A transfer that passes the source outbound limit but exceeds the destination inbound limit is stuck in flight
+until inbound capacity becomes available.
+
+**What to do:** Size destination inbound capacity to absorb the full outbound capacity of every source lane pointing at
+it, and re-verify the relationship after every change to either side. See
+[How Rate Limits Work](/ccip/concepts/rate-limit-management/how-rate-limits-work) and
+[Update Rate Limits](/ccip/concepts/rate-limit-management/update-rate-limits).
+
+### Enable rate limits on every production lane
+
+Token pool rate limits are the primary in-protocol control over how much value can move on a lane within a given window.
+A disabled bucket applies no volume ceiling in that direction.
+
+**Risk:** Without rate limits, a compromise elsewhere in your system can move the full transferable supply through CCIP
+before you are able to intervene.
+
+**What to do:** Enable both inbound and outbound rate limits on every production lane, and confirm the deployed values
+match what you intended. See [Rate Limit Management](/ccip/concepts/rate-limit-management/overview) and
+[Inspect Current Rate Limits](/ccip/concepts/rate-limit-management/inspect-current-rate-limits).
+
+### Prepare an emergency pause path before you need it
+
+Rate limit changes are your main lever during an incident, and they are only useful if you can execute them quickly.
+The owner path behind a multi-signature account and timelock is slow by design.
+
+**Risk:** Without a prepared fast path, pausing a lane takes as long as your slowest governance process while an
+incident drains value in minutes.
+
+**What to do:**
+
+- Give the rate limit admin role to signers who can execute within minutes. See
+  [Delegate rate limit changes to the rate limit admin role](#delegate-rate-limit-changes-to-the-rate-limit-admin-role).
+- The role can raise limits as well as lower them, so scope what your fast path can do.
+- Write the pause runbook in advance: which lanes, which values for your deployed pool version (see
+  [Distinguish an intentional pause from a misconfiguration](#distinguish-an-intentional-pause-from-a-misconfiguration)),
+  who executes, and how the decision to lift it is made.
+- Rehearse the runbook on a testnet lane regularly.
+
+## Strongly recommended
+
+### Remove stale remote pool addresses after a migration
+
+Zero-downtime pool upgrades temporarily configure more than one remote pool address for a chain so that in-flight
+messages from the previous pool can still be processed.
+
+**Risk:** A deprecated pool left configured continues to be accepted as a message source, and may contain faulty or
+unintended logic.
+
+**What to do:** Once all in-flight messages from the old pool have settled, remove the stale remote pool address with
+`removeRemotePool`. Confirm there are no pending or failed transactions referencing the old pool in the
+[CCIP Explorer](/ccip/tools-resources/ccip-explorer) before removing it. See
+[Upgradability](/ccip/concepts/cross-chain-token/evm/upgradability) and the
+[TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool).
+
+### Clear an unintended pending token administrator
+
+Transferring the token administrator role is a two-step process. Until the proposed address accepts, the transfer sits
+pending and can be accepted at any time.
+
+**Risk:** An address proposed in error, or one that is no longer trusted, can take the administrator role whenever it
+chooses.
+
+**What to do:** Cancel an unintended transfer by calling `transferAdminRole(localToken, address(0))` on the
+TokenAdminRegistry. This clears the pending administrator without changing the active one. See the
+[TokenAdminRegistry API reference](/ccip/api-reference/evm/v1.6.1/token-admin-registry).
+
+### Clear an unintended pending owner
+
+Token, token pool, and related contracts that use a two-step ownership transfer keep a proposed owner able to accept
+until the transfer is cleared.
+
+**Risk:** An address proposed in error can take ownership of the contract at any time.
+
+**What to do:** Cancel an unintended ownership transfer by re-initiating the transfer to the zero address. Audit every
+CCT-related contract you own for pending transfers, not only the pools.
+
+### Restrict burn and mint rights to the active pool
+
+Mint and burn permissions on your token determine who can change supply. In a CCIP deployment, only the active token
+pool needs them for cross-chain operation.
+
+**Risk:** Any additional address holding mint rights can create unbacked supply; any address holding burn rights can
+destroy user balances.
+
+**What to do:** Enumerate every address holding mint or burn permissions and revoke each one that is not the active
+token pool or an owner-like administrative role you have deliberately retained. Re-run this audit after every pool
+migration. See [Tokens](/ccip/concepts/cross-chain-token/evm/tokens).
+
+### Remove lanes pointing at chains the router does not support
+
+A pool can be configured with a remote chain selector that the CCIP router does not currently serve.
+
+**Risk:** The lane may appear configured while transfers revert. If that chain is later added to the router, the lane
+becomes live without a deliberate decision to enable it.
+
+**What to do:** Validate every configured chain selector against the [CCIP Directory](/ccip/directory), and remove any
+remote chain that was not intentionally configured.
+
+### Keep `destGasOverhead` consistent across lanes
+
+`destGasOverhead` covers the gas your token pool consumes on the destination chain. It is part of the token transfer
+fee configuration that CCIP maintains for your token; for current pool versions, non-default values are applied by
+Chainlink Labs on your behalf. Using a non-default value is justified only when your pool or token costs more to
+execute.
+
+**Risk:** An insufficient value causes transfers to fail automatic execution and require manual execution. An
+unnecessarily high value causes users to overpay. Inconsistent values across lanes pointing at the same destination
+usually indicate a configuration error.
+
+**What to do:**
+
+- Test that token transfers execute automatically on every configured lane before going to production.
+- Include first-time receivers in that test — an account that has never held your token can cost more gas.
+- Use consistent values across lanes pointing at the same destination unless you have a documented reason not to.
+- See [Token Pools](/ccip/concepts/cross-chain-token/evm/token-pools) and
+  [Network Specific](/ccip/tools-resources/network-specific).
+
+### Give inbound capacity headroom over outbound
+
+Matching destination inbound capacity exactly to source outbound capacity leaves no margin. While a transfer is in
+flight, the destination bucket is also being consumed by other traffic and refilling at its own rate.
+
+**Risk:** Transfers that arrive without enough inbound capacity require manual execution, or wait for the bucket to
+refill before they can be executed.
+
+**What to do:** Set destination inbound capacity above the corresponding source outbound capacity, sized against the
+destination refill rate and the latency of the lane. See
+[Common Scenarios](/ccip/concepts/rate-limit-management/common-scenarios).
+
+### Tune the refill rate for both availability and throttling
+
+The refill rate determines how quickly a bucket returns to full capacity after being consumed.
+
+**Risk:** A refill rate that is too slow blocks legitimate transfers for extended periods. One that is too fast fails to
+throttle abnormal flows.
+
+**What to do:** Choose a refill rate that restores capacity fast enough for normal user activity but slow enough to
+constrain a sustained abnormal flow. Treat any starting point as an initial value to be revised: monitor transfer
+success rates and observed volume, and adjust as your traffic patterns become established. See
+[Common Scenarios](/ccip/concepts/rate-limit-management/common-scenarios) and
+[How Rate Limits Work](/ccip/concepts/rate-limit-management/how-rate-limits-work).
+
+### Distinguish an intentional pause from a misconfiguration
+
+A lane is paused through its rate limits, and a paused lane is also what an accidental misconfiguration looks like.
+Pause deliberately and record it.
+
+**Risk:** An accidental pause blocks users indefinitely, and a pause applied with the wrong values either fails to stop
+transfers or removes rate limiting entirely.
+
+**What to do:**
+
+- On pools reporting `1.6.1` or later, pause a lane by setting `isEnabled: true`, `capacity: 0`, `rate: 0` on the
+  affected direction via `setChainRateLimiterConfig` (or `setChainRateLimiterConfigs` for several lanes at once). This
+  blocks all transfers in that direction — an inbound pause intentionally holds in-flight transfers — until you restore
+  normal values.
+- On these same pools, do not set `rate: 0` with a non-zero capacity: validation accepts it, but once the bucket
+  depletes, transfers fail with an arithmetic panic instead of a clean rate-limit error.
+- Keep `isEnabled: true` when pausing. A disabled bucket (which requires `capacity: 0`, `rate: 0`) turns rate limiting
+  off entirely.
+- On pools reporting versions before `1.6.1`, a full stop through rate limits is not possible: use the smallest
+  accepted configuration, `capacity: 2`, `rate: 1`, and account for the small trickle that remains possible, which can
+  be material for tokens with few decimals.
+- Record every intentional pause, including who applied it and the condition for lifting it, and review paused lanes on
+  a fixed interval.
+
+See [Emergency Actions](/ccip/concepts/rate-limit-management/emergency-actions).
+
+### Review network-specific requirements before enabling a chain
+
+Some networks have configuration requirements, gas behavior, RPC characteristics, or service limits that differ from
+the defaults.
+
+**Risk:** A configuration that is correct on one chain can cause failed execution or an outage on another.
+
+**What to do:** Read the guidance for each network before you enable a lane to it. See
+[Network Specific](/ccip/tools-resources/network-specific) and [Service Limits](/ccip/service-limits/evm).
+
+### Settle in-flight transfers before reducing inbound capacity
+
+Reducing a destination inbound capacity affects messages that are already in flight toward that chain, not only future
+ones.
+
+**Risk:** In-flight transfers whose amounts exceed the new inbound capacity stall until an administrator intervenes or
+capacity refills.
+
+**What to do:**
+
+1. Set the new outbound capacities on the source chains first.
+2. Check the [CCIP Explorer](/ccip/tools-resources/ccip-explorer) for in-flight messages whose amounts exceed the
+   inbound capacities you intend to set.
+3. Wait for those transfers to settle on their destination chains.
+4. Then reduce the inbound capacities.
+
+See [Update Rate Limits](/ccip/concepts/rate-limit-management/update-rate-limits).
+
+### Run the latest available TokenPool release
+
+Older TokenPool releases have limitations in decimal handling, rate limit enforcement, and upgradeability. Pools
+predating v1.5 add further complexity to configuration and management.
+
+**Risk:** Operating on an older release exposes you to resolved issues and makes some remediation steps unavailable.
+
+**What to do:** Confirm what you are running with `typeAndVersion()` on each pool, compare against the published
+releases of [`@chainlink/contracts-ccip`](https://www.npmjs.com/package/@chainlink/contracts-ccip?activeTab=versions),
+and upgrade when feasible. The on-chain version string does not always match the package release: a pool built from
+the `1.6.0` release reports `1.5.1`, and some releases report development stamps such as `1.6.x-dev`. See
+[Upgradability](/ccip/concepts/cross-chain-token/evm/upgradability).
+
+### Shut down lanes that carry little or no traffic
+
+Every enabled lane is an active path into and out of your token.
+
+**Risk:** An unused lane contributes no benefit while remaining available during an incident on either of the chains it
+connects.
+
+**What to do:** Review traffic per lane periodically and remove remote chains serving lanes that do not justify the
+exposure. Where possible, consolidate toward a hub-and-spoke topology rather than connecting every chain to every
+other chain.
+
+### Delegate rate limit changes to the rate limit admin role
+
+The token pool owner can assign a separate rate limit admin (`setRateLimitAdmin`), an address permitted to change rate
+limits but nothing else about the pool configuration.
+
+**Risk:** Rate limit changes are made relatively often, including under time pressure during an incident. Performing
+them with the pool owner key exposes your highest-privilege credential to routine use.
+
+**What to do:** Assign the rate limit admin role to a dedicated multi-party signer, or to a contract if you want to
+constrain it further to specific pre-defined adjustments. Keep the pool owner key reserved for changes that require
+it. See the [TokenPool API reference](/ccip/api-reference/evm/v1.6.1/token-pool) and
+[Prerequisites and Permissions](/ccip/concepts/rate-limit-management/prerequisites-and-permissions).
+
+## Get help
+
+If you are assessing an existing CCT deployment, or want a second opinion on your authority structure or rate limit
+configuration, [contact Chainlink Labs](https://chain.link/ccip-contact). For the division of
+responsibilities between token developers, application developers, and Chainlink, see
+[CCIP Service Responsibility](/ccip/service-responsibility).


### PR DESCRIPTION
1. Added a new operational Security page to address content gaps flagged by PMs and GTMs