### PR TITLE
Data Feeds: Arc mainnet integration

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -407,6 +407,14 @@
   },
   "data": [
     {
+      "category": "integration",
+      "date": "2026-09-09",
+      "description": "Chainlink Data Feeds is available on Arc Mainnet. View the available price feed information on the [Price Feed Addresses](https://docs.chain.link/data-feeds/price-feeds/addresses?network=arc&page=1) page.",
+      "relatedNetworks": ["arc"],
+      "title": "Data Feeds Expands to Arc Mainnet",
+      "topic": "Data Feeds"
+    },
+    {
       "category": "deprecation",
       "date": "2026-09-08",
       "description": "CCIP is no longer supported on Bitlayer Testnet.",

--- a/src/components/QuickLinks/data/productChainLinks.ts
+++ b/src/components/QuickLinks/data/productChainLinks.ts
@@ -147,6 +147,7 @@ export const productChainLinks: ProductChainLinks = {
     chains: {
       aptos: "/data-feeds/price-feeds/addresses?page=1&network=aptos#networks",
       arbitrum: "/data-feeds/price-feeds/addresses?page=1&network=arbitrum#networks",
+      arc: "/data-feeds/price-feeds/addresses?page=1&network=arc#networks",
       avalanche: "/data-feeds/price-feeds/addresses?page=1&network=avalanche#networks",
       base: "/data-feeds/price-feeds/addresses?page=1&network=base#networks",
       "bnb-chain": "/data-feeds/price-feeds/addresses?page=1&network=bnb-chain#networks",

--- a/src/features/data/chains.ts
+++ b/src/features/data/chains.ts
@@ -109,6 +109,26 @@ export const CHAINS: Chain[] = [
     ],
   },
   {
+    page: "arc",
+    title: "Arc Data Feeds",
+    img: "/assets/chains/arc.svg",
+    networkStatusUrl: "https://status.arc.network/",
+    tags: ["default", "smartData"],
+    supportedFeatures: ["feeds"],
+    networks: [
+      {
+        name: "Arc Mainnet",
+        explorerUrl: "https://www.arcexplorer.org/address/%s",
+        networkType: "mainnet",
+        rddUrl: "https://reference-data-directory.vercel.app/feeds-arc-mainnet.json",
+        rddBundleUrl: "https://reference-data-directory.vercel.app/bundle-proxies-arc-mainnet.json",
+        queryString: "arc-mainnet",
+        tags: ["smartData"],
+      },
+    ],
+    label: "Arc",
+  },
+  {
     page: "avalanche",
     title: "Avalanche Data Feeds",
     img: "/assets/chains/avalanche.svg",

--- a/src/scripts/data/detect-new-data.ts
+++ b/src/scripts/data/detect-new-data.ts
@@ -53,6 +53,7 @@ const NETWORK_ENDPOINTS: Record<string, string> = {
   megaeth: "https://reference-data-directory.vercel.app/feeds-megaeth-mainnet.json",
   robinhood: "https://reference-data-directory.vercel.app/feeds-robinhood-mainnet.json",
   tempo: "https://reference-data-directory.vercel.app/feeds-tempo-mainnet.json",
+  arc: "https://reference-data-directory.vercel.app/feeds-arc-mainnet.json",
 }
 
 const STREAM_DEPRECATION_ENDPOINTS: Array<{ network: string; networkType: "mainnet" | "testnet"; url: string }> = [


### PR DESCRIPTION
This pull request adds support for the Arc network and its data feeds throughout the application. The main changes include updating the relevant configuration files and links to include Arc, as well as adding a changelog entry to announce the availability of Chainlink Data Feeds on Arc Mainnet.

**Arc network integration:**

* Added Arc network details to the `CHAINS` array, including display name, icon, status URL, and network configuration for Arc Mainnet. (`src/features/data/chains.ts`)
* Included Arc network endpoints in the `NETWORK_ENDPOINTS` mapping for data feed detection. (`src/scripts/data/detect-new-data.ts`)
* Updated `productChainLinks` to provide a quick link to Arc's price feeds address page. (`src/components/QuickLinks/data/productChainLinks.ts`)

**Changelog update:**

* Added a new changelog entry announcing the expansion of Chainlink Data Feeds to Arc Mainnet, with a link to the relevant documentation. (`public/changelog.json`)