### PR TITLE
Document support for multiple Chainlink Node secrets files

### DIFF
--- a/src/content/chainlink-nodes/configuring-nodes.mdx
+++ b/src/content/chainlink-nodes/configuring-nodes.mdx
@@ -119,10 +119,10 @@ Test your node to verify that it works as intended. If you are using a VPS, open
 
 ## Using multiple config files
 
-You can use multiple config and secrets files. The config settings from each file are applied in the order that you specify when you run your node. Duplicated fields override values specified in earlier config files. This allows you to create a common config that applies to many nodes with specific configs for nodes that need unique configuration settings. Specifying multiple secrets files is invalid.
+You can use multiple config and secrets files. The config settings from each file are applied in the order that you specify when you run your node. Duplicated fields override values specified in earlier config files. This allows you to create a common config that applies to many nodes with specific configs for nodes that need unique configuration settings. Secret fields from multiple secrets files are merged, but each secret field can appear in only one file. Duplicated secret fields are invalid.
 
-To specify multiple config files, add additional `-config` flags to the `docker run` command:
+To specify multiple config or secrets files, add additional `-config` or `-secrets` flags to the `docker run` command:
 
 ```shell
-docker run --platform linux/x86_64/v8 --name chainlink -v ~/.chainlink:/chainlink -it -p 6688:6688 --add-host=host.docker.internal:host-gateway smartcontract/chainlink:1.13.0 -config /chainlink/config.toml -config /chainlink/config2.toml -config /chainlink/config3.toml -secrets /chainlink/secrets.toml node start
+docker run --platform linux/x86_64/v8 --name chainlink -v ~/.chainlink:/chainlink -it -p 6688:6688 --add-host=host.docker.internal:host-gateway smartcontract/chainlink:1.13.0 -config /chainlink/config.toml -config /chainlink/config2.toml -config /chainlink/config3.toml -secrets /chainlink/secrets.toml -secrets /chainlink/secrets2.toml node start
 ```


### PR DESCRIPTION
## Closing issues

closes #1505

## Description

Documents the current Chainlink Node CLI behavior for multiple secrets files: distinct secret fields are merged, while duplicate secret fields are rejected.

## Changes

- Replace the incorrect statement that multiple secrets files are invalid.
- Explain the duplicate-secret-field restriction.
- Show repeated -secrets flags in the Docker command.

## Validation

- Passed the project Prettier check for the changed MDX file.
- Passed focused #1505 documentation regression checks.
- Passed Git whitespace validation.
- Repository-wide format and lint commands were executed, but fail on existing Windows CRLF and style drift outside this change.
- The link checker could not run on this Windows host because its project script requires Unix nohup and a Vercel production build; Docker is unavailable.

## CI status

- The Vercel preview status cannot start because the Chainlink Labs Vercel integration requires organization-side GitHub authorization. This is an integration-access failure, not a reported source build or test failure.