### PR TITLE
Data Streams: Deprecation visibility improvements

### DIFF
--- a/src/features/feeds/components/Tables.tsx
+++ b/src/features/feeds/components/Tables.tsx
@@ -1385,8 +1385,11 @@ const streamsCategoryMap = {
 }
 
 export const StreamsTr = ({ metadata, isMainnet, showRiskColumn = isMainnet }) => {
-  const finalTier = metadata.finalCategory
   const isDeprecating = !!metadata.docs?.shutdownDate
+  // Deprecating streams always show the deprecating category, even when the
+  // stream is rendered from a path that doesn't enrich finalCategory (e.g. the
+  // deprecating streams page) or when no Supabase risk tier is available.
+  const finalTier = isDeprecating ? "deprecating" : metadata.finalCategory
   const hideFeedId = shouldHideStreamFeedId(metadata)
 
   // Temporary calculated stream detection until proper metadata tagging is implemented

--- a/src/scripts/data/detect-new-data.ts
+++ b/src/scripts/data/detect-new-data.ts
@@ -61,11 +61,6 @@ const STREAM_DEPRECATION_ENDPOINTS: Array<{ network: string; networkType: "mainn
     networkType: "mainnet",
     url: "https://reference-data-directory.vercel.app/feeds-ethereum-mainnet-arbitrum-1.json",
   },
-  {
-    network: "arbitrum",
-    networkType: "testnet",
-    url: "https://reference-data-directory.vercel.app/feeds-ethereum-testnet-sepolia-arbitrum-1.json",
-  },
 ]
 
 // Path to the baseline JSON file that contains known feed IDs


### PR DESCRIPTION
This pull request introduces a fix to how deprecating streams are categorized in the UI and removes an unused testnet endpoint from the stream deprecation detection script. The main goal is to ensure that deprecating streams are always clearly marked as such, even if certain metadata is missing, and to clean up unnecessary configuration.

**Deprecating Streams Handling:**

* Updated the logic in `StreamsTr` (in `Tables.tsx`) so that streams marked as deprecating are always assigned the "deprecating" category, regardless of the source of their metadata. This ensures consistent labeling for deprecating streams in the UI.

**Script Cleanup:**

* Removed the Arbitrum testnet endpoint from the `STREAM_DEPRECATION_ENDPOINTS` array in `detect-new-data.ts`, as it was not needed.