### PR TITLE
Data Feeds: aligned notes and badges for svr detection

### DIFF
--- a/src/features/feeds/components/Tables.tsx
+++ b/src/features/feeds/components/Tables.tsx
@@ -18,13 +18,7 @@ import {
 import type { MarketPricingRiskProduct } from "../content/marketPricingRiskTerms.ts"
 import { REPORT_SCHEMA_DEFINITIONS, type SchemaDefinition } from "./reportSchemaData.ts"
 import schemaFieldsTableStyles from "../../data-streams/common/schemaFieldsTable.module.css"
-import {
-  isSharedSVR,
-  isAaveSVR,
-  isNewSharedSVR,
-  getSvrType,
-  type SvrFeedType,
-} from "~/features/feeds/utils/svrDetection.ts"
+import { getSvrType, type SvrFeedType } from "~/features/feeds/utils/svrDetection.ts"
 import { ExpandableTableWrapper } from "./ExpandableTableWrapper.tsx"
 import {
   shouldHideAddress,
@@ -730,7 +724,7 @@ const DefaultTr = ({
                     )}
                   </dd>
                 </div>
-                {isAaveSVR(metadata) && !hideAddress && (
+                {getSvrType(metadata, network) === "Aave-SVR" && !hideAddress && (
                   <div className={clsx(tableStyles.aaveCallout)}>
                     <strong>⚠️ Aave Dedicated Feed:</strong> This SVR proxy feed is dedicated exclusively for use by the
                     Aave protocol. Learn more about{" "}
@@ -740,7 +734,7 @@ const DefaultTr = ({
                     .
                   </div>
                 )}
-                {isNewSharedSVR(metadata) && !hideAddress && (
+                {getSvrType(metadata, network) === "SVR" && !hideAddress && (
                   <div className={clsx(tableStyles.sharedCallout)}>
                     <strong>🔗 SVR Feed:</strong> This SVR proxy feed is usable by any protocol. Learn more about{" "}
                     <a href="/data-feeds/svr-feeds" target="_blank">
@@ -749,7 +743,7 @@ const DefaultTr = ({
                     .
                   </div>
                 )}
-                {isSharedSVR(metadata) && !hideAddress && (
+                {getSvrType(metadata, network) === "SVR-Backup" && !hideAddress && (
                   <div className={clsx(tableStyles.sharedCallout)}>
                     <strong>🔗 SVR-Backup Feed:</strong> This is a legacy SVR proxy feed. New integrations should use
                     the <strong>SVR</strong> feeds. Learn more about{" "}


### PR DESCRIPTION
This pull request refactors how SVR feed types are detected and displayed in the `Tables.tsx` component. The main change is consolidating multiple specific SVR detection functions into a single call to `getSvrType`, which improves code maintainability and clarity. The logic for rendering SVR-related callouts is now based on the return value of `getSvrType` rather than individual helper functions.

SVR feed detection refactor:

* Removed the imports for `isSharedSVR`, `isAaveSVR`, and `isNewSharedSVR` from `svrDetection.ts`, keeping only `getSvrType` and `SvrFeedType`.
* Updated the rendering logic in `DefaultTr` to use `getSvrType(metadata, network)` for determining SVR feed types ("Aave-SVR", "SVR", "SVR-Backup") instead of the previous helper functions. [[1]](diffhunk://#diff-ef3526edcbc07ee07216ef3f69138a4fcf75429e5783f0a1ce8f4fb960c82904L733-R727) [[2]](diffhunk://#diff-ef3526edcbc07ee07216ef3f69138a4fcf75429e5783f0a1ce8f4fb960c82904L743-R737) [[3]](diffhunk://#diff-ef3526edcbc07ee07216ef3f69138a4fcf75429e5783f0a1ce8f4fb960c82904L752-R746)