### PR TITLE
Fix remote pool addresses in CCT Burn & Mint fork tutorial

### DIFF
--- a/src/content/chainlink-local/build/ccip/foundry/cct-burn-and-mint-fork.mdx
+++ b/src/content/chainlink-local/build/ccip/foundry/cct-burn-and-mint-fork.mdx
@@ -438,11 +438,11 @@ contract CCIPv1_5BurnMintPoolFork is Test {
 
     vm.startPrank(alice);
     TokenPool.ChainUpdate[] memory chains = new TokenPool.ChainUpdate[](1);
-    bytes[] memory remotePoolAddressesEthSepolia = new bytes[](1);
-    remotePoolAddressesEthSepolia[0] = abi.encode(address(burnMintTokenPoolEthSepolia));
+    bytes[] memory remotePoolAddressesBaseSepolia = new bytes[](1);
+    remotePoolAddressesBaseSepolia[0] = abi.encode(address(burnMintTokenPoolBaseSepolia));
     chains[0] = TokenPool.ChainUpdate({
       remoteChainSelector: baseSepoliaNetworkDetails.chainSelector,
-      remotePoolAddresses: remotePoolAddressesEthSepolia,
+      remotePoolAddresses: remotePoolAddressesBaseSepolia,
       remoteTokenAddress: abi.encode(address(mockERC20TokenBaseSepolia)),
       outboundRateLimiterConfig: RateLimiter.Config({ isEnabled: true, capacity: 100_000, rate: 167 }),
       inboundRateLimiterConfig: RateLimiter.Config({ isEnabled: true, capacity: 100_000, rate: 167 })
@@ -466,11 +466,11 @@ contract CCIPv1_5BurnMintPoolFork is Test {
 
     vm.startPrank(alice);
     chains = new TokenPool.ChainUpdate[](1);
-    bytes[] memory remotePoolAddressesBaseSepolia = new bytes[](1);
-    remotePoolAddressesBaseSepolia[0] = abi.encode(address(burnMintTokenPoolEthSepolia));
+    bytes[] memory remotePoolAddressesEthSepolia = new bytes[](1);
+    remotePoolAddressesEthSepolia[0] = abi.encode(address(burnMintTokenPoolEthSepolia));
     chains[0] = TokenPool.ChainUpdate({
       remoteChainSelector: ethSepoliaNetworkDetails.chainSelector,
-      remotePoolAddresses: remotePoolAddressesBaseSepolia,
+      remotePoolAddresses: remotePoolAddressesEthSepolia,
       remoteTokenAddress: abi.encode(address(mockERC20TokenEthSepolia)),
       outboundRateLimiterConfig: RateLimiter.Config({ isEnabled: true, capacity: 100_000, rate: 167 }),
       inboundRateLimiterConfig: RateLimiter.Config({ isEnabled: true, capacity: 100_000, rate: 167 })
@@ -742,11 +742,11 @@ contract CCIPv1_5BurnMintPoolFork is Test {
 
     vm.startPrank(alice);
     TokenPool.ChainUpdate[] memory chains = new TokenPool.ChainUpdate[](1);
-    bytes[] memory remotePoolAddressesEthSepolia = new bytes[](1);
-    remotePoolAddressesEthSepolia[0] = abi.encode(address(burnMintTokenPoolEthSepolia));
+    bytes[] memory remotePoolAddressesBaseSepolia = new bytes[](1);
+    remotePoolAddressesBaseSepolia[0] = abi.encode(address(burnMintTokenPoolBaseSepolia));
     chains[0] = TokenPool.ChainUpdate({
       remoteChainSelector: baseSepoliaNetworkDetails.chainSelector,
-      remotePoolAddresses: remotePoolAddressesEthSepolia,
+      remotePoolAddresses: remotePoolAddressesBaseSepolia,
       remoteTokenAddress: abi.encode(address(mockERC20TokenBaseSepolia)),
       outboundRateLimiterConfig: RateLimiter.Config({ isEnabled: true, capacity: 100_000, rate: 167 }),
       inboundRateLimiterConfig: RateLimiter.Config({ isEnabled: true, capacity: 100_000, rate: 167 })
@@ -760,11 +760,11 @@ contract CCIPv1_5BurnMintPoolFork is Test {
 
     vm.startPrank(alice);
     chains = new TokenPool.ChainUpdate[](1);
-    bytes[] memory remotePoolAddressesBaseSepolia = new bytes[](1);
-    remotePoolAddressesBaseSepolia[0] = abi.encode(address(burnMintTokenPoolEthSepolia));
+    bytes[] memory remotePoolAddressesEthSepolia = new bytes[](1);
+    remotePoolAddressesEthSepolia[0] = abi.encode(address(burnMintTokenPoolEthSepolia));
     chains[0] = TokenPool.ChainUpdate({
       remoteChainSelector: ethSepoliaNetworkDetails.chainSelector,
-      remotePoolAddresses: remotePoolAddressesBaseSepolia,
+      remotePoolAddresses: remotePoolAddressesEthSepolia,
       remoteTokenAddress: abi.encode(address(mockERC20TokenEthSepolia)),
       outboundRateLimiterConfig: RateLimiter.Config({ isEnabled: true, capacity: 100_000, rate: 167 }),
       inboundRateLimiterConfig: RateLimiter.Config({ isEnabled: true, capacity: 100_000, rate: 167 })


### PR DESCRIPTION
## Summary
- Correct the remote pool reference when configuring the Ethereum Sepolia pool for Base Sepolia.
- Align remote-pool variable names with their corresponding remote chains in both the step-by-step tutorial and final example.

## Validation
- Ran focused regression checks confirming both chain-direction configurations appear in the tutorial and final example.
- Ran git diff --check.
- Ran Prettier MDX parser/idempotence validation.

## Not run
- A live Foundry fork test was not run because Foundry and testnet RPC credentials are unavailable in this environment.

## CI status
- The Vercel preview check cannot start because the Chainlink Labs Vercel integration requires organization-side authorization. This is an integration-access failure, not a reported source build or test failure.

Fixes #4114