### PR TITLE
Docs site: Hero image + Link anchoring fix

### DIFF
--- a/src/components/ClickToZoom.astro
+++ b/src/components/ClickToZoom.astro
@@ -11,7 +11,7 @@ const { src, alt, style, caption } = Astro.props as Props
 ---
 
 <div class="click-to-zoom-container">
-  <ClickToZoomCustom src={src} alt={alt} style={style} caption={caption} client:only="react" />
+  <ClickToZoomCustom src={src} alt={alt} style={style} caption={caption} client:load />
 </div>
 
 <style>

--- a/src/components/HeadSEO.astro
+++ b/src/components/HeadSEO.astro
@@ -29,7 +29,7 @@ const description = metadata?.description ?? SITE.description
 const baseExcerpt = metadata?.excerpt ?? description
 
 // Check that the metadata image property exists, else use OPEN_GRAPH.image.src
-var canonicalImageSrc = OPEN_GRAPH.image.src
+var canonicalImageSrc = toAbsoluteUrl(OPEN_GRAPH.image.src, Astro.site)
 let ogImageType = "image/png"
 let ogImageAlt = OPEN_GRAPH.image.alt
 if (metadata?.image) {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -37,6 +37,12 @@ const canonicalURL = new URL(canonicalURLStr)
     {structuredData && <StructuredData data={structuredData} />}
     <style>
       html {
+        scroll-behavior: auto;
+      }
+      /* Enabled by prepareSections() once the initial hash scroll has been corrected,
+         so the first jump-to-fragment on page load is instant but later in-page
+         navigation (e.g. TOC clicks) is still animated. */
+      html.smooth-scroll {
         scroll-behavior: smooth;
       }
     </style>

--- a/src/scripts/prepArticleContent.ts
+++ b/src/scripts/prepArticleContent.ts
@@ -88,6 +88,20 @@ const prepareSection = (e: Element) => {
   return wrapSection(e)
 }
 
+// The browser resolves the URL fragment scroll before this script wraps headers in
+// <section> elements, so the page reflows (sticky headers, section padding) after the
+// initial scroll already landed. Re-align once the DOM has settled.
+const restoreScrollToHash = () => {
+  if (!window.location.hash) return
+  let target: Element | null = null
+  try {
+    target = document.getElementById(decodeURIComponent(window.location.hash.slice(1)))
+  } catch {
+    return
+  }
+  target?.scrollIntoView({ behavior: "instant" as ScrollBehavior, block: "start" })
+}
+
 /**
  * Performs all transformations on top-level article headers
  *
@@ -100,4 +114,5 @@ export const prepareSections = () => {
   while (start) {
     start = prepareSection(start)
   }
+  restoreScrollToHash()
 }

--- a/src/scripts/prepArticleContent.ts
+++ b/src/scripts/prepArticleContent.ts
@@ -115,4 +115,5 @@ export const prepareSections = () => {
     start = prepareSection(start)
   }
   restoreScrollToHash()
+  document.documentElement.classList.add("smooth-scroll")
 }


### PR DESCRIPTION
This pull request introduces improvements to how images and in-page navigation are handled on the site. The most significant changes ensure that Open Graph images use absolute URLs and that in-page anchor navigation correctly scrolls to the intended section even after dynamic DOM manipulation.

**SEO and Open Graph image handling:**
- Changed the assignment of `canonicalImageSrc` in `HeadSEO.astro` to use `toAbsoluteUrl`, ensuring that the Open Graph image always has an absolute URL.

**In-page anchor navigation fixes:**
- Added a new function `restoreScrollToHash` in `prepArticleContent.ts` to re-align the scroll position to the correct section after headers are wrapped in `<section>` elements, fixing issues with sticky headers and section padding after initial navigation.
- Called `restoreScrollToHash()` at the end of `prepareSections` to ensure the scroll position is corrected once DOM transformations are complete.