### PR TITLE
Update Onchain Write Overview link in documentation

### DIFF
--- a/src/content/cre/guides/workflow/using-evm-client/onchain-write/submitting-reports-onchain.mdx
+++ b/src/content/cre/guides/workflow/using-evm-client/onchain-write/submitting-reports-onchain.mdx
@@ -307,7 +307,7 @@ See the [CLI Reference](/cre/reference/cli/workflow#cre-workflow-simulate) for m
 
 ## Learn more
 
-- **[Onchain Write Overview](/cre/guides/workflow/using-evm-client/onchain-write)**: Understand all onchain write approaches
+- **[Onchain Write Overview](/cre/guides/workflow/using-evm-client/onchain-write/overview-go)**: Understand all onchain write approaches
 - **[Using WriteReportFrom Helpers](/cre/guides/workflow/using-evm-client/onchain-write/using-write-report-helpers)**: Use the simpler all-in-one helper for struct submission
 - **[Generating Reports: Single Values](/cre/guides/workflow/using-evm-client/onchain-write/generating-reports-single-values)**: Generate reports for single primitive values
 - **[Generating Reports: Structs](/cre/guides/workflow/using-evm-client/onchain-write/generating-reports-structs)**: Generate reports for struct data


### PR DESCRIPTION
## Closing issues

closes #4154 

## Description

Replaces the `/cre/guides/workflow/using-evm-client/onchain-write` link at the bottom with the `/cre/guides/workflow/using-evm-client/onchain-write/overview-go` file 
 
## Changes 
 
 Solves the 404 page not found error reported on 4154. 
- No longer points to a folder 
- points to the onchain-write overview 