### PR TITLE
Data Feeds: shared svr backup detection

### DIFF
--- a/src/features/feeds/components/Tables.tsx
+++ b/src/features/feeds/components/Tables.tsx
@@ -552,9 +552,9 @@ const DefaultTr = ({
                 href="/data-feeds/svr-feeds"
                 target="_blank"
                 className={tableStyles.feedVariantBadge}
-                title={`${getSvrType(metadata)} Feed`}
+                title={`${getSvrType(metadata, network)} Feed`}
               >
-                {getSvrType(metadata)}
+                {getSvrType(metadata, network)}
               </a>
             </div>
           )}
@@ -697,7 +697,7 @@ const DefaultTr = ({
                 <div className={tableStyles.separator} />
                 <div className={tableStyles.assetAddress}>
                   <dt>
-                    <span className="label">{getSvrType(metadata)} Proxy:</span>
+                    <span className="label">{getSvrType(metadata, network)} Proxy:</span>
                   </dt>
                   <dd>
                     {hideAddress ? (
@@ -1716,10 +1716,10 @@ export const MainnetTable = ({
   const typeFilteredMetadata = useMemo(() => {
     if (!isSvr || !svrTypeFilters || svrTypeFilters.size === 0) return filteredMetadata
     return filteredMetadata.filter((m) => {
-      const svrType = getSvrType(m)
+      const svrType = getSvrType(m, network)
       return svrType && !svrTypeFilters.has(svrType)
     })
-  }, [filteredMetadata, isSvr, svrTypeFilters])
+  }, [filteredMetadata, isSvr, svrTypeFilters, network])
 
   const slicedFilteredMetadata = typeFilteredMetadata.slice(firstAddr, lastAddr)
 

--- a/src/features/feeds/utils/svrDetection.ts
+++ b/src/features/feeds/utils/svrDetection.ts
@@ -66,11 +66,40 @@ export const isAaveSVR = (metadata: ChainMetadata): boolean => {
 }
 
 /**
- * Returns the SVR feed type label for a given feed metadata.
+ * Determines whether a network has at least one new shared SVR feed
+ * (path ends with "-shared-svr-2"). When a network has both versions,
+ * the legacy "-shared-svr" feeds are considered backups.
  */
-export const getSvrType = (metadata: ChainMetadata): SvrFeedType | null => {
+export const networkHasNewSharedSVR = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  network: any
+): boolean => {
+  return (
+    network?.metadata?.some(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (feed: any) => isNewSharedSVR(feed)
+    ) ?? false
+  )
+}
+
+/**
+ * Returns the SVR feed type label for a given feed metadata.
+ *
+ * Classification is network-aware: a "-shared-svr" feed is only labeled
+ * "SVR-Backup" when the network also has a "-shared-svr-2" feed. On networks
+ * that only have "-shared-svr" feeds (e.g. BNB, Arbitrum, Monad), those feeds
+ * are the canonical SVR feeds and are labeled "SVR".
+ */
+export const getSvrType = (
+  metadata: ChainMetadata,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  network?: any
+): SvrFeedType | null => {
   if (!metadata?.secondaryProxyAddress) return null
   if (isNewSharedSVR(metadata)) return "SVR"
-  if (isSharedSVR(metadata)) return "SVR-Backup"
+  if (isSharedSVR(metadata)) {
+    // Only treat as backup when the network also has a new shared SVR feed.
+    return networkHasNewSharedSVR(network) ? "SVR-Backup" : "SVR"
+  }
   return "Aave-SVR"
 }


### PR DESCRIPTION
This pull request updates the logic for labeling SVR feed types to be network-aware and ensures that UI components display the correct SVR type based on the network context. The main changes include updating the `getSvrType` utility to accept a `network` parameter, adding a helper to detect new shared SVR feeds, and updating all usages to pass the network as needed.

**SVR Feed Type Classification Improvements:**

* [`src/features/feeds/utils/svrDetection.ts`](diffhunk://#diff-0871950638fd334f799fb717b44d01df890e2d414d9b6c12b232c24f893c34dbR68-R103): Updated `getSvrType` to accept a `network` parameter and classify "-shared-svr" feeds as "SVR-Backup" only if the network also has a "-shared-svr-2" feed. Added a new helper `networkHasNewSharedSVR` to detect this condition.

**UI Updates for Accurate Feed Labeling:**

* [`src/features/feeds/components/Tables.tsx`](diffhunk://#diff-ef3526edcbc07ee07216ef3f69138a4fcf75429e5783f0a1ce8f4fb960c82904L555-R557): Updated all usages of `getSvrType` in the UI (`DefaultTr` and `MainnetTable`) to pass the `network` parameter, ensuring that SVR type labels and tooltips reflect the correct classification based on network context. Also updated the dependency array in `useMemo` to include `network`. [[1]](diffhunk://#diff-ef3526edcbc07ee07216ef3f69138a4fcf75429e5783f0a1ce8f4fb960c82904L555-R557) [[2]](diffhunk://#diff-ef3526edcbc07ee07216ef3f69138a4fcf75429e5783f0a1ce8f4fb960c82904L700-R700) [[3]](diffhunk://#diff-ef3526edcbc07ee07216ef3f69138a4fcf75429e5783f0a1ce8f4fb960c82904L1719-R1722)