### PR TITLE
Data Feeds: arc explorer update

### DIFF
--- a/src/features/data/chains.ts
+++ b/src/features/data/chains.ts
@@ -118,7 +118,7 @@ export const CHAINS: Chain[] = [
     networks: [
       {
         name: "Arc Mainnet",
-        explorerUrl: "https://www.arcexplorer.org/address/%s",
+        explorerUrl: "https://explorer.arc.io/address/%s",
         networkType: "mainnet",
         rddUrl: "https://reference-data-directory.vercel.app/feeds-arc-mainnet.json",
         rddBundleUrl: "https://reference-data-directory.vercel.app/bundle-proxies-arc-mainnet.json",


### PR DESCRIPTION
This pull request makes a small update to the Arc Mainnet network configuration in the `CHAINS` array. The change updates the block explorer URL to point to the correct address.

* Updated the `explorerUrl` for the Arc Mainnet network from `https://www.arcexplorer.org/address/%s` to `https://explorer.arc.io/address/%s` in `src/features/data/chains.ts`