### PR TITLE
CRE: CLI 1.32 Release Notes

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -730,6 +730,13 @@
     },
     {
       "category": "release",
+      "date": "2026-09-03",
+      "description": "CRE CLI version 1.32.0 is now available. This release fixes bugs that could cause `cre login` to fail, makes Windows installation safer by verifying the downloaded CLI is authentic before installing, and includes updates to Solana workflow support.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.31.0...v1.32.0)",
+      "title": "CRE CLI v1.32.0 — Login Fixes, Safer Windows Installation, and Solana Updates",
+      "topic": "CRE"
+    },
+    {
+      "category": "release",
       "date": "2026-08-27",
       "description": "CRE CLI version 1.31.0 is now available. This release includes reliability improvements for Solana workflows in CRE.\n\nUpdate your CLI by running `cre update` when prompted, or follow the [CLI Installation guide](https://docs.chain.link/cre/getting-started/cli-installation) for fresh installations.\n\n[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.30.0...v1.31.0)",
       "title": "CRE CLI v1.31.0 — Improved Solana Workflow Stability",

--- a/src/config/versions/index.ts
+++ b/src/config/versions/index.ts
@@ -77,8 +77,9 @@ export const VERSIONS = {
   },
   // CRE CLI Versions — update LATEST here for each new release
   "cre-cli": {
-    LATEST: "v1.31.0",
+    LATEST: "v1.32.0",
     ALL: [
+      "v1.32.0",
       "v1.31.0",
       "v1.30.0",
       "v1.29.0",
@@ -105,6 +106,7 @@ export const VERSIONS = {
       "v1.8.0",
     ] as const,
     RELEASE_DATES: {
+      "v1.32.0": "2026-09-03T00:00:00Z",
       "v1.31.0": "2026-08-27T00:00:00Z",
       "v1.30.0": "2026-08-13T00:00:00Z",
       "v1.29.0": "2026-08-07T00:00:00Z",

--- a/src/content/cre/llms-full-go.txt
+++ b/src/content/cre/llms-full-go.txt
@@ -534,9 +534,24 @@ To help us assist you faster, please include:
 
 # Release Notes
 Source: https://docs.chain.link/cre/release-notes
-Last Updated: 2026-08-28
+Last Updated: 2026-09-03
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.32.0 - September 3, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.32.0" target="_blank">CRE CLI version 1.32.0</a> is now available.**
+
+- **Improved login reliability**: Fixed bugs that could cause `cre login` to fail or leave the CLI in an inconsistent state.
+- **Safer Windows installation**: The Windows PowerShell installer now checks that the downloaded CLI is authentic and untampered before installing it.
+- **Solana workflow updates**: This release includes updates to Solana workflow support.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.31.0...v1.32.0)
 
 ## CLI v1.31.0 - August 27, 2026
 

--- a/src/content/cre/llms-full-ts.txt
+++ b/src/content/cre/llms-full-ts.txt
@@ -534,9 +534,24 @@ To help us assist you faster, please include:
 
 # Release Notes
 Source: https://docs.chain.link/cre/release-notes
-Last Updated: 2026-08-28
+Last Updated: 2026-09-03
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.32.0 - September 3, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.32.0" target="_blank">CRE CLI version 1.32.0</a> is now available.**
+
+- **Improved login reliability**: Fixed bugs that could cause `cre login` to fail or leave the CLI in an inconsistent state.
+- **Safer Windows installation**: The Windows PowerShell installer now checks that the downloaded CLI is authentic and untampered before installing it.
+- **Solana workflow updates**: This release includes updates to Solana workflow support.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.31.0...v1.32.0)
 
 ## CLI v1.31.0 - August 27, 2026
 

--- a/src/content/cre/release-notes.mdx
+++ b/src/content/cre/release-notes.mdx
@@ -5,12 +5,27 @@ date: Last Modified
 metadata:
   description: "Discover what's new in CRE: latest features, changes, and improvements in each release of the Chainlink Runtime Environment."
   datePublished: "2025-11-04"
-  lastModified: "2026-08-28"
+  lastModified: "2026-09-03"
 ---
 
 import { Aside } from "@components"
 
 This page provides detailed release notes for CRE. It includes information on new features, significant changes, and known limitations.
+
+## CLI v1.32.0 - September 3, 2026
+
+**<a href="https://github.com/smartcontractkit/cre-cli/releases/tag/v1.32.0" target="_blank">CRE CLI version 1.32.0</a> is now available.**
+
+- **Improved login reliability**: Fixed bugs that could cause `cre login` to fail or leave the CLI in an inconsistent state.
+- **Safer Windows installation**: The Windows PowerShell installer now checks that the downloaded CLI is authentic and untampered before installing it.
+- **Solana workflow updates**: This release includes updates to Solana workflow support.
+
+**How to update:**
+
+- **Automatic update**: When you run any CRE command, the CLI will automatically detect if a newer version is available and prompt you to update. Simply run `cre update` to install the latest version.
+- **Fresh installation**: If you're installing the CLI for the first time, follow the [CLI Installation guide](/cre/getting-started/cli-installation).
+
+[See all changes on GitHub](https://github.com/smartcontractkit/cre-cli/compare/v1.31.0...v1.32.0)
 
 ## CLI v1.31.0 - August 27, 2026
 


### PR DESCRIPTION
This pull request adds documentation and configuration updates for the release of CRE CLI version 1.32.0. The changes announce the new version, highlight its key improvements, and update version tracking throughout the codebase.

Release notes and documentation updates:

* Added release notes for CRE CLI v1.32.0 to `src/content/cre/release-notes.mdx`, `src/content/cre/llms-full-go.txt`, and `src/content/cre/llms-full-ts.txt`, describing improved login reliability, safer Windows installation, and Solana workflow updates. [[1]](diffhunk://#diff-8f255833e502c901bafae6bf2a2dc1c1e3b950451989d8c88c006351d8ddf444L8-R29) [[2]](diffhunk://#diff-d21697112052d15dcee26004076b4b48eb96c1916ed16b4db9c7d1b12fee7edeL537-R555) [[3]](diffhunk://#diff-00897a240c0bf02a67ac3a2d735b7487f8941cec8a3085d3818e52d1801116e4L537-R555)
* Updated the changelog in `public/changelog.json` to include the v1.32.0 release entry.

Version configuration updates:

* Set `cre-cli` LATEST version to `v1.32.0`, added it to the version list, and recorded its release date in `src/config/versions/index.ts`. [[1]](diffhunk://#diff-11892e6b40841ca0f483f57267775d1ae2ccf579daa451f843c66de7f1558b3aL80-R82) [[2]](diffhunk://#diff-11892e6b40841ca0f483f57267775d1ae2ccf579daa451f843c66de7f1558b3aR109)

Meta-data update:

* Updated the `lastModified` date in `src/content/cre/release-notes.mdx` to reflect the new release.